### PR TITLE
Use correct type for EsJNIFunctions

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -5871,7 +5871,7 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 	J9InitializeJavaVMArgs * initArgs = userData;
 	void * osMainThread = initArgs->osMainThread;
 	J9JavaVM * vm = initArgs->vm;
-	extern struct JNINativeInterface_ * EsJNIFunctions;
+	extern struct JNINativeInterface_ EsJNIFunctions;
 	J9VMThread *env = NULL;
 	UDATA parseError = FALSE;
 	jint stageRC = 0;


### PR DESCRIPTION
Fixes compiler warning on newer compilers.

Fixes: #10393

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>