### PR TITLE
(v0.22.0-release) Unsafe copySwapMemory: no memory addresses overlap for different objects

### DIFF
--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -1129,7 +1129,9 @@ Java_jdk_internal_misc_Unsafe_registerNatives(JNIEnv *env, jclass clazz)
 jboolean
  memOverlapIsNone(j9object_t sourceObject, UDATA sourceOffset, j9object_t destObject, UDATA destOffset, UDATA actualCopySize) {
 	jboolean result = JNI_FALSE;
-	if ((sourceObject == NULL) && (destObject == NULL)) {
+	if (sourceObject != destObject) {
+		result = JNI_TRUE;
+	} else if ((sourceObject == NULL) && (destObject == NULL)) {
 		if (sourceOffset > (destOffset + actualCopySize)) {
 			result = JNI_TRUE;
 		} else if (destOffset > (sourceOffset + actualCopySize)) {


### PR DESCRIPTION
Fixed `memOverlapIsNone` to return `JNI_TRUE` for different objects assuming no memory addresses overlap.

Backported from https://github.com/eclipse/openj9/pull/10556

Signed-off-by: Jason Feng <fengj@ca.ibm.com>