### PR TITLE
Use `--depth` flag to `git clone` in Dockerfiles, to save space

### DIFF
--- a/buildenv/docker/jdk8/s390x/ubuntu16/jitserver/build/Dockerfile
+++ b/buildenv/docker/jdk8/s390x/ubuntu16/jitserver/build/Dockerfile
@@ -77,7 +77,7 @@ RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/pr
 # Grab sources from openj9-openjdk-jdk8 and JITServer repos
 # Then builds JITServer
 WORKDIR /root
-RUN git clone https://github.com/ibmruntimes/openj9-openjdk-jdk8 \
+RUN git clone --depth 1 https://github.com/ibmruntimes/openj9-openjdk-jdk8 \
  && cd openj9-openjdk-jdk8 \
  && bash ./get_source.sh -openj9-repo=$openj9_repo -omr-repo=$omr_repo \
  && bash ./configure --with-freemarker-jar=/root/freemarker.jar --enable-jitserver\

--- a/buildenv/docker/jdk8/s390x/ubuntu16/jitserver/test/Dockerfile
+++ b/buildenv/docker/jdk8/s390x/ubuntu16/jitserver/test/Dockerfile
@@ -57,7 +57,7 @@ ENV JAVA_HOME=/root/j2sdk-image
 # Builds tests
 
 RUN cd /root/test \
- && git clone https://github.com/AdoptOpenJDK/TKG.git \
+ && git clone --depth 1 https://github.com/AdoptOpenJDK/TKG.git \
  && cd TKG \
  && make compile
 

--- a/buildenv/docker/jdk8/x86_64/rhel7/jitserver/build/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/rhel7/jitserver/build/Dockerfile
@@ -89,7 +89,7 @@ RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/pr
 # Grab sources from openj9-openjdk-jdk8 and JITServer repos
 # Then builds JITServer
 WORKDIR /root
-RUN git clone https://github.com/ibmruntimes/openj9-openjdk-jdk8 \
+RUN git clone --depth 1 https://github.com/ibmruntimes/openj9-openjdk-jdk8 \
  && cd openj9-openjdk-jdk8 \
  && bash ./get_source.sh -openj9-repo=$openj9_repo -omr-repo=$omr_repo \
  && bash ./configure --with-freemarker-jar=/root/freemarker.jar --enable-jitserver \

--- a/buildenv/docker/jdk8/x86_64/ubuntu16/jitserver/build/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu16/jitserver/build/Dockerfile
@@ -58,7 +58,7 @@ RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/pr
 # Grab sources from openj9-openjdk-jdk8 and JITServer repos
 # Then builds JITServer
 WORKDIR /root
-RUN git clone https://github.com/ibmruntimes/openj9-openjdk-jdk8 \
+RUN git clone --depth 1 https://github.com/ibmruntimes/openj9-openjdk-jdk8 \
  && cd openj9-openjdk-jdk8 \
  && bash ./get_source.sh -openj9-repo=$openj9_repo -omr-repo=$omr_repo \
  && bash ./configure --with-freemarker-jar=/root/freemarker.jar --enable-jitserver \

--- a/buildenv/docker/jdk8/x86_64/ubuntu16/jitserver/buildserver/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu16/jitserver/buildserver/Dockerfile
@@ -59,7 +59,7 @@ RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/pr
 # Grab sources from openj9-openjdk-jdk8 and JITServer repos
 # Then builds JITServer
 WORKDIR /root
-RUN git clone https://github.com/ibmruntimes/openj9-openjdk-jdk8 \
+RUN git clone --depth 1 https://github.com/ibmruntimes/openj9-openjdk-jdk8 \
  && cd openj9-openjdk-jdk8 \
  && bash ./get_source.sh -openj9-repo=$openj9_repo -omr-repo=$omr_repo \
  && bash ./configure --with-freemarker-jar=/root/freemarker.jar --enable-jitserver \

--- a/buildenv/docker/jdk8/x86_64/ubuntu16/jitserver/test/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu16/jitserver/test/Dockerfile
@@ -56,7 +56,7 @@ ENV JAVA_HOME=/root/j2sdk-image
 
 # Builds tests
 RUN cd /root/test \
- && git clone https://github.com/AdoptOpenJDK/TKG.git \
+ && git clone --depth 1 https://github.com/AdoptOpenJDK/TKG.git \
  && cd TKG \
  && make compile
 

--- a/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/build/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/build/Dockerfile
@@ -59,7 +59,7 @@ RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/pr
 # Grab sources from openj9-openjdk-jdk8 and JITServer repos
 # Then builds JITServer
 WORKDIR /root
-RUN git clone https://github.com/ibmruntimes/openj9-openjdk-jdk8 \
+RUN git clone --depth 1 https://github.com/ibmruntimes/openj9-openjdk-jdk8 \
  && cd openj9-openjdk-jdk8 \
  && bash ./get_source.sh -openj9-repo=$openj9_repo -omr-repo=$omr_repo \
  && bash ./configure --with-freemarker-jar=/root/freemarker.jar --enable-jitserver \

--- a/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/buildserver/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/buildserver/Dockerfile
@@ -58,7 +58,7 @@ RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/pr
 # Grab sources from openj9-openjdk-jdk8 and JITServer repos
 # Then builds JITServer
 WORKDIR /root
-RUN git clone https://github.com/ibmruntimes/openj9-openjdk-jdk8 \
+RUN git clone --depth 1 https://github.com/ibmruntimes/openj9-openjdk-jdk8 \
  && cd openj9-openjdk-jdk8 \
  && bash ./get_source.sh -openj9-repo=$openj9_repo -omr-repo=$omr_repo \
  && bash ./configure --with-freemarker-jar=/root/freemarker.jar --enable-jitserver \

--- a/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/test/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/test/Dockerfile
@@ -56,7 +56,7 @@ ENV JAVA_HOME=/root/j2sdk-image
 
 # Builds tests
 RUN cd /root/test \
- && git clone https://github.com/AdoptOpenJDK/TKG.git \
+ && git clone --depth 1 https://github.com/AdoptOpenJDK/TKG.git \
  && cd TKG \
  && make compile
 


### PR DESCRIPTION
optimize the git clone using --depth flag in term of size of clone
and also in term's of time taken to fetch the files and commit history
of whole repository .

More detail can be found at blog
https://www.atlassian.com/git/tutorials/big-repositories

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>