### PR TITLE
Fix max stack calculation in VT generator

### DIFF
--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -441,8 +441,11 @@ public class ValueTypeGenerator extends ClassLoader {
 		}
 		mv.visitMethodInsn(INVOKESTATIC, className, specificMethodName, "(" + makeValueSig + ")" + getSigFromSimpleName(className, isRef), false);
 		mv.visitInsn(ARETURN);
-
-		mv.visitMaxs(makeMaxLocal, makeMaxLocal);
+		int maxStack = makeMaxLocal;
+		if (0 == maxStack) {
+			maxStack += 1;
+		}
+		mv.visitMaxs(maxStack, makeMaxLocal);
 		mv.visitEnd();
 	}
 	


### PR DESCRIPTION
Fix max stack calculation in VT generator

Currently, instance fields are used to determine the amount of stack
space that will be used when creating a VT in the generic path. If the
VT doesn't have any instance fields then maxStack is set to zero which
is wrong. This PR ensures that maxStack is at least 1 in the generic
path.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>