### PR TITLE
Enable OpenJDK VarHandles by disabling OpenJ9 VarHandles

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/ArrayVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ArrayVarHandle.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
  * Copyright (c) 2016, 2020 IBM Corp. and others
  *

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ByteArrayViewVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ByteArrayViewVarHandle.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ByteBufferViewVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ByteBufferViewVarHandle.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
  * Copyright (c) 2016, 2020 IBM Corp. and others
  *

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
  * Copyright (c) 2016, 2020 IBM Corp. and others
  *

--- a/jcl/src/java.base/share/classes/java/lang/invoke/InstanceFieldVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/InstanceFieldVarHandle.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/invoke/StaticFieldVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/StaticFieldVarHandle.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
  * Copyright (c) 2017, 2020 IBM Corp. and others
  *

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandleInternal.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandleInternal.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ViewVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ViewVarHandle.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar19-SE & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
  * Copyright (c) 2016, 2020 IBM Corp. and others
  *


### PR DESCRIPTION
This code allows OpenJDK VarHandle classes to be enabled by disabling
the corresponding OpenJ9 VarHandle classes.

Related: #7352

Co-authored-by: Jack Lu <Jack.S.Lu@ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>