### PR TITLE
Move argument memory size parsing to j9argscan

### DIFF
--- a/runtime/gc_modron_startup/mmparse.h
+++ b/runtime/gc_modron_startup/mmparse.h
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -90,8 +90,8 @@ jint gcParseXXgcArguments(J9JavaVM *vm, char *optArg);
 bool scan_udata_helper(J9JavaVM *javaVM, char **cursor, UDATA *value, const char *argName);
 bool scan_u32_helper(J9JavaVM *javaVM, char **cursor, U_32 *value, const char *argName);
 bool scan_u64_helper(J9JavaVM *javaVM, char **cursor, U_64 *value, const char *argName);
-bool scan_udata_memory_size_helper(J9JavaVM *javaVM, char **cursor, UDATA *value, const char *argName);
-bool scan_u64_memory_size_helper(J9JavaVM *javaVM, char **cursor, U_64 *value, const char *argName);
+bool scan_udata_memory_size_helper(J9JavaVM *javaVM, char **cursor, uintptr_t *value, const char *argName);
+bool scan_u64_memory_size_helper(J9JavaVM *javaVM, char **cursor, uint64_t *value, const char *argName);
 bool scan_hex_helper(J9JavaVM *javaVM, char **cursor, UDATA *value, const char *argName);
 void gcParseXgcpolicy(MM_GCExtensions *extensions);
 

--- a/runtime/oti/j9argscan.h
+++ b/runtime/oti/j9argscan.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -157,6 +157,22 @@ uintptr_t scan_u64(char **scan_start, uint64_t* result);
 * @return uint32_t
 */
 uintptr_t scan_u32(char **scan_start, uint32_t* result);
+
+/**
+* @brief
+* @param **scan_start
+* @param result
+* @return uintptr_t
+*/
+uintptr_t scan_u64_memory_size(char **scan_start, uint64_t* result);
+
+/**
+* @brief
+* @param **scan_start
+* @param result
+* @return uintptr_t
+*/
+uintptr_t scan_udata_memory_size(char **scan_start, uintptr_t* result);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
Previously, parsing methods were only accessible within the GC. Moving these methods into j9argscan enables them to be used generally by VM, and JIT.

Signed-off-by: AlenBadel <Alen.Badel@ibm.com>