### PR TITLE
ClassFileOracle changes to adopt OpenJDK MethodHandles and VarHandles

### DIFF
--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -2394,14 +2394,18 @@ ClassFileOracle::shouldConvertInvokeVirtualToMethodHandleBytecodeForMethodRef(U_
 	J9CfrConstantPoolInfo *name = &_classFile->constantPool[nas->slot1];
 	UDATA result = 0;
 
-	/* Invoking against java.lang.invoke.MethodHandle? */
+	/* Invoking against java.lang.invoke.MethodHandle. */
 	if (J9UTF8_LITERAL_EQUALS(targetClassName->bytes, targetClassName->slot1, "java/lang/invoke/MethodHandle")) {
 		if (J9UTF8_LITERAL_EQUALS(name->bytes, name->slot1, "invokeExact")) {
 			/* MethodHandle.invokeExact */
 			result = CFR_BC_invokehandle;
 		} else if (J9UTF8_LITERAL_EQUALS(name->bytes, name->slot1, "invoke")) {
 			/* MethodHandle.invoke */
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+ 			result = CFR_BC_invokehandle;
+#else /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 			result = CFR_BC_invokehandlegeneric;
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 		}
 	}
 

--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -2375,121 +2375,6 @@ ClassFileOracle::methodIsNonStaticNonAbstract(U_16 methodIndex)
 	return J9_ARE_NO_BITS_SET(_classFile->methods[methodIndex].accessFlags, (CFR_ACC_STATIC | CFR_ACC_ABSTRACT));
 }
 
-#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
-/**
- * Determine if the method name corresponds to a VarHandle method with polymorphic
- * signature.
- *
- * @param methodName the bytes of the method name
- * @param methodNameLength the length of the method name
- *
- * @return true for a VarHandle method with polymorphic signature. Otherwise,
- * return false.
- */
-bool
-ClassFileOracle::isPolymorphicVarHandleMethod(U_8 *methodName, U_32 methodNameLength)
-{
-	bool result = false;
-
-	switch (methodNameLength) {
-	case 3:
-		if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "get")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "set")) {
-			result = true;
-		}
-		break;
-	case 9:
-		if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getAndSet")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getAndAdd")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getOpaque")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "setOpaque")) {
-			result = true;
-		}
-		break;
-	case 10:
-		if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getAcquire")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "setRelease")) {
-			result = true;
-		}
-		break;
-	case 11:
-		if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getVolatile")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "setVolatile")) {
-			result = true;
-		}
-		break;
-	case 16:
-		if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getAndSetAcquire")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getAndSetRelease")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getAndAddAcquire")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getAndAddRelease")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getAndBitwiseAnd")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getAndBitwiseXor")) {
-			result = true;
-		}
-		break;
-	case 22:
-		if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getAndBitwiseOrAcquire")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getAndBitwiseOrRelease")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "weakCompareAndSetPlain")) {
-			result = true;
-		}
-		break;
-	case 23:
-		if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getAndBitwiseAndAcquire")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getAndBitwiseAndRelease")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getAndBitwiseXorAcquire")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getAndBitwiseXorRelease")) {
-			result = true;
-		}
-		break;
-	case 24:
-		if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "weakCompareAndSetAcquire")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "weakCompareAndSetRelease")) {
-			result = true;
-		}
-		break;
-	case 25:
-		if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "compareAndExchangeAcquire")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "compareAndExchangeRelease")) {
-			result = true;
-		}
-		break;
-	default:
-		if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "compareAndSet")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "getAndBitwiseOr")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "weakCompareAndSet")) {
-			result = true;
-		} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "compareAndExchange")) {
-			result = true;
-		}
-		break;
-	}
-
-	return result;
-}
-#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
-
 /**
  * Method to determine if an invokevirtual instruction should be re-written to be an
  * invokehandle or invokehandlegeneric bytecode.  Modifications as follows:
@@ -2527,7 +2412,7 @@ ClassFileOracle::shouldConvertInvokeVirtualToMethodHandleBytecodeForMethodRef(U_
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 	/* Invoking against java.lang.invoke.VarHandle. */
 	if (J9UTF8_LITERAL_EQUALS(targetClassName->bytes, targetClassName->slot1, "java/lang/invoke/VarHandle")
-		&& isPolymorphicVarHandleMethod(name->bytes, name->slot1)
+	&& VM_VMHelpers::isPolymorphicVarHandleMethod((const U_8 *)name->bytes, name->slot1)
 	) {
 		result = CFR_BC_invokehandle;
 	}

