### PR TITLE
Fix GCMap issue for read only unresolved field resolution and resolve virtual call sequence

### DIFF
--- a/runtime/compiler/z/codegen/J9UnresolvedDataReadOnlySnippet.hpp
+++ b/runtime/compiler/z/codegen/J9UnresolvedDataReadOnlySnippet.hpp
@@ -59,6 +59,7 @@ class UnresolvedDataReadOnlySnippet : public TR::Snippet
       intptr_t resolveDataAddress,
       TR::LabelSymbol *startResolveSequenceLabel,
       TR::LabelSymbol *volatileFenceLabel,
+      TR::LabelSymbol *snippetCallNextInstrLabel,
       TR::LabelSymbol *doneLabel);
 
    virtual Kind getKind() { return IsUnresolvedDataReadOnly; }
@@ -89,6 +90,7 @@ class UnresolvedDataReadOnlySnippet : public TR::Snippet
    TR::LabelSymbol *startResolveSequenceLabel;
    TR::LabelSymbol *volatileFenceLabel;
    TR::LabelSymbol *doneLabel;
+   TR::LabelSymbol *snippetCallNextInstrLabel;
 
    intptr_t resolveDataAddress;
    };

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -1600,6 +1600,10 @@ TR::S390VirtualUnresolvedReadOnlySnippet::emitSnippetBody()
    *reinterpret_cast<int32_t*>(cursor) = static_cast<int32_t>(doneLabelAddress - (intptr_t)helperCallRA);
    cursor += sizeof(int32_t);
 
+   intptr_t nextInstrFromSnippetCallAddress = reinterpret_cast<intptr_t>(snippetCallNextInstrLabel->getCodeLocation());
+   *reinterpret_cast<int32_t*>(cursor) = static_cast<int32_t>(nextInstrFromSnippetCallAddress - (intptr_t)helperCallRA);
+   cursor += sizeof(int32_t);
+
    return cursor;
 
    }
@@ -1636,7 +1640,10 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390VirtualUnresolvedReadOnlySnippet *sn
    printPrefix(pOutFile, NULL, bufferPos, sizeof(int32_t));
    trfprintf(pOutFile, "<%p>\t# RIP offset to post vtable dispatch sequence",
                     (void*)*(int32_t*)bufferPos);
-
+   bufferPos += sizeof(int32_t);
+   printPrefix(pOutFile, NULL, bufferPos, sizeof(int32_t));
+   trfprintf(pOutFile, "<%p>\t# RIP offset to post snippet call in mainline",
+                    (void*)*(int32_t*)bufferPos);
    }
 
 
@@ -1646,8 +1653,9 @@ TR::S390VirtualUnresolvedReadOnlySnippet::getLength(int32_t estimatedSnippetStar
    // TODO: Need to get the length of the call from the GlobalFunctionCall Data, this hard-coded way is not recommended
    return    6 /*LGRL*/ 
            + 2 /*BASR*/
-           + sizeof(int32_t) /*RIP offset to vtableData*/
-           + sizeof(int32_t) /*RIP offset to vtable load instruction in mainline*/
-           + sizeof(int32_t); /*RIP offset to post vtable dispatch sequence*/
+           + sizeof(int32_t)  /*RIP offset to vtableData*/
+           + sizeof(int32_t)  /*RIP offset to vtable load instruction in mainline*/
+           + sizeof(int32_t)  /*RIP offset to post vtable dispatch sequence*/
+           + sizeof(int32_t); /*RIP offset to post snippet call in mainline*/
    }
 

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.hpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.hpp
@@ -137,9 +137,11 @@ class S390VirtualUnresolvedReadOnlySnippet : public TR::Snippet
 
    TR::LabelSymbol *doneLabel;
 
+   TR::LabelSymbol *snippetCallNextInstrLabel;
+
    public:
