### PR TITLE
[v0.22.0-release] Make the static variant of asDirect a private method

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -580,7 +580,7 @@ public abstract class VarHandle extends VarHandleInternal
 
 		try {
 			MethodType replaceWithDirectType = MethodType.methodType(VarHandle.class, VarHandle.class);
-			MethodHandle replaceWithDirect = MethodHandles.publicLookup().findStatic(VarHandle.class, "asDirect", replaceWithDirectType);
+			MethodHandle replaceWithDirect = MethodHandles.lookup().findStatic(VarHandle.class, "asDirect", replaceWithDirectType);
 
 			for (AccessMode mode : AccessMode.values()) {
 				int index = mode.ordinal();
@@ -1674,7 +1674,7 @@ public abstract class VarHandle extends VarHandleInternal
 	 * 
 	 * @return the direct-target VarHandle for the input VarHandle.
 	 */
-	public static VarHandle asDirect(VarHandle varHandle) {
+	private static VarHandle asDirect(VarHandle varHandle) {
 		return varHandle.asDirect();
 	}
 /*[ENDIF] Java15 */


### PR DESCRIPTION
The static variant of asDirect is converted to a private method since it is not
part of the public API.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>