### PR TITLE
Fix incorrect signature in _classByNameMap cache

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -180,12 +180,12 @@ TR_J9ServerVM::getSystemClassFromClassName(const char * name, int32_t length, bo
    J9ClassLoader *cl = (J9ClassLoader *)getSystemClassLoader();
    std::string className(name, length);
    ClassLoaderStringPair key = {cl, className};
-   PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> & classByNameMap = _compInfoPT->getClientData()->getClassByNameMap();
+   PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> & classBySignatureMap = _compInfoPT->getClientData()->getClassBySignatureMap();
 
    {
    OMR::CriticalSection getSystemClassCS(_compInfoPT->getClientData()->getClassMapMonitor());
-   auto it = classByNameMap.find(key);
-   if (it != classByNameMap.end())
+   auto it = classBySignatureMap.find(key);
+   if (it != classBySignatureMap.end())
       return it->second;
    }
    // classname not found; ask the client and cache the answer
@@ -195,7 +195,7 @@ TR_J9ServerVM::getSystemClassFromClassName(const char * name, int32_t length, bo
    if (clazz)
       {
       OMR::CriticalSection getSystemClassCS(_compInfoPT->getClientData()->getClassMapMonitor());
-      classByNameMap[key] = clazz;
+      classBySignatureMap[key] = clazz;
       }
    else
       {
@@ -299,11 +299,11 @@ TR_J9ServerVM::getClassFromSignature(const char *sig, int32_t length, TR_Resolve
    TR_OpaqueClassBlock * clazz = NULL;
    J9ClassLoader * cl = ((TR_ResolvedJ9Method *)method)->getClassLoader();
    ClassLoaderStringPair key = {cl, std::string(sig, length)};
-   PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> & classByNameMap = _compInfoPT->getClientData()->getClassByNameMap();
+   PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> & classBySignatureMap = _compInfoPT->getClientData()->getClassBySignatureMap();
       {
       OMR::CriticalSection classFromSigCS(_compInfoPT->getClientData()->getClassMapMonitor());
-      auto it = classByNameMap.find(key);
-      if (it != classByNameMap.end())
+      auto it = classBySignatureMap.find(key);
+      if (it != classBySignatureMap.end())
          return it->second;
       }
    // classname not found; ask the client and cache the answer
@@ -311,7 +311,7 @@ TR_J9ServerVM::getClassFromSignature(const char *sig, int32_t length, TR_Resolve
    if (clazz)
       {
       OMR::CriticalSection classFromSigCS(_compInfoPT->getClientData()->getClassMapMonitor());
-      classByNameMap[key] = clazz;
+      classBySignatureMap[key] = clazz;
       }
    else
       {
@@ -2043,11 +2043,11 @@ TR_J9SharedCacheServerVM::getClassFromSignature(const char * sig, int32_t sigLen
    TR_OpaqueClassBlock* clazz = NULL;
    J9ClassLoader * cl = ((TR_ResolvedJ9Method *)method)->getClassLoader();
    ClassLoaderStringPair key = {cl, std::string(sig, sigLength)};
-   PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> & classByNameMap = _compInfoPT->getClientData()->getClassByNameMap();
+   PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> & classBySignatureMap = _compInfoPT->getClientData()->getClassBySignatureMap();
       {
       OMR::CriticalSection classFromSigCS(_compInfoPT->getClientData()->getClassMapMonitor());
-      auto it = classByNameMap.find(key);
-      if (it != classByNameMap.end())
+      auto it = classBySignatureMap.find(key);
+      if (it != classBySignatureMap.end())
          clazz = it->second;
       }
    if (!clazz)
@@ -2058,7 +2058,7 @@ TR_J9SharedCacheServerVM::getClassFromSignature(const char * sig, int32_t sigLen
          {
             {
             OMR::CriticalSection classFromSigCS(_compInfoPT->getClientData()->getClassMapMonitor());
-            classByNameMap[key] = clazz;
+            classBySignatureMap[key] = clazz;
             }
          if (!validateClass((TR_OpaqueMethodBlock *)resolvedJITServerMethod->getPersistentIdentifier(), clazz, isVettedForAOT))
             {
@@ -2073,7 +2073,6 @@ TR_J9SharedCacheServerVM::getClassFromSignature(const char * sig, int32_t sigLen
          // In theory we could consider this a special case and watch the CHTable updates
          // for a class load event for Ljava/lang/String$StringCompressionFlag, but it may not
          // be worth the trouble.
-         //static unsigned long errorsSystem = 0;
          //printf("ErrorSystem %lu for cl=%p\tclassName=%.*s\n", ++errorsSystem, cl, length, sig);
          }
       }

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -35,7 +35,7 @@ ClientSessionData::ClientSessionData(uint64_t clientUID, uint32_t seqNo) :
    _chTableClassMap(decltype(_chTableClassMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _romClassMap(decltype(_romClassMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _J9MethodMap(decltype(_J9MethodMap)::allocator_type(TR::Compiler->persistentAllocator())),
-   _classByNameMap(decltype(_classByNameMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _classBySignatureMap(decltype(_classBySignatureMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _classChainDataMap(decltype(_classChainDataMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _constantPoolToClassMap(decltype(_constantPoolToClassMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _unloadedClassAddresses(NULL),
@@ -109,7 +109,8 @@ void
 ClientSessionData::processUnloadedClasses(const std::vector<TR_OpaqueClassBlock*> &classes, bool updateUnloadedClasses)
    {
    const size_t numOfUnloadedClasses = classes.size();
-   int32_t compThreadID = TR::compInfoPT->getCompThreadId();
+   auto compInfoPT = TR::compInfoPT;
+   int32_t compThreadID = compInfoPT->getCompThreadId();
 
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))
       TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d will process a list of %zu unloaded classes for clientUID %llu", 
@@ -146,9 +147,27 @@ ClientSessionData::processUnloadedClasses(const std::vector<TR_OpaqueClassBlock*
          J9ROMClass *romClass = it->second._romClass;
 
          J9UTF8 *clazzName = NNSRP_GET(romClass->className, J9UTF8 *);
-         std::string className((const char *)clazzName->data, (int32_t)clazzName->length);
+         char *className = (char *) clazzName->data;
+         int32_t sigLen = (int32_t) clazzName->length;
+         sigLen = (className[0] == '[' ? sigLen : sigLen + 2);
+
+         // copy of classNameToSignature method which can't be used
+         // here because compilation object hasn't been initialized yet
+         
+         std::string sigStr(sigLen, 0);
+         if (className[0] == '[')
+            {
+            memcpy(&sigStr[0], className, sigLen);
+            }
+         else
+            {
+            sigStr[0] = 'L';
+            memcpy(&sigStr[1], className, sigLen - 2);
+            sigStr[sigLen-1]=';';
+            }
+
          J9ClassLoader * cl = (J9ClassLoader *)(it->second._classLoader);
-         ClassLoaderStringPair key = { cl, className };
+         ClassLoaderStringPair key = { cl, sigStr };
          //Class is cached, so retain the data to be used for purging the caches.
          unloadedClasses.push_back({ clazz, key, cp, true });
 
@@ -192,7 +211,7 @@ ClientSessionData::processUnloadedClasses(const std::vector<TR_OpaqueClassBlock*
    // purge Class by name cache
    {
    OMR::CriticalSection classMapCS(getClassMapMonitor());
-   purgeCache(&unloadedClasses, getClassByNameMap(), &ClassUnloadedData::_pair);
+   purgeCache(&unloadedClasses, getClassBySignatureMap(), &ClassUnloadedData::_pair);
    }
 
    // purge Constant pool to class cache
@@ -429,7 +448,7 @@ ClientSessionData::clearCaches()
    {
       {
       OMR::CriticalSection clearCache(getClassMapMonitor());
-      _classByNameMap.clear();
+      _classBySignatureMap.clear();
       }
    OMR::CriticalSection getRemoteROMClass(getROMMapMonitor());
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -344,7 +344,7 @@ class ClientSessionData
    PersistentUnorderedMap<TR_OpaqueClassBlock*, TR_PersistentClassInfo*> & getCHTableClassMap() { return _chTableClassMap; }
    PersistentUnorderedMap<J9Class*, ClassInfo> & getROMClassMap() { return _romClassMap; }
    PersistentUnorderedMap<J9Method*, J9MethodInfo> & getJ9MethodMap() { return _J9MethodMap; }
-   PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> & getClassByNameMap() { return _classByNameMap; }
+   PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> & getClassBySignatureMap() { return _classBySignatureMap; }
    PersistentUnorderedMap<J9Class *, UDATA *> & getClassChainDataCache() { return _classChainDataMap; }
    PersistentUnorderedMap<J9ConstantPool *, TR_OpaqueClassBlock*> & getConstantPoolToClassMap() { return _constantPoolToClassMap; }
    void initializeUnloadedClassAddrRanges(const std::vector<TR_AddressRange> &unloadedClassRanges, int32_t maxRanges);
@@ -431,7 +431,7 @@ class ClientSessionData
    PersistentUnorderedMap<J9Method*, J9MethodInfo> _J9MethodMap;
    // The following hashtable caches <classname> --> <J9Class> mappings
    // All classes in here are loaded by the systemClassLoader so we know they cannot be unloaded
-   PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> _classByNameMap;
+   PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> _classBySignatureMap;
 
    PersistentUnorderedMap<J9Class *, UDATA *> _classChainDataMap;
    //Constant pool to class map


### PR DESCRIPTION
_classByNameMap was using the signature of a class as part of the key,
but when deleting from the cache, the name of a class was used, which is slightly different.
Because of that most unloaded classes were not removed from the cache,
causing segfaults. This commit fixes the issue by transforming
the name into signature before deleting and renaming the cache appropriately.