--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -35,6 +35,9 @@
 #include "bcnames.h"
 
 #include "BuildResult.hpp"
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+#include "VMHelpers.hpp"
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 /*
  * It is not guaranteed that slot1 value for constantpool index=0 entry will be zero. 
@@ -1172,10 +1175,6 @@ private:
 	static int compareLineNumbers(const void *left, const void *right);
 	void compressLineNumberTable(U_16 methodIndex, U_32 lineNumbersCount);
 	void sortAndCompressLineNumberTable(U_16 methodIndex, U_32 lineNumbersCount, U_8 *lineNumbersInfoCompressedInitial);
-
-#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
-	static VMINLINE bool isPolymorphicVarHandleMethod(U_8 *methodName, U_32 length);
-#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 };
 
 #endif /* CLASSFILEORACLE_HPP_ */

--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -1172,6 +1172,10 @@ private:
 	static int compareLineNumbers(const void *left, const void *right);
 	void compressLineNumberTable(U_16 methodIndex, U_32 lineNumbersCount);
 	void sortAndCompressLineNumberTable(U_16 methodIndex, U_32 lineNumbersCount, U_8 *lineNumbersInfoCompressedInitial);
+
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	static VMINLINE bool isPolymorphicVarHandleMethod(U_8 *methodName, U_32 length);
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 };
 
 #endif /* CLASSFILEORACLE_HPP_ */

--- a/runtime/bcutil/ConstantPoolMap.hpp
+++ b/runtime/bcutil/ConstantPoolMap.hpp
@@ -303,8 +303,6 @@ public:
 	}
 
 private:
-	bool isVarHandleMethod(U_32 classIndex, U_32 nasIndex);
-
 	/* TODO turn EntryFlags into static const UDATAs instead of an enum type that is never used */
 
 	/* Indices into the ConstantPoolEntry.flags bool array. See comment at the top of the file for more info. */

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1710,6 +1710,7 @@ exit:
 		}
 		return method;
 	}
+
 	static VMINLINE bool
 	objectArrayStoreAllowed(J9VMThread const *currentThread, j9object_t array, j9object_t storeValue)
 	{
@@ -1728,6 +1729,120 @@ exit:
 		return rc;
 	}
 
