### PR TITLE
Ensure Lookup::defineClass links the class

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
@@ -1,17 +1,6 @@
 /*[INCLUDE-IF Sidecar16]*/
-package com.ibm.oti.vm;
-
-import java.util.Properties;
-
-/*[IF Sidecar19-SE]*/
-import jdk.internal.reflect.ConstantPool;
-/*[ELSE]*/
-import sun.reflect.ConstantPool;
-/*[ENDIF]*/
-
-
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corp. and others
+ * Copyright (c) 2012, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,6 +20,16 @@ import sun.reflect.ConstantPool;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+package com.ibm.oti.vm;
+
+import java.util.Properties;
+
+/*[IF Sidecar19-SE]*/
+import jdk.internal.reflect.ConstantPool;
+/*[ELSE]*/
+import sun.reflect.ConstantPool;
+/*[ENDIF]*/
 
 /**
  * Interface to allow privileged access to classes

--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
@@ -169,4 +169,12 @@ public interface VMLangAccess {
 	 * @return      A java.lang.Thread created
 	 */
 	public Thread createThread(Runnable runnable, String threadName, boolean isSystemThreadGroup, boolean inheritThreadLocals, boolean isDaemon, ClassLoader contextClassLoader);
+
+
+	/**
+	 * Prepare the passed in class
+	 *
+	 * @param theClass The class to prepare
+	 */
+	public void prepare(Class<?> theClass);
 }

--- a/jcl/src/java.base/share/classes/java/lang/VMAccess.java
+++ b/jcl/src/java.base/share/classes/java/lang/VMAccess.java
@@ -220,4 +220,9 @@ final class VMAccess implements VMLangAccess {
 	public Thread createThread(Runnable runnable, String threadName, boolean isSystemThreadGroup, boolean inheritThreadLocals, boolean isDaemon, ClassLoader contextClassLoader) {
 		return new Thread(runnable, threadName, isSystemThreadGroup, inheritThreadLocals, isDaemon, contextClassLoader);
 	}
+
+	@Override
+	public void prepare(Class<?> theClass) {
+		J9VMInternals.prepare(theClass);
+	}
 }

--- a/jcl/src/java.base/share/classes/java/lang/VMAccess.java
+++ b/jcl/src/java.base/share/classes/java/lang/VMAccess.java
@@ -1,8 +1,6 @@
 /*[INCLUDE-IF Sidecar16]*/
-package java.lang;
-
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corp. and others
+ * Copyright (c) 2012, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +20,8 @@ package java.lang;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+package java.lang;
 
 import java.util.Objects;
 import java.util.Properties;

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2160,6 +2160,9 @@ public class MethodHandles {
 			JavaLangAccess jlAccess = SharedSecrets.getJavaLangAccess();
 			Class<?> targetClass = jlAccess.defineClass(accessClass.getClassLoader(), targetClassName, classBytes, accessClass.getProtectionDomain(), null);
 			
+			/* Class needs to be linked but without having been initialized */
+			getVMLangAccess().prepare(targetClass);
+
 			return targetClass;
 		}
 		/*[ENDIF] Sidecar19-SE-OpenJ9*/


### PR DESCRIPTION
From the VM spec:
Linking a class or interface involves verifying and preparing that class....

Calling prepare() on the class is sufficient to ensure it is
linked without calling the <clinit> method (which this method is not
supposed to do).

Fixes: #10297

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>