### PR TITLE
Recover gr16 as a general register in POWER10

### DIFF
--- a/runtime/compiler/p/codegen/PPCJNILinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCJNILinkage.cpp
@@ -219,7 +219,12 @@ TR::Register *J9::Power::JNILinkage::buildDirectDispatch(TR::Node *callNode)
       {
       // We need to kill all the non-volatiles so that they'll be in a stack frame in case
       // gc needs to find them.
-      if (comp()->target().is32Bit())
+      if (comp()->target().is64Bit())
+         {
+         if (comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P10))
+            TR::addDependency(deps, NULL, TR::RealRegister::gr16, TR_GPR, cg());
+         }
+      else
          {
          // gr15 and gr16 are reserved in 64-bit, normal non-volatile in 32-bit
          TR::addDependency(deps, NULL, TR::RealRegister::gr15, TR_GPR, cg());


### PR DESCRIPTION
After disableTOC is turned on in POWER10, we can recoup
gr16 as a preserved general purpose register, instead of
a reserved register. This is the first time we set up the
compiler-visible machine resources according to the CPU type.

The side-effect needs to be taken care of in JNI dispatch.
Plus, TOCBaseRegister should be prohibited from being referenced
in codegen. Otherwise, register assigner will crash.

Signed-off-by: Julian Wang <zlwang@ca.ibm.com>