### PR TITLE
AArch64: Use a method to kill temporary registers in register dependencies

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64JNILinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64JNILinkage.cpp
@@ -946,5 +946,7 @@ TR::Register *J9::ARM64::JNILinkage::buildDirectDispatch(TR::Node *callNode)
    generateLabelInstruction(cg(), TR::InstOpCode::label, callNode, depLabel, postLabelDeps);
 
    callNode->setRegister(returnRegister);
+
+   deps->stopUsingDepRegs(cg(), returnRegister);
    return returnRegister;
    }

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -1242,6 +1242,8 @@ TR::Register *J9::ARM64::PrivateLinkage::buildDirectDispatch(TR::Node *callNode)
       }
 
    callNode->setRegister(retReg);
+
+   dependencies->stopUsingDepRegs(cg(), retReg);
    return retReg;
    }
 
@@ -1439,6 +1441,8 @@ TR::Register *J9::ARM64::PrivateLinkage::buildIndirectDispatch(TR::Node *callNod
       }
 
    callNode->setRegister(retReg);
+
+   dependencies->stopUsingDepRegs(cg(), retReg);
    return retReg;
    }
 


### PR DESCRIPTION
This commit changes JNI Linkage and Private Linkage classes to use
`stopUsingDepRegs` helper method to properly kill temporary registers
added to register dependencies.

Depends on https://github.com/eclipse/omr/pull/5521

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>