### PR TITLE
Mark all ConstPatch entries as referenced in CP

### DIFF
--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -117,6 +117,16 @@ Java_sun_misc_Unsafe_defineAnonymousClass(JNIEnv *env, jobject receiver, jclass 
 				return NULL;
 			}
 		}
+
+		for (U_16 i = 0; i < cpPatchMap.size; i++) {
+			j9object_t item = J9JAVAARRAYOFOBJECT_LOAD(currentThread, patchArray, i);
+			if (item != NULL) {
+				/* mark the index with patch entry, this forces the CP entry to be stored in constantpool */
+				cpPatchMap.indexMap[i] = 1;
+			} else {
+				cpPatchMap.indexMap[i] = 0;
+			}
+		}
 	}
 
 	vmFuncs->internalExitVMToJNI(currentThread);


### PR DESCRIPTION
During the constantpool creation process, VM will delete constantpool
entires that are not referenced by any bytecode/cp as an optimization.

This will break the patching logic if any of the patched object is not
referenced. So we mark all entries being patched as referenced to keep
them in the RAM class constantpool.

Related: #7352 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>