### PR TITLE
(v0.22.0) Fix LambdaNestedInnerTest

### DIFF
--- a/test/TestConfig/resources/excludes/latest_exclude_15.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_15.txt
@@ -24,3 +24,9 @@
 
 org.openj9.test.vm.Test_MsgHelp:test_loadMessages_EN AN-https://github.ibm.com/runtimes/test/issues/46 generic-all
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr 244 generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPIInValidMembers NA generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPIInValidHost NA generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPIInValidHostWrongPackage NA generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPINestMemberWrongPackage NA generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPINestMemberWrongNestHost NA generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPINestMemberWrongNestHost2 NA generic-all

--- a/test/TestConfig/resources/excludes/latest_exclude_16.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_16.txt
@@ -24,3 +24,9 @@
 
 org.openj9.test.vm.Test_MsgHelp:test_loadMessages_EN AN-https://github.ibm.com/runtimes/test/issues/46 generic-all
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr 244 generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPIInValidMembers NA generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPIInValidHost NA generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPIInValidHostWrongPackage NA generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPINestMemberWrongPackage NA generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPINestMemberWrongNestHost NA generic-all
+org.openj9.test.nestmates.NestAttributeTest:testGetNestMembersAPINestMemberWrongNestHost2 NA generic-all


### PR DESCRIPTION
Return the host class as nesthost if a hidden class cannot find its 
nest host.

Do not rethrown any exception if a class cannot find its nesthost 
in java 15 and up.

Exclude tests that expect LinkageError on clazz.getNestMembers().

issue #10345

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>