### PR TITLE
Report Monitor References in gc-end

### DIFF
--- a/runtime/gc_glue_java/MarkingSchemeRootClearer.cpp
+++ b/runtime/gc_glue_java/MarkingSchemeRootClearer.cpp
@@ -307,8 +307,11 @@ void
 MM_MarkingSchemeRootClearer::doMonitorReference(J9ObjectMonitor *objectMonitor, GC_HashTableIterator *monitorReferenceIterator)
 {
 	J9ThreadAbstractMonitor * monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
+	_env->getGCEnvironment()->_markJavaStats._monitorReferenceCandidates += 1;
+
 	if(!_markingScheme->isMarked((omrobjectptr_t )monitor->userData)) {
 		monitorReferenceIterator->removeSlot();
+		_env->getGCEnvironment()->_markJavaStats._monitorReferenceCleared += 1;
 		/* We must call objectMonitorDestroy (as opposed to omrthread_monitor_destroy) when the
 		 * monitor is not internal to the GC */
 		static_cast<J9JavaVM*>(_omrVM->_language_vm)->internalVMFunctions->objectMonitorDestroy(static_cast<J9JavaVM*>(_omrVM->_language_vm), (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);

--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -224,6 +224,9 @@ MM_ScavengerDelegate::mergeGCStats_mergeLangStats(MM_EnvironmentBase * envBase)
 	finalGCJavaStats->_softReferenceStats.merge(&scavJavaStats->_softReferenceStats);
 	finalGCJavaStats->_phantomReferenceStats.merge(&scavJavaStats->_phantomReferenceStats);
 
+	finalGCJavaStats->_monitorReferenceCleared += scavJavaStats->_monitorReferenceCleared;
+	finalGCJavaStats->_monitorReferenceCandidates += scavJavaStats->_monitorReferenceCandidates;
+
 	scavJavaStats->clear();
 }
 

--- a/runtime/gc_glue_java/ScavengerRootClearer.hpp
+++ b/runtime/gc_glue_java/ScavengerRootClearer.hpp
@@ -188,12 +188,15 @@ public:
 		bool const compressed = _extensions->compressObjectReferences();
 		J9ThreadAbstractMonitor * monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
 		omrobjectptr_t objectPtr = (omrobjectptr_t )monitor->userData;
+		_env->getGCEnvironment()->_scavengerJavaStats._monitorReferenceCandidates += 1;
+		
 		if(_scavenger->isObjectInEvacuateMemory(objectPtr)) {
 			MM_ForwardedHeader forwardedHeader(objectPtr, compressed);
 			omrobjectptr_t forwardPtr = forwardedHeader.getForwardedObject();
 			if(NULL != forwardPtr) {
 				monitor->userData = (uintptr_t)forwardPtr;
 			} else {
+				_env->getGCEnvironment()->_scavengerJavaStats._monitorReferenceCleared += 1;
 				monitorReferenceIterator->removeSlot();
 				/* We must call objectMonitorDestroy (as opposed to omrthread_monitor_destroy) when the
 				 * monitor is not internal to the GC

--- a/runtime/gc_stats/CopyForwardStats.hpp
+++ b/runtime/gc_stats/CopyForwardStats.hpp
@@ -64,6 +64,9 @@ public:
 	UDATA _stringConstantsCleared;  /**< The number of string constants that have been cleared during marking */
 	UDATA _stringConstantsCandidates; /**< The number of string constants that have been visited in string table during marking */
 
+	UDATA _monitorReferenceCleared; /**< The number of monitor references that have been cleared during marking */
+	UDATA _monitorReferenceCandidates; /**< The number of monitor references that have been visited in monitor table during marking */
+
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 	UDATA _doubleMappedArrayletsCleared; /**< The number of double mapped arraylets that have been cleared durign marking */
 	UDATA _doubleMappedArrayletsCandidates; /**< The number of double mapped arraylets that have been visited during marking */
@@ -93,6 +96,9 @@ public:
 		_stringConstantsCleared = 0;
 		_stringConstantsCandidates = 0;
 
+		_monitorReferenceCleared = 0;
+		_monitorReferenceCandidates = 0;
+
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 		_doubleMappedArrayletsCleared = 0;
 		_doubleMappedArrayletsCandidates = 0;
@@ -117,6 +123,9 @@ public:
 		_stringConstantsCleared += stats->_stringConstantsCleared;
 		_stringConstantsCandidates += stats->_stringConstantsCandidates;
 
+		_monitorReferenceCleared += stats->_monitorReferenceCleared;
+		_monitorReferenceCandidates += stats->_monitorReferenceCandidates;
+
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 		_doubleMappedArrayletsCleared += stats->_doubleMappedArrayletsCleared;
 		_doubleMappedArrayletsCandidates += stats->_doubleMappedArrayletsCandidates;
@@ -134,6 +143,8 @@ public:
 		, _phantomReferenceStats()
 		, _stringConstantsCleared(0)
 		, _stringConstantsCandidates(0)
+		, _monitorReferenceCleared(0)
+		, _monitorReferenceCandidates(0)
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 		, _doubleMappedArrayletsCleared(0)
 		, _doubleMappedArrayletsCandidates(0)

--- a/runtime/gc_stats/MarkJavaStats.cpp
+++ b/runtime/gc_stats/MarkJavaStats.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,6 +42,9 @@ MM_MarkJavaStats::clear()
 	_stringConstantsCleared = 0;
 	_stringConstantsCandidates = 0;
 
+	_monitorReferenceCleared = 0;
+	_monitorReferenceCandidates = 0;
+
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 	splitArraysProcessed = 0;
 	splitArraysAmount = 0;
@@ -63,6 +66,9 @@ MM_MarkJavaStats::merge(MM_MarkJavaStats* statsToMerge)
 
 	_stringConstantsCleared += statsToMerge->_stringConstantsCleared;
 	_stringConstantsCandidates += statsToMerge->_stringConstantsCandidates;
+
+	_monitorReferenceCleared += statsToMerge->_monitorReferenceCleared;
+	_monitorReferenceCandidates += statsToMerge->_monitorReferenceCandidates;
 
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 	/* It may not ever be useful to merge these stats, but do it anyways */

--- a/runtime/gc_stats/MarkJavaStats.hpp
+++ b/runtime/gc_stats/MarkJavaStats.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,6 +53,9 @@ public:
 	UDATA _stringConstantsCleared; /**< The number of string constants that have been cleared during marking */
 	UDATA _stringConstantsCandidates; /**< The number of string constants that have been visited in string table during marking */
 
+	UDATA _monitorReferenceCleared; /**< The number of monitor references that have been cleared during marking */
+	UDATA _monitorReferenceCandidates; /**< The number of monitor references that have been visited in monitor table during marking */
+
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 	UDATA splitArraysProcessed; /**< The number of array chunks (not counting parts smaller than the split size) processed by this thread */
 	UDATA splitArraysAmount;
@@ -76,6 +79,8 @@ public:
 		, _phantomReferenceStats()
 		, _stringConstantsCleared(0)
 		, _stringConstantsCandidates(0)
+		, _monitorReferenceCleared(0)
+		, _monitorReferenceCandidates(0)
 	{
 		clear();
 	}

--- a/runtime/gc_stats/MarkVLHGCStats.hpp
+++ b/runtime/gc_stats/MarkVLHGCStats.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,6 +68,9 @@ public:
 	UDATA _stringConstantsCleared;  /**< The number of string constants that have been cleared during marking */
 	UDATA _stringConstantsCandidates; /**< The number of string constants that have been visited in string table during marking */
 
+	UDATA _monitorReferenceCleared; /**< The number of monitor references that have been cleared during marking */
+	UDATA _monitorReferenceCandidates; /**< The number of monitor references that have been visited in monitor table during marking */
+
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 	UDATA _doubleMappedArrayletsCleared; /**< The number of double mapped arraylets that have been cleared durign marking */
 	UDATA _doubleMappedArrayletsCandidates; /**< The number of double mapped arraylets that have been visited during marking */
@@ -99,6 +102,9 @@ public:
 		_stringConstantsCleared = 0;
 		_stringConstantsCandidates = 0;
 
+		_monitorReferenceCleared = 0;
+		_monitorReferenceCandidates = 0;
+
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 		_doubleMappedArrayletsCleared = 0;
 		_doubleMappedArrayletsCandidates = 0;
@@ -126,6 +132,9 @@ public:
 		_stringConstantsCleared += statsToMerge->_stringConstantsCleared;
 		_stringConstantsCandidates += statsToMerge->_stringConstantsCandidates;
 
+		_monitorReferenceCleared += statsToMerge->_monitorReferenceCleared;
+		_monitorReferenceCandidates += statsToMerge->_monitorReferenceCandidates;
+
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 		_doubleMappedArrayletsCleared += statsToMerge->_doubleMappedArrayletsCleared;
 		_doubleMappedArrayletsCandidates += statsToMerge->_doubleMappedArrayletsCandidates;
@@ -150,6 +159,8 @@ public:
 		,_phantomReferenceStats()
 		,_stringConstantsCleared(0)
 		,_stringConstantsCandidates(0)
+		,_monitorReferenceCleared(0)
+		,_monitorReferenceCandidates(0)
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 		,_doubleMappedArrayletsCleared(0)
 		,_doubleMappedArrayletsCandidates(0)

--- a/runtime/gc_stats/ScavengerJavaStats.cpp
+++ b/runtime/gc_stats/ScavengerJavaStats.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,6 +32,8 @@ MM_ScavengerJavaStats::MM_ScavengerJavaStats() :
 	,_weakReferenceStats()
 	,_softReferenceStats()
 	,_phantomReferenceStats()
+	,_monitorReferenceCleared(0)
+	,_monitorReferenceCandidates(0)
 {
 }
 
@@ -48,6 +50,9 @@ MM_ScavengerJavaStats::clear()
 	_weakReferenceStats.clear();
 	_softReferenceStats.clear();
 	_phantomReferenceStats.clear();
+
+	_monitorReferenceCleared = 0;
+	_monitorReferenceCandidates = 0;
 };
 
 

--- a/runtime/gc_stats/ScavengerJavaStats.hpp
+++ b/runtime/gc_stats/ScavengerJavaStats.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,6 +57,9 @@ public:
 	MM_ReferenceStats _weakReferenceStats;  /**< Weak reference stats for the cycle */
 	MM_ReferenceStats _softReferenceStats;  /**< Soft reference stats for the cycle */
 	MM_ReferenceStats _phantomReferenceStats;  /**< Phantom reference stats for the cycle */
+
+	UDATA _monitorReferenceCleared; /**< The number of monitor references that have been cleared during scavenge */
+	UDATA _monitorReferenceCandidates; /**< The number of monitor references that have been visited in monitor table during scavenge */
 
 protected:
 

--- a/runtime/gc_verbose_handler_standard_java/VerboseHandlerOutputStandardJava.cpp
+++ b/runtime/gc_verbose_handler_standard_java/VerboseHandlerOutputStandardJava.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -163,6 +163,7 @@ MM_VerboseHandlerOutputStandardJava::handleMarkEndInternal(MM_EnvironmentBase* e
 	outputReferenceInfo(env, 1, "phantom", &markJavaStats->_phantomReferenceStats, 0, 0);
 
 	outputStringConstantInfo(env, 1, markJavaStats->_stringConstantsCandidates, markJavaStats->_stringConstantsCleared);
+	outputMonitorReferenceInfo(env, 1, markJavaStats->_monitorReferenceCandidates, markJavaStats->_monitorReferenceCleared);
 
 	if (workPacketStats->getSTWWorkStackOverflowOccured()) {
 		_manager->getWriterChain()->formatAndOutput(env, 1, "<warning details=\"work packet overflow\" count=\"%zu\" packetcount=\"%zu\" />",
@@ -243,6 +244,8 @@ MM_VerboseHandlerOutputStandardJava::handleScavengeEndInternal(MM_EnvironmentBas
 		outputReferenceInfo(env, 1, "soft", &scavengerJavaStats->_softReferenceStats, extensions->getDynamicMaxSoftReferenceAge(), extensions->getMaxSoftReferenceAge());
 		outputReferenceInfo(env, 1, "weak", &scavengerJavaStats->_weakReferenceStats, 0, 0);
 		outputReferenceInfo(env, 1, "phantom", &scavengerJavaStats->_phantomReferenceStats, 0, 0);
+
+		outputMonitorReferenceInfo(env, 1, scavengerJavaStats->_monitorReferenceCandidates, scavengerJavaStats->_monitorReferenceCleared);
 	}
 }
 #endif /*defined(J9VM_GC_MODRON_SCAVENGER) */

--- a/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.cpp
+++ b/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -418,6 +418,7 @@ MM_VerboseHandlerOutputVLHGC::handleCopyForwardEnd(J9HookInterface** hook, UDATA
 	outputReferenceInfo(env, 1, "phantom", &copyForwardStats->_phantomReferenceStats, 0, 0);
 
 	outputStringConstantInfo(env, 1, copyForwardStats->_stringConstantsCandidates, copyForwardStats->_stringConstantsCleared);
+	outputMonitorReferenceInfo(env, 1, copyForwardStats->_monitorReferenceCandidates, copyForwardStats->_monitorReferenceCleared);
 
 	if(0 != copyForwardStats->_heapExpandedCount) {
 		U_64 expansionMicros = j9time_hires_delta(0, copyForwardStats->_heapExpandedTime, J9PORT_TIME_DELTA_IN_MICROSECONDS);
@@ -574,6 +575,7 @@ MM_VerboseHandlerOutputVLHGC::outputMarkSummary(MM_EnvironmentBase *env, const c
 	outputReferenceInfo(env, 1, "phantom", &markStats->_phantomReferenceStats, 0, 0);
 
 	outputStringConstantInfo(env, 1, markStats->_stringConstantsCandidates, markStats->_stringConstantsCleared);
+	outputMonitorReferenceInfo(env, 1, markStats->_monitorReferenceCandidates, markStats->_monitorReferenceCleared);
 
 	switch (env->_cycleState->_reasonForMarkCompactPGC) {
 	case MM_CycleState::reason_not_exceptional:

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -3833,6 +3833,7 @@ private:
 
 	virtual void doMonitorReference(J9ObjectMonitor *objectMonitor, GC_HashTableIterator *monitorReferenceIterator) {
 		J9ThreadAbstractMonitor * monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
+		MM_EnvironmentVLHGC::getEnvironment(_env)->_copyForwardStats._monitorReferenceCandidates += 1;
 		J9Object *objectPtr = (J9Object *)monitor->userData;
 		if(!_copyForwardScheme->isLiveObject(objectPtr)) {
 			Assert_MM_true(_copyForwardScheme->isObjectInEvacuateMemory(objectPtr));
@@ -3843,6 +3844,7 @@ private:
 			} else {
 				Assert_MM_mustBeClass(forwardedHeader.getPreservedClass());
 				monitorReferenceIterator->removeSlot();
+				MM_EnvironmentVLHGC::getEnvironment(_env)->_copyForwardStats._monitorReferenceCleared += 1;
 				/* We must call objectMonitorDestroy (as opposed to omrthread_monitor_destroy) when the
 				 * monitor is not internal to the GC
 				 */

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -1192,8 +1192,10 @@ private:
 
 	virtual void doMonitorReference(J9ObjectMonitor *objectMonitor, GC_HashTableIterator *monitorReferenceIterator) {
 		J9ThreadAbstractMonitor * monitor = (J9ThreadAbstractMonitor*)objectMonitor->monitor;
+		MM_EnvironmentVLHGC::getEnvironment(_env)->_markVLHGCStats._monitorReferenceCandidates += 1;
 		if(!_markingScheme->isMarked((J9Object *)monitor->userData)) {
 			monitorReferenceIterator->removeSlot();
+			MM_EnvironmentVLHGC::getEnvironment(_env)->_markVLHGCStats._monitorReferenceCleared += 1;
 			/* We must call objectMonitorDestroy (as opposed to omrthread_monitor_destroy) when the
 			 * monitor is not internal to the GC */
 			static_cast<J9JavaVM*>(_omrVM->_language_vm)->internalVMFunctions->objectMonitorDestroy(static_cast<J9JavaVM*>(_omrVM->_language_vm), (J9VMThread *)_env->getLanguageVMThread(), (omrthread_monitor_t)monitor);


### PR DESCRIPTION
Report Monitor References in following types of GC operations:
	mark,scavenge,mark increment, copy forward

Depends on: https://github.com/eclipse/omr/pull/5472

Signed-off-by: Enson Guo <enson.guo@ibm.com>