### PR TITLE
Bump ALS on Z to z10

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1809,8 +1809,7 @@ J9::Options::fePreProcess(void * base)
 #if defined(TR_HOST_POWER)
    preferTLHPrefetch = TR::Compiler->target.cpu.isAtLeast(OMR_PROCESSOR_PPC_P6) && TR::Compiler->target.cpu.isAtMost(OMR_PROCESSOR_PPC_P7);
 #elif defined(TR_HOST_S390)
-   // TODO: processor arch is not initialized at this point. Once we switch to the new api this problem will go away
-   preferTLHPrefetch = TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10);
+   preferTLHPrefetch = true;
 #else // TR_HOST_X86
    preferTLHPrefetch = true;
    // Disable TM on x86 because we cannot tell whether a Haswell chip supports TM or not, plus it's killing the performance on dayTrader3

--- a/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
@@ -300,19 +300,8 @@ J9::Z::TreeEvaluator::udsl2pdEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          // code is present. Because of this deviation from the COBOL treatment of sign codes we must
          // take a specialized control path when generating instructions for Java.
 
-         if (comp->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10))
-            {
-            generateSILInstruction(cg, TR::InstOpCode::CLHHSI, node, generateS390LeftAlignedMemoryReference(*sourceMR, node, 0, cg, sourceSignEndByte), 0x002D);
-            generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, cFlowRegionEnd);
-            }
-         else
-            {
-            generateSIInstruction(cg, TR::InstOpCode::CLI, node, generateS390LeftAlignedMemoryReference(*sourceMR, node, 0, cg, sourceSignEndByte), 0x00);
-            generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, cFlowRegionEnd);
-
-            generateSIInstruction(cg, TR::InstOpCode::CLI, node, generateS390LeftAlignedMemoryReference(*sourceMR, node, 1, cg, sourceSignEndByte), 0x2D);
-            generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, cFlowRegionEnd);
-            }
+         generateSILInstruction(cg, TR::InstOpCode::CLHHSI, node, generateS390LeftAlignedMemoryReference(*sourceMR, node, 0, cg, sourceSignEndByte), 0x002D);
+         generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, cFlowRegionEnd);
          }
       else
          {
@@ -4102,7 +4091,7 @@ J9::Z::TreeEvaluator::pdnegEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    // also do for assumed (PFD) preferred and clean signs?
    int32_t srcSign = srcReg->hasKnownOrAssumedSignCode() ? srcReg->getKnownOrAssumedSignCode() : TR::DataType::getInvalidSignCode();
-   bool useRegBasedSequence = comp->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10) && srcReg->hasKnownValidSign();
+   bool useRegBasedSequence = srcReg->hasKnownValidSign();
    bool isSrcSign0xF     = srcSign == 0xf;
    bool isSimpleSignFlip = srcSign == TR::DataType::getPreferredPlusCode() ||
                            srcSign == TR::DataType::getPreferredMinusCode() ||

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -182,7 +182,7 @@ J9::Z::CodeGenerator::CodeGenerator() :
 
    cg->getS390Linkage()->initS390RealRegisterLinkage();
 
-   const bool accessStaticsIndirectly = !comp->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10) ||
+   const bool accessStaticsIndirectly =
          comp->getOption(TR_DisableDirectStaticAccessOnZ) ||
          (comp->compileRelocatableCode() && !comp->getOption(TR_UseSymbolValidationManager));
 
@@ -2061,7 +2061,7 @@ J9::Z::CodeGenerator::genSignCodeSetting(TR::Node *node, TR_PseudoRegister *targ
       case TR::ZonedDecimal:
       case TR::ZonedDecimalSignLeadingEmbedded:
          {
-         if (comp->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10) && isPacked && digitsToClear >= 3)
+         if (isPacked && digitsToClear >= 3)
             {
             int32_t bytesToSet = (digitsToClear+1)/2;
             int32_t leftMostByte = 0;
@@ -3010,12 +3010,6 @@ J9::Z::CodeGenerator::canCopyWithOneOrTwoInstrs(char *lit, size_t size)
       return false;
       }
 
-   // z9 does not support these complex move instructions
-   if (!self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10) && size > 2)
-      {
-      return false;
-      }
-
    bool canCopy = false;
    switch (size)
       {
@@ -3110,15 +3104,7 @@ J9::Z::CodeGenerator::useMoveImmediateCommon(TR::Node *node,
          break;
       case 2:  // MVI/MVI or MVHHI
          {
-         if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10))
-            {
-            genMVHHI(destMR, node, (lit[0]<<8)|lit[1], cg);
-            }
-         else
-            {
-            genMVI(destMR, node, lit[0], cg);
-            genMVI(getNextMR(destMR, node, 1, destLeftMostByte, isBCD, cg), node, lit[1], cg);
-            }
+         genMVHHI(destMR, node, (lit[0]<<8)|lit[1], cg);
          break;
          }
       case 3:  // MVHHI/MVI