+	/**
+	 * Determine if the method name corresponds to a VarHandle method with polymorphic
+	 * signature.
+	 *
+	 * @param methodNameData the bytes of the method name
+	 * @param methodNameLength the length of the method name
+	 *
+	 * @return true for a VarHandle method with polymorphic signature. Otherwise,
+	 * return false.
+	 */
+	static VMINLINE bool
+	isPolymorphicVarHandleMethod(const U_8 *methodNameData, U_32 methodNameLength)
+	{
+		bool result = false;
+
+		switch (methodNameLength) {
+		case 3:
+			if ((0 == memcmp(methodNameData, "get", methodNameLength))
+			|| (0 == memcmp(methodNameData, "set", methodNameLength))
+			) {
+				result = true;
+			}
+			break;
+		case 9:
+			if ((0 == memcmp(methodNameData, "getOpaque", methodNameLength))
+			|| (0 == memcmp(methodNameData, "setOpaque", methodNameLength))
+			|| (0 == memcmp(methodNameData, "getAndSet", methodNameLength))
+			|| (0 == memcmp(methodNameData, "getAndAdd", methodNameLength))
+			) {
+				result = true;
+			}
+			break;
+		case 10:
+			if ((0 == memcmp(methodNameData, "getAcquire", methodNameLength))
+			|| (0 == memcmp(methodNameData, "setRelease", methodNameLength))
+			) {
+				result = true;
+			}
+			break;
+		case 11:
+			if ((0 == memcmp(methodNameData, "getVolatile", methodNameLength))
+			|| (0 == memcmp(methodNameData, "setVolatile", methodNameLength))
+			) {
+				result = true;
+			}
+			break;
+		case 13:
+			if (0 == memcmp(methodNameData, "compareAndSet", methodNameLength)) {
+				result = true;
+			}
+			break;
+		case 15:
+			if (0 == memcmp(methodNameData, "getAndBitwiseOr", methodNameLength)) {
+				result = true;
+			}
+			break;
+		case 16:
+			if ((0 == memcmp(methodNameData, "getAndSetAcquire", methodNameLength))
+			|| (0 == memcmp(methodNameData, "getAndSetRelease", methodNameLength))
+			|| (0 == memcmp(methodNameData, "getAndAddAcquire", methodNameLength))
+			|| (0 == memcmp(methodNameData, "getAndAddRelease", methodNameLength))
+			|| (0 == memcmp(methodNameData, "getAndBitwiseAnd", methodNameLength))
+			|| (0 == memcmp(methodNameData, "getAndBitwiseXor", methodNameLength))
+			) {
+				result = true;
+			}
+			break;
+		case 17:
+			if (0 == memcmp(methodNameData, "weakCompareAndSet", methodNameLength)) {
+				result = true;
+			}
+			break;
+		case 18:
+			if (0 == memcmp(methodNameData, "compareAndExchange", methodNameLength)) {
+				result = true;
+			}
+			break;
+		case 22:
+			if ((0 == memcmp(methodNameData, "getAndBitwiseOrAcquire", methodNameLength))
+			|| (0 == memcmp(methodNameData, "getAndBitwiseOrRelease", methodNameLength))
+			|| (0 == memcmp(methodNameData, "weakCompareAndSetPlain", methodNameLength))
+			) {
+				result = true;
+			}
+			break;
+		case 23:
+			if ((0 == memcmp(methodNameData, "getAndBitwiseAndAcquire", methodNameLength))
+			|| (0 == memcmp(methodNameData, "getAndBitwiseAndRelease", methodNameLength))
+			|| (0 == memcmp(methodNameData, "getAndBitwiseXorAcquire", methodNameLength))
+			|| (0 == memcmp(methodNameData, "getAndBitwiseXorRelease", methodNameLength))
+			) {
+				result = true;
+			}
+			break;
+		case 24:
+			if ((0 == memcmp(methodNameData, "weakCompareAndSetAcquire", methodNameLength))
+			|| (0 == memcmp(methodNameData, "weakCompareAndSetRelease", methodNameLength))
+			) {
+				result = true;
+			}
+			break;
+		case 25:
+			if ((0 == memcmp(methodNameData, "compareAndExchangeAcquire", methodNameLength))
+			|| (0 == memcmp(methodNameData, "compareAndExchangeRelease", methodNameLength))
+			) {
+				result = true;
+			}
+			break;
+		default:
+			break;
+		}
+
+		return result;
+	}
 };
 
 #endif /* VMHELPERS_HPP_ */


### PR DESCRIPTION
1. For the OpenJDK MethodHandles (MHs), MH.invoke and MH.invokeExact have the
same behavior. So, MH.invoke and MH.invokeExact are translated to the
same bytecode, invokehandle. Then, invokehandlegeneric becomes unused. 

2. For the OpenJDK implementation, the invokevirtual calls to the VarHandle
polymorphic methods are also translated to the invokehandle bytecode.

3. The OpenJDK MH/VH implementation relies upon LambdaForms to dynamically
generate bytecodes on the Java side. So, operations such as asType are handled
on the Java side. This allows MH.invoke, MH.invokeExact and VH polymorphic
methods to share a common path in the interpreter.

4. A new utility function, VM_VMHelpers::isPolymorphicVarHandleMethod, has
been added to check for polymorphic VarHandle methods, and the associated
redundant code has been removed.

Related: #7352

Co-authored-by: Jack Lu <Jack.S.Lu@ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>

