### PR TITLE
Use flexible array member for J9UTF8

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/walkers/LocalVariableTableIterator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/walkers/LocalVariableTableIterator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -140,14 +140,14 @@ public abstract class LocalVariableTableIterator implements Iterator<LocalVariab
 					return null;
 				}
 				name = J9UTF8Pointer.cast(SelfRelativePointer.cast(localVariableTablePtr).get());
-				localVariableTablePtr = localVariableTablePtr.add(J9UTF8.SIZEOF);
+				localVariableTablePtr = localVariableTablePtr.add(SelfRelativePointer.SIZEOF);
 				
 				signature = J9UTF8Pointer.cast(SelfRelativePointer.cast(localVariableTablePtr).get());
-				localVariableTablePtr = localVariableTablePtr.add(J9UTF8.SIZEOF);
+				localVariableTablePtr = localVariableTablePtr.add(SelfRelativePointer.SIZEOF);
 
 				if (visibilityLength.anyBitsIn(J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_VARIABLE_TABLE_HAS_GENERIC)) {
 					genericSignature = J9UTF8Pointer.cast(SelfRelativePointer.cast(localVariableTablePtr).get());
-					localVariableTablePtr = localVariableTablePtr.add(J9UTF8.SIZEOF);
+					localVariableTablePtr = localVariableTablePtr.add(SelfRelativePointer.SIZEOF);
 				} else {
 					genericSignature = J9UTF8Pointer.NULL;
 				}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9UTF8Helper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9UTF8Helper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,9 +24,14 @@ package com.ibm.j9ddr.vm29.pointer.helper;
 import java.io.UnsupportedEncodingException;
 import com.ibm.j9ddr.CorruptDataException;
 import com.ibm.j9ddr.vm29.pointer.generated.J9UTF8Pointer;
