### PR TITLE
Fix class unloading processing in classBySignature cache

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -304,7 +304,9 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto method = std::get<1>(recv);
          bool isVettedForAOT = std::get<2>(recv);
          auto clazz = fej9->getClassFromSignature(sig.c_str(), sig.length(), method, isVettedForAOT);
-         client->write(response, clazz);
+         J9ClassLoader *cl = clazz ? reinterpret_cast<J9ClassLoader *>(fe->getClassLoader(clazz)) : NULL;
+         J9ClassLoader *methodCL = reinterpret_cast<J9ClassLoader *>(fe->getClassLoader(fe->getClassOfMethod(method)));
+         client->write(response, clazz, cl, methodCL);
          }
          break;
       case MessageType::VM_jitFieldsOrStaticsAreSame:

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -171,6 +171,15 @@ ClientSessionData::processUnloadedClasses(const std::vector<TR_OpaqueClassBlock*
          //Class is cached, so retain the data to be used for purging the caches.
          unloadedClasses.push_back({ clazz, key, cp, true });
 
+         // For _classBySignatureMap entries that were cached by referencing class loader
+         // we need to delete them using the correct class loader
+         auto &classLoadersMap = it->second._referencingClassLoaders;
+         for (auto it = classLoadersMap.begin(); it != classLoadersMap.end(); ++it)
+            {
+            ClassLoaderStringPair key = { *it, sigStr };
+            unloadedClasses.push_back({ clazz, key, cp, true });
+            }
+
          J9Method *methods = it->second._methodsOfClass;
          // delete all the cached J9Methods belonging to this unloaded class
          for (size_t i = 0; i < romClass->romMethodCount; i++)
@@ -369,7 +378,8 @@ ClientSessionData::ClassInfo::ClassInfo() :
    _jitFieldsCache(decltype(_jitFieldsCache)::allocator_type(TR::Compiler->persistentAllocator())),
    _fieldOrStaticDeclaringClassCache(decltype(_fieldOrStaticDeclaringClassCache)::allocator_type(TR::Compiler->persistentAllocator())),
    _fieldOrStaticDefiningClassCache(decltype(_fieldOrStaticDefiningClassCache)::allocator_type(TR::Compiler->persistentAllocator())),	
-   _J9MethodNameCache(decltype(_J9MethodNameCache)::allocator_type(TR::Compiler->persistentAllocator()))
+   _J9MethodNameCache(decltype(_J9MethodNameCache)::allocator_type(TR::Compiler->persistentAllocator())),
+   _referencingClassLoaders(decltype(_referencingClassLoaders)::allocator_type(TR::Compiler->persistentAllocator()))
    {
    }
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -267,6 +267,7 @@ class ClientSessionData
       // a different API to populate it. In the future we may want to unify these two caches
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _fieldOrStaticDefiningClassCache;
       PersistentUnorderedMap<int32_t, J9MethodNameAndSignature> _J9MethodNameCache; // key is a cpIndex
+      PersistentUnorderedSet<J9ClassLoader *> _referencingClassLoaders;
 
       char* getROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
       char* getRemoteROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);


### PR DESCRIPTION
When caching the result of `TR_J9ServerVM::getClassFromSignature`
we incorrectly assume that the class loader of the referencing constant pool
is the same as class loader of the resulting class.
The problem is that when we delete unloaded classes from the cache,
we use the actual class loader as key, instead of referencing one
which will result in entries for unloaded classes not being deleted properly.

This commit fixes it by keeping track of which class loaders reference
a class in `ClassInfo`. When processing unloaded classes, we find
correct entries for deletion by retrieving class loaders from
`ClassInfo`.

Closes: #10397