--- a/runtime/compiler/z/codegen/J9MemoryReference.cpp
+++ b/runtime/compiler/z/codegen/J9MemoryReference.cpp
@@ -347,28 +347,18 @@ J9::Z::MemoryReference::createPatchableDataInLitpool(TR::Node * node, TR::CodeGe
    // create a patchable data in litpool
    TR::S390WritableDataSnippet * litpool = cg->CreateWritableConstant(node);
    litpool->setUnresolvedDataSnippet(uds);
+   litpool->resetNeedLitPoolBasePtr();
+   TR::S390RILInstruction * LRLinst;
+   LRLinst = (TR::S390RILInstruction *) generateRILInstruction(cg, TR::InstOpCode::getLoadRelativeLongOpCode(), node, tempReg, reinterpret_cast<uintptr_t*>(0xBABE), 0);
+   uds->setDataReferenceInstruction(LRLinst);
+   LRLinst->setSymbolReference(uds->getDataSymbolReference());
+   LRLinst->setTargetSnippet(litpool);
+   LRLinst->setTargetSymbol(uds->getDataSymbol());
+   TR_Debug * debugObj = cg->getDebug();
 
-   if (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10))
+   if (debugObj)
       {
-      litpool->resetNeedLitPoolBasePtr();
-      TR::S390RILInstruction * LRLinst;
-      LRLinst = (TR::S390RILInstruction *) generateRILInstruction(cg, TR::InstOpCode::getLoadRelativeLongOpCode(), node, tempReg, reinterpret_cast<uintptr_t*>(0xBABE), 0);
-      uds->setDataReferenceInstruction(LRLinst);
-      LRLinst->setSymbolReference(uds->getDataSymbolReference());
-      LRLinst->setTargetSnippet(litpool);
-      LRLinst->setTargetSymbol(uds->getDataSymbol());
-      TR_Debug * debugObj = cg->getDebug();
-
-      if (debugObj)
-         {
-         debugObj->addInstructionComment(LRLinst, "LoadLitPoolEntry");
-         }
-      }
-   else
-      {
-      auto dataMemoryReference = generateS390MemoryReference(litpool, cg, 0, node);
-
-      generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, tempReg, dataMemoryReference);
+      debugObj->addInstructionComment(LRLinst, "LoadLitPoolEntry");
       }
 
    self()->setBaseRegister(tempReg, cg);

--- a/runtime/compiler/z/codegen/J9Peephole.cpp
+++ b/runtime/compiler/z/codegen/J9Peephole.cpp
@@ -45,37 +45,10 @@ J9::Z::Peephole::performOnInstruction(TR::Instruction* cursor)
       if (cursor->getNode() != NULL && cursor->getNode()->getOpCodeValue() == TR::BBStart)
          {
          self()->comp()->setCurrentBlock(cursor->getNode()->getBlock());
-
-         TR::Block* block = cursor->getNode()->getBlock();
-         if (block->isCatchBlock() && (block->getFirstInstruction() == cursor))
-            reloadLiteralPoolRegisterForCatchBlock(cursor);
          }
       }
 
    performed |= OMR::PeepholeConnector::performOnInstruction(cursor);
 
    return performed;
-   }
-
-void
-J9::Z::Peephole::reloadLiteralPoolRegisterForCatchBlock(TR::Instruction* cursor)
-   {
-   // When dynamic lit pool reg is disabled, we lock R6 as dedicated lit pool reg.
-   // This causes a failure when we come back to a catch block because the register context will not be preserved.
-   // Hence, we can not assume that R6 will still contain the lit pool register and hence need to reload it.
-
-   bool isZ10 = self()->comp()->target().cpu.getSupportsArch(TR::CPU::z10);
-
-   // we only need to reload literal pool for Java on older z architecture on zos when on demand literal pool is off
-   if ( self()->comp()->target().isZOS() && !isZ10 && !self()->cg()->isLiteralPoolOnDemandOn())
-      {
-      // check to make sure that we actually need to use the literal pool register
-      TR::Snippet * firstSnippet = self()->cg()->getFirstSnippet();
-      if ((self()->cg()->getLinkage())->setupLiteralPoolRegister(firstSnippet) > 0)
-         {
-         // the imm. operand will be patched when the actual address of the literal pool is known at binary encoding phase
-         TR::S390RILInstruction * inst = (TR::S390RILInstruction *) generateRILInstruction(self()->cg(), TR::InstOpCode::LARL, cursor->getNode(), self()->cg()->getLitPoolRealRegister(), reinterpret_cast<void*>(0xBABE), cursor);
-         inst->setIsLiteralPoolAddress();
-         }
-      }
    }

