### PR TITLE
Rework the code with Thread.interrupt()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -712,12 +712,7 @@ public void interrupt() {
 		sun.nio.ch.Interruptible localBlockOn = blockOn;
 		if (localBlockOn != null) {
 			localBlockOn.interrupt(this);
-        }
-        /*[IF Java14]*/
-        if (!isAlive()) {
-		deadInterrupt = true;
-        }
-        /*[ENDIF] Java 14 */
+		}
 	}
 }
 
@@ -809,11 +804,6 @@ public final boolean isDaemon() {
  */
 public boolean isInterrupted() {
 	synchronized(lock) {
-		/*[IF Java14]*/
-		if (!isAlive()) {
-			return deadInterrupt;
-		}
-		/*[ENDIF] Java14 */
 		return isInterruptedImpl();
 	}
 }

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1402,16 +1402,20 @@ done:
 	static VMINLINE bool
 	threadIsInterruptedImpl(J9VMThread *currentThread, j9object_t threadObject)
 	{
+		J9VMThread *targetThread = J9VMJAVALANGTHREAD_THREADREF(currentThread, threadObject);
 		bool result = false;
 		/* If the thread is alive, ask the OS thread.  Otherwise, answer false. */
-		if (J9VMJAVALANGTHREAD_STARTED(currentThread, threadObject)) {
-			J9VMThread *targetThread = J9VMJAVALANGTHREAD_THREADREF(currentThread, threadObject);
-			if (NULL != targetThread) {
-				if (omrthread_interrupted(targetThread->osThread)) {
-					result = true;
-				}
+		if (J9VMJAVALANGTHREAD_STARTED(currentThread, threadObject) && (NULL != targetThread)) {
+			if (omrthread_interrupted(targetThread->osThread)) {
+				result = true;
 			}
 		}
+#if JAVA_SPEC_VERSION >= 14
+		else {
+			result = J9VMJAVALANGTHREAD_DEADINTERRUPT(currentThread, threadObject);
+		}
+#endif /* JAVA_SPEC_VERSION >= 14 */
+
 		return result;
 	}
 


### PR DESCRIPTION
The change is to remove the previous code
in suspendThread() plus a few modifications
in Thread to support Thread.interrupt().

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>