-   S390VirtualUnresolvedReadOnlySnippet(TR::CodeGenerator *cg, TR::Node *callNode, TR::LabelSymbol *lab, TR::LabelSymbol *loadVTableOffsetLabel, TR::LabelSymbol *doneLabel, intptr_t resolveVirtualDataAddress)
-      : TR::Snippet(cg, callNode, lab, false), loadVTableOffsetLabel(loadVTableOffsetLabel), doneLabel(doneLabel), resolveVirtualDataAddress(resolveVirtualDataAddress)
+   S390VirtualUnresolvedReadOnlySnippet(TR::CodeGenerator *cg, TR::Node *callNode, TR::LabelSymbol *lab, TR::LabelSymbol *loadVTableOffsetLabel, TR::LabelSymbol *doneLabel, TR::LabelSymbol *snippetCallNextInstrLabel, intptr_t resolveVirtualDataAddress)
+      : TR::Snippet(cg, callNode, lab, false), loadVTableOffsetLabel(loadVTableOffsetLabel), doneLabel(doneLabel), snippetCallNextInstrLabel(snippetCallNextInstrLabel), resolveVirtualDataAddress(resolveVirtualDataAddress)
       {
       }
    

--- a/runtime/compiler/z/runtime/PicBuilder.m4
+++ b/runtime/compiler/z/runtime/PicBuilder.m4
@@ -152,6 +152,7 @@ SETVAL(eq_ResolveVirtual_j2iThunk,24)
 SETVAL(eq_ResolveVirtual_vtableOffset,32)
 SETVAL(eq_resolveVirtualDispatchReadOnly_RA,4)
 SETVAL(eq_returnAddressDirectMethod,8)
+SETVAL(eq_resolveVirtualJitEIPForHelperCall,12)
 SETVAL(eq_ResolveVirtualData_RIP,0)
 
 ZZ These two should really be in codert/jilconsts.inc
@@ -1728,7 +1729,7 @@ ZZ ===================================================================
 
     LR_GPR r1,r3
     LR_GPR r2,r14
-    AGF r2,eq_resolveVirtualDispatchReadOnly_RA(r2)
+    AGF r2,eq_resolveVirtualJitEIPForHelperCall(r2)
     LR_GPR r0,r14
 ZZ Load jitResolveVirtualMethod Address
 LOAD_ADDR_FROM_TOC(r14,TR_S390jitResolveVirtualMethod)

--- a/runtime/compiler/z/runtime/PicBuilder.m4
+++ b/runtime/compiler/z/runtime/PicBuilder.m4
@@ -178,6 +178,7 @@ SETVAL(eq_isVolatile_inDSRO,16)
 SETVAL(eq_CCUnresolvedData_inDSRO,0)
 SETVAL(eq_cpIndex_inDSRO,4)
 SETVAL(eq_codeRA_inDSRO,8)
+SETVAL(eq_gcMapRA_inDSRO,12)
 
 ZZ  MethodFlags is a 32bit integer,but occupies 8 byte slot on 64bit
 SETVAL(eq_methodFlagsOffset,(J9TR_MethodFlagsOffset+4))
@@ -226,6 +227,7 @@ SETVAL(eq_isVolatile_inDSRO,8)
 SETVAL(eq_CCUnresolvedData_inDSRO,0)
 SETVAL(eq_cpIndex_inDSRO,4)
 SETVAL(eq_codeRA_inDSRO,8)
+SETVAL(eq_gcMapRA_inDSRO,12)
 
 SETVAL(eq_methodFlagsOffset,J9TR_MethodFlagsOffset)
 
@@ -1411,8 +1413,8 @@ ZZ ===================================================================
     LGF_GPR r1,eq_CCUnresolvedData_inDSRO(,r14)
     L_GPR   r1,eq_cpAddress_inDSRO(r1,r14)
     LGF_GPR r2,eq_cpIndex_inDSRO(,r14)
