### PR TITLE
Hidden class implementation 4

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -86,6 +86,8 @@ class MethodHandleNatives {
 	static Object classData(Class<?> c) {
 		return JLA.classData(c);
 	}
+
+	native static void checkClassBytes(byte[] bytes);
 	/*[ENDIF] Java15 */
 }
 /*[ENDIF] Java11 */

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -1150,6 +1150,7 @@ public final class MethodType implements Serializable
 		return wrapperClass;
 	}
 	
+	/* The string returned by this method should be in sync with Class.descriptorString() */
 	static String getBytecodeStringName(Class<?> c){
 		if (c.isPrimitive()) {
 			if (c == int.class) {
@@ -1172,7 +1173,22 @@ public final class MethodType implements Serializable
 				return "S"; //$NON-NLS-1$
 			}
 		}
+		Class<?> clazz = c;
+		if (c.isArray()) {
+			clazz = c.getComponentType();
+			while (clazz.isArray()) {
+				clazz = clazz.getComponentType();
+			}
+		}
 		String name = c.getName().replace('.', '/');
+		/*[IF Java15]*/
+		if (clazz.isHidden()) {
+			/* keep the last "." before romaddress for hidden classes */
+			int index = name.lastIndexOf('/');
+			name = name.substring(0, index) + '.' + name.substring(index + 1,name.length());
+		}
+		/*[ENDIF] Java15 */
+		
 		if (c.isArray()) {
 			return name;
 		}

--- a/runtime/bcutil/BuildResult.hpp
+++ b/runtime/bcutil/BuildResult.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,6 +48,7 @@ enum BuildResult {
 	InvalidAnnotation = BCT_ERR_INVALID_ANNOTATION,
 	LineNumberTableDecompressFailed = BCT_ERR_LINE_NUMBER_TABLE_DECOMPRESS_FAILED,
 	InvalidBytecodeSize = BCT_ERR_INVALID_BYTECODE_SIZE,
+	InvalidClassType = BCT_ERR_INVALID_CLASS_TYPE,
 };
 
 #endif /* BUILDRESULT_HPP_ */

--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -227,6 +227,11 @@ ClassFileOracle::ClassFileOracle(BufferManager *bufferManager, J9CfrClassFile *c
 	if (OK == _buildResult) {
 		walkAttributes();
 	}
+	
+	if (_context->isClassHidden()) {
+		checkHiddenClass();
+	}
+	
 	if (OK == _buildResult) {
 		walkInterfaces();
 	}
@@ -507,21 +512,28 @@ ClassFileOracle::walkAttributes()
 		}
 #if JAVA_SPEC_VERSION >= 11
 		case CFR_ATTRIBUTE_NestMembers:
-			_nestMembers = (J9CfrAttributeNestMembers *)attrib;
-			_nestMembersCount = _nestMembers->numberOfClasses;
-			/* The classRefs are never resolved & therefore do not need to
-			 * be kept in the constant pool.
-			 */
-			for (U_16 i = 0; i < _nestMembersCount; i++) {
-				U_16 classNameIndex = UTF8_INDEX_FROM_CLASS_INDEX(_classFile->constantPool, _nestMembers->classes[i]);
-				markConstantUTF8AsReferenced(classNameIndex);
+			/* ignore CFR_ATTRIBUTE_NestMembers for hidden classes, as the nest members never know the name of hidden classes */
+			if (!_context->isClassHidden()) {
+				_nestMembers = (J9CfrAttributeNestMembers *)attrib;
+				_nestMembersCount = _nestMembers->numberOfClasses;
+				/* The classRefs are never resolved & therefore do not need to
+				 * be kept in the constant pool.
+				 */
+				for (U_16 i = 0; i < _nestMembersCount; i++) {
+					U_16 classNameIndex = UTF8_INDEX_FROM_CLASS_INDEX(_classFile->constantPool, _nestMembers->classes[i]);
+					markConstantUTF8AsReferenced(classNameIndex);
+				}
 			}
 			break;
 
 		case CFR_ATTRIBUTE_NestHost: {
-			U_16 hostClassIndex = ((J9CfrAttributeNestHost *)attrib)->hostClassIndex;
-			_nestHost = UTF8_INDEX_FROM_CLASS_INDEX(_classFile->constantPool, hostClassIndex);
-			markConstantUTF8AsReferenced(_nestHost);
+			/* Ignore CFR_ATTRIBUTE_NestHost for hidden classes, as the nest host of a hidden class is not decided by CFR_ATTRIBUTE_NestHost.
+			 * The nesthost of a hidden class is its host class if ClassOption.NESTMATE is used or itself if ClassOption.NESTMATE is not used. */
+			if (!_context->isClassHidden()) {
+				U_16 hostClassIndex = ((J9CfrAttributeNestHost *)attrib)->hostClassIndex;
+				_nestHost = UTF8_INDEX_FROM_CLASS_INDEX(_classFile->constantPool, hostClassIndex);
+				markConstantUTF8AsReferenced(_nestHost);
+			}
 			break;
 		}
 #endif /* JAVA_SPEC_VERSION >= 11 */
@@ -537,6 +549,38 @@ ClassFileOracle::walkAttributes()
 				_hasVerifyExcludeAttribute = true;
 			}
 		}
