### PR TITLE
Update invokedynamic and invokehandle bytecode handlers

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -1074,9 +1074,9 @@ J9::CodeGenerator::lowerTreeIfNeeded(
        !node->getSymbol()->castToMethodSymbol()->isHelper() &&
        (node->getSymbol()->castToMethodSymbol()->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeBasic))
       {
-      // invokeBasic is signature-polymorphic, so the location of the method handle receiver object on the stack will depend
-      // on the number of arguments in the invokeBasic call. Therefore, the number of stack slots used by the args of the call
-      // is stored in vmThread.tempSlot so that the interpreter can locate the receiver object on the stack.
+      // invokeBasic is signature-polymorphic, so the location of the method handle receiver object on the stack will be
+      // the number of arg slots in the invokeBasic call minus 1 accounting for the receiver slot. This value is is stored
+      // in vmThread.tempSlot so that the interpreter can locate the receiver object on the stack.
       TR::SymbolReference *vmThreadTempSlotSymRef = self()->comp()->getSymRefTab()->findOrCreateVMThreadTempSlotFieldSymbolRef();
       int32_t numParameterStackSlots = node->getSymbol()->castToResolvedMethodSymbol()->getNumParameterSlots();
       TR::Node * numArgsNode = NULL;

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -1074,9 +1074,23 @@ J9::CodeGenerator::lowerTreeIfNeeded(
        !node->getSymbol()->castToMethodSymbol()->isHelper() &&
        (node->getSymbol()->castToMethodSymbol()->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeBasic))
       {
+      // invokeBasic is signature-polymorphic, so the location of the method handle receiver object on the stack will depend
+      // on the number of arguments in the invokeBasic call. Therefore, the number of stack slots used by the args of the call
+      // is stored in vmThread.tempSlot so that the interpreter can locate the receiver object on the stack.
       TR::SymbolReference *vmThreadTempSlotSymRef = self()->comp()->getSymRefTab()->findOrCreateVMThreadTempSlotFieldSymbolRef();
-      TR::Node *numArgsNode = TR::Node::iconst(node, node->getNumArguments() - 1);
-      TR::Node *storeNode = TR::Node::createStore(vmThreadTempSlotSymRef, numArgsNode, TR::istore);
+      int32_t numParameterStackSlots = node->getSymbol()->castToResolvedMethodSymbol()->getNumParameterSlots();
+      TR::Node * numArgsNode = NULL;
+      TR::Node * storeNode = NULL;
+      if (self()->comp()->target().is64Bit())
+         {
+         numArgsNode = TR::Node::lconst(node, numParameterStackSlots - 1);
+         storeNode = TR::Node::createStore(vmThreadTempSlotSymRef, numArgsNode, TR::lstore);
+         }
+      else
+         {
+         numArgsNode = TR::Node::iconst(node, numParameterStackSlots - 1);
+         storeNode = TR::Node::createStore(vmThreadTempSlotSymRef, numArgsNode, TR::istore);
+         }
       storeNode->setByteCodeIndex(node->getByteCodeIndex());
       TR::TreeTop::create(self()->comp(), tt->getPrevTreeTop(), storeNode);
       }

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -562,7 +562,7 @@ TR::SymbolReference *
 J9::SymbolReferenceTable::refineInvokeCacheElementSymRefWithKnownObjectIndex(TR::ResolvedMethodSymbol * owningMethodSymbol,  TR::SymbolReference * originalSymRef, uintptr_t arrayElementRef)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
-   TR::VMAccessCriticalSection invokeCacheEntry(comp());
+   TR_ASSERT(fej9->haveAccess(), "Require VM access to be acquired by caller");
    TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
    if (!knot) return originalSymRef;
    TR_ResolvedJ9Method *owningMethod = static_cast<TR_ResolvedJ9Method*>(owningMethodSymbol->getResolvedMethod());

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -107,8 +107,13 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    TR::SymbolReference * findOrCreateDynamicMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t callSiteIndex);
    TR::SymbolReference * findOrCreateHandleMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex);
    TR::SymbolReference * findOrCreateHandleMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, char *signature);
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+   TR::SymbolReference * findOrCreateCallSiteTableEntrySymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t callSiteIndex, bool isMemberNameObject = false);
+   TR::SymbolReference * findOrCreateMethodTypeTableEntrySymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, bool isMemberNameObject = false);
+#else
    TR::SymbolReference * findOrCreateCallSiteTableEntrySymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t callSiteIndex);
    TR::SymbolReference * findOrCreateMethodTypeTableEntrySymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex);
+#endif
    TR::SymbolReference * findOrCreateVarHandleMethodTypeTableEntrySymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex);
    TR::SymbolReference * methodSymRefWithSignature(TR::SymbolReference *original, char *effectiveSignature, int32_t effectiveSignatureLength);
    TR::SymbolReference * findOrCreateTypeCheckArrayStoreSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -104,20 +104,19 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    TR::SymbolReference * findOrCreateSpecialMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex);
    TR::SymbolReference * findOrCreateVirtualMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex);
    TR::SymbolReference * findOrCreateInterfaceMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex);
-   TR::SymbolReference * findOrCreateDynamicMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t callSiteIndex);
-   TR::SymbolReference * findOrCreateHandleMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex);
+   TR::SymbolReference * findOrCreateDynamicMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t callSiteIndex, bool * unresolvedInCP = 0);
+   TR::SymbolReference * findOrCreateHandleMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, bool * unresolvedInCP = 0);
    TR::SymbolReference * findOrCreateHandleMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, char *signature);
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
    /**
     * \brief
     *    Refines invokeCache element symRef with known object index for invokehandle and invokedynamic bytecode
     *
-    * \param owningMethodSymbol the owning method symbol
     * \param originalSymRef the original symref to refine
     * \param arrayElementRef the array element ref
     * \return TR::SymbolReference* the refined symRef
     */
