### PR TITLE
Add jitConfig parm to CH Table Constructor

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1656,12 +1656,12 @@ onLoadInternal(
 #if defined(J9VM_OPT_JITSERVER)
       if (persistentMemory->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
          {
-         chtable = new (PERSISTENT_NEW) JITClientPersistentCHTable(persistentMemory);
+         chtable = new (PERSISTENT_NEW) JITClientPersistentCHTable(persistentMemory, jitConfig);
          }
       else
 #endif
          {
-         chtable = new (PERSISTENT_NEW) TR_PersistentCHTable(persistentMemory);
+         chtable = new (PERSISTENT_NEW) TR_PersistentCHTable(persistentMemory, jitConfig);
          }
       if (chtable == NULL)
          return -1;

--- a/runtime/compiler/env/JITServerPersistentCHTable.cpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.cpp
@@ -30,8 +30,8 @@
 #include "runtime/JITClientSession.hpp"
 
 
-JITServerPersistentCHTable::JITServerPersistentCHTable(TR_PersistentMemory *trMemory)
-   : TR_PersistentCHTable(trMemory),
+JITServerPersistentCHTable::JITServerPersistentCHTable(TR_PersistentMemory *trMemory, J9JITConfig *jitConfig)
+   : TR_PersistentCHTable(trMemory, jitConfig),
    _classMap(decltype(_classMap)::allocator_type(TR::Compiler->persistentAllocator()))
    {
    _chTableMonitor = TR::Monitor::create("JIT-JITServerCHTableMonitor");
@@ -397,8 +397,8 @@ FlatPersistentClassInfo::deserializeHierarchy(const std::string& data)
 // JITClient
 // TODO: check for race conditions with _dirty/_remove
 
-JITClientPersistentCHTable::JITClientPersistentCHTable(TR_PersistentMemory *trMemory)
-   : TR_PersistentCHTable(trMemory)
+JITClientPersistentCHTable::JITClientPersistentCHTable(TR_PersistentMemory *trMemory, J9JITConfig *jitConfig)
+   : TR_PersistentCHTable(trMemory, jitConfig)
    , _dirty(decltype(_dirty)::allocator_type(TR::Compiler->persistentAllocator()))
    , _remove(decltype(_remove)::allocator_type(TR::Compiler->persistentAllocator()))
    {

--- a/runtime/compiler/env/JITServerPersistentCHTable.hpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.hpp
@@ -55,7 +55,7 @@ class JITServerPersistentCHTable : public TR_PersistentCHTable
 public:
    TR_ALLOC(TR_Memory::PersistentCHTable)
 
-   JITServerPersistentCHTable(TR_PersistentMemory *);
+   JITServerPersistentCHTable(TR_PersistentMemory *, J9JITConfig *);
    ~JITServerPersistentCHTable();
 
    bool isInitialized() { return !_classMap.empty(); } // needs CHTable monitor in hand
@@ -102,7 +102,7 @@ class JITClientPersistentCHTable : public TR_PersistentCHTable
 public:
    TR_ALLOC(TR_Memory::PersistentCHTable)
 
-   JITClientPersistentCHTable(TR_PersistentMemory *);
+   JITClientPersistentCHTable(TR_PersistentMemory *, J9JITConfig *);
 
    std::pair<std::string, std::string> serializeUpdates();
 

--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -50,7 +50,7 @@
 
 class TR_OpaqueClassBlock;
 
-TR_PersistentCHTable::TR_PersistentCHTable(TR_PersistentMemory *trPersistentMemory)
+TR_PersistentCHTable::TR_PersistentCHTable(TR_PersistentMemory *trPersistentMemory, J9JITConfig *jitConfig)
    : _trPersistentMemory(trPersistentMemory)
    {
    /*

--- a/runtime/compiler/env/PersistentCHTable.hpp
+++ b/runtime/compiler/env/PersistentCHTable.hpp
@@ -49,7 +49,7 @@ class TR_PersistentCHTable
    public:
    TR_ALLOC(TR_Memory::PersistentCHTable)
 
-   TR_PersistentCHTable(TR_PersistentMemory *);
+   TR_PersistentCHTable(TR_PersistentMemory *, J9JITConfig *);
 
    virtual TR_PersistentClassInfo * findClassInfo(TR_OpaqueClassBlock * classId);
 

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -542,7 +542,7 @@ ClientSessionData::getCHTable()
    {
    if (!_chTable)
       {
-      _chTable = new (PERSISTENT_NEW) JITServerPersistentCHTable(trPersistentMemory);
+      _chTable = new (PERSISTENT_NEW) JITServerPersistentCHTable(trPersistentMemory, jitConfig);
       }
    return _chTable;
    }


### PR DESCRIPTION
Add JITConfig parameter to the constructor of the various CH Table
objects to minimize merge conflicts with the snapshot branch.

Signed-off-by: Irwin D'Souza <dsouzai.gh@gmail.com>