### PR TITLE
CompactOnIdle disabled

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1931,15 +1931,12 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 					vm->vmRuntimeStateListener.idleTuningFlags |= (UDATA)J9_IDLE_TUNING_GC_ON_IDLE;
 					/*
  					 * 
-				  	 * CompactOnIdle is enabled only if XX:+IdleTuningGcOnIdle is set and:
-				  	 * 1. -XX:+IdleTuningCompactOnIdle is set, or
-				  	 * 2. running in container
+				  	 * CompactOnIdle is enabled only if XX:+IdleTuningGcOnIdle is set and
+				  	 * -XX:+IdleTuningCompactOnIdle is set
 				  	 *
 				  	 * Setting Xtune:virtualized on java versions 9 or above does not enable CompactOnIdle.
 				  	 */
-					if ((argIndexCompactOnIdleEnable > argIndexCompactOnIdleDisable)
-					|| ((-1 == argIndexCompactOnIdleDisable) && inContainer)
-					) {
+					if (argIndexCompactOnIdleEnable > argIndexCompactOnIdleDisable) {
 						vm->vmRuntimeStateListener.idleTuningFlags |= (UDATA)J9_IDLE_TUNING_COMPACT_ON_IDLE;
 					} else {
 						vm->vmRuntimeStateListener.idleTuningFlags &= ~(UDATA)J9_IDLE_TUNING_COMPACT_ON_IDLE;


### PR DESCRIPTION
CompactOnIdle is disabled by default, regardless if running in Container
or not.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>