-   TR::SymbolReference * refineInvokeCacheElementSymRefWithKnownObjectIndex(TR::ResolvedMethodSymbol * owningMethodSymbol,  TR::SymbolReference * originalSymRef, uintptr_t arrayElementRef);
+   TR::SymbolReference * refineInvokeCacheElementSymRefWithKnownObjectIndex(TR::SymbolReference * originalSymRef, uintptr_t arrayElementRef);
 
 #endif
    TR::SymbolReference * findOrCreateCallSiteTableEntrySymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t callSiteIndex);

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -108,12 +108,20 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    TR::SymbolReference * findOrCreateHandleMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex);
    TR::SymbolReference * findOrCreateHandleMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, char *signature);
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
-   TR::SymbolReference * findOrCreateCallSiteTableEntrySymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t callSiteIndex, bool isMemberNameObject = false);
-   TR::SymbolReference * findOrCreateMethodTypeTableEntrySymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, bool isMemberNameObject = false);
-#else
+   /**
+    * \brief
+    *    Refines invokeCache element symRef with known object index for invokehandle and invokedynamic bytecode
+    *
+    * \param owningMethodSymbol the owning method symbol
+    * \param originalSymRef the original symref to refine
+    * \param arrayElementRef the array element ref
+    * \return TR::SymbolReference* the refined symRef
+    */
+   TR::SymbolReference * refineInvokeCacheElementSymRefWithKnownObjectIndex(TR::ResolvedMethodSymbol * owningMethodSymbol,  TR::SymbolReference * originalSymRef, uintptr_t arrayElementRef);
+
+#endif
    TR::SymbolReference * findOrCreateCallSiteTableEntrySymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t callSiteIndex);
    TR::SymbolReference * findOrCreateMethodTypeTableEntrySymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex);
-#endif
    TR::SymbolReference * findOrCreateVarHandleMethodTypeTableEntrySymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex);
    TR::SymbolReference * methodSymRefWithSignature(TR::SymbolReference *original, char *effectiveSignature, int32_t effectiveSignatureLength);
    TR::SymbolReference * findOrCreateTypeCheckArrayStoreSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);

--- a/runtime/compiler/env/JSR292Methods.h
+++ b/runtime/compiler/env/JSR292Methods.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,4 +53,7 @@
 
 #define JSR292_FieldGetterHandle "java/lang/invoke/FieldGetterHandle"
 #define JSR292_FieldSetterHandle "java/lang/invoke/FieldSetterHandle"
+
+#define JSR292_invokeCacheArrayMemberNameIndex 0
+#define JSR292_invokeCacheArrayAppendixIndex 1
 #endif

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4853,6 +4853,46 @@ TR_J9VMBase::targetMethodFromMethodHandle(uintptr_t methodHandle)
       "vmentry",             "Ljava/lang/invoke/MemberName;");
    return targetMethodFromMemberName(vmentry);
    }