+import com.ibm.j9ddr.vm29.types.U16;
 
 public class J9UTF8Helper {
-	
+
+	// Do not use J9UTF8.SIZEOF here in order to maintain compatibility
+	// with older core files.
+	public static int J9UTF8_HEADER_SIZE = U16.SIZEOF;
+
 	public static String stringValue(J9UTF8Pointer utf8pointer) throws CorruptDataException 
 	{
 		byte[] buffer = new byte[utf8pointer.length().intValue()];

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/LinearDumper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/LinearDumper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -661,7 +661,7 @@ public class LinearDumper implements IClassWalkCallbacks {
 	}
 	private int getUTF8Length(J9UTF8Pointer j9utf8Pointer) throws CorruptDataException {
 
-		UDATA length = new UDATA(j9utf8Pointer.length().longValue() + J9UTF8.SIZEOF - U8.SIZEOF * 2 /*TODO sizeof(utf8->data)*/);
+		UDATA length = new UDATA(j9utf8Pointer.length().longValue() + J9UTF8Helper.J9UTF8_HEADER_SIZE);
 		if (length.anyBitsIn(1)) {
 			length = length.add(1);
 		}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ShrCCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ShrCCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -986,7 +986,7 @@ public class ShrCCommand extends Command
 				} else if (itemType.eq(TYPE_SCOPE)) {
 					utf8 = J9UTF8Pointer.cast(ShcItemHelper.ITEMDATA(it));
 					scopeMetaLen += ShcItem.SIZEOF + ShcItemHdr.SIZEOF;
-					scopeDataLen += J9UTF8.SIZEOF + utf8.length().longValue();
+					scopeDataLen += J9UTF8Helper.J9UTF8_HEADER_SIZE + utf8.length().longValue();
 					if ((statTypes & SCOPE_STATS) != 0) {
 						entryFound = true;
 						CommandUtils.dbgPrint(out, "%d: %s SCOPE !j9utf8 %s %s\n", it.jvmID().longValue(), it.getHexAddress(), utf8.getHexAddress(), J9UTF8Helper.stringValue(utf8));
@@ -1080,7 +1080,7 @@ public class ShrCCommand extends Command
 				} else if (itemType.eq(TYPE_PREREQ_CACHE)) { 
 					utf8 = J9UTF8Pointer.cast(ShcItemHelper.ITEMDATA(it));
 					scopeMetaLen += ShcItem.SIZEOF + ShcItemHdr.SIZEOF;
-					scopeDataLen += J9UTF8.SIZEOF + utf8.length().longValue();
+					scopeDataLen += J9UTF8Helper.J9UTF8_HEADER_SIZE + utf8.length().longValue();
 					if ((statTypes & PREREQ_CACHE_STATS) != 0) {
 						entryFound = true;
 						CommandUtils.dbgPrint(out, "%d: %s PREREQ CACHE UNIQUE ID !j9utf8 %s %s\n", it.jvmID().longValue(), it.getHexAddress(), utf8.getHexAddress(), J9UTF8Helper.stringValue(utf8));

--- a/runtime/bcutil/ComparingCursor.cpp
+++ b/runtime/bcutil/ComparingCursor.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -551,12 +551,11 @@ ComparingCursor::isRangeValidForUTF8Ptr(J9UTF8 *utf8)
 	U_8 *ptr = (U_8*)utf8;
 
 	if (_checkRangeInSharedCache) {
-		return j9shr_Query_IsAddressInCache(_javaVM, utf8, sizeof(J9UTF8)) &&
-			   j9shr_Query_IsAddressInCache(_javaVM, ptr + offsetof(J9UTF8, data), J9UTF8_LENGTH(utf8));
+		return FALSE != j9shr_Query_IsAddressInCache(_javaVM, utf8, J9UTF8_TOTAL_SIZE(utf8));
 	} else {
 		UDATA maxLength = getMaximumValidLengthForPtrInSegment(ptr);
 
-		return (sizeof(J9UTF8) < maxLength) && (J9UTF8_LENGTH(utf8) < (maxLength - offsetof(J9UTF8, data)));
+		return J9UTF8_TOTAL_SIZE(utf8) < maxLength;
 	}
 }
 

--- a/runtime/bcverify/vrfyhelp.c
+++ b/runtime/bcverify/vrfyhelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -121,13 +121,14 @@ addClassName(J9BytecodeVerificationData * verifyData, U_8 * name, UDATA length, 
 	offset = (U_32 *) verifyData->classNameSegmentFree;
 	utf8 = (J9UTF8 *) (offset + 1);
 	J9UTF8_SET_LENGTH(utf8, (U_16) length);
-	verifyData->classNameSegmentFree += (sizeof(U_32) + sizeof(J9UTF8));
+	verifyData->classNameSegmentFree += sizeof(U_32);
 	if (classNameInClass) {
 		offset[0] = (U_32) ((UDATA) name - (UDATA) romClass);
+		verifyData->classNameSegmentFree += sizeof(U_32);
 	} else {
 		offset[0] = 0;
 		strncpy((char *) J9UTF8_DATA(utf8), (char *) name, length);
-		verifyData->classNameSegmentFree += (length - 2 + sizeof(U_32) - 1) & ~(sizeof(U_32) - 1);	/* next U_32 boundary */
+		verifyData->classNameSegmentFree += (sizeof(J9UTF8) + length + sizeof(U_32) - 1) & ~(sizeof(U_32) - 1);	/* next U_32 boundary */
 	}
 	verifyData->classNameList[index] = (J9UTF8 *) offset;
 	verifyData->classNameList[index + 1] = NULL;
@@ -152,7 +153,7 @@ findClassName(J9BytecodeVerificationData * verifyData, U_8 * name, UDATA length)
 
 
 	while ((offset = (U_32 *) verifyData->classNameList[index]) != NULL) {
-		utf8 = (J9UTF8 *) offset + 1;
+		utf8 = (J9UTF8 *) (offset + 1);
 		if ((UDATA) J9UTF8_LENGTH(utf8) == length) {
 			data = (U_8 *) ((UDATA) offset[0] + (UDATA) romClass);
 
@@ -192,7 +193,7 @@ convertClassNameToStackMapType(J9BytecodeVerificationData * verifyData, U_8 *nam
 
 
 	while ((offset = (U_32 *) verifyData->classNameList[index]) != NULL) {
-		utf8 = (J9UTF8 *) offset + 1;
+		utf8 = (J9UTF8 *) (offset + 1);
 		if ((UDATA) J9UTF8_LENGTH(utf8) == (UDATA)length) {
 			data = (U_8 *) ((UDATA) offset[0] + (UDATA) romClass);
 

--- a/runtime/cfdumper/romdump.c
+++ b/runtime/cfdumper/romdump.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -154,9 +154,10 @@ addRegion(J9Pool *regionPool, UDATA offset, UDATA length, UDATA type, const char
 static UDATA
 getUTF8Length(J9UTF8 *utf8)
 {
-	UDATA length = sizeof(J9UTF8) + J9UTF8_LENGTH(utf8) - sizeof(J9UTF8_DATA(utf8));
-	if (length & 1) {
-		length++;
+	UDATA length = sizeof(J9UTF8) + J9UTF8_LENGTH(utf8);
+	/* Keep UTFs aligned to 2 bytes */
+	if (0 != (length & 1)) {
+		length += 1;
 	}
 	return length;
 }

--- a/runtime/codert_vm/thunkcrt.c
+++ b/runtime/codert_vm/thunkcrt.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -115,7 +115,7 @@ j9ThunkLookupNameAndSig(void * jitConfig, void *parm)
 
 	Trc_Thunk_j9ThunkLookupNameAndSig_Entry();
 
-	thunkAddress = j9ThunkLookupSignature(jitConfig, J9UTF8_LENGTH(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature)), (char *) &J9UTF8_DATA((J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature))));
+	thunkAddress = j9ThunkLookupSignature(jitConfig, J9UTF8_LENGTH(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature)), (char *) J9UTF8_DATA((J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature))));
 
 	if (NULL == thunkAddress) {
 		Trc_Thunk_j9ThunkLookupNameAndSig_Exit_ThunkNotFound();
@@ -233,7 +233,7 @@ j9ThunkNewNameAndSig(void * jitConfig, void *parm, void *thunkAddress)
 {
 	J9ROMNameAndSignature *nameAndSignature = (J9ROMNameAndSignature *) parm;
 
-	return j9ThunkNewSignature(jitConfig, J9UTF8_LENGTH(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature)), (char *) &J9UTF8_DATA((J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature))), thunkAddress);
+	return j9ThunkNewSignature(jitConfig, J9UTF8_LENGTH(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature)), (char *) J9UTF8_DATA((J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature))), thunkAddress);
 }
 
 IDATA
@@ -485,5 +485,5 @@ j9ThunkVMHelperFromNameAndSig(void * jitConfig, void *parm)
 {
 	J9ROMNameAndSignature *nameAndSignature = (J9ROMNameAndSignature *) parm;
 
-	return j9ThunkVMHelperFromSignature(jitConfig, J9UTF8_LENGTH(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature)), (char *) &J9UTF8_DATA((J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature))));
+	return j9ThunkVMHelperFromSignature(jitConfig, J9UTF8_LENGTH(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature)), (char *) J9UTF8_DATA((J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature))));
 }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -581,10 +581,10 @@ bool TR::CompilationInfo::importantMethodForStartup(J9Method *method)
       J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClazz);
       if (TR::Compiler->target.numberOfProcessors() <= 2)
          {
-         if (className->length == 16 && 0==memcmp(utf8Data(className), "java/lang/String", 16))
+         if (J9UTF8_LENGTH(className) == 16 && 0==memcmp(utf8Data(className), "java/lang/String", 16))
             return true;
          }
