### PR TITLE
(0.22) JEP 360 edge cases

### DIFF
--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -497,11 +497,15 @@ ClassFileOracle::walkAttributes()
 			break;
 		}
 		case CFR_ATTRIBUTE_PermittedSubclasses: {
-			_isSealed = true;
-			_permittedSubclassesAttribute = (J9CfrAttributePermittedSubclasses *)attrib;
-			for (U_16 numberOfClasses = 0; numberOfClasses < _permittedSubclassesAttribute->numberOfClasses; numberOfClasses++) {
-				U_16 classCpIndex = _permittedSubclassesAttribute->classes[numberOfClasses];
-				markClassAsReferenced(classCpIndex);
+			/* PermittedSubclasses verification is for Java 15 preview only. Don't record the attribute for other class versions
+			 * since it may be corrupt. */
+			if ((59 == _classFile->majorVersion) && (0 < _classFile->minorVersion)) {
+				_isSealed = true;
+				_permittedSubclassesAttribute = (J9CfrAttributePermittedSubclasses *)attrib;
+				for (U_16 numberOfClasses = 0; numberOfClasses < _permittedSubclassesAttribute->numberOfClasses; numberOfClasses++) {
+					U_16 classCpIndex = _permittedSubclassesAttribute->classes[numberOfClasses];
+					markClassAsReferenced(classCpIndex);
+				}
 			}
 			break;
 		}

--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1560,3 +1560,10 @@ J9NLS_CFR_ERR_PERMITTEDSUBCLASSES_CLASS_ENTRY_NOT_CLASS_TYPE.explanation=Please 
 J9NLS_CFR_ERR_PERMITTEDSUBCLASSES_CLASS_ENTRY_NOT_CLASS_TYPE.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
 J9NLS_CFR_ERR_PERMITTEDSUBCLASSES_CLASS_ENTRY_NOT_CLASS_TYPE.user_response=Contact the provider of the classfile for a corrected version.
 # END NON-TRANSLATABLE
+
+J9NLS_CFR_ERR_SEALED_CLASS_HAS_INVALID_NUMBER_SUBCLASSES=Sealed classes must have at least one permitted subclass
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_SEALED_CLASS_HAS_INVALID_NUMBER_SUBCLASSES.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_SEALED_CLASS_HAS_INVALID_NUMBER_SUBCLASSES.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_SEALED_CLASS_HAS_INVALID_NUMBER_SUBCLASSES.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE


### PR DESCRIPTION
- ClassFormatException should be thrown if SealedClass has 0 permitted subclasses
- PermittedSubclass verification error should not be thrown for class versions other than 59.65536

port from: https://github.com/eclipse/openj9/pull/10475

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>