### PR TITLE
Allow SDK_FILENAME to be configured via variable file

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -581,6 +581,7 @@ def build_all() {
                         // to correctly expand $HOME variable
                         variableFile.set_build_variables_per_node()
                         get_source()
+                        variableFile.set_sdk_variables()
                         build()
                         archive_sdk()
                     } finally {

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -88,6 +88,8 @@ misc:
     sanity.openjdk: 'true'
     extended.openjdk: 'true'
     special.openjdk: 'true'
+  sdk_filename_template:
+    default: "OpenJ9-JDK${SDK_VERSION}-${SPEC}-${DATESTAMP}${SDK_FILE_EXT}"
 credentials:
   github: 'b6987280-6402-458f-bdd6-7affc2e360d4'
 test_dependencies_job_name: 'test.getDependency'


### PR DESCRIPTION
Give the option to allow SDK_FILENAME to be configurable
via the defaults.yml or any vendor variable file. Set it
based on BUILD_IDENTIFIER and fallback to 'default'.
Default to the existing definition for OpenJ9. Move the sdk
variables setup into the Archive SDK function. We don't
need it set earlier and this allows FULL_SDK_VERSION
to be set from the OpenJDK source tag. Also allow variables
to be used in the SDK_FILENAME template. The Groovy template
engine is used to resolve the variables defined in the yml.

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>