### PR TITLE
Add the case where there might not be a superclass

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -568,7 +568,11 @@ public class StructureReader {
 		}
 
 		public String toString() {
-			return name + " extends " + superName;
+			if (superName == null || superName.isEmpty()) {
+				return String.valueOf(name);
+			} else {
+				return name + " extends " + superName;
+			}
 		}
 
 		public String getPointerName() {


### PR DESCRIPTION
"extends" keyword is printed regardless if there exists a superclass or not. Modified so that "extends" is only shown when there is a superclass