### PR TITLE
Add impl in playlist.xml for openj9/ibm tests

### DIFF
--- a/test/functional/cmdLineTests/bootstrapMethodArgumentTest/playlist.xml
+++ b/test/functional/cmdLineTests/bootstrapMethodArgumentTest/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2019, 2019 IBM Corp. and others
+  Copyright (c) 2019, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,6 +41,10 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
 		<subsets>
 			<subset>11</subset>
 		</subsets>

--- a/test/functional/cmdLineTests/proxyFieldAccess/playlist.xml
+++ b/test/functional/cmdLineTests/proxyFieldAccess/playlist.xml
@@ -36,6 +36,10 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
 		<subsets>
 			<subset>8</subset>
 		</subsets>
@@ -53,6 +57,10 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
 		<subsets>
 			<subset>11+</subset>
 		</subsets>


### PR DESCRIPTION
cmdLineTester_bootstrapMethodArgumentTest and cmdLineTester_ProxyFieldAccess are openj9/ibm specific tests. Add impl in playlist.xml

[ci skip]
Signed-off-by: lanxia <lan_xia@ca.ibm.com>