### PR TITLE
CMake: use clang to build the interpreter on windows

### DIFF
--- a/runtime/cmake/modules/CMakeDetermineJ9VM_CXXCompiler.cmake
+++ b/runtime/cmake/modules/CMakeDetermineJ9VM_CXXCompiler.cmake
@@ -20,23 +20,11 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-list(APPEND OMR_PLATFORM_DEFINITIONS
-	-D_CRT_NONSTDC_NO_WARNINGS
-)
+set(CMAKE_J9VM_CXX_COMPILER_LIST clang)
+set(CMAKE_J9VM_CXX_COMPILER_ENV_VAR J9CXX)
+find_program(CMAKE_J9VM_CXX_COMPILER "clang")
 
-# Remove some default flags cmake gives us
-set(flags_to_remove /O2 /Ob1 /DNDEBUG)
-omr_remove_flags(CMAKE_C_FLAGS ${flags_to_remove})
-omr_remove_flags(CMAKE_CXX_FLAGS ${flags_to_remove})
-foreach(build_type IN ITEMS ${CMAKE_CONFIGURATION_TYPES} ${CMAKE_BUILD_TYPE})
-	string(TOUPPER ${build_type} build_type)
-	omr_remove_flags(CMAKE_C_FLAGS_${build_type} ${flags_to_remove})
-	omr_remove_flags(CMAKE_CXX_FLAGS_${build_type} ${flags_to_remove})
-endforeach()
+configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeJ9VM_CXXCompiler.cmake.in
+	${CMAKE_PLATFORM_INFO_DIR}/CMakeJ9VM_CXXCompiler.cmake @ONLY)
 
-# /Ox = enable most speed optimizations
-# /Zi = produce separate pdb files
-list(APPEND OMR_PLATFORM_COMPILE_OPTIONS  /Ox /Zi)
-
-list(APPEND OMR_PLATFORM_EXE_LINKER_OPTIONS /debug /opt:icf /opt:ref)
-list(APPEND OMR_PLATFORM_SHARED_LINKER_OPTIONS /debug /opt:icf /opt:ref)
+include("${CMAKE_CURRENT_LIST_DIR}/CMakeJ9VM_CXXInformation.cmake")

--- a/runtime/cmake/modules/CMakeJ9VM_CXXCompiler.cmake.in
+++ b/runtime/cmake/modules/CMakeJ9VM_CXXCompiler.cmake.in
@@ -20,23 +20,13 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-list(APPEND OMR_PLATFORM_DEFINITIONS
-	-D_CRT_NONSTDC_NO_WARNINGS
-)
+set(CMAKE_J9VM_CXX_COMPILER "@CMAKE_J9VM_CXX_COMPILER@")
+set(CMAKE_J9VM_CXX_COMPILER_ARG1 "@_CMAKE_J9VM_CXX_COMPILER_ARG1@")
+set(CMAKE_AR "@CMAKE_AR@")
+set(CMAKE_RANLIB "@CMAKE_RANLIB@")
+set(CMAKE_LINKER "@CMAKE_LINKER@")
+set(CMAKE_J9VM_CXX_COMPILER_LOADED 1)
+set(CMAKE_J9VM_CXX_COMPILER_ID gcc)
 
-# Remove some default flags cmake gives us
-set(flags_to_remove /O2 /Ob1 /DNDEBUG)
-omr_remove_flags(CMAKE_C_FLAGS ${flags_to_remove})
-omr_remove_flags(CMAKE_CXX_FLAGS ${flags_to_remove})
-foreach(build_type IN ITEMS ${CMAKE_CONFIGURATION_TYPES} ${CMAKE_BUILD_TYPE})
-	string(TOUPPER ${build_type} build_type)
-	omr_remove_flags(CMAKE_C_FLAGS_${build_type} ${flags_to_remove})
-	omr_remove_flags(CMAKE_CXX_FLAGS_${build_type} ${flags_to_remove})
-endforeach()
-
-# /Ox = enable most speed optimizations
-# /Zi = produce separate pdb files
-list(APPEND OMR_PLATFORM_COMPILE_OPTIONS  /Ox /Zi)
-
-list(APPEND OMR_PLATFORM_EXE_LINKER_OPTIONS /debug /opt:icf /opt:ref)
-list(APPEND OMR_PLATFORM_SHARED_LINKER_OPTIONS /debug /opt:icf /opt:ref)
+set(CMAKE_J9VM_CXX_IGNORE_EXTENSIONS h;H;o;O;obj;OBJ;def;DEF;rc;RC)
+set(CMAKE_J9VM_CXX_LINKER_PREFERENCE 0)

--- a/runtime/cmake/modules/CMakeJ9VM_CXXInformation.cmake
+++ b/runtime/cmake/modules/CMakeJ9VM_CXXInformation.cmake
@@ -20,23 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-list(APPEND OMR_PLATFORM_DEFINITIONS
-	-D_CRT_NONSTDC_NO_WARNINGS
-)
-
-# Remove some default flags cmake gives us
-set(flags_to_remove /O2 /Ob1 /DNDEBUG)
-omr_remove_flags(CMAKE_C_FLAGS ${flags_to_remove})
-omr_remove_flags(CMAKE_CXX_FLAGS ${flags_to_remove})
-foreach(build_type IN ITEMS ${CMAKE_CONFIGURATION_TYPES} ${CMAKE_BUILD_TYPE})
-	string(TOUPPER ${build_type} build_type)
-	omr_remove_flags(CMAKE_C_FLAGS_${build_type} ${flags_to_remove})
-	omr_remove_flags(CMAKE_CXX_FLAGS_${build_type} ${flags_to_remove})
-endforeach()
-
-# /Ox = enable most speed optimizations
-# /Zi = produce separate pdb files
-list(APPEND OMR_PLATFORM_COMPILE_OPTIONS  /Ox /Zi)
-
-list(APPEND OMR_PLATFORM_EXE_LINKER_OPTIONS /debug /opt:icf /opt:ref)
-list(APPEND OMR_PLATFORM_SHARED_LINKER_OPTIONS /debug /opt:icf /opt:ref)
+set(CMAKE_J9VM_CXX_DEFINE_FLAG -D)
+set(CMAKE_INCLUDE_FLAG_J9VM_CXX -I)
+set(CMAKE_J9VM_CXX_OUTPUT_EXTENSION .o)
+set(CMAKE_J9VM_CXX_COMPILE_OBJECT "<CMAKE_J9VM_CXX_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT>  -c <SOURCE>")