--- a/runtime/compiler/z/codegen/J9Peephole.hpp
+++ b/runtime/compiler/z/codegen/J9Peephole.hpp
@@ -49,18 +49,6 @@ class OMR_EXTENSIBLE Peephole : public OMR::PeepholeConnector
    Peephole(TR::Compilation* comp);
 
    virtual bool performOnInstruction(TR::Instruction* cursor);
-
-   private:
-      
-   /** \brief
-    *     Reloads the literal pool register in the catch block when literal pool on demand is turned off. This is
-    *     required because the signal handler will take control of the execution and we are not guaranteed that
-    *     the literal pool register will remaind valid once control is transferred back to the catch block.
-    *
-    *  \param cursor
-    *     The instruction cursor currently being processed.
-    */
-   void reloadLiteralPoolRegisterForCatchBlock(TR::Instruction* cursor);
    };
 }
 

--- a/runtime/compiler/z/codegen/J9SystemLinkagezOS.cpp
+++ b/runtime/compiler/z/codegen/J9SystemLinkagezOS.cpp
@@ -169,16 +169,7 @@ J9::Z::zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::Re
    if (cg()->supportsJITFreeSystemStackPointer())
       {
       auto* systemSPOffsetMR = generateS390MemoryReference(methodMetaDataVirtualRegister, static_cast<int32_t>(fej9->thisThreadGetSystemSPOffset()), codeGen);
-
-      if (comp->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10))
-         {
-         generateSILInstruction(codeGen, TR::InstOpCode::getMoveHalfWordImmOpCode(), callNode, systemSPOffsetMR, 0);
-         }
-      else
-         {
-         generateRIInstruction(codeGen, TR::InstOpCode::getLoadHalfWordImmOpCode(), callNode, methodAddressReg, 0);
-         generateRXInstruction(codeGen, TR::InstOpCode::getStoreOpCode(), callNode, methodAddressReg, systemSPOffsetMR);
-         }
+      generateSILInstruction(codeGen, TR::InstOpCode::getMoveHalfWordImmOpCode(), callNode, systemSPOffsetMR, 0);
       }
 
    /**


### PR DESCRIPTION
The current **unofficial** Architecture Level Set (ALS) on Z for the
IBM Java 8 JDK and AdoptOpenJDK drivers is z9, because this is what we
specify in the `-march` xlC/gcc argument when building the JVM.

The current **official** ALS for the IBM Java 8 JDK [1] for both z/OS
and Linux on Z is z10, and the current official ALS on AdoptOpenJDK
drivers for Linux on Z is z196 [2].

The proposal here is to drop the unofficial support for z9 in the IBM
Java 8 JDK and AdoptOpenJDK drivers and to change the `-march` build
parameter to allow the JVM to be built using z10 instructions. The
following is a list of support data for making this change:

- We do not have access to z9 machines to test the JDK on so the
current unofficial support is untested
- z/OS 2.2 is the minimum JVM supported version which has an ALS of
z10, so it is not an issue to drop z9 support from the perspective of
z/OS
- For IBM JDK, SLES 12, RHEL 7.4, and Ubuntu 16.04 are the minimum
supported OS versions, and according to [3] (which we got from the
Linux on Z OM - Jens Voelker) z9 is not supported on any of the OS
version specified
- For AdoptOpenJDK, the list is the same as above [2], in addition to
Centos 7.4 which is based off of RHEL 7.4, meaning there is no support
for z9 systems either
- z9 has been out of service since January 2019 [4]
- Updating the `-march` build flags will allow the compiler to build
the JVM using z10 instructions which can allow for better C/C++ JVM
code to be generated which improves performance
- Allows for better code maintenance and reduces complexity of the JIT
compiler, particularly in the area of supporting non-relative based
instruction sequences for z9
- Field research from z/OS OMs and Linux on Z OMs suggest that there is
a very small footprint of customers who still have z9 systems, and of
those the % using the latest JVM will be even smaller, if not zero
- Officially, no documentation needs to be updated, since we do not
claim support for z9 publicly so the transition can be transparent

[1] https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.80.doc/user/supported_env_80.html
[2] https://adoptopenjdk.net/supported_platforms.html
[3] https://www.ibm.com/it-infrastructure/z/os/linux-tested-platforms
[4] https://www-03.ibm.com/support/techdocs/atsmastr.nsf/WebIndex/TD105503

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>