### PR TITLE
Match RI naming scheme for hidden classes

### DIFF
--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -1313,7 +1313,7 @@ ROMClassBuilder::compareROMClassForEquality(U_8 *romClass,bool romClassIsShared,
 	if (isLambda) {
 		if (sizeof(U_64) < abs((int)(romSize - ((J9ROMClass *)romClass)->romSize))) {
 			/* If the class is a lambda class, we compare the romSizes first to save time. Lambda class names are in the format of
-			 * HostClassName$$Lambda$<IndexNumber>/0000000000000000. When we reach this check, the host class names will be the
+			 * HostClassName$$Lambda$<IndexNumber>/0x0000000000000000. When we reach this check, the host class names will be the
 			 * same for both the classes because of the hash key check earlier so the only difference in the size will be the
 			 * difference between the number of digits of the index number. The same lambda class might have a different index
 			 * number from run to run and when the number of digits of the index number increases by 1, romSize increases by 2.

--- a/runtime/oti/cfr.h
+++ b/runtime/oti/cfr.h
@@ -932,11 +932,11 @@ typedef struct J9CfrClassFile {
 #define CFR_J9FLAG_IS_SEALED        4
 
 #if defined(J9VM_ENV_DATA64)
-#define ROM_ADDRESS_LENGTH 16
-#define ROM_ADDRESS_FORMAT "%016X\0"
+#define ROM_ADDRESS_LENGTH 18
+#define ROM_ADDRESS_FORMAT "0x%016x\0"
 #else
-#define ROM_ADDRESS_LENGTH 8
-#define ROM_ADDRESS_FORMAT "%08X\0"
+#define ROM_ADDRESS_LENGTH 10
+#define ROM_ADDRESS_FORMAT "0x%08x\0"
 #endif
 
 #define CFR_METHOD_EXT_HAS_METHOD_TYPE_ANNOTATIONS 0x01

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -2280,7 +2280,7 @@ uint64_t
 getOpenJ9Sha();
 
 /**
- * If the class is a lambda class get the pointer to the last '$' sign of the class name which is in the format of HostClassName$$Lambda$<IndexNumber>/0000000000000000.
+ * If the class is a lambda class get the pointer to the last '$' sign of the class name which is in the format of HostClassName$$Lambda$<IndexNumber>/0x0000000000000000.
  * NULL otherwise.
  *
  * @param[in] className  pointer to the class name

--- a/runtime/util/shchelp_j9.c
+++ b/runtime/util/shchelp_j9.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2019 IBM Corp. and others
+ * Copyright (c) 2013, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -88,7 +88,7 @@ getOpenJ9Sha()
 }
 
 /**
- * If the class is a lambda class get the pointer to the last '$' sign of the class name which is in the format of HostClassName$$Lambda$<IndexNumber>/0000000000000000.
+ * If the class is a lambda class get the pointer to the last '$' sign of the class name which is in the format of HostClassName$$Lambda$<IndexNumber>/0x0000000000000000.
  * NULL otherwise.
  *
  * @param[in] className  pointer to the class name

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
@@ -80,6 +80,10 @@
 		JVMSHRC443E Cache CRC is incorrect indicating a corrupt cache. Incorrect cache CRC: 0x0.
 		JVMDUMP013I Processed dump event "corruptcache", detail "".
 		JVMSHRC442E Shared cache "jim" is corrupt. Corruption code is -1. Corrupt value is 0x0. No new JVMs will be allowed to connect to the cache.
+	
+	The tests match anon/hidden class names with 10 or 18 zeroes (0000000000|000000000000000000), the extra two zeroes are for the 0x in the
+		address. The 0x is written along with the romAddress which is done after the tracepoint that these tests rely on is called.
+	
 	-->
 		
 	<test id="Start : Cleanup: persistent" timeout="600" runPath=".">
@@ -1058,9 +1062,9 @@
 	
 	<test id="Test 57-a: Make sure that lambda classes work and get stored in the shared class cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259} $CP_HANOI$ $PROGRAM_LAMBDA$ 0</command>
-		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000) </output>
 		<output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
-		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000) </output>
     
    		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
    		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1069,8 +1073,8 @@
 
 	<test id="Test 57-b: Make sure that lambda classes are stored in the cache as orphans" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,printstats=orphan</command>
-		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) at</output>
-		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) at</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000) at</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000) at</output>
 	    
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
@@ -1080,11 +1084,11 @@
 	
 	<test id="Test 57-c: Make sure that when the program runs again lambda classes are used from the cache and not stored again" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259,j9bcu.270} $CP_HANOI$ $PROGRAM_LAMBDA$ 0</command>
-		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000)'</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000)'</output>
 		<output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
-		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000)'</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000)'</output>
 	    
-		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000) </output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1095,9 +1099,9 @@
 	<test id="Test 58: Make sure that when the program runs again without the first lambda class, the second lambda class is still used from the cache and not stored again" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259,j9bcu.270} $CP_HANOI$ $PROGRAM_LAMBDA$ 1</command>
 		<output type="success" caseSensitive="yes" regex="no">Lambda test done!</output>
-		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000)'</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000)'</output>
 	    
-		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000) </output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1120,9 +1124,9 @@
 	
 	<test id="Test 59-a: Run and store 10 lambda classes in the cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259} $CP_HANOI$ $PROGRAM_LAMBDA$ 2</command>
-		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000) </output>
 		<output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
-		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000) </output>
 	    
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
@@ -1132,11 +1136,11 @@
 	
 	<test id="Test 59-b: Do not run the first lambda class to check if a class with 1 digit index number gets matched to the one stored in the cache but with 2 digits index number (10th class in the previous run will be matched to 9th in this run)" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259,j9bcu.270} $CP_HANOI$ $PROGRAM_LAMBDA$ 3</command>
-		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000)'</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000)'</output>
 		<output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
-		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000)'</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000)'</output>
 	    
-		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000) </output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1159,10 +1163,10 @@
 	
 	<test id="Test 60-a: Make sure that lambda classes work and get stored in the cache when another function with lambda classes in another file is being called from the current file" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259} $CP_HANOI$ $PROGRAM_LAMBDA$ 4</command>
-		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000) </output>
 		<output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
-		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test2..Lambda.([\d]+)/(00000000|0000000000000000) </output>
-		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test2..Lambda.([\d]+)/(0000000000|000000000000000000) </output>
+		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000) </output>
 	    
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
@@ -1172,13 +1176,13 @@
 	
 	<test id="Test 60-b: Make sure that the classes are used from the cache when the the program is being run again" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259,j9bcu.270} $CP_HANOI$ $PROGRAM_LAMBDA$ 4</command>
-		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000)'</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000)'</output>
 		<output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
-		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test2..Lambda.([\d]+)/(00000000|0000000000000000)'</output>
-		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000)'</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test2..Lambda.([\d]+)/(0000000000|000000000000000000)'</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000)'</output>
 	    
-		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
-		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test2..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000) </output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test2..Lambda.([\d]+)/(0000000000|000000000000000000) </output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1203,7 +1207,7 @@
 		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259} -XX:-ShareAnonymousClasses $CP_HANOI$ $PROGRAM_LAMBDA$ 0</command>
 		<output type="success" caseSensitive="yes" regex="no">Lambda test done!</output>
 
-		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000) </output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1214,7 +1218,7 @@
 		<command>$JAVA_EXE$ $currentMode$,printstats=orphan</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1 at</output>
 
-		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) at</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0000000000|000000000000000000) at</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1250,7 +1254,7 @@
 	<test id="Test 62-b: Check whether they have been stored correctly" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,printstats=orphan</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/ClassTest at</output>		
-		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(00000000|0000000000000000) at</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0000000000|000000000000000000) at</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest at</output>
 	    
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
@@ -1265,10 +1269,10 @@
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Test</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Hello</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/classtests/AnonClassAndUnsafeClassTest'</output>
-		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(00000000|0000000000000000)'</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0000000000|000000000000000000)'</output>
 		
 		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/classtests/AnonClassAndUnsafeClassTest </output>
-		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(00000000|0000000000000000) </output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0000000000|000000000000000000) </output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1282,10 +1286,10 @@
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Another Test</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">World</output>		
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 0 for class name 'org/openj9/test/classtests/AnonClassAndUnsafeClassTest'</output>
-		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 0 for class name 'org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(00000000|0000000000000000)'</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 0 for class name 'org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0000000000|000000000000000000)'</output>
 
 		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/classtests/AnonClassAndUnsafeClassTest'</output>
-		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(00000000|0000000000000000)'</output>	
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0000000000|000000000000000000)'</output>	
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1321,7 +1325,7 @@
 	<test id="Test 63-b: Check whether the Anonymous Class has been stored correctly" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,printstats=orphan</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/ClassTest at</output>	
-		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(00000000|0000000000000000) at</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0000000000|000000000000000000) at</output>
 	    
 		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest at</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
@@ -1361,7 +1365,7 @@
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/ClassTest at</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest at</output>
 
-		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(00000000|0000000000000000) at</output>	    
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0000000000|000000000000000000) at</output>	    
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1398,7 +1402,7 @@
 		<command>$JAVA_EXE$ $currentMode$,printstats=orphan</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/ClassTest at</output>
 	    
-		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(00000000|0000000000000000) at</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0000000000|000000000000000000) at</output>
 		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest at</output>		
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>

--- a/test/functional/cmdLineTests/shareClassTests/URLHelperTests/URLHelperTests.xml
+++ b/test/functional/cmdLineTests/shareClassTests/URLHelperTests/URLHelperTests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2006, 2019 IBM Corp. and others
+  Copyright (c) 2006, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -108,12 +108,16 @@
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 	</test>
-	
+
+	<!--
+		The tests match anon/hidden class names with 10 or 18 zeroes (0000000000|000000000000000000), the extra two zeroes are for the 0x in the
+		address. The 0x is written along with the romAddress which is done after the tracepoint that these tests rely on is called.
+	-->
 	<test id="APITests.NullPointerAndEmptyArrayTest" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$ $BOOTCLASSPATH$ -Xtrace:print={j9jcl.162,j9jcl.163,j9jcl.486} APITests.NullPointerAndEmptyArrayTest </command>
 		<output type="success" caseSensitive="yes" regex="no">NullPointerAndEmptyArrayTest : TEST PASSED</output>
 		<output type="required" caseSensitive="yes" regex="no">Exiting because URL count is 0</output>
-		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">Entering with url (00000000|0000000000000000)</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">Entering with url (0000000000|000000000000000000)</output>
 		<output type="required" caseSensitive="yes" regex="no">Exiting with 0 as CallObjectMethod failed for URLgetPathID</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>

--- a/test/functional/cmdLineTests/shareClassTests/URLHelperTests/URLHelperTests_80.xml
+++ b/test/functional/cmdLineTests/shareClassTests/URLHelperTests/URLHelperTests_80.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -109,11 +109,15 @@
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 	</test>
 	
+	<!--
+		The tests match anon/hidden class names with 10 or 18 zeroes (0000000000|000000000000000000), the extra two zeroes are for the 0x in the
+		address. The 0x is written along with the romAddress which is done after the tracepoint that these tests rely on is called.
+	-->
 	<test id="APITests.NullPointerAndEmptyArrayTest" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$ $BOOTCLASSPATH$ -Xtrace:print={j9jcl.162,j9jcl.163,j9jcl.486} APITests.NullPointerAndEmptyArrayTest </command>
 		<output type="success" caseSensitive="yes" regex="no">NullPointerAndEmptyArrayTest : TEST PASSED</output>
 		<output type="required" caseSensitive="yes" regex="no">Exiting because URL count is 0</output>
-		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">Entering with url (00000000|0000000000000000)</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">Entering with url (0000000000|000000000000000000)</output>
 		<output type="required" caseSensitive="yes" regex="no">Exiting with 0 as CallObjectMethod failed for URLgetPathID</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>


### PR DESCRIPTION
Match RI naming scheme for hidden classes

Previously it was, Hello$$Lambda$1/00000000F0378590. Now it is
Hello$$Lambda$1/0x00000000f0378590.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>