### PR TITLE
Add J9UTF8Helper.dataEA()

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9UTF8Helper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9UTF8Helper.java
@@ -22,7 +22,10 @@
 package com.ibm.j9ddr.vm29.pointer.helper;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
 import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.vm29.pointer.U8Pointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9UTF8Pointer;
 import com.ibm.j9ddr.vm29.types.U16;
 
@@ -30,16 +33,18 @@ public class J9UTF8Helper {
 
 	// Do not use J9UTF8.SIZEOF here in order to maintain compatibility
 	// with older core files.
-	public static int J9UTF8_HEADER_SIZE = U16.SIZEOF;
+	public static final int J9UTF8_HEADER_SIZE = U16.SIZEOF;
 
-	public static String stringValue(J9UTF8Pointer utf8pointer) throws CorruptDataException 
+	public static U8Pointer dataEA(J9UTF8Pointer utf8pointer) throws CorruptDataException
+	{
+		return U8Pointer.cast(utf8pointer).add(J9UTF8_HEADER_SIZE);
+	}
+
+	public static String stringValue(J9UTF8Pointer utf8pointer) throws CorruptDataException
 	{
 		byte[] buffer = new byte[utf8pointer.length().intValue()];
-		utf8pointer.dataEA().getBytesAtOffset(0, buffer);
-		try {
-			return new String(buffer, "UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new IllegalArgumentException("Can't find UTF-8 Encoding");
-		}
+		dataEA(utf8pointer).getBytesAtOffset(0, buffer);
+		return new String(buffer, StandardCharsets.UTF_8);
 	}
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/VmCheckCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/VmCheckCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,6 +60,7 @@ import com.ibm.j9ddr.vm29.pointer.helper.J9MethodHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9RASHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9ROMClassHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9ROMMethodHelper;
+import com.ibm.j9ddr.vm29.pointer.helper.J9UTF8Helper;
 import com.ibm.j9ddr.vm29.structure.J9ClassInitFlags;
 import com.ibm.j9ddr.vm29.structure.J9Consts;
 import com.ibm.j9ddr.vm29.structure.J9MemorySegment;
@@ -495,7 +496,7 @@ public class VmCheckCommand extends Command
 			return false;
 		}
 		UDATA length = new UDATA(utf8.length());
-		U8Pointer utf8Data = utf8.dataEA();
+		U8Pointer utf8Data = J9UTF8Helper.dataEA(utf8);
 		while (length.longValue() > 0) {
 			U16 temp = new U16(0); // not used
 


### PR DESCRIPTION
Fixes: #10418.

To workaround a deficiency in DDR tooling on AIX.

Also, use StandardCharsets.UTF_8 to eliminate need to catch UnsupportedEncodingException.