### PR TITLE
JDK16 bringup - add bindToLoader & JVM_DefineArchivedModules

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
  * Copyright (c) 2007, 2020 IBM Corp. and others
  *
@@ -430,6 +430,12 @@ final class Access implements JavaLangAccess {
 		return StringConcatHelper.mix(arg0, string);
 	}
 /*[ENDIF] Java15 */
+	
+	/*[IF Java16]*/
+	public void bindToLoader(ModuleLayer ml, ClassLoader cl) {
+		ml.bindToLoader(cl);
+	}
+	/*[ENDIF] Java16 */
 
 /*[ENDIF] Sidecar19-SE */
 }

--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -363,6 +363,13 @@ if(NOT JAVA_SPEC_VERSION LESS 15)
 	)
 endif()
 
+if(NOT JAVA_SPEC_VERSION LESS 16)
+	jvm_add_exports(jvm
+		# Additions for Java 16 (General)
+		JVM_DefineArchivedModules
+	)
+endif()
+
 if(J9VM_OPT_JITSERVER)
 	jvm_add_exports(jvm
 		JITServer_CreateServer

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -354,4 +354,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="JVM_IsCDSSharingEnabled"/>
 	</exports>
 
+	<exports group="jdk16">
+		<!-- Additions for Java 16 (General) -->
+		<export name="JVM_DefineArchivedModules"/>
+	</exports>
+
 </exportlists>

--- a/runtime/j9vm/javanextvmi.c
+++ b/runtime/j9vm/javanextvmi.c
@@ -19,6 +19,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+#include <assert.h>
 #include <jni.h>
 
 #include "bcverify_api.h"
@@ -30,6 +31,14 @@
 /* Define for debug
 #define DEBUG_BCV
 */
+
+#if JAVA_SPEC_VERSION >= 16
+JNIEXPORT void JNICALL
+JVM_DefineArchivedModules(JNIEnv *env, jobject obj1, jobject obj2)
+{
+	assert(!"JVM_DefineArchivedModules unimplemented");
+}
+#endif /* JAVA_SPEC_VERSION >= 16 */
 
 #if JAVA_SPEC_VERSION >= 11
 JNIEXPORT void JNICALL

--- a/runtime/j9vm/module.xml
+++ b/runtime/j9vm/module.xml
@@ -64,6 +64,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group name="jdk15">
 				<include-if condition="spec.java15"/>
 			</group>
+			<group name="jdk16">
+				<include-if condition="spec.java16"/>
+			</group>
 		</exports>
 		<includes>
 			<include path="j9include"/>

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -332,4 +332,6 @@ _IF([JAVA_SPEC_VERSION >= 15],
 	[_X(JVM_IsCDSDumpingEnabled, JNICALL, false, jboolean, JNIEnv *env)])
 _IF([JAVA_SPEC_VERSION >= 15],
 	[_X(JVM_IsCDSSharingEnabled, JNICALL, false, jboolean, JNIEnv *env)])
+_IF([JAVA_SPEC_VERSION >= 16],
+	[_X(JVM_DefineArchivedModules, JNICALL, false, void, JNIEnv *env, jobject obj1, jobject obj2)])
 _X(JVM_IsUseContainerSupport, JNICALL, false, jboolean, JNIEnv *env)

--- a/runtime/redirector/module.xml
+++ b/runtime/redirector/module.xml
@@ -65,6 +65,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group name="jdk15">
 				<include-if condition="spec.java15"/>
 			</group>
+			<group name="jdk16">
+				<include-if condition="spec.java16"/>
+			</group>
 		</exports>
 		<includes>
 			<include path="j9include"/>


### PR DESCRIPTION
Implemented `java.lang.Access.bindToLoader(ModuleLayer ml, ClassLoader cl)`;
Added stub method `JVM_DefineArchivedModules`.

Built JDK16 with `-version` output:
```
openjdk version "16-internal" 2021-03-16
OpenJDK Runtime Environment (build 16-internal+0-adhoc.fengjcaibmcom.git2-openj9-openjdk-jdk)
Eclipse OpenJ9 VM (build jdk16bindtoloader-f974b24af3, JRE 16 Mac OS X amd64-64-Bit Compressed References 20200914_000000 (JIT enabled, AOT enabled)
OpenJ9   - f974b24af3
OMR      - 58b0c1838
JCL      - 27ff4be1334 based on jdk-16+15)
```

closes: #10593 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>