--- a/runtime/cmake/modules/CMakeTestJ9VM_CXXCompiler.cmake
+++ b/runtime/cmake/modules/CMakeTestJ9VM_CXXCompiler.cmake
@@ -20,23 +20,4 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-list(APPEND OMR_PLATFORM_DEFINITIONS
-	-D_CRT_NONSTDC_NO_WARNINGS
-)
-
-# Remove some default flags cmake gives us
-set(flags_to_remove /O2 /Ob1 /DNDEBUG)
-omr_remove_flags(CMAKE_C_FLAGS ${flags_to_remove})
-omr_remove_flags(CMAKE_CXX_FLAGS ${flags_to_remove})
-foreach(build_type IN ITEMS ${CMAKE_CONFIGURATION_TYPES} ${CMAKE_BUILD_TYPE})
-	string(TOUPPER ${build_type} build_type)
-	omr_remove_flags(CMAKE_C_FLAGS_${build_type} ${flags_to_remove})
-	omr_remove_flags(CMAKE_CXX_FLAGS_${build_type} ${flags_to_remove})
-endforeach()
-
-# /Ox = enable most speed optimizations
-# /Zi = produce separate pdb files
-list(APPEND OMR_PLATFORM_COMPILE_OPTIONS  /Ox /Zi)
-
-list(APPEND OMR_PLATFORM_EXE_LINKER_OPTIONS /debug /opt:icf /opt:ref)
-list(APPEND OMR_PLATFORM_SHARED_LINKER_OPTIONS /debug /opt:icf /opt:ref)
+set(CMAKE_J9VM_CXX_COMPILER_WORKS 1 CACHE INTERNAL "")

--- a/runtime/cmake/platform/os/win.cmake
+++ b/runtime/cmake/platform/os/win.cmake
@@ -32,3 +32,17 @@ if(OMR_ENV_DATA64)
         -D_WIN64
     )
 endif()
+
+# Set flags we use to build the interpreter
+omr_stringify(CMAKE_J9VM_CXX_FLAGS
+    -O3
+    -fno-rtti
+    -fno-threadsafe-statics
+    -fno-strict-aliasing
+    -fno-exceptions
+    -fno-asynchronous-unwind-tables
+    -std=c++0x
+    -D_CRT_SUPPRESS_RESTRICT
+    -DVS12AndHigher
+    ${OMR_PLATFORM_DEFINITIONS}
+)

--- a/runtime/vm/CMakeLists.txt
+++ b/runtime/vm/CMakeLists.txt
@@ -22,6 +22,17 @@
 
 omr_add_tracegen(j9vm.tdf)
 
+if(OMR_TOOLCONFIG STREQUAL "msvc")
+	# bypass omr provided warning flag handling, because we don't want
+	# the warning flags to get passed to clang.
+	# Note: the updated variables are scoped to this directory
+	set(OMR_ENHANCED_WARNINGS OFF)
+	set(OMR_WARNINGS_AS_ERRORS OFF)
+	set(OMR_BASE_WARNING_FLAGS)
+	omr_append_flags(CMAKE_C_FLAGS ${OMR_ENHANCED_WARNING_FLAG} ${OMR_WARNING_AS_ERROR_FLAG})
+	omr_append_flags(CMAKE_CXX_FLAGS ${OMR_ENHANCED_WARNING_FLAG} ${OMR_WARNING_AS_ERROR_FLAG})
+endif()
+
 set(interp_flags_to_remove) # list of flags removed when compiling the interpreter
 set(interp_new_flags) # flags to be added when compiling the interpreter
 
@@ -41,7 +52,6 @@ if(OMR_ARCH_POWER AND OMR_OS_AIX)
 		endif()
 		]]
 	endif()
-
 endif()
 
 if(interp_flags_to_remove)
@@ -198,14 +208,22 @@ if(interp_new_flags)
 endif()
 
 
-# JIT helper methods require us to disable buffer security checks on Windows
-# See https://github.com/eclipse/openj9/pull/1494 for rationale
 if(OMR_OS_WINDOWS AND (OMR_TOOLCONFIG STREQUAL "msvc"))
+	# JIT helper methods require us to disable buffer security checks on Windows
+	# See https://github.com/eclipse/openj9/pull/1494 for rationale
 	set_property(
 		SOURCE
 			cnathelp.cpp
 			SharedService.c
 		APPEND PROPERTY COMPILE_FLAGS "/GS-"
+	)
+
+	# Use J9VM_CXX compiler (aka clang) to build the interpreter
+	enable_language(J9VM_CXX)
+	set_source_files_properties(
+		${interpreter_sources}
+		PROPERTIES
+		LANGUAGE J9VM_CXX
 	)
 endif()
 


### PR DESCRIPTION
- Add a new language in cmake (J9VM_CXX) which uses clang to compile
- Mark interpreter sources as J9VM_CXX files

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>