### PR TITLE
Split MHInterpreter into compressed and full versions

### DIFF
--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -526,7 +526,7 @@ CLANG_CXXFLAGS+=-std=c++0x -D_CRT_SUPPRESS_RESTRICT -DVS12AndHigher
 	CLANG_CXXFLAGS+=-D_M_X64
 </#if>
 endif
-# special handling BytecodeInterpreterFull.cpp, BytecodeInterpreterCompressed.cpp, DebugBytecodeInterpreterFull.cpp and DebugBytecodeInterpreterCompressed.cpp
+# special handling MHInterpreterFull.cpp, MHInterpreterCompressed.cpp, BytecodeInterpreterFull.cpp, BytecodeInterpreterCompressed.cpp, DebugBytecodeInterpreterFull.cpp and DebugBytecodeInterpreterCompressed.cpp
 BytecodeInterpreterFull$(UMA_DOT_O):BytecodeInterpreterFull.cpp
 	$(CLANG_CXX) $(CLANG_CXXFLAGS) -c $< -o $@
 
@@ -539,7 +539,10 @@ DebugBytecodeInterpreterFull$(UMA_DOT_O):DebugBytecodeInterpreterFull.cpp
 DebugBytecodeInterpreterCompressed$(UMA_DOT_O):DebugBytecodeInterpreterCompressed.cpp
 	$(CLANG_CXX) $(CLANG_CXXFLAGS) -c $< -o $@
 
-MHInterpreter$(UMA_DOT_O):MHInterpreter.cpp
+MHInterpreterFull$(UMA_DOT_O):MHInterpreterFull.cpp
+	$(CLANG_CXX) $(CLANG_CXXFLAGS) -c $< -o $@
+
+MHInterpreterCompressed$(UMA_DOT_O):MHInterpreterCompressed.cpp
 	$(CLANG_CXX) $(CLANG_CXXFLAGS) -c $< -o $@
 
 endif
@@ -581,7 +584,10 @@ DebugBytecodeInterpreterFull$(UMA_DOT_O):DebugBytecodeInterpreterFull.cpp
 DebugBytecodeInterpreterCompressed$(UMA_DOT_O):DebugBytecodeInterpreterCompressed.cpp
 	$(CXX) $(SPECIALCXXFLAGS) $(NEW_OPTIMIZATION_FLAG) -c $<
 
-MHInterpreter$(UMA_DOT_O):MHInterpreter.cpp
+MHInterpreterFull$(UMA_DOT_O):MHInterpreterFull.cpp
+	$(CXX) $(SPECIALCXXFLAGS) $(NEW_OPTIMIZATION_FLAG) -c $<
+
+MHInterpreterCompressed$(UMA_DOT_O):MHInterpreterCompressed.cpp
 	$(CXX) $(SPECIALCXXFLAGS) $(NEW_OPTIMIZATION_FLAG) -c $<
 
 endif

--- a/runtime/makelib/targets.mk.linux.inc.ftl
+++ b/runtime/makelib/targets.mk.linux.inc.ftl
@@ -519,7 +519,7 @@ endif
 <#if uma.spec.processor.ppc && !uma.spec.type.aix>
 ifdef USE_PPC_GCC
 
-# special handling BytecodeInterpreterFull.cpp, BytecodeInterpreterCompressed.cpp, DebugBytecodeInterpreterFull.cpp and DebugBytecodeInterpreterCompressed.cpp
+# special handling MHInterpreterFull.cpp, MHInterpreterCompressed.cpp, BytecodeInterpreterFull.cpp, BytecodeInterpreterCompressed.cpp, DebugBytecodeInterpreterFull.cpp and DebugBytecodeInterpreterCompressed.cpp
 
 BytecodeInterpreterFull$(UMA_DOT_O) : BytecodeInterpreterFull.cpp
 	$(PPC_GCC_CXX) $(PPC_GCC_CXXFLAGS) -c $<
@@ -533,7 +533,10 @@ DebugBytecodeInterpreterFull$(UMA_DOT_O) : DebugBytecodeInterpreterFull.cpp
 DebugBytecodeInterpreterCompressed$(UMA_DOT_O) : DebugBytecodeInterpreterCompressed.cpp
 	$(PPC_GCC_CXX) $(PPC_GCC_CXXFLAGS) -c $<
 
