### PR TITLE
Suppress warnings regarding flexible array members

### DIFF
--- a/runtime/compiler/build/toolcfg/win-msvc/common.mk
+++ b/runtime/compiler/build/toolcfg/win-msvc/common.mk
@@ -106,6 +106,7 @@ CX_FLAGS+=\
     -wd4244 \
     -wd4018 \
     -we4700 \
+    -wd4200 \
     -MD
 
 CXX_FLAGS+=\

--- a/runtime/makelib/targets.mk.win.inc.ftl
+++ b/runtime/makelib/targets.mk.win.inc.ftl
@@ -193,10 +193,14 @@ ifdef USE_CLANG
   CLANG_CXXFLAGS+=-DWINVER=$(UMA_WINVER) -D_WIN32_WINNT=$(UMA_WINVER) -D_WIN32_WINDOWS=$(UMA_WINVER)
 endif
 
-# -Zm200 max memory is 200% default
-# -Zi add debug symbols
-CFLAGS+=  -D_MT -D_WINSOCKAPI_ -Zm400 -W3 -Zi
-CXXFLAGS+=-D_MT -D_WINSOCKAPI_ -Zm400 -W3 -Zi
+# Option   Meaning
+# ------   -------
+# -Zm400   max memory is 400% default
+# -W3      enable warnings up to level 3
+# -Zi      add debug symbols
+# -wd4200  disable warnings regarding flexible array members
+CFLAGS   += -D_MT -D_WINSOCKAPI_ -Zm400 -W3 -Zi -wd4200
+CXXFLAGS += -D_MT -D_WINSOCKAPI_ -Zm400 -W3 -Zi -wd4200
 ifdef USE_CLANG
   CLANG_CXXFLAGS+=-D_MT -D_WINSOCKAPI_
 endif


### PR DESCRIPTION
This is a prerequisite to merging eclipse/omr#5444.