### PR TITLE
Get target JITServer's CPU before CG object is created

### DIFF
--- a/runtime/compiler/compile/Compilation.hpp
+++ b/runtime/compiler/compile/Compilation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,7 +49,8 @@ class OMR_EXTENSIBLE Compilation : public J9::CompilationConnector
          TR::Region &heapMemoryRegion,
          TR_Memory *memory,
          TR_OptimizationPlan *optimizationPlan,
-         TR_RelocationRuntime *reloRuntime) :
+         TR_RelocationRuntime *reloRuntime,
+         TR::Environment *target = NULL) :
       J9::CompilationConnector(
          compThreadId,
          j9vmThread,
@@ -60,7 +61,8 @@ class OMR_EXTENSIBLE Compilation : public J9::CompilationConnector
          heapMemoryRegion,
          memory,
          optimizationPlan,
-         reloRuntime)
+         reloRuntime,
+         target)
       {}
 
    ~Compilation() {}

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -136,7 +136,8 @@ J9::Compilation::Compilation(int32_t id,
       TR::Region &heapMemoryRegion,
       TR_Memory *m,
       TR_OptimizationPlan *optimizationPlan,
-      TR_RelocationRuntime *reloRuntime)
+      TR_RelocationRuntime *reloRuntime,
+      TR::Environment *target)
    : OMR::CompilationConnector(
       id,
       j9vmThread->omrVMThread,
@@ -146,7 +147,8 @@ J9::Compilation::Compilation(int32_t id,
       options,
       heapMemoryRegion,
       m,
-      optimizationPlan),
+      optimizationPlan,
+      target),
    _updateCompYieldStats(
       options.getOption(TR_EnableCompYieldStats) ||
       options.getVerboseOption(TR_VerboseCompYieldStats) ||
@@ -183,23 +185,6 @@ J9::Compilation::Compilation(int32_t id,
 #endif /* defined(J9VM_OPT_JITSERVER) */
    _osrProhibitedOverRangeOfTrees(false)
    {
-#if defined(J9VM_OPT_JITSERVER)
-   // In JITServer, we would like to use JITClient's processor info for the compilation
-   // The following code effectively replaces the cpu with client's cpu through the getProcessorDescription() that has JITServer support
-   if (self()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
-      {
-      OMRProcessorDesc JITClientProcessorDesc = TR::Compiler->target.cpu.getProcessorDescription();
-      _target.cpu = TR::CPU(JITClientProcessorDesc);
-      }
-   else
-#endif /* defined(J9VM_OPT_JITSERVER) */
-      {
-      if (((TR_J9VMBase *)fe)->isAOT_DEPRECATED_DO_NOT_USE() && TR::Compiler->target.cpu.isX86())
-         {
-         _target = TR::Compiler->relocatableTarget;
-         }
-      }
-
    _symbolValidationManager = new (self()->region()) TR::SymbolValidationManager(self()->region(), compilee);
 
    _aotClassClassPointer = NULL;

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -97,7 +97,8 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
          TR::Region &heapMemoryRegion,
          TR_Memory *,
          TR_OptimizationPlan *optimizationPlan,
-         TR_RelocationRuntime *reloRuntime);
+         TR_RelocationRuntime *reloRuntime,
+         TR::Environment *target = NULL);
 
    ~Compilation();
 

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -270,6 +270,7 @@ public:
    virtual bool needRelocationsForPersistentInfoData() { return false; }
    virtual bool needRelocationsForLookupEvaluationData() { return false; }
    virtual bool nopsAlsoProcessedByRelocations() { return false; }
+   virtual bool needRelocatableTarget() { return false; }
 
    bool supportsContextSensitiveInlining () { return true; }
 
@@ -1142,6 +1143,7 @@ public:
    virtual bool               supportsJitMethodEntryAlignment()               { return false; }
    virtual bool               isBenefitInliningCheckIfFinalizeObject()        { return true; }
    virtual bool               needsContiguousCodeAndDataCacheAllocation()     { return true; }
+   virtual bool               needRelocatableTarget()                          { return true; }
    virtual bool               shouldDelayAotLoad();
 
    virtual bool               isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT = false);


### PR DESCRIPTION
This is needed so that the codegen is able to set the correct
flags when initializing.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>