### PR TITLE
Export JVM_IsUseContainerSupport for all Java versions

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -289,6 +289,7 @@ jvm_add_exports(jvm
 	_JVM_GetFieldTypeAnnotations@8
 	_JVM_GetMethodParameters@8
 	_JVM_GetMethodTypeAnnotations@8
+	JVM_IsUseContainerSupport
 	_JVM_IsVMGeneratedMethodIx@12
 	JVM_GetTemporaryDirectory
 	_JVM_CopySwapMemory@44
@@ -341,7 +342,6 @@ else()
 		JVM_AreNestMates
 		JVM_InitClassName
 		JVM_InitializeFromArchive
-		JVM_IsUseContainerSupport
 	)
 endif()
 

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -290,6 +290,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="_JVM_GetFieldTypeAnnotations@8"/>
 		<export name="_JVM_GetMethodParameters@8"/>
 		<export name="_JVM_GetMethodTypeAnnotations@8"/>
+		<export name="JVM_IsUseContainerSupport"/>
 		<export name="_JVM_IsVMGeneratedMethodIx@12"/>
 		<export name="JVM_GetTemporaryDirectory"/>
 		<export name="_JVM_CopySwapMemory@44"/>
@@ -337,7 +338,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="JVM_AreNestMates"/>
 		<export name="JVM_InitClassName"/>
 		<export name="JVM_InitializeFromArchive"/>
-		<export name="JVM_IsUseContainerSupport"/>
 	</exports>
 
 	<exports group="jdk14">

--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -1785,7 +1785,6 @@ JVM_IsCDSSharingEnabled(JNIEnv *env)
 }
 #endif /* JAVA_SPEC_VERSION >= 15 */
 
-#if JAVA_SPEC_VERSION >= 11
 JNIEXPORT jboolean JNICALL
 JVM_IsUseContainerSupport(JNIEnv *env)
 {
@@ -1795,4 +1794,3 @@ JVM_IsUseContainerSupport(JNIEnv *env)
 
 	return inContainer ? JNI_TRUE : JNI_FALSE;
 }
-#endif /* JAVA_SPEC_VERSION >= 11 */

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -332,5 +332,4 @@ _IF([JAVA_SPEC_VERSION >= 15],
 	[_X(JVM_IsCDSDumpingEnabled, JNICALL, false, jboolean, JNIEnv *env)])
 _IF([JAVA_SPEC_VERSION >= 15],
 	[_X(JVM_IsCDSSharingEnabled, JNICALL, false, jboolean, JNIEnv *env)])
-_IF([JAVA_SPEC_VERSION >= 11],
-	[_X(JVM_IsUseContainerSupport, JNICALL, false, jboolean, JNIEnv *env)])
+_X(JVM_IsUseContainerSupport, JNICALL, false, jboolean, JNIEnv *env)


### PR DESCRIPTION
Support for detecting containers on Linux was back-ported to jdk8:
* 8250627: Use -XX:+/-UseContainerSupport for enabling/disabling Java container metrics

See failure in the [acceptance build](https://ci.eclipse.org/openj9/job/Build_JDK8_x86-64_linux_OpenJDK8/57/):
```
22:49:03  /home/jenkins/workspace/Build_JDK8_x86-64_linux_OpenJDK8/jdk/src/linux/native/jdk/internal/platform/cgroupv1/Metrics.c:34: undefined reference to `JVM_IsUseContainerSupport'
22:49:03  collect2: error: ld returned 1 exit status
22:49:03  lib/CoreLibraries.gmk:213: recipe for target '/home/jenkins/workspace/Build_JDK8_x86-64_linux_OpenJDK8/build/linux-x86_64-normal-server-release/jdk/lib/amd64/libjava.so' failed
```