-      else if (className->length >= 14)
+      else if (J9UTF8_LENGTH(className) >= 14)
          {
          if (0==memcmp(utf8Data(className), "java/lang/Stri", 14) ||
              0==memcmp(utf8Data(className), "java/util/zip/", 14) ||
@@ -720,7 +720,7 @@ bool TR::CompilationInfo::shouldDowngradeCompReq(TR_MethodToBeCompiled *entry)
          if (!doDowngrade)
             {
             J9UTF8 * className = J9ROMCLASS_CLASSNAME(methodDetails.getRomClass());
-            if (className->length == 23 && !memcmp(utf8Data(className), "java/lang/J9VMInternals", 23))
+            if (J9UTF8_LENGTH(className) == 23 && !memcmp(utf8Data(className), "java/lang/J9VMInternals", 23))
                {
                doDowngrade = true;
                }

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -620,7 +620,7 @@ static void jitHookInitializeSendTarget(J9HookInterface * * hook, UDATA eventNum
       J9UTF8 * className = J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(method)->romClass);
       J9UTF8 * name      = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method));
       J9UTF8 * signature = J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(method));
-      int32_t sigLen = sprintf(buf, "%.*s.%.*s%.*s", className->length, utf8Data(className), name->length, utf8Data(name), signature->length, utf8Data(signature));
+      int32_t sigLen = sprintf(buf, "%.*s.%.*s%.*s", J9UTF8_LENGTH(className), utf8Data(className), J9UTF8_LENGTH(name), utf8Data(name), J9UTF8_LENGTH(signature), utf8Data(signature));
       printf("Initial: Signature %s Count %d isLoopy %d isAOT %lu is in SCC %d SCCContainsProfilingInfo %d \n",buf,TR::CompilationInfo::getInvocationCount(method),J9ROMMETHOD_HAS_BACKWARDS_BRANCHES(romMethod),
             TR::Options::sharedClassCache() ? jitConfig->javaVM->sharedClassConfig->existsCachedCodeForROMMethod(vmThread, romMethod) : 0,
             TR::Options::sharedClassCache() ? TR_J9VMBase::get(jitConfig, vmThread, TR_J9VMBase::AOT_VM)->sharedCache()->isROMClassInSharedCache(J9_CLASS_FROM_METHOD(method)->romClass) : 0,containsInfo) ; fflush(stdout);

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1157,7 +1157,7 @@ static intptr_t getInitialCountForMethod(TR_ResolvedMethod *rm, TR::Compilation 
                 {
                 J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClass);
 
-                if (className->length > 5 &&
+                if (J9UTF8_LENGTH(className) > 5 &&
                     !strncmp(utf8Data(className), "java/", 5))
                   {
                   initialCount = 10000;

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1805,9 +1805,9 @@ TR_RelocationRecordThunks::relocateAndRegisterThunk(
    bool matchFound = false;
 
    int32_t signatureLength = J9UTF8_LENGTH(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature));
-   char *signatureString = (char *) &(J9UTF8_DATA(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature)));
+   char *signatureString = (char *) J9UTF8_DATA(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature));
 
-   RELO_LOG(reloRuntime->reloLogger(), 6, "\t\trelocateAndRegisterThunk: %.*s%.*s\n", J9UTF8_LENGTH(J9ROMNAMEANDSIGNATURE_NAME(nameAndSignature)), &(J9UTF8_DATA(J9ROMNAMEANDSIGNATURE_NAME(nameAndSignature))),  signatureLength, signatureString);
+   RELO_LOG(reloRuntime->reloLogger(), 6, "\t\trelocateAndRegisterThunk: %.*s%.*s\n", J9UTF8_LENGTH(J9ROMNAMEANDSIGNATURE_NAME(nameAndSignature)), J9UTF8_DATA(J9ROMNAMEANDSIGNATURE_NAME(nameAndSignature)),  signatureLength, signatureString);
 
    // Everything below is run with VM Access in hand
    TR::VMAccessCriticalSection relocateAndRegisterThunkCriticalSection(reloRuntime->fej9());
@@ -2067,8 +2067,8 @@ TR_RelocationRecordInlinedAllocation::preparePrivateData(TR_RelocationRuntime *r
       {
       RELO_LOG(reloRuntime->reloLogger(), 6, "\tpreparePrivateData: clazz %p %.*s\n",
                                                  clazz,
-                                                 J9ROMCLASS_CLASSNAME(clazz->romClass)->length,
-                                                 J9ROMCLASS_CLASSNAME(clazz->romClass)->data);
+                                                 J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(clazz->romClass)),
+                                                 J9UTF8_DATA(J9ROMCLASS_CLASSNAME(clazz->romClass)));
 
       if (verifyClass(reloRuntime, reloTarget, (TR_OpaqueClassBlock *)clazz))
          inlinedCodeIsOkay = true;
@@ -2185,7 +2185,7 @@ TR_RelocationRecordInlinedMethod::print(TR_RelocationRuntime *reloRuntime)
    TR_RelocationRecordConstantPoolWithIndex::print(reloRuntime);
    J9ROMClass *inlinedCodeRomClass = reloRuntime->fej9()->sharedCache()->romClassFromOffsetInSharedCache(romClassOffsetInSharedCache(reloTarget));
    J9UTF8 *inlinedCodeClassName = J9ROMCLASS_CLASSNAME(inlinedCodeRomClass);
-   reloLogger->printf("\tromClassOffsetInSharedCache %x %.*s\n", romClassOffsetInSharedCache(reloTarget), inlinedCodeClassName->length, inlinedCodeClassName->data );
+   reloLogger->printf("\tromClassOffsetInSharedCache %x %.*s\n", romClassOffsetInSharedCache(reloTarget), J9UTF8_LENGTH(inlinedCodeClassName), J9UTF8_DATA(inlinedCodeClassName));
    //reloLogger->printf("\tromClassOffsetInSharedCache %x %.*s\n", romClassOffsetInSharedCache(reloTarget), J9UTF8_LENGTH(inlinedCodeClassname), J9UTF8_DATA(inlinedCodeClassName));
    }
 