+	}
+}
+
+void
+ClassFileOracle::checkHiddenClass()
+{
+	ROMClassVerbosePhase v(_context, ClassFileAttributesAnalysis);
+	/* Hidden Class cannot be a record or enum. */
+	U_16 superClassNameIndex = getSuperClassNameIndex();
+	bool isEnum = false;
+	
+	/**
+	 * See test case jdk/java/lang/invoke/defineHiddenClass/BasicTest.emptyHiddenClass().
+	 * A normal Enum cannot be defined as a hidden class. But an empty enum class that does not
+	 * define constants of its type can still be defined as a hidden class. 
+	 * So when setting isEnum, add a check for field count. 
+	 */
+	if (0 != superClassNameIndex) {
+		isEnum = J9_ARE_ALL_BITS_SET(_classFile->accessFlags, CFR_ACC_ENUM) && 
+				J9UTF8_DATA_EQUALS(getUTF8Data(superClassNameIndex), getUTF8Length(superClassNameIndex), "java/lang/Enum", LITERAL_STRLEN("java/lang/Enum")) &&
+				(getFieldsCount() > 0);
+	}
+	if (_isRecord  || isEnum) {
+		PORT_ACCESS_FROM_PORT(_context->portLibrary());
+		char msg[] = "Hidden Class cannot be a record or enum";
+		UDATA len = sizeof(msg);
+		char *error = (char *) j9mem_allocate_memory(len, J9MEM_CATEGORY_CLASSES);
+		if (NULL != error) {
+			strcpy(error, msg);
+			_context->recordCFRError((U_8*)error);
+		}
+		_buildResult = InvalidClassType;
 	}
 }
 
