### PR TITLE
Maintain CH table per JITServer client

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -293,6 +293,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/env/J9JitMemory.cpp \
     compiler/env/J9KnownObjectTable.cpp \
     compiler/env/J9ObjectModel.cpp \
+    compiler/env/J9PersistentInfo.cpp \
     compiler/env/J9SegmentAllocator.cpp \
     compiler/env/J9SegmentCache.cpp \
     compiler/env/J9SegmentProvider.cpp \

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -476,7 +476,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
             clientSession->processUnloadedClasses(unloadedClasses, false);
             }
 
-         auto chTable = (JITServerPersistentCHTable*)compInfo->getPersistentInfo()->getPersistentCHTable();
+         auto chTable = static_cast<JITServerPersistentCHTable *>(compInfo->getPersistentInfo()->getPersistentCHTable());
          // Need CHTable mutex
          TR_ASSERT_FATAL(!chTable->isInitialized(), "CHTable must be empty for clientUID=%llu", (unsigned long long)clientId);
          if (TR::Options::getVerboseOption(TR_VerboseJITServer))

--- a/runtime/compiler/env/CMakeLists.txt
+++ b/runtime/compiler/env/CMakeLists.txt
@@ -44,6 +44,7 @@ j9jit_files(
 	env/J9KnownObjectTable.cpp
 	env/j9method.cpp
 	env/J9ObjectModel.cpp
+	env/J9PersistentInfo.cpp
 	env/J9SegmentAllocator.cpp
 	env/J9SegmentCache.cpp
 	env/J9SegmentProvider.cpp

--- a/runtime/compiler/env/J9PersistentInfo.cpp
+++ b/runtime/compiler/env/J9PersistentInfo.cpp
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#include "j9cfg.h" // for J9VM_OPT_JITSERVER
+#include "env/PersistentInfo.hpp"
+#if defined(J9VM_OPT_JITSERVER)
+#include "control/CompilationThread.hpp"
+#include "runtime/JITClientSession.hpp"
+#endif
+
+TR_PersistentCHTable *
+J9::PersistentInfo::getPersistentCHTable()
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (getRemoteCompilationMode() == JITServer::SERVER)
+      {
+      // Get per-client CH table
+      auto clientSession = TR::compInfoPT->getClientData();
+      return clientSession->getCHTable();
+      }
+#endif
+   return _persistentCHTable;
+   }
+
+void
+J9::PersistentInfo::setPersistentCHTable(TR_PersistentCHTable *table)
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   TR_ASSERT_FATAL(getRemoteCompilationMode() != JITServer::SERVER, "server-side CH table must be set per-client in ClientSessionData");
+#endif
+   _persistentCHTable = table;
+   }

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -246,8 +246,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    void setInvokeExactJ2IThunkTable(TR_J2IThunkTable *table){ _invokeExactJ2IThunkTable = table; }
 
 
-   TR_PersistentCHTable * getPersistentCHTable() { return _persistentCHTable; }
-   void setPersistentCHTable(TR_PersistentCHTable *table) { _persistentCHTable = table; }
+   TR_PersistentCHTable * getPersistentCHTable();
+   void setPersistentCHTable(TR_PersistentCHTable *table);
 
    TR_RuntimeAssumptionTable *getRuntimeAssumptionTable() { return &_runtimeAssumptionTable; }
 

--- a/runtime/compiler/env/JITServerPersistentCHTable.hpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.hpp
@@ -56,14 +56,17 @@ public:
    TR_ALLOC(TR_Memory::PersistentCHTable)
 
    JITServerPersistentCHTable(TR_PersistentMemory *);
+   ~JITServerPersistentCHTable();
 
-   bool isInitialized() { return !getData().empty(); } // needs CHTable mutex in hand
+   bool isInitialized() { return !_classMap.empty(); } // needs CHTable monitor in hand
    bool initializeCHTable(TR_J9VMBase *fej9, const std::string &rawData);
    void doUpdate(TR_J9VMBase *fej9, const std::string &removeStr, const std::string &modifyStr);
 
    virtual TR_PersistentClassInfo * findClassInfo(TR_OpaqueClassBlock * classId) override;
    virtual TR_PersistentClassInfo * findClassInfoAfterLocking(TR_OpaqueClassBlock * classId, TR::Compilation *, bool returnClassInfoForAOT = false) override;
    virtual TR_PersistentClassInfo * findClassInfoAfterLocking(TR_OpaqueClassBlock * classId, TR_FrontEnd *, bool returnClassInfoForAOT = false) override;
+
+   TR::Monitor *getCHTableMonitor() { return _chTableMonitor; }
 
 #ifdef COLLECT_CHTABLE_STATS
    // Statistical counters
@@ -79,7 +82,8 @@ private:
    void commitRemoves(const std::string &data);
    void commitModifications(const std::string &data);
 