-    LGF_GPR r3,eq_codeRA_inDSRO(,r14)
-    LA      r3,8(r3,r14)
+    LGF_GPR r3,eq_gcMapRA_inDSRO(,r14)
+    LA      r3,0(r3,r14)
 
 LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveFieldSetter)
 
@@ -1435,8 +1437,8 @@ ZZ ===================================================================
     LGF_GPR r1,eq_CCUnresolvedData_inDSRO(,r14)
     L_GPR   r1,eq_cpAddress_inDSRO(r1,r14)
     LGF_GPR r2,eq_cpIndex_inDSRO(,r14)
-    LGF_GPR r3,eq_codeRA_inDSRO(,r14)
-    LA      r3,8(r3,r14)
+    LGF_GPR r3,eq_gcMapRA_inDSRO(,r14)
+    LA      r3,0(r3,r14)
 
 LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveField)
 
@@ -1458,8 +1460,8 @@ ZZ ===================================================================
     LGF_GPR r1,eq_CCUnresolvedData_inDSRO(,r14)
     L_GPR   r1,eq_cpAddress_inDSRO(r1,r14)
     LGF_GPR r2,eq_cpIndex_inDSRO(,r14)
-    LGF_GPR r3,eq_codeRA_inDSRO(,r14)
-    LA      r3,8(r3,r14)
+    LGF_GPR r3,eq_gcMapRA_inDSRO(,r14)
+    LA      r3,0(r3,r14)
 
 LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveClassFromStaticField)
 
@@ -1481,8 +1483,8 @@ ZZ ===================================================================
     LGF_GPR r1,eq_CCUnresolvedData_inDSRO(,r14)
     L_GPR   r1,eq_cpAddress_inDSRO(r1,r14)
     LGF_GPR r2,eq_cpIndex_inDSRO(,r14)
-    LGF_GPR r3,eq_codeRA_inDSRO(,r14)
-    LA      r3,8(r3,r14)
+    LGF_GPR r3,eq_gcMapRA_inDSRO(,r14)
+    LA      r3,0(r3,r14)
 
 LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveClass)
 
@@ -1504,8 +1506,8 @@ ZZ ===================================================================
     LGF_GPR r1,eq_CCUnresolvedData_inDSRO(,r14)
     L_GPR   r1,eq_cpAddress_inDSRO(r1,r14)
     LGF_GPR r2,eq_cpIndex_inDSRO(,r14)
-    LGF_GPR r3,eq_codeRA_inDSRO(,r14)
-    LA      r3,8(r3,r14)
+    LGF_GPR r3,eq_gcMapRA_inDSRO(,r14)
+    LA      r3,0(r3,r14)
 
 LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveString)
 
@@ -1527,8 +1529,8 @@ ZZ ===================================================================
     LGF_GPR r1,eq_CCUnresolvedData_inDSRO(,r14)
     L_GPR   r1,eq_cpAddress_inDSRO(r1,r14)
     LGF_GPR r2,eq_cpIndex_inDSRO(,r14)
-    LGF_GPR r3,eq_codeRA_inDSRO(,r14)
-    LA      r3,8(r3,r14)
+    LGF_GPR r3,eq_gcMapRA_inDSRO(,r14)
+    LA      r3,0(r3,r14)
 
 LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveMethodType)
 
@@ -1550,8 +1552,8 @@ ZZ ===================================================================
     LGF_GPR r1,eq_CCUnresolvedData_inDSRO(,r14)
     L_GPR   r1,eq_cpAddress_inDSRO(r1,r14)
     LGF_GPR r2,eq_cpIndex_inDSRO(,r14)
-    LGF_GPR r3,eq_codeRA_inDSRO(,r14)
-    LA      r3,8(r3,r14)
+    LGF_GPR r3,eq_gcMapRA_inDSRO(,r14)
+    LA      r3,0(r3,r14)
 
 LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveMethodHandle)
 