@@ -1316,9 +1360,9 @@ ClassFileOracle::walkMethodCodeAttributeAttributes(U_16 methodIndex)
 	/* Verify that each LVTT entry has a matching local variable. Since there is no guaranteed order
 	 * for code attributes, this check must be performed after all attributes are processed.
 	 * 
-	 * According to the JVM spec: ”Each entry in the local_variable_type_table array ... 
+	 * According to the JVM spec: "Each entry in the local_variable_type_table array ... 
 	 * indicates the index into the local variable array of the current frame at which 
-	 * that local variable can be found.”
+	 * that local variable can be found."
 	 * 
 	 * While multiple LocalVariableTypeTable attributes may exist according to the spec, upon observation 
 	 * it is the common case for 'javac' to generate only one attribute per method. To take advantage of this 

--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -1084,6 +1084,7 @@ private:
 	void walkHeader();
 	void walkFields();
 	void walkAttributes();
+	void checkHiddenClass();
 	void walkInterfaces();
 	void walkMethods();
 	void walkRecordComponents(J9CfrAttributeRecord *attrib);

--- a/runtime/bcutil/ROMClassCreationContext.cpp
+++ b/runtime/bcutil/ROMClassCreationContext.cpp
@@ -157,6 +157,7 @@ ROMClassCreationContext::buildResultString(BuildResult result)
 	case UnknownAnnotation: return "UnknownAnnotation";
 	case ClassNameMismatch: return "ClassNameMismatch";
 	case InvalidAnnotation: return "InvalidAnnotation";
+	case InvalidClassType: return "InvalidClassType";
 	default: return "Unknown";
 	}
 }

--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -2701,6 +2701,11 @@ j9bcutil_readClassFileBytes(J9PortLibrary *portLib,
 		return -1;
 	}
 
+	if (J9_ARE_ANY_BITS_SET(flags, BCT_BasicCheckOnly)) {
+		Trc_BCU_j9bcutil_readClassFileBytes_Basic_Check_Exit(0);
+		return 0;
+	}
+
 	if (J9_ARE_ANY_BITS_SET(findClassFlags, J9_FINDCLASS_FLAG_UNSAFE)) {
 		flags |= BCT_Unsafe;
 	}
@@ -3601,3 +3606,18 @@ sortMethodIndex(J9CfrConstantPoolInfo* constantPool, J9CfrMethod *list, IDATA st
 		}
 	}
 }
+
+#if JAVA_SPEC_VERSION >= 15
+I_32
+checkClassBytes(J9VMThread *currentThread, U_8* classBytes, UDATA classBytesLength, U_8* segment, U_32 segmentLength) 
+{
+	I_32 rc = 0;
+	U_32 cfrFlags = BCT_JavaMaxMajorVersionShifted | BCT_AnyPreviewVersion | BCT_BasicCheckOnly;
+	PORT_ACCESS_FROM_VMC(currentThread);
+	if (NULL != classBytes) {
+		rc = j9bcutil_readClassFileBytes(PORTLIB, NULL, classBytes, classBytesLength, segment, segmentLength, cfrFlags, NULL, NULL, 0, 0);
+	}
+	return rc;
+}
+#endif /* JAVA_SPEC_VERSION >= 15 */
+

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -887,6 +887,7 @@ createROMClassFromClassFile(J9VMThread *currentThread, J9LoadROMClassData *loadD
 		 * Error messages are contents of vm->dynamicLoadBuffers->classFileError if anything is assigned
 		 * otherwise just the classname.
 		 */
+		case BCT_ERR_INVALID_CLASS_TYPE:
 		case BCT_ERR_CLASS_NAME_MISMATCH:
 			exceptionNumber = J9VMCONSTANTPOOL_JAVALANGNOCLASSDEFFOUNDERROR;
 			/* FALLTHROUGH */

--- a/runtime/bcutil/j9bcu.tdf
+++ b/runtime/bcutil/j9bcu.tdf
@@ -378,3 +378,4 @@ TraceEvent=Trc_BCU_compareROMClassForEquality_event NoEnv Overhead=1 Level=7 Tem
 TraceAssert=Trc_BCU_Assert_True_Level1 NoEnv Overhead=1 Level=1 Assert="(P1)"
 
 TraceEvent=Trc_BCU_ClassFileOracle_walkRecordComponents_UnknownAttribute Noenv Overhead=1 Level=3 Template="BCU ClassFileOracle::walkRecordComponents: Unknown attribute tag=%d name=%.*s length=%d"
+TraceExit=Trc_BCU_j9bcutil_readClassFileBytes_Basic_Check_Exit NoEnv Overhead=1 Level=3 Template="BCU j9bcutil_readClassFileBytes: exiting with result=%d" 

--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -283,6 +283,7 @@ Java_com_ibm_oti_vm_VM_getClassNameImpl(JNIEnv *env, jclass recv, jclass jlClass
 	UDATA utfLength;
 	UDATA freeUTFData = FALSE;
 	U_8 onStackBuffer[64];
+	bool anonClassName = false;
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 
@@ -331,16 +332,17 @@ Java_com_ibm_oti_vm_VM_getClassNameImpl(JNIEnv *env, jclass recv, jclass jlClass
 				utfData[utfLength - 1] = ';';
 			}
 		}
+		anonClassName = J9_ARE_ANY_BITS_SET(leafROMClass->extraModifiers, J9AccClassAnonClass | J9AccClassHidden);
 	} else {
 		J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
 		utfLength = J9UTF8_LENGTH(className);
 		utfData = J9UTF8_DATA(className);
+		anonClassName = J9_ARE_ANY_BITS_SET(romClass->extraModifiers, J9AccClassAnonClass | J9AccClassHidden);
 	}
 
 	if (NULL != utfData) {
 		UDATA flags = J9_STR_INTERN | J9_STR_XLAT;
-
-		if (J9_ARE_ANY_BITS_SET(romClass->extraModifiers, J9AccClassAnonClass | J9AccClassHidden)) {
+		if (anonClassName) {
 			flags |= J9_STR_ANON_CLASS_NAME;
 		}
 		j9object_t classNameObject = vm->memoryManagerFunctions->j9gc_createJavaLangString(currentThread, utfData, utfLength, flags);

--- a/runtime/jcl/common/reflecthelp.c
+++ b/runtime/jcl/common/reflecthelp.c
@@ -830,11 +830,12 @@ createField(struct J9VMThread *vmThread, jfieldID fieldID)
 #if defined(USE_SUN_REFLECT)
 	J9VMJAVALANGREFLECTFIELD_SET_MODIFIERS(vmThread, fieldObject, j9FieldID->field->modifiers & CFR_FIELD_ACCESS_MASK);
 #if JAVA_SPEC_VERSION >= 15
-	/* trust that static final fields and final record class fields will not be modified. */
+	/* trust that static final fields and final record or hidden class fields will not be modified. */
 	if (J9_ARE_ALL_BITS_SET(j9FieldID->field->modifiers, J9AccFinal)) {
 		if (J9_ARE_ALL_BITS_SET(j9FieldID->field->modifiers, J9AccStatic)
-			|| J9ROMCLASS_IS_RECORD(j9FieldID->declaringClass->romClass))
-		{
+			|| J9ROMCLASS_IS_RECORD(j9FieldID->declaringClass->romClass)
+			|| J9ROMCLASS_IS_HIDDEN(j9FieldID->declaringClass->romClass)
+		) {
 			J9VMJAVALANGREFLECTFIELD_SET_TRUSTEDFINAL(vmThread, fieldObject, JNI_TRUE);
 		}
 	}

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -584,5 +584,6 @@ if(NOT JAVA_SPEC_VERSION LESS 15)
 	omr_add_exports(jclse
 		Java_java_lang_Class_isHiddenImpl
 		Java_java_lang_ClassLoader_defineClassImpl1
+		Java_java_lang_invoke_MethodHandleNatives_checkClassBytes
 	)
 endif()

--- a/runtime/jcl/uma/se15_exports.xml
+++ b/runtime/jcl/uma/se15_exports.xml
@@ -23,4 +23,5 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<export name="Java_java_lang_Class_permittedSubclassesImpl"/>
 	<export name="Java_java_lang_Class_isHiddenImpl"/>
 	<export name="Java_java_lang_ClassLoader_defineClassImpl1"/>
+	<export name="Java_java_lang_invoke_MethodHandleNatives_checkClassBytes"/>
 </exports>

--- a/runtime/oti/bcutil.h
+++ b/runtime/oti/bcutil.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 IBM Corp. and others
+ * Copyright (c) 2011, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,3 +37,5 @@
 #define BCT_ERR_LINE_NUMBER_TABLE_DECOMPRESS_FAILED -14
 #define BCT_ERR_INVALID_BYTECODE_SIZE -15
 #define BCT_ERR_GENERIC_ERROR_CUSTOM_MSG  -16
+#define BCT_ERR_INVALID_CLASS_TYPE -17
+

--- a/runtime/oti/bcutil_api.h
+++ b/runtime/oti/bcutil_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -178,6 +178,21 @@ bcutil_J9VMDllMain (J9JavaVM* vm, IDATA stage, void* reserved);
 */
 I_32 
 j9bcutil_readClassFileBytes (J9PortLibrary *portLib, IDATA (*verifyFunction) (J9PortLibrary *aPortLib, J9CfrClassFile* classfile, U_8* segment, U_8* segmentLength, U_8* freePointer, U_32 vmVersionShifted, U_32 flags, I_32 *hasRET), U_8* data, UDATA dataLength, U_8* segment, UDATA segmentLength, U_32 flags, U_8** segmentFreePointer, void *verboseContext, UDATA findClassFlags, UDATA romClassSortingThreshold);
+
+#if JAVA_SPEC_VERSION >= 15
+/**
+ * check the class bytes that will be used to define a class.
+ * @param currentThread The current VM thread.
+ * @param classBytes Pointer to the class bytes that is to be checked.
+ * @param classBytesLength The length of class bytes.
+ * @param segment A memory segment that will be used to verify the class bytes.
+ * @param segmentLength The length of memory segment.
+ * 
+ * @param return 0 class bytes is legal or a negative value otherwise.
+ */
+I_32
+checkClassBytes(J9VMThread *currentThread, U_8* classBytes, UDATA classBytesLength, U_8* segment, U_32 segmentLength);
+#endif /* JAVA_SPEC_VERSION >= 15 */
 
 /* ---------------- defineclass.c ---------------- */
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1973,6 +1973,7 @@ typedef struct J9BCTranslationData {
 #define BCT_AnyPreviewVersion  0x100000
 #define BCT_EnablePreview 0x200000
 #define BCT_Unsafe  0x400000
+#define BCT_BasicCheckOnly  0x800000
 #define BCT_DumpMaps  0x40000000
 
 #define BCT_J9DescriptionCpTypeScalar  0
@@ -4587,6 +4588,9 @@ typedef struct J9InternalVMFunctions {
 	j9object_t ( *getFlattenableField)(struct J9VMThread *currentThread, J9RAMFieldRef *cpEntry, j9object_t receiver, BOOLEAN fastPath);
 	j9object_t ( *cloneValueType)(struct J9VMThread *currentThread, struct J9Class *receiverClass, j9object_t original, BOOLEAN fastPath);
 	void ( *putFlattenableField)(struct J9VMThread *currentThread, struct J9RAMFieldRef *cpEntry, j9object_t receiver, j9object_t paramObject);
+#if JAVA_SPEC_VERSION >= 15
+	I_32 (*checkClassBytes) (struct J9VMThread *currentThread, U_8* classBytes, UDATA classBytesLength, U_8* segment, U_32 segmentLength);
+#endif /* JAVA_SPEC_VERSION >= 15 */
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -940,6 +940,10 @@ Java_java_lang_invoke_MethodHandles_findNativeAddress(JNIEnv *env, jclass jlClas
 
 /* java_dyn_methodtype.c */
 jobject JNICALL Java_java_lang_invoke_MethodType_makeTenured(JNIEnv *env, jclass clazz, jobject receiverObject);
+#if JAVA_SPEC_VERSION >= 15
+extern J9_CFUNC void JNICALL
+Java_java_lang_invoke_MethodHandleNatives_checkClassBytes(JNIEnv *env, jclass jlClass, jbyteArray classRep);
+#endif /* JAVA_SPEC_VERSION >= 15 */
 
 /* java_lang_invoke_VarHandle.c */
 jlong JNICALL Java_java_lang_invoke_FieldVarHandle_lookupField(JNIEnv *env, jobject handle, jclass lookupClass, jstring name, jstring signature, jclass type, jboolean isStatic, jclass accessClass);

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -2806,18 +2806,21 @@ done:
 		J9Class *receiverClazz = J9VM_J9CLASS_FROM_HEAPCLASS(_currentThread, *(j9object_t*)_sp);
 		j9object_t simpleName = NULL;
 		J9ROMClass *romClass = receiverClazz->romClass;
-		J9UTF8 *simpleNameUTF = getSimpleNameForROMClass(_vm, receiverClazz->classLoader, romClass);
-		if (NULL != simpleNameUTF) {
-			buildInternalNativeStackFrame(REGISTER_ARGS);
-			updateVMStruct(REGISTER_ARGS);
-			simpleName = _vm->memoryManagerFunctions->j9gc_createJavaLangString(_currentThread, J9UTF8_DATA(simpleNameUTF), J9UTF8_LENGTH(simpleNameUTF), 0);
-			VMStructHasBeenUpdated(REGISTER_ARGS);
-			releaseOptInfoBuffer(_vm, romClass);
-			if (NULL == simpleName) {
-				rc = GOTO_THROW_CURRENT_EXCEPTION;
-				goto done;
+		/* Simple name of a hidden class is NULL */
+		if (!J9ROMCLASS_IS_HIDDEN(romClass)) {
+			J9UTF8 *simpleNameUTF = getSimpleNameForROMClass(_vm, receiverClazz->classLoader, romClass);
+			if (NULL != simpleNameUTF) {
+				buildInternalNativeStackFrame(REGISTER_ARGS);
+				updateVMStruct(REGISTER_ARGS);
+				simpleName = _vm->memoryManagerFunctions->j9gc_createJavaLangString(_currentThread, J9UTF8_DATA(simpleNameUTF), J9UTF8_LENGTH(simpleNameUTF), 0);
+				VMStructHasBeenUpdated(REGISTER_ARGS);
+				releaseOptInfoBuffer(_vm, romClass);
+				if (NULL == simpleName) {
+					rc = GOTO_THROW_CURRENT_EXCEPTION;
+					goto done;
+				}
+				restoreInternalNativeStackFrame(REGISTER_ARGS);
 			}
-			restoreInternalNativeStackFrame(REGISTER_ARGS);
 		}
 		returnObjectFromINL(REGISTER_ARGS, simpleName, 1);
 done:

--- a/runtime/vm/ClassInitialization.cpp
+++ b/runtime/vm/ClassInitialization.cpp
@@ -157,12 +157,11 @@ performVerification(J9VMThread *currentThread, J9Class *clazz)
 		/* See if this class should be verified:
 		 *
 		 * - Do not verify any class created by sun.misc.Unsafe
-		 * - Do not verify hidden classes
 		 * - Do not verify any class which is marked for exclusion in the optional flags
 		 * - Verify every class whose bytecodes have been modified
 		 * - Do not verify bootstrap classes if the appropriate runtime flag is set
 		 */
-		if (((!J9CLASS_IS_EXEMPT_FROM_VALIDATION(clazz)) && !J9ROMCLASS_IS_HIDDEN(romClass))
+		if ((!J9CLASS_IS_EXEMPT_FROM_VALIDATION(clazz))
 			&& J9_ARE_NO_BITS_SET(romClass->optionalFlags, J9_ROMCLASS_OPTINFO_VERIFY_EXCLUDE)
 		) {
 			J9BytecodeVerificationData * bcvd = vm->bytecodeVerificationData;

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -1719,6 +1719,13 @@ loadSuperClassAndInterfaces(J9VMThread *vmThread, J9ClassLoader *classLoader, J9
 
 				for (i = 0; i<romClass->interfaceCount; i++) {
 					J9UTF8 *interfaceName = NNSRP_GET(interfaceNames[i], J9UTF8*);
+					
+					if (J9UTF8_EQUALS(interfaceName, className)) {
+						/* className and interfaceName are the same */
+						setCurrentException(vmThread, J9VMCONSTANTPOOL_JAVALANGCLASSCIRCULARITYERROR, NULL);
+						return FALSE;
+					}
+					
 					J9Class *interfaceClass = internalFindClassUTF8(vmThread, J9UTF8_DATA(interfaceName), J9UTF8_LENGTH(interfaceName), classLoader, classPreloadFlags);
 
 					Trc_VM_CreateRAMClassFromROMClass_loadedInterface(vmThread, J9UTF8_LENGTH(interfaceName), J9UTF8_DATA(interfaceName), interfaceClass);
@@ -2035,20 +2042,22 @@ nativeOOM:
 				omrthread_monitor_exit(javaVM->classTableMutex);
 				javaVM->memoryManagerFunctions->j9gc_modron_global_collect_with_overrides(vmThread, J9MMCONSTANT_EXPLICIT_GC_NATIVE_OUT_OF_MEMORY);
 				omrthread_monitor_enter(javaVM->classTableMutex);
-
-				/* If the class was successfully loaded while we were GCing, use that one */
-				if (elementClass == NULL) {
-					alreadyLoadedClass = hashClassTableAt(classLoader, J9UTF8_DATA(className), J9UTF8_LENGTH(className));
-				} else {
-					alreadyLoadedClass = elementClass->arrayClass;
-				}
-				if (alreadyLoadedClass != NULL) {
-					goto alreadyLoaded;
-				}
-
-				/* Try the store again - if it fails again, throw native OOM */
-				if (hashClassTableAtPut(vmThread, classLoader, J9UTF8_DATA(className), J9UTF8_LENGTH(className), state->ramClass)) {
-					goto nativeOOM;
+				
+				if (J9_ARE_NO_BITS_SET(options, J9_FINDCLASS_FLAG_HIDDEN)) {
+					/* If the class was successfully loaded while we were GCing, use that one */
+					if (elementClass == NULL) {
+						alreadyLoadedClass = hashClassTableAt(classLoader, J9UTF8_DATA(className), J9UTF8_LENGTH(className));
+					} else {
+						alreadyLoadedClass = elementClass->arrayClass;
+					}
+					if (alreadyLoadedClass != NULL) {
+						goto alreadyLoaded;
+					}
+	
+					/* Try the store again - if it fails again, throw native OOM */
+					if (hashClassTableAtPut(vmThread, classLoader, J9UTF8_DATA(className), J9UTF8_LENGTH(className), state->ramClass)) {
+						goto nativeOOM;
+					}
 				}
 			}
 

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -386,4 +386,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	getFlattenableField,
 	cloneValueType,
 	putFlattenableField,
+#if JAVA_SPEC_VERSION >= 15
+	checkClassBytes,
+#endif /* JAVA_SPEC_VERSION >= 15 */
 };

--- a/test/functional/Java12andUp/src/org/openj9/test/java_lang/Test_Class.java
+++ b/test/functional/Java12andUp/src/org/openj9/test/java_lang/Test_Class.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,6 +25,7 @@ import java.lang.constant.ClassDesc;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.util.Optional;
+import java.util.NoSuchElementException;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -131,17 +132,11 @@ public class Test_Class {
 	 */
 	private void describeConstableTestLambda(String testName) {
 		Optional<ClassDesc> optionalDesc = lambdaExpTest.describeConstable();
-		ClassDesc desc = optionalDesc.orElseThrow();
-
-		/*
-		 * verify that descriptor can be resolved. Otherwise exception will be thrown.
-		 */
 		try {
-			Class<?> resolvedClass = (Class<?>)desc.resolveConstantDesc(MethodHandles.lookup());
-			Assert.fail(testName + " : resolveConstantDesc did not throw an error.");
-		} catch (Throwable e) {
-			/* resolveConstantDesc is expected to fail */
-			logger.debug(testName + ": exception thrown for resolveConstantDesc was " + e.toString());
+			ClassDesc desc = optionalDesc.orElseThrow(); 
+		} catch (NoSuchElementException e) {
+			/* In Java 15 and up, lambda classes are hidden classes whose describeConstable is an empty Optional. */
+			logger.debug(testName + ": exception thrown for optionalDesc.orElseThrow() was " + e.toString());
 		}
 	}
 


### PR DESCRIPTION
1. Add checks for class bytes for hidden classes in MethodHandles.
2. Do bytecode verification for hidden classes.
3. Do not allow record and enum to be defined as hidden classes.
4. Fix APIs for hidden classes in Class.java.

Closes #9328

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>