-MHInterpreter$(UMA_DOT_O) : MHInterpreter.cpp
+MHInterpreterFull$(UMA_DOT_O) : MHInterpreterFull.cpp
+	$(PPC_GCC_CXX) $(PPC_GCC_CXXFLAGS) -c $<
+
+MHInterpreterCompressed$(UMA_DOT_O) : MHInterpreterCompressed.cpp
 	$(PPC_GCC_CXX) $(PPC_GCC_CXXFLAGS) -c $<
 
 endif

--- a/runtime/makelib/targets.mk.zos.inc.ftl
+++ b/runtime/makelib/targets.mk.zos.inc.ftl
@@ -151,5 +151,8 @@ DebugBytecodeInterpreterFull.o : DebugBytecodeInterpreterFull.cpp
 DebugBytecodeInterpreterCompressed.o : DebugBytecodeInterpreterCompressed.cpp
 	$(CXX) $(SPECIALCXXFLAGS) $(MRABIG) $(NEW_OPTIMIZATION_FLAG) -c $< > $*.asmlist
 
-MHInterpreter$(UMA_DOT_O) : MHInterpreter.cpp
+MHInterpreterFull$(UMA_DOT_O) : MHInterpreterFull.cpp
+	$(CXX) $(SPECIALCXXFLAGS) $(MRABIG) $(NEW_OPTIMIZATION_FLAG) -c $< > $*.asmlist
+
+MHInterpreterCompressed$(UMA_DOT_O) : MHInterpreterCompressed.cpp
 	$(CXX) $(SPECIALCXXFLAGS) $(MRABIG) $(NEW_OPTIMIZATION_FLAG) -c $< > $*.asmlist

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4239,7 +4239,7 @@ queryLogOptions (J9JavaVM *vm, I_32 buffer_size, void *options, I_32 *data_size)
 UDATA
 setLogOptions (J9JavaVM *vm, char *options);
 
-/* -------------------- MHInterpreter.cpp ------------ */
+/* -------------------- NativeHelpers.cpp ------------ */
 
 /**
 * @brief

--- a/runtime/vm/BytecodeInterpreterCompressed.cpp
+++ b/runtime/vm/BytecodeInterpreterCompressed.cpp
@@ -27,6 +27,4 @@
 #define LOOP_NAME bytecodeLoopCompressed
 #define INTERPRETER_CLASS VM_BytecodeInterpreterCompressed
 #include "BytecodeInterpreter.inc"
-#else
-#define LOOP_NAME 0
 #endif /* OMR_GC_COMPRESSED_POINTERS */

--- a/runtime/vm/BytecodeInterpreterFull.cpp
+++ b/runtime/vm/BytecodeInterpreterFull.cpp
@@ -27,6 +27,4 @@
 #define LOOP_NAME bytecodeLoopFull
 #define INTERPRETER_CLASS VM_BytecodeInterpreterFull
 #include "BytecodeInterpreter.inc"
-#else
-#define LOOP_NAME 0
 #endif /* OMR_GC_FULL_POINTERS */