@@ -1573,8 +1575,8 @@ ZZ ===================================================================
     LGF_GPR r1,eq_CCUnresolvedData_inDSRO(,r14)
     L_GPR   r1,eq_cpAddress_inDSRO(r1,r14)
     LGF_GPR r2,eq_cpIndex_inDSRO(,r14)
-    LGF_GPR r3,eq_codeRA_inDSRO(,r14)
-    LA      r3,8(r3,r14)
+    LGF_GPR r3,eq_gcMapRA_inDSRO(,r14)
+    LA      r3,0(r3,r14)
 
 LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveInvokeDynamic)
 
@@ -1596,8 +1598,8 @@ ZZ ===================================================================
     LGF_GPR r1,eq_CCUnresolvedData_inDSRO(,r14)
     L_GPR   r1,eq_cpAddress_inDSRO(r1,r14)
     LGF_GPR r2,eq_cpIndex_inDSRO(,r14)
-    LGF_GPR r3,eq_codeRA_inDSRO(,r14)
-    LA      r3,8(r3,r14)
+    LGF_GPR r3,eq_gcMapRA_inDSRO(,r14)
+    LA      r3,0(r3,r14)
 
 LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveHandleMethod)
 
@@ -1619,8 +1621,8 @@ ZZ ===================================================================
     LGF_GPR r1,eq_CCUnresolvedData_inDSRO(,r14)
     L_GPR   r1,eq_cpAddress_inDSRO(r1,r14)
     LGF_GPR r2,eq_cpIndex_inDSRO(,r14)
-    LGF_GPR r3,eq_codeRA_inDSRO(,r14)
-    LA      r3,8(r3,r14)
+    LGF_GPR r3,eq_gcMapRA_inDSRO(,r14)
+    LA      r3,0(r3,r14)
 
 LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveConstantDynamic)
 
@@ -1642,8 +1644,8 @@ ZZ ===================================================================
     LGF_GPR r1,eq_CCUnresolvedData_inDSRO(,r14)
     L_GPR   r1,eq_cpAddress_inDSRO(r1,r14)
     LGF_GPR r2,eq_cpIndex_inDSRO(,r14)
-    LGF_GPR r3,eq_codeRA_inDSRO(,r14)
-    LA      r3,8(r3,r14)
+    LGF_GPR r3,eq_gcMapRA_inDSRO(,r14)
+    LA      r3,0(r3,r14)
 
 LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticFieldSetter)
 
@@ -1666,8 +1668,8 @@ ZZ ===================================================================
     LGF_GPR r1,eq_CCUnresolvedData_inDSRO(,r14)
     L_GPR   r1,eq_cpAddress_inDSRO(r1,r14)
     LGF_GPR r2,eq_cpIndex_inDSRO(,r14)
-    LGF_GPR r3,eq_codeRA_inDSRO(,r14)
-    LA      r3,8(r3,r14)
+    LGF_GPR r3,eq_gcMapRA_inDSRO(,r14)
+    LA      r3,0(r3,r14)
 
 LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticField)
 
@@ -1707,7 +1709,6 @@ LABEL(LVolatileCheckReadOnlyDone)
     RestoreRegs
 
     AGF     r14,eq_codeRA_inDSRO(,r14)
-    AGFI    r14,8
     BR      r14
 
     END_FUNC(_interpreterUnresolvedStaticFieldReadOnlyGlue,iUSFRO,8)


### PR DESCRIPTION
For the read only unresolved field resolution and resolution of virtual , JIT helper glue code will have set up the return address to be the start of the resolution sequence where after returning from the helper, we again load the correct index or
address in case of field resolution and vTable offset for virtual call from the resolution data block. If the helper we call ends up triggering GC, the stack walker will use the JIT return address we passed to walk current JIT frame and find the GC map associated with the return address. The GC map logic subtracts 1 which means that unless we create the GC Map on an instruction before the return label, we will retrieve the wrong GC map. Correct fix here would be passing the address of next instruction after the snippet call in mainline as jitEIP when we call JIT helper. This commit fixes this issue.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>