@@ -2291,9 +2291,9 @@ TR_RelocationRecordInlinedMethod::inlinedSiteValid(TR_RelocationRuntime *reloRun
    J9UTF8 *callerMethodSignature;
    getClassNameSignatureFromMethod(callerMethod, callerClassName, callerMethodName, callerMethodSignature);
    RELO_LOG(reloRuntime->reloLogger(), 6, "\tinlinedSiteValid: caller method %.*s.%.*s%.*s\n",
-                                              callerClassName->length, callerClassName->data,
-                                              callerMethodName->length, callerMethodName->data,
-                                              callerMethodSignature->length, callerMethodSignature->data);
+                                              J9UTF8_LENGTH(callerClassName), J9UTF8_DATA(callerClassName),
+                                              J9UTF8_LENGTH(callerMethodName), J9UTF8_DATA(callerMethodName),
+                                              J9UTF8_LENGTH(callerMethodSignature), J9UTF8_DATA(callerMethodSignature));
 
    J9ConstantPool *cp = NULL;
    if (!isUnloadedInlinedMethod(callerMethod))
@@ -2356,9 +2356,9 @@ TR_RelocationRecordInlinedMethod::inlinedSiteValid(TR_RelocationRuntime *reloRun
             J9UTF8 *methodSignature;
             getClassNameSignatureFromMethod(currentMethod, className, methodName, methodSignature);
             RELO_LOG(reloRuntime->reloLogger(), 6, "\tinlinedSiteValid: inlined method %.*s.%.*s%.*s\n",
-                                                       className->length, className->data,
-                                                       methodName->length, methodName->data,
-                                                       methodSignature->length, methodSignature->data);
+                                                       J9UTF8_LENGTH(className), J9UTF8_DATA(className),
+                                                       J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName),
+                                                       J9UTF8_LENGTH(methodSignature), J9UTF8_DATA(methodSignature));
             }
          else
             {
@@ -2806,7 +2806,7 @@ TR_RelocationRecordProfiledInlinedMethod::preparePrivateData(TR_RelocationRuntim
       {
       J9ROMClass *inlinedCodeRomClass = reloRuntime->fej9()->sharedCache()->romClassFromOffsetInSharedCache(romClassOffsetInSharedCache(reloTarget));
       J9UTF8 *inlinedCodeClassName = J9ROMCLASS_CLASSNAME(inlinedCodeRomClass);
-      RELO_LOG(reloRuntime->reloLogger(), 6,"\tpreparePrivateData: inlinedCodeRomClass %p %.*s\n", inlinedCodeRomClass, inlinedCodeClassName->length, inlinedCodeClassName->data);
+      RELO_LOG(reloRuntime->reloLogger(), 6,"\tpreparePrivateData: inlinedCodeRomClass %p %.*s\n", inlinedCodeRomClass, J9UTF8_LENGTH(inlinedCodeClassName), J9UTF8_DATA(inlinedCodeClassName));
 
 #if defined(PUBLIC_BUILD)
       J9ClassLoader *classLoader = NULL;

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -459,12 +459,12 @@ TR_RelocationRuntime::relocateAOTCodeAndData(U_8 *tempDataStart,
       _exceptionTable->constantPool = ramCP();
       getClassNameSignatureFromMethod(_method, _exceptionTable->className, _exceptionTable->methodName, _exceptionTable->methodSignature);
       RELO_LOG(reloLogger(), 1, "relocateAOTCodeAndData: method %.*s.%.*s%.*s\n",
-                                    _exceptionTable->className->length,
-                                    _exceptionTable->className->data,
-                                    _exceptionTable->methodName->length,
-                                    _exceptionTable->methodName->data,
-                                    _exceptionTable->methodSignature->length,
-                                    _exceptionTable->methodSignature->data);
+                                    J9UTF8_LENGTH(_exceptionTable->className),
+                                    J9UTF8_DATA(_exceptionTable->className),
+                                    J9UTF8_LENGTH(_exceptionTable->methodName),
+                                    J9UTF8_DATA(_exceptionTable->methodName),
+                                    J9UTF8_LENGTH(_exceptionTable->methodSignature),
+                                    J9UTF8_DATA(_exceptionTable->methodSignature));
 
       /* Now it is safe to perform the JITExceptionTable structure relocations */
       relocateMethodMetaData((UDATA)codeStart - (UDATA)oldCodeStart, (UDATA)_exceptionTable - (UDATA)((U_8 *)oldDataStart + _aotMethodHeaderEntry->offsetToExceptionTable + sizeof(J9JITDataCacheHeader)));

--- a/runtime/jvmti/jvmtiModules.c
+++ b/runtime/jvmti/jvmtiModules.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -80,13 +80,13 @@ addModuleExportsOrOpens(jvmtiEnv* jvmtiEnv, jobject fromModule, const char* pkgN
 		} else  {
 			IDATA len = strlen(pkgName);
 			J9UTF8 *pkgNameUTF8 = NULL;
-			char buf[JVMTI_PACKAGE_NAME_BUFFER_LENGTH + sizeof(pkgNameUTF8->length) + 1];
+			char buf[JVMTI_PACKAGE_NAME_BUFFER_LENGTH + sizeof(J9UTF8) + 1];
 			PORT_ACCESS_FROM_VMC(currentThread);
 			J9Module *foundModule = NULL;
 
 			pkgNameUTF8 = (J9UTF8 *) buf;
 			if (JVMTI_PACKAGE_NAME_BUFFER_LENGTH < len) {
-				pkgNameUTF8 = j9mem_allocate_memory(len + sizeof(pkgNameUTF8->length) + 1, OMRMEM_CATEGORY_VM);
+				pkgNameUTF8 = j9mem_allocate_memory(len + sizeof(J9UTF8) + 1, OMRMEM_CATEGORY_VM);
 				if (NULL == pkgNameUTF8) {
 					rc = JVMTI_ERROR_OUT_OF_MEMORY;
 					vmFuncs->internalExitVMToJNI(currentThread);
@@ -272,7 +272,7 @@ jvmtiGetNamedModule(jvmtiEnv* jvmtiEnv, jobject class_loader, const char* packag
 		J9ClassLoader *vmClassLoader = NULL;
 		J9Module *vmModule = NULL;
 		J9UTF8 *packageName = NULL;
-		char buf[J9VM_PACKAGE_NAME_BUFFER_LENGTH + sizeof(packageName->length) + 1];
+		char buf[J9VM_PACKAGE_NAME_BUFFER_LENGTH + sizeof(J9UTF8) + 1];
 		UDATA packageNameLength = 0;
 		PORT_ACCESS_FROM_JAVAVM(vm);
 
@@ -304,7 +304,7 @@ jvmtiGetNamedModule(jvmtiEnv* jvmtiEnv, jobject class_loader, const char* packag
 		packageNameLength = strlen(package_name);
 		packageName = (J9UTF8 *) buf;
 		if (packageNameLength > JVMTI_PACKAGE_NAME_BUFFER_LENGTH) {
-			packageName = j9mem_allocate_memory(packageNameLength + sizeof(packageName->length) + 1, J9MEM_CATEGORY_JVMTI_ALLOCATE);
+			packageName = j9mem_allocate_memory(packageNameLength + sizeof(J9UTF8) + 1, J9MEM_CATEGORY_JVMTI_ALLOCATE);
 			if (NULL == packageName) {
 				rc = JVMTI_ERROR_OUT_OF_MEMORY;
 				goto done;

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -167,7 +167,7 @@ typedef struct J9ClassLoaderWalkState {
 #define J9UTF8_LENGTH(j9UTF8Address) (((struct J9UTF8 *)(j9UTF8Address))->length)
 #define J9UTF8_SET_LENGTH(j9UTF8Address, len) (((struct J9UTF8 *)(j9UTF8Address))->length = (len))
 #define J9UTF8_DATA(j9UTF8Address) (((struct J9UTF8 *)(j9UTF8Address))->data)
-
+#define J9UTF8_TOTAL_SIZE(j9UTF8Address) (sizeof(J9UTF8) + J9UTF8_LENGTH(j9UTF8Address))
 #define J9UTF8_DATA_EQUALS(data1, length1, data2, length2) ((((length1) == (length2)) && (memcmp((data1), (data2), (length1)) == 0)))
 #define J9UTF8_EQUALS(utf1, utf2) (((utf1) == (utf2)) || (J9UTF8_DATA_EQUALS(J9UTF8_DATA(utf1), J9UTF8_LENGTH(utf1), J9UTF8_DATA(utf2), J9UTF8_LENGTH(utf2))))
 #define J9UTF8_LITERAL_EQUALS(data1, length1, cString) (J9UTF8_DATA_EQUALS((data1), (length1), (cString), sizeof(cString) - 1))

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3218,10 +3218,19 @@ typedef struct J9ClassLoader {
 #define J9CLASSLOADER_SET_CLASSLOADEROBJECT(vmThread, object, value) J9VMTHREAD_JAVAVM(vmThread)->memoryManagerFunctions->j9gc_objaccess_storeObjectToInternalVMSlot((vmThread), (j9object_t*)&((object)->classLoaderObject), (value))
 #define TMP_J9CLASSLOADER_CLASSLOADEROBJECT(object) ((object)->classLoaderObject)
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4200)
+#endif /* defined(_MSC_VER) */
+
 typedef struct J9UTF8 {
 	U_16 length;
-	U_8 data[2];
+	U_8 data[];
 } J9UTF8;
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif /* defined(_MSC_VER) */
 
 typedef struct J9ROMClass {
 	U_32 romSize;

--- a/runtime/rasdump/TextFileStream.cpp
+++ b/runtime/rasdump/TextFileStream.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2019 IBM Corp. and others
+ * Copyright (c) 2003, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -149,7 +149,7 @@ TextFileStream::writeCharacters(const char* data, IDATA length)
 void
 TextFileStream::writeCharacters(const J9UTF8* data)
 {
-	writeCharacters((char*)data + offsetof(J9UTF8, data), J9UTF8_LENGTH(data));
+	writeCharacters((char*)J9UTF8_DATA(data), J9UTF8_LENGTH(data));
 }
 
 /* Method for writing characters described by a pointer to the file*/

--- a/runtime/rastrace/method_trigger.c
+++ b/runtime/rastrace/method_trigger.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corp. and others
+ * Copyright (c) 2014, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -134,12 +134,12 @@ rasTriggerMethod(J9VMThread *thr, J9Method *method, I_32 entry, const TriggerPha
 
 	dbg_err_printf(1, PORTLIB, "<RAS> Trigger hit for method %s: %.*s.%.*s%.*s\n",
 					entry ? "entry" : "return",
-					J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(method)->romClass)->length,
-					J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(method)->romClass)->data,
-					J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method))->length,
-					J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method))->data,
-					J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(method))->length,
-					J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(method))->data);
+					J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(method)->romClass)),
+					J9UTF8_DATA(J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(method)->romClass)),
+					J9UTF8_LENGTH(J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method))),
+					J9UTF8_DATA(J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method))),
+					J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(method))),
+					J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(method))));
 
 	/*
 	 * Go through each of the rules seeing if this method is one of theirs

--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -5695,7 +5695,7 @@ SH_CacheMap::getCachedUTFString(J9VMThread* currentThread, const char* local, U_
 	const J9UTF8* pathUTF = NULL;
 	U_8 temp[J9SH_MAXPATH + sizeof(J9UTF8)];
 	J9UTF8* temputf = (J9UTF8*)&temp;
-	char* tempstr = (char*)&(J9UTF8_DATA(temputf));
+	char* tempstr = (char*)J9UTF8_DATA(temputf);
 	SH_ScopeManager* localSCM;
 	bool allowUpdate = true;
 

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -3397,7 +3397,7 @@ j9shr_init(J9JavaVM *vm, UDATA loadFlags, UDATA* nonfatal)
 
 	cmBytes = SH_CacheMap::getRequiredConstrBytes(false);
 	nameBytes = (strlen(modifiedCacheNamePtr)+1) * sizeof(char);
-	modContextBytes = modContext ? ((strlen(modContext) * sizeof(char)) + sizeof(J9UTF8)) : 0;
+	modContextBytes = modContext ? (((strlen(modContext) + 1) * sizeof(char)) + sizeof(J9UTF8)) : 0;
 	memBytesNeeded = sizeof(J9SharedClassConfig) + sizeof(J9SharedClassCacheDescriptor) + cmBytes + nameBytes + modContextBytes;
 
 	tempConfig = (J9SharedClassConfig*)j9mem_allocate_memory(memBytesNeeded, J9MEM_CATEGORY_CLASSES);

--- a/runtime/tests/bcprof/bcproftest.c
+++ b/runtime/tests/bcprof/bcproftest.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -153,7 +153,7 @@ parseBuffer(J9VMThread* vmThread, const U_8* dataStart, UDATA size)
 				if (TEST_verbose) {
 					J9ROMClass* romClass = receiverClass->romClass;
 					J9UTF8* name = J9ROMCLASS_CLASSNAME(romClass);
-					j9tty_printf(PORTLIB, "pc=%p (cast bc=%d) operand=%.*s(%p)\n", pc, *pc, (UDATA)name->length, name->data, receiverClass);
+					j9tty_printf(PORTLIB, "pc=%p (cast bc=%d) operand=%.*s(%p)\n", pc, *pc, (UDATA)J9UTF8_LENGTH(name), J9UTF8_DATA(name), receiverClass);
 				}
 				break;
 			case JBinvokevirtual:
@@ -164,7 +164,7 @@ parseBuffer(J9VMThread* vmThread, const U_8* dataStart, UDATA size)
 				if (TEST_verbose) {
 					J9ROMClass* romClass = receiverClass->romClass;
 					J9UTF8* name = J9ROMCLASS_CLASSNAME(romClass);
-					j9tty_printf(PORTLIB, "pc=%p (invoke bc=%d) operand=%.*s(%p)\n", pc, *pc, (UDATA)name->length, name->data, receiverClass);
+					j9tty_printf(PORTLIB, "pc=%p (invoke bc=%d) operand=%.*s(%p)\n", pc, *pc, (UDATA)J9UTF8_LENGTH(name), J9UTF8_DATA(name), receiverClass);
 				}
 				break;
 			case JBlookupswitch:

--- a/runtime/tests/shared/CompiledMethodTest.cpp
+++ b/runtime/tests/shared/CompiledMethodTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,8 +35,8 @@
 #define TEST_METHOD_NAME "testMethod"
 #define TEST_METHOD_SIG "()"
 #define METHOD_SPEC "*." TEST_METHOD_NAME "" TEST_METHOD_SIG
-#define METHOD_NAME_SIZE sizeof(TEST_METHOD_NAME) + sizeof(((J9UTF8 *)0)->length)
-#define METHOD_SIG_SIZE sizeof(TEST_METHOD_SIG) + sizeof(((J9UTF8 *)0)->length)
+#define METHOD_NAME_SIZE (sizeof(TEST_METHOD_NAME) + sizeof(J9UTF8))
+#define METHOD_SIG_SIZE (sizeof(TEST_METHOD_SIG) + sizeof(J9UTF8))
 #define NUM_ROMMETHOD 4
 
 typedef char* BlockPtr;

--- a/runtime/tests/vm/resolvefield_tests.c
+++ b/runtime/tests/vm/resolvefield_tests.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,7 +61,7 @@ calculateJ9UTFSize(UDATA stringLength)
 		stringLength++;
 	}
 
-	return offsetof(J9UTF8, data) + stringLength;
+	return sizeof(J9UTF8) + stringLength;
 }
 
 static UDATA

--- a/runtime/util/cphelp.c
+++ b/runtime/util/cphelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -155,7 +155,7 @@ getModuleJRTURL(J9VMThread *currentThread, J9ClassLoader *classLoader, J9Module 
 			/* its java.base module */
 			J9_DECLARE_CONSTANT_UTF8(jrtJavaBaseUrl, "jrt:/java.base");
 			const U_16 length = J9UTF8_LENGTH(&jrtJavaBaseUrl);