--- a/runtime/vm/CMakeLists.txt
+++ b/runtime/vm/CMakeLists.txt
@@ -86,7 +86,8 @@ j9vm_add_library(j9vm SHARED
 	logsupport.c
 	lookuphelper.c
 	lookupmethod.c
-	MHInterpreter.cpp
+	MHInterpreterCompressed.cpp
+	MHInterpreterFull.cpp
 	ModularityHashTables.c
 	monhelpers.c
 	montable.c

--- a/runtime/vm/DebugBytecodeInterpreterFull.cpp
+++ b/runtime/vm/DebugBytecodeInterpreterFull.cpp
@@ -28,6 +28,4 @@
 #define LOOP_NAME debugBytecodeLoopFull
 #define INTERPRETER_CLASS VM_DebugBytecodeInterpreterFull
 #include "BytecodeInterpreter.inc"
-#else
-#define LOOP_NAME 0
 #endif /* OMR_GC_FULL_POINTERS */

--- a/runtime/vm/MHInterpreter.hpp
+++ b/runtime/vm/MHInterpreter.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,14 @@
 
 #if !defined(MHINTERPRETER_HPP_)
 #define MHINTERPRETER_HPP_
+
+#if defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
+#if OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES
+#define VM_MHInterpreter VM_MHInterpreterCompressed
+#else /* OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#define VM_MHInterpreter VM_MHInterpreterFull
+#endif /* OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#endif /* defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 
 #include "ffi.h"
 #include "j9.h"
@@ -664,11 +672,11 @@ public:
 	 * ConstructorHandle:
 	 * 		[ ... newUninitializedObject bytecodeframe] --> [ ... newInitializedObject]
 	 * FoldHandle:
-	 * 		Refer to the implementation in MHInterpreter.cpp
+	 * 		Refer to the implementation in MHInterpreter.inc
 	 * GuardWithTestHandle:
-	 * 		Refer to the implementation in MHInterpreter.cpp
+	 * 		Refer to the implementation in MHInterpreter.inc
 	 * FilterArgumentsHandle:
-	 * 		Refer to the implementation in MHInterpreter.cpp
+	 * 		Refer to the implementation in MHInterpreter.inc
 	 */
 	VM_BytecodeAction
 	impdep1();

--- a/runtime/vm/MHInterpreter.inc
+++ b/runtime/vm/MHInterpreter.inc
@@ -863,48 +863,6 @@ VM_MHInterpreter::impdep1()
 	return rc;
 }
 
-extern "C" J9SFMethodTypeFrame *
-buildMethodTypeFrame(J9VMThread * currentThread, j9object_t methodType)
-{
-#define ROUND_U32_TO(granularity, number) (((number) + (granularity) - 1) & ~((U_32)(granularity) - 1))
-	U_32 argSlots = (U_32)J9VMJAVALANGINVOKEMETHODTYPE_ARGSLOTS(currentThread, methodType);
-	j9object_t stackDescriptionBits = J9VMJAVALANGINVOKEMETHODTYPE_STACKDESCRIPTIONBITS(currentThread, methodType);
-	U_32 descriptionInts = J9INDEXABLEOBJECT_SIZE(currentThread, stackDescriptionBits);
-	U_32 descriptionBytes = ROUND_U32_TO(sizeof(UDATA), descriptionInts * sizeof(I_32));
-	I_32 * description;
-	U_32 i;
-	J9SFMethodTypeFrame * methodTypeFrame;
-	UDATA * newA0 = currentThread->sp + argSlots;
-
-	/* Push the description bits */
-
-	description = (I_32 *) ((U_8 *)currentThread->sp - descriptionBytes);
-	for (i = 0; i < descriptionInts; ++i) {
-		description[i] = J9JAVAARRAYOFINT_LOAD(currentThread, stackDescriptionBits, i);
-	}
-
-	/* Push the frame */
-
-	methodTypeFrame = (J9SFMethodTypeFrame *) ((U_8 *)description - sizeof(J9SFMethodTypeFrame));
-	methodTypeFrame->methodType = methodType;
-	methodTypeFrame->argStackSlots = argSlots;
-	methodTypeFrame->descriptionIntCount = descriptionInts;
-	methodTypeFrame->specialFrameFlags = 0;
-	methodTypeFrame->savedCP = currentThread->literals;
-	methodTypeFrame->savedPC = currentThread->pc;
-	methodTypeFrame->savedA0 = (UDATA *) ((UDATA)currentThread->arg0EA | J9SF_A0_INVISIBLE_TAG);
-
-	/* Update VM thread to point to new frame */
-
-	currentThread->sp = (UDATA *) methodTypeFrame;
-	currentThread->pc = (U_8 *) J9SF_FRAME_TYPE_METHODTYPE;
-	currentThread->literals = NULL;
-	currentThread->arg0EA = newA0;
-
-	return methodTypeFrame;
-#undef ROUND_U32_TO
-}
-
 j9object_t
 VM_MHInterpreter::convertArgumentsForAsType(j9object_t methodHandle)
 {

--- a/runtime/vm/MHInterpreterCompressed.cpp
+++ b/runtime/vm/MHInterpreterCompressed.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,9 +23,6 @@
 #include "j9cfg.h"
 
 #if defined(OMR_GC_COMPRESSED_POINTERS)
-#define DEBUG_VERSION
 #define OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES 1
-#define LOOP_NAME debugBytecodeLoopCompressed
-#define INTERPRETER_CLASS VM_DebugBytecodeInterpreterCompressed
-#include "BytecodeInterpreter.inc"
+#include "MHInterpreter.inc"
 #endif /* OMR_GC_COMPRESSED_POINTERS */

--- a/runtime/vm/MHInterpreterFull.cpp
+++ b/runtime/vm/MHInterpreterFull.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,10 +22,7 @@
 
 #include "j9cfg.h"
 
-#if defined(OMR_GC_COMPRESSED_POINTERS)
-#define DEBUG_VERSION
-#define OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES 1
-#define LOOP_NAME debugBytecodeLoopCompressed
-#define INTERPRETER_CLASS VM_DebugBytecodeInterpreterCompressed
-#include "BytecodeInterpreter.inc"
-#endif /* OMR_GC_COMPRESSED_POINTERS */
+#if defined(OMR_GC_FULL_POINTERS)
+#define OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES 0
+#include "MHInterpreter.inc"
+#endif /* OMR_GC_FULL_POINTERS */

--- a/runtime/vm/NativeHelpers.cpp
+++ b/runtime/vm/NativeHelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -147,6 +147,48 @@ convertCStringToByteArray(J9VMThread *currentThread, const char *cString)
 		VM_ArrayCopyHelpers::memcpyToArray(currentThread, result, (UDATA)0, 0, size, (void*)cString);
 	}
 	return result;
