### PR TITLE
Add Portable AOT Support on Z

### DIFF
--- a/runtime/compiler/z/env/J9CPU.cpp
+++ b/runtime/compiler/z/env/J9CPU.cpp
@@ -44,11 +44,89 @@
 
 extern J9JITConfig * jitConfig;
 
+
+TR::CPU
+J9::Z::CPU::detectRelocatable(OMRPortLibrary * const omrPortLib)
+   {
+   if (omrPortLib == NULL)
+      return TR::CPU();
+
+   TR::CPU host = TR::CPU::detect(omrPortLib);
+   OMRProcessorDesc portableProcessorDescription = host.getProcessorDescription();
+   if (portableProcessorDescription.processor > OMR_PROCESSOR_S390_Z10)
+      { 
+      portableProcessorDescription.processor = OMR_PROCESSOR_S390_Z10;
+      portableProcessorDescription.physicalProcessor = OMR_PROCESSOR_S390_Z10;
+      TR::CPU::adjustProcessorFeatures(portableProcessorDescription);
+      }
+   return TR::CPU(portableProcessorDescription);
+   }
+
+void
+J9::Z::CPU::adjustProcessorFeatures(OMRProcessorDesc& processorDescription)
+   {
+   OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
+   if (processorDescription.processor < OMR_PROCESSOR_S390_Z10)
+      {
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_DFP, FALSE);
+      }
+
+   if (processorDescription.processor < OMR_PROCESSOR_S390_Z196)
+      {
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_HIGH_WORD, FALSE);
+      }
+
+   if (processorDescription.processor < OMR_PROCESSOR_S390_ZEC12)
+      {
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_TE, FALSE);
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_RI, FALSE);
+      }
+
+   if (processorDescription.processor < OMR_PROCESSOR_S390_Z13)
+      {
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_VECTOR_FACILITY, FALSE);
+      }
+
+   if (processorDescription.processor < OMR_PROCESSOR_S390_Z14)
+      {
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_2, FALSE);
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL, FALSE);
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_1, FALSE);
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_GUARDED_STORAGE, FALSE);
+      }
+
+   if (processorDescription.processor < OMR_PROCESSOR_S390_Z15)
+      {
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_3, FALSE);
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_2, FALSE);
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY, FALSE);
+      }
+
+   // This variable is used internally by the j9sysinfo macros below and cannot be folded away
+   J9PortLibrary* privatePortLibrary = TR::Compiler->portLib;
+
+#if defined(LINUX)
+   if (TRUE == omrsysinfo_processor_has_feature(&processorDescription, OMR_FEATURE_S390_RI))
+      {
+      if (0 != j9ri_enableRISupport())
+         {
+         omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_RI, FALSE);
+         }
+      }
+#endif
+
+   if (TRUE == omrsysinfo_processor_has_feature(&processorDescription, OMR_FEATURE_S390_GUARDED_STORAGE))
+      {
+      if (TR::Compiler->javaVM->memoryManagerFunctions->j9gc_software_read_barrier_enabled(TR::Compiler->javaVM))
+         {
+         omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_GUARDED_STORAGE, FALSE);
+         }
+      }
+   }
+
 void
 J9::Z::CPU::applyUserOptions()
    {
-   OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
-
    if (_processorDescription.processor >= OMR_PROCESSOR_S390_Z10 && TR::Options::getCmdLineOptions()->getOption(TR_DisableZ10))
       _processorDescription.processor = OMR_PROCESSOR_S390_FIRST;
    else if (_processorDescription.processor >= OMR_PROCESSOR_S390_Z196 && TR::Options::getCmdLineOptions()->getOption(TR_DisableZ196))
@@ -64,62 +142,7 @@ J9::Z::CPU::applyUserOptions()
    else if (_processorDescription.processor >= OMR_PROCESSOR_S390_ZNEXT && TR::Options::getCmdLineOptions()->getOption(TR_DisableZNext))
       _processorDescription.processor = OMR_PROCESSOR_S390_Z15;
 
-   if (_processorDescription.processor < OMR_PROCESSOR_S390_Z10)
-      {
-      omrsysinfo_processor_set_feature(&_processorDescription, OMR_FEATURE_S390_DFP, FALSE);
-      }
-
-   if (_processorDescription.processor < OMR_PROCESSOR_S390_Z196)
-      {
-      omrsysinfo_processor_set_feature(&_processorDescription, OMR_FEATURE_S390_HIGH_WORD, FALSE);
-      }
-
-   if (_processorDescription.processor < OMR_PROCESSOR_S390_ZEC12)
-      {
-      omrsysinfo_processor_set_feature(&_processorDescription, OMR_FEATURE_S390_TE, FALSE);
-      omrsysinfo_processor_set_feature(&_processorDescription, OMR_FEATURE_S390_RI, FALSE);
-      }
-
-   if (_processorDescription.processor < OMR_PROCESSOR_S390_Z13)
-      {
-      omrsysinfo_processor_set_feature(&_processorDescription, OMR_FEATURE_S390_VECTOR_FACILITY, FALSE);
-      }
-
-   if (_processorDescription.processor < OMR_PROCESSOR_S390_Z14)
-      {
-      omrsysinfo_processor_set_feature(&_processorDescription, OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_2, FALSE);
-      omrsysinfo_processor_set_feature(&_processorDescription, OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL, FALSE);
-      omrsysinfo_processor_set_feature(&_processorDescription, OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_1, FALSE);
-      omrsysinfo_processor_set_feature(&_processorDescription, OMR_FEATURE_S390_GUARDED_STORAGE, FALSE);
-      }
-
-   if (_processorDescription.processor < OMR_PROCESSOR_S390_Z15)
-      {
-      omrsysinfo_processor_set_feature(&_processorDescription, OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_3, FALSE);
-      omrsysinfo_processor_set_feature(&_processorDescription, OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_2, FALSE);
-      omrsysinfo_processor_set_feature(&_processorDescription, OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY, FALSE);
-      }
-
-   // This variable is used internally by the j9sysinfo macros below and cannot be folded away
-   J9PortLibrary* privatePortLibrary = TR::Compiler->portLib;
-
-#if defined(LINUX)
-   if (TRUE == omrsysinfo_processor_has_feature(&_processorDescription, OMR_FEATURE_S390_RI))
-      {
-      if (0 != j9ri_enableRISupport())
-         {
-         omrsysinfo_processor_set_feature(&_processorDescription, OMR_FEATURE_S390_RI, FALSE);
-         }
-      }
-#endif
-
-   if (TRUE == omrsysinfo_processor_has_feature(&_processorDescription, OMR_FEATURE_S390_GUARDED_STORAGE))
-      {
-      if (TR::Compiler->javaVM->memoryManagerFunctions->j9gc_software_read_barrier_enabled(TR::Compiler->javaVM))
-         {
-         omrsysinfo_processor_set_feature(&_processorDescription, OMR_FEATURE_S390_GUARDED_STORAGE, FALSE);
-         }
-      }
+   TR::CPU::adjustProcessorFeatures(_processorDescription);
    }
 
 bool