-			jrtURL = j9mem_allocate_memory(sizeof(((J9UTF8*)0)->length) + length, OMRMEM_CATEGORY_VM);
+			jrtURL = j9mem_allocate_memory(sizeof(J9UTF8) + length, OMRMEM_CATEGORY_VM);
 			if (NULL == jrtURL) {
 				goto _exit;
 			}

--- a/runtime/util/modularityHelper.c
+++ b/runtime/util/modularityHelper.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -132,8 +132,8 @@ addUTFNameToPackage(J9VMThread *currentThread, J9Package *j9package, const char 
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	j9package->packageName = (J9UTF8*)buf;
 	packageNameLength = (UDATA) strlen(packageName);
-	if ((NULL == j9package->packageName) || ((packageNameLength + sizeof(j9package->packageName->length) + 1) > bufLen)) {
-		j9package->packageName = j9mem_allocate_memory(packageNameLength + sizeof(j9package->packageName->length) + 1, OMRMEM_CATEGORY_VM);
+	if ((NULL == j9package->packageName) || ((packageNameLength + sizeof(J9UTF8) + 1) > bufLen)) {
+		j9package->packageName = j9mem_allocate_memory(packageNameLength + sizeof(J9UTF8) + 1, OMRMEM_CATEGORY_VM);
 		if (NULL == j9package->packageName) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 			return FALSE;
@@ -168,7 +168,7 @@ getPackageDefinitionWithName(J9VMThread *currentThread, J9Module *fromModule, U_
 	char buf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	PORT_ACCESS_FROM_VMC(currentThread);
 	J9UTF8 *packageNameBuf = (J9UTF8 *) buf;
-	UDATA J9UTF8len = len + sizeof(packageNameBuf->length);
+	UDATA J9UTF8len = len + sizeof(J9UTF8);
 
 	if (J9VM_PACKAGE_NAME_BUFFER_LENGTH < J9UTF8len) {
 		packageNameBuf = j9mem_allocate_memory(J9UTF8len, OMRMEM_CATEGORY_VM);

--- a/runtime/verbose/verbose.c
+++ b/runtime/verbose/verbose.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1653,9 +1653,9 @@ toExternalQualifiedName(J9PortLibrary* portLibrary, VerboseVerificationBuffer* b
 
 		/* if existing buffer dose not fit the data, use allocated buffer from heap */
 		if (buf->size < (UDATA)J9UTF8_LENGTH(utf)) {
-			qualified = (J9UTF8*)j9mem_allocate_memory((sizeof(utf->length) + utf->length), OMRMEM_CATEGORY_VM);
+			qualified = (J9UTF8*)j9mem_allocate_memory(sizeof(J9UTF8) + J9UTF8_LENGTH(utf), OMRMEM_CATEGORY_VM);
 			if (NULL == qualified) {
-				Trc_VRB_Allocate_Memory_Failed(sizeof(utf->length) + utf->length);
+				Trc_VRB_Allocate_Memory_Failed(sizeof(J9UTF8) + J9UTF8_LENGTH(utf));
 				return NULL;
 			} else {
 				buf->buffer = (U_8*)qualified;
@@ -1664,17 +1664,17 @@ toExternalQualifiedName(J9PortLibrary* portLibrary, VerboseVerificationBuffer* b
 			qualified = (J9UTF8*)buf->buffer;
 		}
 
-		data = utf->data;
-		extData = qualified->data;
-		qualified->length = 0;
-		while (qualified->length != utf->length) {
+		data = J9UTF8_DATA(utf);
+		extData = J9UTF8_DATA(qualified);
+		J9UTF8_SET_LENGTH(qualified, 0);
+		while (J9UTF8_LENGTH(qualified) != J9UTF8_LENGTH(utf)) {
 			*extData = (('/' == *data) ? '.' : *data);
 			extData += 1;
 			data += 1;
-			qualified->length += 1;
+			J9UTF8_SET_LENGTH(qualified, J9UTF8_LENGTH(qualified) + 1);
 		}
 
-		buf->cursor = sizeof(qualified->length) + qualified->length;
+		buf->cursor = sizeof(J9UTF8) + J9UTF8_LENGTH(qualified);
 	}
 
 	return qualified;

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -7872,8 +7872,8 @@ done:
 #endif
 		/* Examine the method signature to determine the return type (number of return slots) */
 		sig = J9ROMMETHOD_SIGNATURE(romMethod);
-		sigLength = sig->length;
-		sigData = sig->data;
+		sigLength = J9UTF8_LENGTH(sig);
+		sigData = J9UTF8_DATA(sig);
 		/* are we returning an array? */
 		if ('[' == sigData[sigLength - 2]) {
 			returnSlots = 1;
@@ -7882,7 +7882,7 @@ done:
 			case 'V': {
 				/* Is this a constructor? */
 				J9UTF8 *name = J9ROMMETHOD_NAME(romMethod);
-				if ((strlen("<init>") == name->length) && ('<' == name->data[0])) {
+				if ((strlen("<init>") == J9UTF8_LENGTH(name)) && ('<' == J9UTF8_DATA(name)[0])) {
 					isConstructor = TRUE;
 					VM_AtomicSupport::writeBarrier();
 				}

--- a/runtime/vm/BytecodeInterpreter.inc
+++ b/runtime/vm/BytecodeInterpreter.inc
@@ -85,7 +85,7 @@ getMethodName(J9PortLibrary *PORTLIB, J9Method *method, U_8 *pc, char *buffer)
 		if (0 == ((UDATA)method->extra & 1)) {
 			strcat(buffer, "JITTED ");
 		}
-		j9str_printf(PORTLIB, temp, sizeof(temp), "%.*s.%.*s%.*s (%p)", className->length, className->data, methodName->length, methodName->data, methodSig->length, methodSig->data, method);
+		j9str_printf(PORTLIB, temp, sizeof(temp), "%.*s.%.*s%.*s (%p)", J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName), J9UTF8_LENGTH(methodSig), J9UTF8_DATA(methodSig), method);
 		strcat(buffer, temp);
 		if ((U_8*)-1 != pc) {
 			j9str_printf(PORTLIB, temp, sizeof(temp), " @ %p (offset %d)", pc, pc - method->bytecodes);

--- a/runtime/vm/ModularityHashTables.c
+++ b/runtime/vm/ModularityHashTables.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -180,8 +180,8 @@ findModuleForPackage(J9VMThread *currentThread, J9ClassLoader *classLoader, U_8 
 
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
 
-	if ((packageNameLen + sizeof(packageNameUTF8->length) + 1) > sizeof(buf)) {
-		packageNameUTF8 = (J9UTF8 *) j9mem_allocate_memory(packageNameLen + 1 + sizeof(packageNameUTF8->length), J9MEM_CATEGORY_CLASSES);
+	if ((packageNameLen + sizeof(J9UTF8) + 1) > sizeof(buf)) {
+		packageNameUTF8 = (J9UTF8 *) j9mem_allocate_memory(packageNameLen + 1 + sizeof(J9UTF8), J9MEM_CATEGORY_CLASSES);
 	}
 	if (NULL != packageNameUTF8) {
 		memcpy(J9UTF8_DATA(packageNameUTF8), packageName, packageNameLen);

--- a/runtime/vm/resolvefield.cpp
+++ b/runtime/vm/resolvefield.cpp
@@ -367,7 +367,7 @@ calculateJ9UTFSize(UDATA stringLength)
 		stringLength++;
 	}
 
-	return offsetof(J9UTF8, data) + stringLength;
+	return sizeof(J9UTF8) + stringLength;
 }
 
 

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -105,7 +105,7 @@ checkForDecompile(J9VMThread *currentThread, J9ROMMethodRef *romMethodRef, bool 
 		if (!jitCompileTimeResolve && (NULL != vm->jitConfig)) {
 			J9UTF8 *name = J9ROMNAMEANDSIGNATURE_NAME(J9ROMMETHODREF_NAMEANDSIGNATURE(romMethodRef));
 			char *decompileName = vm->decompileName;
-			if (J9UTF8_DATA_EQUALS(name->data, name->length, decompileName, strlen(decompileName))) {
+			if (J9UTF8_DATA_EQUALS(J9UTF8_DATA(name), J9UTF8_LENGTH(name), decompileName, strlen(decompileName))) {
 				if (NULL != jitConfig->jitHotswapOccurred) {
 					acquireExclusiveVMAccess(currentThread);
 					jitConfig->jitHotswapOccurred(currentThread);
@@ -1545,9 +1545,9 @@ resolveVirtualMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA c
 				NNSRP_SET(nameAndSig->signature, modifiedMethodSig);
 
 				/* Change method name to include the suffix "_impl", which are the methods with VarHandle send targets. */
-				modifiedMethodName->length = initialMethodNameLength + 5;
-				memcpy(modifiedMethodName->data, initialMethodName, initialMethodNameLength);
-				memcpy(modifiedMethodName->data + initialMethodNameLength, "_impl", 5);
+				J9UTF8_SET_LENGTH(modifiedMethodName, initialMethodNameLength + 5);
+				memcpy(J9UTF8_DATA(modifiedMethodName), initialMethodName, initialMethodNameLength);
+				memcpy(J9UTF8_DATA(modifiedMethodName) + initialMethodNameLength, "_impl", 5);
 
 				/* Set flag for partial signature lookup. Signature length is already initialized to 0. */
 				lookupOptions |= J9_LOOK_PARTIAL_SIGNATURE;

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -320,7 +320,7 @@ copyStringToJ9UTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA st
 
 	U_8* result = NULL;
 	UDATA stringLength = J9VMJAVALANGSTRING_LENGTH(vmThread, string);
-	UDATA length = sizeof(((J9UTF8*)0)->length) + prependStrLength + (stringLength * 3);
+	UDATA length = sizeof(J9UTF8) + prependStrLength + (stringLength * 3);
 
 	if (J9_ARE_ALL_BITS_SET(stringFlags, J9_STR_NULL_TERMINATE_RESULT)) {
 		++length;
@@ -338,10 +338,10 @@ copyStringToJ9UTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA st
 		UDATA computedUtf8Length = 0;
 
 		if (0 < prependStrLength) {
-			memcpy(result + sizeof(((J9UTF8*)0)->length), prependStr, prependStrLength);
+			memcpy(result + sizeof(J9UTF8), prependStr, prependStrLength);
 		}
 
-		computedUtf8Length = copyStringToUTF8Helper(vmThread, string, stringFlags, 0, stringLength, result + sizeof(((J9UTF8*)0)->length) + prependStrLength, length - sizeof(((J9UTF8*)0)->length) - prependStrLength);
+		computedUtf8Length = copyStringToUTF8Helper(vmThread, string, stringFlags, 0, stringLength, result + sizeof(J9UTF8) + prependStrLength, length - sizeof(J9UTF8) - prependStrLength);
 
 		J9UTF8_SET_LENGTH(result, (U_16)computedUtf8Length + (U_16)prependStrLength);
 	}


### PR DESCRIPTION
Also fix all direct uses of J9UTF8 fields to use the access macros.

Fixes: #10244

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>