+}
+
+J9SFMethodTypeFrame *
+buildMethodTypeFrame(J9VMThread * currentThread, j9object_t methodType)
+{
+#define ROUND_U32_TO(granularity, number) (((number) + (granularity) - 1) & ~((U_32)(granularity) - 1))
+	U_32 argSlots = (U_32)J9VMJAVALANGINVOKEMETHODTYPE_ARGSLOTS(currentThread, methodType);
+	j9object_t stackDescriptionBits = J9VMJAVALANGINVOKEMETHODTYPE_STACKDESCRIPTIONBITS(currentThread, methodType);
+	U_32 descriptionInts = J9INDEXABLEOBJECT_SIZE(currentThread, stackDescriptionBits);
+	U_32 descriptionBytes = ROUND_U32_TO(sizeof(UDATA), descriptionInts * sizeof(I_32));
+	I_32 * description;
+	U_32 i;
+	J9SFMethodTypeFrame * methodTypeFrame;
+	UDATA * newA0 = currentThread->sp + argSlots;
+
+	/* Push the description bits */
+
+	description = (I_32 *) ((U_8 *)currentThread->sp - descriptionBytes);
+	for (i = 0; i < descriptionInts; ++i) {
+		description[i] = J9JAVAARRAYOFINT_LOAD(currentThread, stackDescriptionBits, i);
+	}
+
+	/* Push the frame */
+
+	methodTypeFrame = (J9SFMethodTypeFrame *) ((U_8 *)description - sizeof(J9SFMethodTypeFrame));
+	methodTypeFrame->methodType = methodType;
+	methodTypeFrame->argStackSlots = argSlots;
+	methodTypeFrame->descriptionIntCount = descriptionInts;
+	methodTypeFrame->specialFrameFlags = 0;
+	methodTypeFrame->savedCP = currentThread->literals;
+	methodTypeFrame->savedPC = currentThread->pc;
+	methodTypeFrame->savedA0 = (UDATA *) ((UDATA)currentThread->arg0EA | J9SF_A0_INVISIBLE_TAG);
+
+	/* Update VM thread to point to new frame */
+
+	currentThread->sp = (UDATA *) methodTypeFrame;
+	currentThread->pc = (U_8 *) J9SF_FRAME_TYPE_METHODTYPE;
+	currentThread->literals = NULL;
+	currentThread->arg0EA = newA0;
+
+	return methodTypeFrame;
+#undef ROUND_U32_TO
 }
 
 }


### PR DESCRIPTION
Also remove some extraneous code from the BytecodeInterprerer splitting.

Fixes: #10392

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>