+
+char *
+TR_J9VMBase::getSignatureForLinkToStaticForInvokeHandle(TR::Compilation* comp, J9UTF8* romMethodSignature)
+   {
+   char * signatureString = (char *) comp->trMemory()->allocateMemory((J9UTF8_LENGTH(romMethodSignature)+1)*sizeof(char), heapAlloc);
+   char * linkToStaticSignature = (char *) comp->trMemory()->allocateMemory((J9UTF8_LENGTH(romMethodSignature)+55)*sizeof(char), heapAlloc);
+   strcpy(signatureString, utf8Data(romMethodSignature));
+   if (strncmp(signatureString, "()", 2) == 0)
+      {
+      char * returnTypeToken = strtok(signatureString, "()");
+      sprintf(linkToStaticSignature, "(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)%s", returnTypeToken);
+      }
+   else
+      {
+      char * sigTokenStart = strtok(signatureString, "()");
+      char * sigTokenEnd = strtok(NULL, "()");
+      sprintf(linkToStaticSignature, "(Ljava/lang/Object;%sLjava/lang/Object;Ljava/lang/Object;)%s", sigTokenStart, sigTokenEnd);
+      }
+   return linkToStaticSignature;
+   }
+
+char *
+TR_J9VMBase::getSignatureForLinkToStaticForInvokeDynamic(TR::Compilation* comp, J9UTF8* romMethodSignature)
+   {
+   char * signatureString = (char *) comp->trMemory()->allocateMemory((J9UTF8_LENGTH(romMethodSignature)+1)*sizeof(char), heapAlloc);
+   char * linkToStaticSignature = (char *) comp->trMemory()->allocateMemory((J9UTF8_LENGTH(romMethodSignature)+37)*sizeof(char), heapAlloc);
+   strcpy(signatureString, utf8Data(romMethodSignature));
+   if (strncmp(signatureString, "()", 2) == 0)
+      {
+      char * returnTypeToken = strtok(signatureString, "()");
+      sprintf(linkToStaticSignature, "(Ljava/lang/Object;Ljava/lang/Object;)%s", returnTypeToken);
+      }
+   else
+      {
+      char * sigTokenStart = strtok(signatureString, "()");
+      char * sigTokenEnd = strtok(NULL, "()");
+      sprintf(linkToStaticSignature, "(%sLjava/lang/Object;Ljava/lang/Object;)%s", sigTokenStart, sigTokenEnd);
+      }
+   return linkToStaticSignature;
+   }
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 /**

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4855,12 +4855,13 @@ TR_J9VMBase::targetMethodFromMethodHandle(uintptr_t methodHandle)
    }
 
 char *
-TR_J9VMBase::getSignatureForLinkToStaticForInvokeHandle(TR::Compilation* comp, J9UTF8* romMethodSignature)
+TR_J9VMBase::getSignatureForLinkToStaticForInvokeHandle(TR::Compilation* comp, J9UTF8* romMethodSignature, int32_t &signatureLength)
    {
+   signatureLength = J9UTF8_LENGTH(romMethodSignature) + 55; // 55 accounts for the number of chars added to ROM method signature to construct the linkToStatic signature from it
    char * signatureString = (char *) comp->trMemory()->allocateMemory((J9UTF8_LENGTH(romMethodSignature)+1)*sizeof(char), heapAlloc);
    char * linkToStaticSignature = (char *) comp->trMemory()->allocateMemory((J9UTF8_LENGTH(romMethodSignature)+55)*sizeof(char), heapAlloc);
    strcpy(signatureString, utf8Data(romMethodSignature));
-   if (strncmp(signatureString, "()", 2) == 0)
+   if (strncmp(signatureString, "()", 2) == 0) // handles empty signature
       {
       char * returnTypeToken = strtok(signatureString, "()");
       sprintf(linkToStaticSignature, "(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)%s", returnTypeToken);
@@ -4875,14 +4876,15 @@ TR_J9VMBase::getSignatureForLinkToStaticForInvokeHandle(TR::Compilation* comp, J
    }
 
 char *
-TR_J9VMBase::getSignatureForLinkToStaticForInvokeDynamic(TR::Compilation* comp, J9UTF8* romMethodSignature)
+TR_J9VMBase::getSignatureForLinkToStaticForInvokeDynamic(TR::Compilation* comp, J9UTF8* romMethodSignature, int32_t &signatureLength)
    {
+   signatureLength = J9UTF8_LENGTH(romMethodSignature) + 37; // 37 accounts for the number of chars added to ROM method signature to construct linkToStatic signature from it
    char * signatureString = (char *) comp->trMemory()->allocateMemory((J9UTF8_LENGTH(romMethodSignature)+1)*sizeof(char), heapAlloc);
    char * linkToStaticSignature = (char *) comp->trMemory()->allocateMemory((J9UTF8_LENGTH(romMethodSignature)+37)*sizeof(char), heapAlloc);
    strcpy(signatureString, utf8Data(romMethodSignature));
    if (strncmp(signatureString, "()", 2) == 0)
       {
-      char * returnTypeToken = strtok(signatureString, "()");
+      char * returnTypeToken = strtok(signatureString, "()"); // handles empty signature
       sprintf(linkToStaticSignature, "(Ljava/lang/Object;Ljava/lang/Object;)%s", returnTypeToken);
       }
    else

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -799,40 +799,42 @@ public:
     */
    TR_OpaqueMethodBlock* targetMethodFromMethodHandle(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
 
-   /**
+   /*
     * \brief
     *    Get the signature For MethodHandle.linkToStatic call for unresolved invokehandle
     *
     *    For unresolved invokeHandle, we do not know the adapter method at
     *    compile time. The call is expressed as a call to the signature-polymorphic
     *    MethodHandle.linkToStatic method. In addition to the arguments of the original call,
-    *    we need to provide the target and appendix objects as the last two arguments, in addition
-    *    to the MethodHandle object as the first argument. Therefore, we need to modify the
-    *    signature of the original call and adapt it to accept three extra arguments.
+    *    we need to provide the memberName and appendix objects as the last two arguments, in
+    *    addition to the MethodHandle object as the first argument. Therefore, we need to modify
+    *    the signature of the original call and adapt it to accept three extra arguments.
     *
     * \param comp the current compilation
     * \param romMethodSignature the ROM Method signature to be processed
+    * \param signatureLength the length of the resulting signature
     * \return char * the signature for linkToStatic
     */
-   char * getSignatureForLinkToStaticForInvokeHandle(TR::Compilation* comp, J9UTF8* romMethodSignature);
+   char * getSignatureForLinkToStaticForInvokeHandle(TR::Compilation* comp, J9UTF8* romMethodSignature, int32_t &signatureLength);
 
 
-   /**
+   /*
     * \brief
     *    Get the signature for MethodHandle.linkToStatic call for unresolved invokedynamic
     *
     *    For unresolved invokeDynamic, we do not know the adapter method at
     *    compile time. The call is expressed as a call to the signature-polymorphic
     *    MethodHandle.linkToStatic method. In addition to the arguments of the original call,
-    *    we need to provide the target and appendix objects as the last two arguments.
+    *    we need to provide the memberName and appendix objects as the last two arguments.
     *    Therefore, we need to modify the signature of the original call and adapt it to accept
     *    the two extra arguments.
     *
     * \param comp the current compilation
     * \param romMethodSignature the ROM Method signature to be processed
+    * \param signatureLength the length of the resulting signature
     * \return char * the signature for linkToStatic
     */
-   char * getSignatureForLinkToStaticForInvokeDynamic(TR::Compilation* comp, J9UTF8* romMethodSignature);
+   char * getSignatureForLinkToStaticForInvokeDynamic(TR::Compilation* comp, J9UTF8* romMethodSignature, int32_t &signatureLength);
 #endif
 
    // JSR292 }}}

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -798,6 +798,41 @@ public:
     *    VM access is not required
     */
    TR_OpaqueMethodBlock* targetMethodFromMethodHandle(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
+
+   /**
+    * \brief
+    *    Get the signature For MethodHandle.linkToStatic call for unresolved invokehandle
+    *
+    *    For unresolved invokeHandle, we do not know the adapter method at
+    *    compile time. The call is expressed as a call to the signature-polymorphic
+    *    MethodHandle.linkToStatic method. In addition to the arguments of the original call,
+    *    we need to provide the target and appendix objects as the last two arguments, in addition
+    *    to the MethodHandle object as the first argument. Therefore, we need to modify the
+    *    signature of the original call and adapt it to accept three extra arguments.
+    *
+    * \param comp the current compilation
+    * \param romMethodSignature the ROM Method signature to be processed
+    * \return char * the signature for linkToStatic
+    */
+   char * getSignatureForLinkToStaticForInvokeHandle(TR::Compilation* comp, J9UTF8* romMethodSignature);
+
+
+   /**
+    * \brief
+    *    Get the signature for MethodHandle.linkToStatic call for unresolved invokedynamic
+    *
+    *    For unresolved invokeDynamic, we do not know the adapter method at
+    *    compile time. The call is expressed as a call to the signature-polymorphic
+    *    MethodHandle.linkToStatic method. In addition to the arguments of the original call,
+    *    we need to provide the target and appendix objects as the last two arguments.
+    *    Therefore, we need to modify the signature of the original call and adapt it to accept
+    *    the two extra arguments.
+    *
+    * \param comp the current compilation
+    * \param romMethodSignature the ROM Method signature to be processed
+    * \return char * the signature for linkToStatic
+    */
+   char * getSignatureForLinkToStaticForInvokeDynamic(TR::Compilation* comp, J9UTF8* romMethodSignature);
 #endif
 
    // JSR292 }}}
@@ -1310,4 +1345,3 @@ inline TR_PersistentMemory * persistentMemory(J9JITConfig * jitConfig) { return 
 bool signalOutOfMemory(J9JITConfig *);
 
 #endif // VMJ9
-

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6222,11 +6222,7 @@ void *
 TR_ResolvedJ9Method::callSiteTableEntryAddress(int32_t callSiteIndex)
    {
    J9Class *ramClass = constantPoolHdr();
-#if defined (J9VM_OPT_OPENJDK_METHODHANDLE)
-   return (void *)(((J9InvokeCacheEntry *)ramClass->callSites) + callSiteIndex);
-#else
    return ramClass->callSites + callSiteIndex;
-#endif
    }
 
 bool
@@ -6276,13 +6272,11 @@ void *
 TR_ResolvedJ9Method::methodTypeTableEntryAddress(int32_t cpIndex)
    {
    J9Class *ramClass = constantPoolHdr();
+   UDATA index = (((J9RAMMethodRef*) literals())[cpIndex]).methodIndexAndArgCount >> 8;
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
-   UDATA invokeCacheIndex = (((J9RAMMethodRef*) literals())[cpIndex]).methodIndexAndArgCount >> 8;
-   return (void *)(((J9InvokeCacheEntry *)ramClass->invokeCache) + invokeCacheIndex);
+   return ramClass->invokeCache + index;
 #else
-   UDATA methodTypeIndex = (((J9RAMMethodRef*) literals())[cpIndex]).methodIndexAndArgCount;
-   methodTypeIndex >>= 8;
-   return ramClass->methodTypes + methodTypeIndex;
+   return ramClass->methodTypes + index;
 #endif
    }
 
@@ -6902,7 +6896,7 @@ TR_ResolvedJ9Method::getResolvedDynamicMethod(TR::Compilation * comp, I_32 callS
       TR_OpaqueMethodBlock * targetJ9MethodBlock = NULL;
          {
          TR::VMAccessCriticalSection getResolvedDynamicMethod(fej9());
-         targetJ9MethodBlock = fej9()->targetMethodFromMemberName((uintptr_t) *((uintptr_t *)memberNameAddressFromInvokeDynamicSideTable(callSiteIndex)));
+         targetJ9MethodBlock = fej9()->targetMethodFromMemberName((uintptr_t) memberNameElementRefFromInvokeDynamicSideTable(callSiteIndex));
          }
       result = fej9()->createResolvedMethod(comp->trMemory(), targetJ9MethodBlock, this);
       return result;
@@ -6958,7 +6952,7 @@ TR_ResolvedJ9Method::getResolvedHandleMethod(TR::Compilation * comp, I_32 cpInde
       TR_OpaqueMethodBlock * targetJ9MethodBlock = NULL;
          {
          TR::VMAccessCriticalSection getResolvedHandleMethod(fej9());
-         targetJ9MethodBlock = fej9()->targetMethodFromMemberName((uintptr_t) *((uintptr_t *)memberNameAddressFromInvokeHandleSideTable(cpIndex)));
+         targetJ9MethodBlock = fej9()->targetMethodFromMemberName((uintptr_t) memberNameElementRefFromInvokeHandleSideTable(cpIndex));
          }
       result = fej9()->createResolvedMethod(comp->trMemory(), targetJ9MethodBlock, this);
       return result;
@@ -7051,31 +7045,39 @@ TR_ResolvedJ9Method::fieldsAreSame(I_32 cpIndex1, TR_ResolvedMethod * m2, I_32 c
 
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 void *
-TR_ResolvedJ9Method::memberNameAddressFromInvokeDynamicSideTable(int32_t callSiteIndex)
+TR_ResolvedJ9Method::memberNameElementRefFromInvokeDynamicSideTable(int32_t callSiteIndex)
    {
-   J9InvokeCacheEntry *invokeCache = (J9InvokeCacheEntry *) callSiteTableEntryAddress(callSiteIndex);
-   return (void *) &invokeCache->target;
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)_fe;
+   uintptr_t * invokeCacheArray = (uintptr_t *) callSiteTableEntryAddress(callSiteIndex);
+   TR::VMAccessCriticalSection getRefElement(fej9);
+   return (void*) fej9->getReferenceElement(*invokeCacheArray, 0);
    }
 
 void *
-TR_ResolvedJ9Method::appendixAddressFromInvokeDynamicSideTable(int32_t callSiteIndex)
+TR_ResolvedJ9Method::appendixElementRefFromInvokeDynamicSideTable(int32_t callSiteIndex)
    {
-   J9InvokeCacheEntry *invokeCache = (J9InvokeCacheEntry *) callSiteTableEntryAddress(callSiteIndex);
-   return (void *) &invokeCache->appendix;
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)_fe;
+   uintptr_t * invokeCacheArray = (uintptr_t *) callSiteTableEntryAddress(callSiteIndex);
+   TR::VMAccessCriticalSection getRefElement(fej9);
+   return (void*) fej9->getReferenceElement(*invokeCacheArray, 1);
    }
 
 void *
-TR_ResolvedJ9Method::memberNameAddressFromInvokeHandleSideTable(int32_t cpIndex)
+TR_ResolvedJ9Method::memberNameElementRefFromInvokeHandleSideTable(int32_t cpIndex)
    {
-   J9InvokeCacheEntry *invokeCache = (J9InvokeCacheEntry *) methodTypeTableEntryAddress(cpIndex);
-   return (void *) &invokeCache->target;
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)_fe;
+   uintptr_t * invokeCacheArray = (uintptr_t *) methodTypeTableEntryAddress(cpIndex);
+   TR::VMAccessCriticalSection getRefElement(fej9);
+   return (void*) fej9->getReferenceElement(*invokeCacheArray, 0);
    }
 
 void *
-TR_ResolvedJ9Method::appendixAddressFromInvokeHandleSideTable(int32_t cpIndex)
+TR_ResolvedJ9Method::appendixElementRefFromInvokeHandleSideTable(int32_t cpIndex)
    {
-   J9InvokeCacheEntry *invokeCache = (J9InvokeCacheEntry *) methodTypeTableEntryAddress(cpIndex);
-   return (void *) &invokeCache->appendix;
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)_fe;
+   uintptr_t * invokeCacheArray = (uintptr_t *) methodTypeTableEntryAddress(cpIndex);
+   TR::VMAccessCriticalSection getRefElement(fej9);
+   return (void*) fej9->getReferenceElement(*invokeCacheArray, 1);
    }
 #endif
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6222,7 +6222,11 @@ void *
 TR_ResolvedJ9Method::callSiteTableEntryAddress(int32_t callSiteIndex)
    {
    J9Class *ramClass = constantPoolHdr();
+#if defined (J9VM_OPT_OPENJDK_METHODHANDLE)
+   return (void *)(((J9InvokeCacheEntry *)ramClass->callSites) + callSiteIndex);
+#else
    return ramClass->callSites + callSiteIndex;
+#endif
    }
 
 bool
@@ -6271,10 +6275,15 @@ TR_ResolvedJ9Method::isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex)
 void *
 TR_ResolvedJ9Method::methodTypeTableEntryAddress(int32_t cpIndex)
    {
+   J9Class *ramClass = constantPoolHdr();
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+   UDATA invokeCacheIndex = (((J9RAMMethodRef*) literals())[cpIndex]).methodIndexAndArgCount >> 8;
+   return (void *)(((J9InvokeCacheEntry *)ramClass->invokeCache) + invokeCacheIndex);
+#else
    UDATA methodTypeIndex = (((J9RAMMethodRef*) literals())[cpIndex]).methodIndexAndArgCount;
    methodTypeIndex >>= 8;
-   J9Class *ramClass = constantPoolHdr();
    return ramClass->methodTypes + methodTypeIndex;
+#endif
    }
 
 bool

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6894,9 +6894,10 @@ TR_ResolvedJ9Method::getResolvedDynamicMethod(TR::Compilation * comp, I_32 callS
    if (!isUnresolvedCallSiteTableEntry(callSiteIndex))
       {
       TR_OpaqueMethodBlock * targetJ9MethodBlock = NULL;
+      uintptr_t * invokeCacheArray = (uintptr_t *) callSiteTableEntryAddress(callSiteIndex);
          {
          TR::VMAccessCriticalSection getResolvedDynamicMethod(fej9());
-         targetJ9MethodBlock = fej9()->targetMethodFromMemberName((uintptr_t) memberNameElementRefFromInvokeDynamicSideTable(callSiteIndex));
+         targetJ9MethodBlock = fej9()->targetMethodFromMemberName((uintptr_t) fej9()->getReferenceElement(*invokeCacheArray, JSR292_invokeCacheArrayMemberNameIndex));
          }
       result = fej9()->createResolvedMethod(comp->trMemory(), targetJ9MethodBlock, this);
       return result;
@@ -6949,10 +6950,11 @@ TR_ResolvedJ9Method::getResolvedHandleMethod(TR::Compilation * comp, I_32 cpInde
 
    if (!isUnresolvedMethodTypeTableEntry(cpIndex))
       {
+      uintptr_t * invokeCacheArray = (uintptr_t *) methodTypeTableEntryAddress(cpIndex);
       TR_OpaqueMethodBlock * targetJ9MethodBlock = NULL;
          {
          TR::VMAccessCriticalSection getResolvedHandleMethod(fej9());
-         targetJ9MethodBlock = fej9()->targetMethodFromMemberName((uintptr_t) memberNameElementRefFromInvokeHandleSideTable(cpIndex));
+         targetJ9MethodBlock = fej9()->targetMethodFromMemberName((uintptr_t) fej9()->getReferenceElement(*invokeCacheArray, JSR292_invokeCacheArrayMemberNameIndex));
          }
       result = fej9()->createResolvedMethod(comp->trMemory(), targetJ9MethodBlock, this);
       return result;
@@ -7042,44 +7044,6 @@ TR_ResolvedJ9Method::fieldsAreSame(I_32 cpIndex1, TR_ResolvedMethod * m2, I_32 c
 
    return false;
    }
-
-#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
-void *
-TR_ResolvedJ9Method::memberNameElementRefFromInvokeDynamicSideTable(int32_t callSiteIndex)
-   {
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)_fe;
-   uintptr_t * invokeCacheArray = (uintptr_t *) callSiteTableEntryAddress(callSiteIndex);
-   TR::VMAccessCriticalSection getRefElement(fej9);
-   return (void*) fej9->getReferenceElement(*invokeCacheArray, 0);
-   }
-
-void *
-TR_ResolvedJ9Method::appendixElementRefFromInvokeDynamicSideTable(int32_t callSiteIndex)
-   {
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)_fe;
-   uintptr_t * invokeCacheArray = (uintptr_t *) callSiteTableEntryAddress(callSiteIndex);
-   TR::VMAccessCriticalSection getRefElement(fej9);
-   return (void*) fej9->getReferenceElement(*invokeCacheArray, 1);
-   }
-
-void *
-TR_ResolvedJ9Method::memberNameElementRefFromInvokeHandleSideTable(int32_t cpIndex)
-   {
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)_fe;
-   uintptr_t * invokeCacheArray = (uintptr_t *) methodTypeTableEntryAddress(cpIndex);
-   TR::VMAccessCriticalSection getRefElement(fej9);
-   return (void*) fej9->getReferenceElement(*invokeCacheArray, 0);
-   }
-
-void *
-TR_ResolvedJ9Method::appendixElementRefFromInvokeHandleSideTable(int32_t cpIndex)
-   {
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)_fe;
-   uintptr_t * invokeCacheArray = (uintptr_t *) methodTypeTableEntryAddress(cpIndex);
-   TR::VMAccessCriticalSection getRefElement(fej9);
-   return (void*) fej9->getReferenceElement(*invokeCacheArray, 1);
-   }
-#endif
 
 bool
 TR_ResolvedJ9Method::staticsAreSame(I_32 cpIndex1, TR_ResolvedMethod * m2, I_32 cpIndex2, bool &sigSame)

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -531,6 +531,40 @@ public:
     */
    virtual bool isFieldFlattened(TR::Compilation *comp, int32_t cpIndex, bool isStatic);
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+   /**
+    * \brief Get member name object address from invokeDynamic side table
+    *
+    * \param callSiteIndex the call site index
+    * \return void * the member name object address
+    */
+   void * memberNameAddressFromInvokeDynamicSideTable(int32_t callSiteIndex);
+
+   /**
+    * \brief Get appendix object address from invokeDynamic side table
+    *
+    * \param callSiteIndex the call site index
+    * \return void * the appendix object address
+    */
+   void * appendixAddressFromInvokeDynamicSideTable(int32_t callSiteIndex);
+
+   /**
+    * \brief Get member name object address from invokeHandle side table
+    *
+    * \param cpIndex the CP index
+    * \return void * the member name object address
+    */
+   void * memberNameAddressFromInvokeHandleSideTable(int32_t cpIndex);
+
+   /**
+    * \brief Get appendix object address from invokeHandle side table
+    *
+    * \param cpIndex the CP index
+    * \return void * the appendix object address
+    */
+   void * appendixAddressFromInvokeHandleSideTable(int32_t cpIndex);
+#endif
+
 protected:
    virtual TR_J9MethodBase *       asJ9Method(){ return this; }
    TR_ResolvedJ9Method(TR_FrontEnd *, TR_ResolvedMethod * owningMethod = 0);

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -533,36 +533,36 @@ public:
 
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
    /**
-    * \brief Get member name object address from invokeDynamic side table
+    * \brief Get member name object ref from invokeCacheArray entry in the invokeDynamic side table
     *
     * \param callSiteIndex the call site index
-    * \return void * the member name object address
+    * \return void * the member name object element ref
     */
-   void * memberNameAddressFromInvokeDynamicSideTable(int32_t callSiteIndex);
+   void * memberNameElementRefFromInvokeDynamicSideTable(int32_t callSiteIndex);
 
    /**
-    * \brief Get appendix object address from invokeDynamic side table
+    * \brief Get appendix object ref from invokeCacheArray entry in the invokeDynamic side table
     *
     * \param callSiteIndex the call site index
-    * \return void * the appendix object address
+    * \return void * the appendix object element ref
     */
-   void * appendixAddressFromInvokeDynamicSideTable(int32_t callSiteIndex);
+   void * appendixElementRefFromInvokeDynamicSideTable(int32_t callSiteIndex);
 
    /**
-    * \brief Get member name object address from invokeHandle side table
+    * \brief Get member name object ref from invokeCacheArray entry in the invokeHandle side table
     *
     * \param cpIndex the CP index
-    * \return void * the member name object address
+    * \return void * the member name object element ref
     */
-   void * memberNameAddressFromInvokeHandleSideTable(int32_t cpIndex);
+   void * memberNameElementRefFromInvokeHandleSideTable(int32_t cpIndex);
 
    /**
-    * \brief Get appendix object address from invokeHandle side table
+    * \brief Get appendix object ref from invokeCacheArray entry in the invokeHandle side table
     *
     * \param cpIndex the CP index
-    * \return void * the appendix object address
+    * \return void * the appendix object element ref
     */
-   void * appendixAddressFromInvokeHandleSideTable(int32_t cpIndex);
+   void * appendixElementRefFromInvokeHandleSideTable(int32_t cpIndex);
 #endif
 
 protected:

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -531,40 +531,6 @@ public:
     */
    virtual bool isFieldFlattened(TR::Compilation *comp, int32_t cpIndex, bool isStatic);
 
-#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
-   /**
-    * \brief Get member name object ref from invokeCacheArray entry in the invokeDynamic side table
-    *
-    * \param callSiteIndex the call site index
-    * \return void * the member name object element ref
-    */
-   void * memberNameElementRefFromInvokeDynamicSideTable(int32_t callSiteIndex);
-
-   /**
-    * \brief Get appendix object ref from invokeCacheArray entry in the invokeDynamic side table
-    *
-    * \param callSiteIndex the call site index
-    * \return void * the appendix object element ref
-    */
-   void * appendixElementRefFromInvokeDynamicSideTable(int32_t callSiteIndex);
-
-   /**
-    * \brief Get member name object ref from invokeCacheArray entry in the invokeHandle side table
-    *
-    * \param cpIndex the CP index
-    * \return void * the member name object element ref
-    */
-   void * memberNameElementRefFromInvokeHandleSideTable(int32_t cpIndex);
-
-   /**
-    * \brief Get appendix object ref from invokeCacheArray entry in the invokeHandle side table
-    *
-    * \param cpIndex the CP index
-    * \return void * the appendix object element ref
-    */
-   void * appendixElementRefFromInvokeHandleSideTable(int32_t cpIndex);
-#endif
-
 protected:
    virtual TR_J9MethodBase *       asJ9Method(){ return this; }
    TR_ResolvedJ9Method(TR_FrontEnd *, TR_ResolvedMethod * owningMethod = 0);

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -122,8 +122,31 @@ private:
    void         genInvokeVirtual(int32_t);
    void         genInvokeInterface(int32_t);
    void         genInvokeDynamic(int32_t callSiteIndex);
-   TR::Node *    genInvokeHandle(int32_t cpIndex);
-   TR::Node *    genInvokeHandleGeneric(int32_t cpIndex);
+   TR::Node *   genInvokeHandle(int32_t cpIndex);
+   TR::Node *   genInvokeHandleGeneric(int32_t cpIndex);
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+   /**
+    * \brief
+    *       Loads appendix and target objects (if required) from call site table
+    *       into the stack to be used as parameters for adapter method call node.
+    *       Needed for OpenJDK method handle implementation.
+    *
+    * \param callSiteIndex
+    *       The call site index for the invokedynamic bytecode
+    */
+   void         loadFromSideTableForInvokeDynamic(int32_t callSiteIndex);
+
+   /**
+    * \brief
+    *       Loads appendix and target objects (if required) from constant pool
+    *       into the stack to be used as parameters for adapter method call node.
+    *       Needed for OpenJDK method handle implementation.
+    *
+    * \param cpIndex
+    *       The CP index for the invokehandle bytecode
+    */
+   void         loadFromSideTableForInvokeHandle(int32_t cpIndex);
+#endif
 
    TR::Node *    genHandleTypeCheck(TR::Node *handle, TR::Node *expectedType);
 

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -445,4 +445,3 @@ private:
    };
 
 #endif