--- a/runtime/compiler/z/env/J9CPU.hpp
+++ b/runtime/compiler/z/env/J9CPU.hpp
@@ -53,10 +53,20 @@ protected:
    CPU(const OMRProcessorDesc& processorDescription) : J9::CPU(processorDescription) {}
 
 public:
+   /**
+    * @brief Returns the processor type and features that will be used by portable AOT compilations
+    * @param[in] omrPortLib : the port library
+    * @return TR::CPU
+    */
+   static TR::CPU detectRelocatable(OMRPortLibrary * const omrPortLib);
    
    void applyUserOptions();
    bool isCompatible(const OMRProcessorDesc& processorDescription);
    OMRProcessorDesc getProcessorDescription();
+
+private:
+
+   static void adjustProcessorFeatures(OMRProcessorDesc& processorDescription);
    };
 
 }

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -2927,7 +2927,7 @@ gcInitializeDefaults(J9JavaVM* vm)
 
 				if (hwSupported) {
 					/* Software Barrier request overwrites HW usage on supported HW */
-					extensions->concurrentScavengerHWSupport = hwSupported && !extensions->softwareRangeCheckReadBarrier;
+					extensions->concurrentScavengerHWSupport = hwSupported && !extensions->softwareRangeCheckReadBarrier && !J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE);
 					extensions->concurrentScavenger = hwSupported || extensions->softwareRangeCheckReadBarrier;
 				} else {
 					extensions->concurrentScavengerHWSupport = false;

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1682,10 +1682,10 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				IDATA argIndex9 = 0;
 				BOOLEAN sharedClassDisabled = FALSE;
 
-#if defined(J9VM_ARCH_X86)
+#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390)
 				IDATA argIndexXXPortableSharedCache = 0;
 				IDATA argIndexXXNoPortableSharedCache = 0;
-#endif /* defined(J9VM_ARCH_X86) */
+#endif /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390) */
 
 				vm->sharedClassPreinitConfig = NULL;
 
@@ -1714,10 +1714,10 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				argIndex8 = FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, VMOPT_XSCMAXJITDATA, NULL);
 				argIndex9 = FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, VMOPT_XXSHARED_CACHE_HARD_LIMIT_EQUALS, NULL);
 
-#if defined(J9VM_ARCH_X86)
+#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390)
 				argIndexXXPortableSharedCache = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXPORTABLESHAREDCACHE, NULL);
 				argIndexXXNoPortableSharedCache = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXNOPORTABLESHAREDCACHE, NULL);
-#endif /* defined(J9VM_ARCH_X86) */
+#endif /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390) */
 
 				if (((!J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm)) && (argIndex < 0))
 					|| (TRUE == sharedClassDisabled)
@@ -1799,7 +1799,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 					vm->sharedClassPreinitConfig = piConfig;
 
 					if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_AOT)) {
-#if defined(J9VM_ARCH_X86)
+#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390)
 						if (argIndexXXPortableSharedCache > argIndexXXNoPortableSharedCache) {
 							vm->extendedRuntimeFlags2 |= J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE;
 						} else if (argIndexXXPortableSharedCache == argIndexXXNoPortableSharedCache) {
@@ -1811,7 +1811,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 								vm->extendedRuntimeFlags2 |= J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE;
 							}
 						}
-#endif /* defined(J9VM_ARCH_X86) */
+#endif /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390) */
 					}
 				}
 


### PR DESCRIPTION
- Use Z10 as the portable cpu processor
- AOT compilation will use Z10 when Portable AOT is enabled and will use host cpu when Portable AOT is not enabled
- Need to disable GS HW support for Portable AOT on Z as it is a Z14 or newer feature
- Enable Portable AOT on Z, compressed reference shift on Z will be fixed to 3 if Portable AOT is enabled
- Portable AOT is controlled by [+|-]PortableSharedCache (enabled by default in containers and disabled by default outside of containers)

Signed-off-by: Harry Yu <harryyu1994@gmail.com>