-   PersistentUnorderedMap<TR_OpaqueClassBlock*, TR_PersistentClassInfo*> &getData();
+   PersistentUnorderedMap<TR_OpaqueClassBlock*, TR_PersistentClassInfo*> _classMap;
+   TR::Monitor *_chTableMonitor;
    };
 
 /**

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1915,6 +1915,25 @@ TR_J9ServerVM::getObjectSizeClass(uintptr_t objectSize)
    }
 
 bool
+TR_J9ServerVM::acquireClassTableMutex()
+   {
+   // Acquire per-client class table lock
+   TR::Monitor *classTableMonitor = static_cast<JITServerPersistentCHTable *>(_compInfoPT->getClientData()->getCHTable())->getCHTableMonitor();
+   TR_ASSERT_FATAL(classTableMonitor, "CH table and its monitor must be initialized");
+   classTableMonitor->enter();
+   return true;
+   }
+
+void
+TR_J9ServerVM::releaseClassTableMutex(bool releaseVMAccess)
+   {
+   // Release per-cient class table lock
+   TR::Monitor *classTableMonitor = static_cast<JITServerPersistentCHTable *>(_compInfoPT->getClientData()->getCHTable())->getCHTableMonitor();
+   TR_ASSERT_FATAL(classTableMonitor, "CH table and its monitor must be initialized");
+   classTableMonitor->exit();
+   }
+
+bool
 TR_J9SharedCacheServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT)
    {
    TR_ASSERT(vettedForAOT, "The TR_J9SharedCacheServerVM version of this method is expected to be called only from isClassLibraryMethod.\n"

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -191,6 +191,9 @@ public:
    virtual uintptr_t getCellSizeForSizeClass(uintptr_t) override;
    virtual uintptr_t getObjectSizeClass(uintptr_t) override;
 
+   virtual bool acquireClassTableMutex() override;
+   virtual void releaseClassTableMutex(bool) override;
+
    bool getCachedField(J9Class *ramClass, int32_t cpIndex, J9Class **declaringClass, UDATA *field);
    void cacheField(J9Class *ramClass, int32_t cpIndex, J9Class *declaringClass, UDATA field);
 

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -28,11 +28,12 @@
 #include "env/ut_j9jit.h"
 #include "net/ServerStream.hpp" // for JITServer::ServerStream
 #include "runtime/RuntimeAssumptions.hpp" // for TR_AddressSet
+#include "env/JITServerPersistentCHTable.hpp"
 
 
 ClientSessionData::ClientSessionData(uint64_t clientUID, uint32_t seqNo) : 
    _clientUID(clientUID), _expectedSeqNo(seqNo), _maxReceivedSeqNo(seqNo), _OOSequenceEntryList(NULL),
-   _chTableClassMap(decltype(_chTableClassMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _chTable(NULL),
    _romClassMap(decltype(_romClassMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _J9MethodMap(decltype(_J9MethodMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _classBySignatureMap(decltype(_classBySignatureMap)::allocator_type(TR::Compiler->persistentAllocator())),
@@ -501,17 +502,17 @@ ClientSessionData::clearCaches()
 
    _classChainDataMap.clear();
 
-   // Free CHTable 
-   for (auto& it : _chTableClassMap)
-      {
-      TR_PersistentClassInfo *classInfo = it.second;
-      classInfo->removeSubClasses();
-      jitPersistentFree(classInfo);
-      }
-   _chTableClassMap.clear();
    _registeredJ2IThunksMap.clear();
    _registeredInvokeExactJ2IThunksSet.clear();
    _bClassUnloadingAttempt = false;
+
+   if (_chTable)
+      {
+      // Free CH table
+      _chTable->~JITServerPersistentCHTable();
+      jitPersistentFree(_chTable);
+      _chTable = NULL;
+      }
    }
 
 void
@@ -534,6 +535,16 @@ ClientSessionData::notifyAndDetachFirstWaitingThread()
       _OOSequenceEntryList = entry->_next;
       }
    return entry;
+   }
+
+TR_PersistentCHTable *
+ClientSessionData::getCHTable()
+   {
+   if (!_chTable)
+      {
+      _chTable = new (PERSISTENT_NEW) JITServerPersistentCHTable(trPersistentMemory);
+      }
+   return _chTable;
    }
 
 char *

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -38,6 +38,8 @@ class J9ConstantPool;
 class TR_IPBytecodeHashTableEntry;
 class TR_MethodToBeCompiled;
 class TR_AddressRange;
+class TR_PersistentCHTable;
+class JITServerPersistentCHTable;
 namespace JITServer { class ServerStream; }
 
 
@@ -354,7 +356,7 @@ class ClientSessionData
 
    void setJavaLangClassPtr(TR_OpaqueClassBlock* j9clazz) { _javaLangClassPtr = j9clazz; }
    TR_OpaqueClassBlock * getJavaLangClassPtr() const { return _javaLangClassPtr; }
-   PersistentUnorderedMap<TR_OpaqueClassBlock*, TR_PersistentClassInfo*> & getCHTableClassMap() { return _chTableClassMap; }
+   TR_PersistentCHTable *getCHTable();
    PersistentUnorderedMap<J9Class*, ClassInfo> & getROMClassMap() { return _romClassMap; }
    PersistentUnorderedMap<J9Method*, J9MethodInfo> & getJ9MethodMap() { return _J9MethodMap; }
    PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> & getClassBySignatureMap() { return _classBySignatureMap; }
@@ -436,8 +438,8 @@ class ClientSessionData
    const uint64_t _clientUID;
    int64_t  _timeOfLastAccess; // in ms
    TR_OpaqueClassBlock *_javaLangClassPtr; // NULL means not set
-   // Server side cache of CHTable
-   PersistentUnorderedMap<TR_OpaqueClassBlock*, TR_PersistentClassInfo*> _chTableClassMap;
+   // Server side CHTable
+   JITServerPersistentCHTable *_chTable;
    // Server side cache of j9classes and their properties; romClass is copied so it can be accessed by the server
    PersistentUnorderedMap<J9Class*, ClassInfo> _romClassMap;
    // Hashtable for information related to one J9Method


### PR DESCRIPTION
Before this commit, server had one global CH table access
to which was controlled by one global lock.
This is not ideal when multiple clients connect to the server
because it leads to scalability issues due to lock contention
and also one client might retrieve data that belongs to another client.

This commit replaces the global CH table with one created per client.
Lock contention is also removed as we now have one lock per client as
well.
