### PR TITLE
Add sbyteswap/lbyteswap to CodeGenGPU.cpp

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -815,7 +815,9 @@ static const char * nvvmOpCodeNames[] =
    NULL,          // TR::lnolz,
    NULL,          // TR::lnotz,
    NULL,          // TR::lpopcnt,
+   NULL,          // TR::sbyteswap,
    NULL,          // TR::ibyteswap,
+   NULL,          // TR::lbyteswap,
 
    NULL,          // TR::bbitpermute,
    NULL,          // TR::sbitpermute,


### PR DESCRIPTION
OMR will be adding new byteswap opcodes for shorts and longs, which will
require that entries for these opcodes be added to the nvvmOpCodeNames
table in CodeGenGPU.cpp to allow OpenJ9 to continue building.

Signed-off-by: Ben Thomas <ben@benthomas.ca>

This PR needs to be merged alongside eclipse/omr#5539.