-

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -146,6 +146,15 @@ private:
     *       The CP index for the invokehandle bytecode
     */
    void         loadFromSideTableForInvokeHandle(int32_t cpIndex);
+
+   /**
+    * \brief
+    *    Generates IL to load elements from invokeCacheArray
+    *
+    * \param tableEntrySymRef the symref representing the invokeCacheArray
+    * \param invokeCacheArray the invokeCacheArray
+    */
+   void         loadInvokeCacheArrayElements(TR::SymbolReference *tableEntrySymRef, uintptr_t * invokeCacheArray);
 #endif
 
    TR::Node *    genHandleTypeCheck(TR::Node *handle, TR::Node *expectedType);

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -127,34 +127,16 @@ private:
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
    /**
     * \brief
-    *       Loads appendix and target objects (if required) from call site table
-    *       into the stack to be used as parameters for adapter method call node.
-    *       Needed for OpenJDK method handle implementation.
-    *
-    * \param callSiteIndex
-    *       The call site index for the invokedynamic bytecode
-    */
-   void         loadFromSideTableForInvokeDynamic(int32_t callSiteIndex);
-
-   /**
-    * \brief
-    *       Loads appendix and target objects (if required) from constant pool
-    *       into the stack to be used as parameters for adapter method call node.
-    *       Needed for OpenJDK method handle implementation.
-    *
-    * \param cpIndex
-    *       The CP index for the invokehandle bytecode
-    */
-   void         loadFromSideTableForInvokeHandle(int32_t cpIndex);
-
-   /**
-    * \brief
-    *    Generates IL to load elements from invokeCacheArray
+    *    Generates IL to load elements from invokeCacheArray, resulting in load of
+    *    appendix and memberName objects into the stack to be used as
+    *    parameters for adapter method call node. memberName object is only required
+    *    to be loaded when the invokedynamic/invokehandle is unresolved
     *
     * \param tableEntrySymRef the symref representing the invokeCacheArray
-    * \param invokeCacheArray the invokeCacheArray
+    * \param invokeCacheArray the static address of the invokeCacheArray
+    * \param isUnresolved
     */
-   void         loadInvokeCacheArrayElements(TR::SymbolReference *tableEntrySymRef, uintptr_t * invokeCacheArray);
+   void         loadInvokeCacheArrayElements(TR::SymbolReference *tableEntrySymRef, uintptr_t * invokeCacheArray, bool isUnresolved);
 #endif
 
    TR::Node *    genHandleTypeCheck(TR::Node *handle, TR::Node *expectedType);

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3381,32 +3381,54 @@ TR_J9ByteCodeIlGenerator::genInvokeHandle(TR::SymbolReference *invokeExactSymRef
 void
 TR_J9ByteCodeIlGenerator::loadFromSideTableForInvokeDynamic(int32_t callSiteIndex)
    {
-   TR::SymbolReference *appendixSymRef = symRefTab()->findOrCreateCallSiteTableEntrySymbol(_methodSymbol, callSiteIndex);
-   TR::Node * appendixNode = loadSymbol(TR::aload, appendixSymRef);
-   if (appendixSymRef->isUnresolved())
+   TR::SymbolReference *callSiteTableEntrySymRef = symRefTab()->findOrCreateCallSiteTableEntrySymbol(_methodSymbol, callSiteIndex);
+   loadSymbol(TR::aload, callSiteTableEntrySymRef);
+   loadConstant(TR::iconst, 1); // appendix object
+   loadArrayElement(TR::Address, comp()->il.opCodeForIndirectLoad(TR::Address), false);
+   if (callSiteTableEntrySymRef->isUnresolved())
       {
       // Appendix being unresolved means the target is also unresolved.
       // Instead of creating a call to the adapter method, we construct
       // a call to linkToStatic and provide appendix and target as
       // additional parameters.
-      TR::SymbolReference *memberNameSymRef = symRefTab()->findOrCreateCallSiteTableEntrySymbol(_methodSymbol, callSiteIndex, true);
-      TR::Node * memberNameNode = loadSymbol(TR::aload, memberNameSymRef);
+      loadSymbol(TR::aload, callSiteTableEntrySymRef);
+      loadConstant(TR::iconst, 0); // membername object
+      loadArrayElement(TR::Address, comp()->il.opCodeForIndirectLoad(TR::Address), false);
+      }
+   else
+      {
+      TR_ResolvedJ9Method* owningMethod = static_cast<TR_ResolvedJ9Method *>(_methodSymbol->getResolvedMethod());
+      uintptr_t arrayElementRef = (uintptr_t) owningMethod->appendixElementRefFromInvokeDynamicSideTable(callSiteIndex);
+      TR::Node * appendixNode = _stack->top();
+      TR::SymbolReference * appendixSymRef = symRefTab()->refineInvokeCacheElementSymRefWithKnownObjectIndex(_methodSymbol, appendixNode->getSymbolReference(), arrayElementRef);
+      appendixNode->setSymbolReference(appendixSymRef);
       }
    }
 
 void
 TR_J9ByteCodeIlGenerator::loadFromSideTableForInvokeHandle(int32_t cpIndex)
    {
-   TR::SymbolReference *appendixSymRef = symRefTab()->findOrCreateMethodTypeTableEntrySymbol(_methodSymbol, cpIndex);
-   TR::Node * appendixNode = loadSymbol(TR::aload, appendixSymRef);
-   if (appendixSymRef->isUnresolved())
+   TR::SymbolReference *methodTypeTableEntrySymRef = symRefTab()->findOrCreateMethodTypeTableEntrySymbol(_methodSymbol, cpIndex);
+   loadSymbol(TR::aload, methodTypeTableEntrySymRef);
+   loadConstant(TR::iconst, 1); // appendix object
+   loadArrayElement(TR::Address, comp()->il.opCodeForIndirectLoad(TR::Address), false);
+   if (methodTypeTableEntrySymRef->isUnresolved())
       {
       // Appendix being unresolved means the target is also unresolved.
       // Instead of creating a call to the adapter method, we construct
       // a call to linkToStatic and provide appendix and target as
       // additional parameters.
-      TR::SymbolReference *memberNameSymRef = symRefTab()->findOrCreateMethodTypeTableEntrySymbol(_methodSymbol, cpIndex, true);
-      TR::Node * memberNameNode = loadSymbol(TR::aload, memberNameSymRef);
+      loadSymbol(TR::aload, methodTypeTableEntrySymRef);
+      loadConstant(TR::iconst, 0); // membername object
+      loadArrayElement(TR::Address, comp()->il.opCodeForIndirectLoad(TR::Address), false);
+      }
+   else
+      {
+      TR_ResolvedJ9Method* owningMethod = static_cast<TR_ResolvedJ9Method *>(_methodSymbol->getResolvedMethod());
+      uintptr_t arrayElementRef = (uintptr_t) owningMethod->appendixElementRefFromInvokeHandleSideTable(cpIndex);
+      TR::Node * appendixNode = _stack->top();
+      TR::SymbolReference * appendixSymRef = symRefTab()->refineInvokeCacheElementSymRefWithKnownObjectIndex(_methodSymbol, appendixNode->getSymbolReference(), arrayElementRef);
+      appendixNode->setSymbolReference(appendixSymRef);
       }
    }
 #endif

--- a/runtime/compiler/optimizer/InterpreterEmulator.hpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/optimizer/InterpreterEmulator.hpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.hpp
@@ -277,6 +277,9 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
       bool isGenerated(int32_t bcIndex) { return _iteratorWithState ? Base::isGenerated(bcIndex): false; }
       void visitInvokedynamic();
       void visitInvokevirtual();
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+      void visitInvokehandle();
+#endif
       void visitInvokespecial();
       void visitInvokestatic();
       void visitInvokeinterface();

--- a/runtime/compiler/optimizer/InterpreterEmulator.hpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.hpp
@@ -279,6 +279,7 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
       void visitInvokevirtual();
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
       void visitInvokehandle();
+      void updateKnotAndCreateCallSiteUsingInvokeCacheArray(TR_ResolvedJ9Method* owningMethod, uintptr_t * invokeCacheArray, int32_t cpIndex);
 #endif
       void visitInvokespecial();
       void visitInvokestatic();


### PR DESCRIPTION
This changeset updates the handling of `invokedynamic` and `invokehandle`
bytecodes in preparation for migrating to the OpenJDK MethodHandle
implementation. The changes are not enabled by default, and are guarded
in the macro `J9VM_OPT_OPENJDK_METHODHANDLE`.

This implementation can handle both resolved and unresolved
`invokedynamic` and `invokehandle` bytecodes.

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>