### PR TITLE
Port cmdLineTester tests into openj9

### DIFF
--- a/test/functional/cmdLineTests/bootStrapStaticVerify/bootStrapStaticVerify.xml
+++ b/test/functional/cmdLineTests/bootStrapStaticVerify/bootStrapStaticVerify.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2016, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 Bootstrap Loader Static Verification Command-Line Option Tests" timeout="300">
+	<variable name="CLASS" value="-cp $UTILSJAR$ VMBench.FibBench" />
+ 
+ 	<test id="Check that static verification is off for the bootclasspath">
+		<command>$EXE$ -Xtrace:print={j9bcverify.14} -XX:+StartupOpts $CLASS$</command>
+		<output type="success" regex="no">Fibonacci: iterations</output>
+		<output type="failure" regex="no">j9bcv_verifyClassStructure - class: java/lang/Class</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+ 	</test>
+ 
+ 	<test id="Check that static verification is on for the bootclasspath with -Xverify:bootclasspathStatic">
+		<command>$EXE$ -Xtrace:print={j9bcverify.14} -XX:+StartupOpts -Xverify:bootclasspathstatic $CLASS$</command>
+		<output type="success" regex="no">Fibonacci: iterations</output>
+		<output type="required" regex="no">j9bcv_verifyClassStructure - class: VMBench/FibBench</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+ 	</test>
+ 
+	<test id="Check that static verification is on for the bootclasspath with -Xfuture">
+		<command>$EXE$ -Xtrace:print={j9bcverify.14} -XX:+StartupOpts -Xfuture $CLASS$</command>
+		<output type="success" regex="no">Fibonacci: iterations</output>
+		<output type="required" regex="no">j9bcv_verifyClassStructure - class: VMBench/FibBench</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+ 
+	<test id="Check that static verification is on for the bootclasspath with -Xverify:all">
+		<command>$EXE$ -Xtrace:print={j9bcverify.14} -XX:+StartupOpts -Xverify:all $CLASS$</command>
+		<output type="success" regex="no">Fibonacci: iterations</output>
+		<output type="required" regex="no">j9bcv_verifyClassStructure - class: VMBench/FibBench</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+ 
+	<test id="Check that static verification is on for the bootclasspath with -Xshareclasses">
+		<command>$EXE$ -Xtrace:print={j9bcverify.14} -XX:+StartupOpts -Xshareclasses:name=testBootStrapStaticVerify $CLASS$</command>
+		<output type="success" regex="no">Fibonacci: iterations</output>
+		<output type="required" regex="no">j9bcv_verifyClassStructure - class: VMBench/FibBench</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Cleanup shared classes cache">
+		<command>$EXE$ -Xshareclasses:name=testBootStrapStaticVerify,destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
+		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+ 
+</suite>

--- a/test/functional/cmdLineTests/bootStrapStaticVerify/build.xml
+++ b/test/functional/cmdLineTests/bootStrapStaticVerify/build.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="cmdLineTests" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests bootStrapStaticVerify
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/bootStrapStaticVerify" />
+	<property name="src" location="." />
+
+	<target name="dist" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml"/>
+		</copy>
+	</target>
+
+	<target name="build" >
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/bootStrapStaticVerify/playlist.xml
+++ b/test/functional/cmdLineTests/bootStrapStaticVerify/playlist.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+	<test>
+		<testCaseName>cmdLineTester_bootStrapStaticVerify</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) \
+	-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)bootStrapStaticVerify.xml$(Q) \
+	-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+</playlist>

--- a/test/functional/cmdLineTests/doProtectedAccessCheck/build.xml
+++ b/test/functional/cmdLineTests/doProtectedAccessCheck/build.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="loadLibraryTest" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests doProtectedAccessCheck
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/doProtectedAccessCheck" />
+	<property name="src" location="./src"/>
+	<property name="build" location="./bin"/>
+
+	<target name="init">
+		<mkdir dir="${DEST}" />
+		<mkdir dir="${build}" />
+	</target>
+
+	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source" >
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
+
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+			<src path="${src}"/>
+			<classpath>
+				<pathelement location="${LIB_DIR}/asm.jar" />
+			</classpath>
+		</javac>
+	</target>
+
+	<target name="dist" depends="compile" description="generate the distribution">
+		<jar jarfile="${DEST}/doProtectedAccessCheck.jar" filesonly="true" manifest="${src}/META-INF/MANIFEST.MF">
+			<fileset dir="${build}" />
+			<fileset dir="${src}" />
+		</jar>
+		<copy todir="${DEST}">
+			<fileset dir="${src}/../" includes="*.xml" />
+		</copy>
+	</target>
+
+	<target name="clean" depends="dist" description="clean up">
+		<!-- Delete the ${build} directory trees -->
+		<delete dir="${build}" />
+	</target>
+
+	<target name="build" >
+		<antcall target="clean" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/doProtectedAccessCheck/doProtectedAccessCheck.xml
+++ b/test/functional/cmdLineTests/doProtectedAccessCheck/doProtectedAccessCheck.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2016, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 -Xverify:doProtectedAccessCheck" timeout="300">
+    <variable name="JAR" value="-Xint -javaagent:$Q$$AGENTPATH$$Q$ -cp $Q$$JARPATH$$Q$ b/B" />
+    
+    <test id="With -Xverify:doProtectedAccessCheck">
+        <command>$EXE$ -Xverify:doProtectedAccessCheck $JAR$</command>
+        <output type="success" regex="no">java.lang.VerifyError</output>
+        <output type="failure" regex="no">retransformed A</output>
+        <output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+        <output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+        <output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+    </test>
+    
+    <test id="Without -Xverify:doProtectedAccessCheck">
+        <command>$EXE$ $JAR$</command>
+        <output type="success" regex="no">retransformed A</output>
+        <output type="failure" regex="no">original A</output>
+        <output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+        <output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+        <output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+        <return value="0" />
+    </test>
+</suite>

--- a/test/functional/cmdLineTests/doProtectedAccessCheck/playlist.xml
+++ b/test/functional/cmdLineTests/doProtectedAccessCheck/playlist.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+	<test>
+		<testCaseName>cmdLineTester_doProtectedAccessCheck</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DAGENTPATH=$(Q)$(TEST_RESROOT)$(D)doProtectedAccessCheck.jar$(Q) \
+	-DJARPATH=$(Q)$(LIB_DIR)$(D)asm-all.jar$(P)$(TEST_RESROOT)$(D)doProtectedAccessCheck.jar$(Q) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) \
+	-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)doProtectedAccessCheck.xml$(Q) \
+	-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+</playlist>

--- a/test/functional/cmdLineTests/doProtectedAccessCheck/src/META-INF/MANIFEST.MF
+++ b/test/functional/cmdLineTests/doProtectedAccessCheck/src/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Main-Class: javaagent.JavaAgent
+Agent-Class: javaagent.JavaAgent
+Can-Redefine-Classes: true
+Can-Retransform-Classes: true
+Premain-Class: javaagent.JavaAgent

--- a/test/functional/cmdLineTests/doProtectedAccessCheck/src/a/A.java
+++ b/test/functional/cmdLineTests/doProtectedAccessCheck/src/a/A.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package a;
+
+public class A {
+	public void foo() {
+		System.out.println("original A");
+	}
+}

--- a/test/functional/cmdLineTests/doProtectedAccessCheck/src/b/B.java
+++ b/test/functional/cmdLineTests/doProtectedAccessCheck/src/b/B.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package b;
+
+import a.A;
+
+public class B extends A {
+	public static void main(String[] args) {
+		A a = new A();
+		a.foo();
+	}
+}

--- a/test/functional/cmdLineTests/doProtectedAccessCheck/src/javaagent/JavaAgent.java
+++ b/test/functional/cmdLineTests/doProtectedAccessCheck/src/javaagent/JavaAgent.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package javaagent;
+
+import java.lang.instrument.Instrumentation;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class JavaAgent {
+
+	public static int transformCount = 0;
+
+	public static void premain(String args, Instrumentation inst) throws Exception {
+		inst.addTransformer(new ProtectedClassFileTransformer(), true);
+		inst.retransformClasses(Class.forName("b.B"), Class.forName("a.A"));
+	}
+}

--- a/test/functional/cmdLineTests/doProtectedAccessCheck/src/javaagent/ProtectedClassFileTransformer.java
+++ b/test/functional/cmdLineTests/doProtectedAccessCheck/src/javaagent/ProtectedClassFileTransformer.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package javaagent;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.IllegalClassFormatException;
+import java.lang.instrument.UnmodifiableClassException;
+import java.security.ProtectionDomain;
+import java.util.Random;
+
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class ProtectedClassFileTransformer implements ClassFileTransformer,
+		Opcodes {
+
+	@Override
+	public byte[] transform(ClassLoader loader, String className,
+			Class<?> classBeingRedefined, ProtectionDomain protectionDomain,
+			byte[] classfileBuffer) throws IllegalClassFormatException {
+
+		/*
+		 * When multiple classes are retransformed at the same time via JVMTI
+		 * the verifier will not see all new class data while each new class is
+		 * being verified. So if we redefine A and B, and verifying A required
+		 * looking at B, we'll see the old B.
+		 * 
+		 * This test retransforms 2 classes (A and B) in the same call, but
+		 * modifies A such that B should fail verification.
+		 * 
+		 * See JAZZ103 40748 and CMVC 193469
+		 */
+
+		if (className.equals("b/B")) {
+			JavaAgent.transformCount += 1;
+		}
+
+		if (JavaAgent.transformCount > 1) {
+
+			/*
+			 * This is an asmified version of
+			 * VM_Test/VM/cmdLineTester_doProtectedAccessCheck/src/a/A.java
+			 * except the foo method is changed from public to protected.
+			 */
+			if (className.equals("a/A")) {
+				ClassWriter cw = new ClassWriter(0);
+				MethodVisitor mv;
+
+				cw.visit(V1_7, ACC_PUBLIC + ACC_SUPER, "a/A", null,
+						"java/lang/Object", null);
+
+				{
+					mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+					mv.visitCode();
+					mv.visitVarInsn(ALOAD, 0);
+					mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object",
+							"<init>", "()V");
+					mv.visitInsn(RETURN);
+					mv.visitMaxs(1, 1);
+					mv.visitEnd();
+				}
+				{
+					mv = cw.visitMethod(ACC_PROTECTED, "foo", "()V", null, null);
+					mv.visitCode();
+					mv.visitFieldInsn(GETSTATIC, "java/lang/System", "out",
+							"Ljava/io/PrintStream;");
+					mv.visitLdcInsn("retransformed A");
+					mv.visitMethodInsn(INVOKEVIRTUAL, "java/io/PrintStream",
+							"println", "(Ljava/lang/String;)V");
+					mv.visitInsn(RETURN);
+					mv.visitMaxs(2, 1);
+					mv.visitEnd();
+
+				}
+				cw.visitEnd();
+
+				return cw.toByteArray();
+			}
+
+			/*
+			 * This is an asmified version of
+			 * VM_Test/VM/cmdLineTester_doProtectedAccessCheck/src/b/B.java
+			 */
+			if (className.equals("b/B")) {
+				ClassWriter cw = new ClassWriter(0);
+				MethodVisitor mv;
+
+				cw.visit(V1_7, ACC_PUBLIC + ACC_SUPER, "b/B", null, "a/A", null);
+
+				{
+					mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+					mv.visitCode();
+					mv.visitVarInsn(ALOAD, 0);
+					mv.visitMethodInsn(INVOKESPECIAL, "a/A", "<init>", "()V");
+					mv.visitInsn(RETURN);
+					mv.visitMaxs(1, 1);
+					mv.visitEnd();
+				}
+				{
+					mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "main",
+							"([Ljava/lang/String;)V", null, null);
+					mv.visitCode();
+					mv.visitTypeInsn(NEW, "a/A");
+					mv.visitInsn(DUP);
+					mv.visitMethodInsn(INVOKESPECIAL, "a/A", "<init>", "()V");
+					mv.visitVarInsn(ASTORE, 1);
+					mv.visitVarInsn(ALOAD, 1);
+					mv.visitMethodInsn(INVOKEVIRTUAL, "a/A", "foo", "()V");
+					mv.visitInsn(RETURN);
+					mv.visitMaxs(2, 2);
+					mv.visitEnd();
+				}
+
+				cw.visitEnd();
+
+				return cw.toByteArray();
+			}
+		}
+
+		return classfileBuffer;
+	}
+}

--- a/test/functional/cmdLineTests/dscr/build.xml
+++ b/test/functional/cmdLineTests/dscr/build.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="cmdLineTests" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests dscr
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/dscr" />
+	<property name="src" location="." />
+
+	<target name="dist" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml"/>
+		</copy>
+	</target>
+
+	<target name="build" >
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/dscr/dscr.xml
+++ b/test/functional/cmdLineTests/dscr/dscr.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2016, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 set HW prefetch AIX Command-Line Option Tests" timeout="2400">
+	<variable name="CLASS" value="-cp $UTILSJAR$ VMBench.FibBench" />
+
+	<test id="Disabling Hardware Prefetch by default">
+		<command>$EXE$ -Xtrace:print={j9util.35-36} $CLASS$</command>
+		<output regex="no" type="success">Fibonacci: iterations</output>
+		<output regex="no" type="required">j9util(j9vm).35       - setHWPrefetch return code = 0 and current value of DSCR = 1</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Disabling Hardware Prefetch -XXsetHWPrefetch:none">
+		<command>$EXE$ -Xtrace:print={j9util.35-36} -XXsetHWPrefetch:none $CLASS$</command>
+		<output regex="no" type="success">Fibonacci: iterations</output>
+		<output regex="no" type="required">j9util(j9vm).35       - setHWPrefetch return code = 0 and current value of DSCR = 1</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Disabling Hardware Prefetch -XXsetHWPrefetch:all">
+		<command>$EXE$ -Xtrace:print={j9util.35-36} -XXsetHWPrefetch:all $CLASS$</command>
+		<output regex="no" type="success">Command-line option unrecognised: -XXsetHWPrefetch:all</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Setting OS Default Value -XXsetHWPrefetch:os-default">
+		<command>$EXE$ -Xtrace:print={j9util.35-36} -XXsetHWPrefetch:os-default $CLASS$</command>
+		<output regex="no" type="success">Fibonacci: iterations</output>
+		<output regex="no" type="required">j9util(j9vm).35       - setHWPrefetch return code = 0 and current value of DSCR = 0</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Setting Default Value -XXsetHWPrefetch=0">
+		<command>$EXE$ -Xtrace:print={j9util.35-36} -XXsetHWPrefetch=0 $CLASS$</command>
+		<output regex="no" type="success">Fibonacci: iterations</output>
+		<output regex="no" type="required">j9util(j9vm).35       - setHWPrefetch return code = 0 and current value of DSCR = 0</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Setting Non Default Value -XXsetHWPrefetch=1">
+		<command>$EXE$ -Xtrace:print={j9util.35-36} -XXsetHWPrefetch=1 $CLASS$</command>
+		<output regex="no" type="success">Fibonacci: iterations</output>
+		<output regex="no" type="required">j9util(j9vm).35       - setHWPrefetch return code = 0 and current value of DSCR = 1</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Invalid Input -XXsetHWPrefetch=-1">
+		<command>$EXE$ -Xtrace:print={j9util.35-36} -XXsetHWPrefetch=-1 $CLASS$</command>
+		<output regex="no" type="success">Parse error for -XXsetHWPrefetch=</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<!--  RTC 110469: AIX cmdLineTester_dscr fails on aix71p8vm6.canlab.ibm.com.  Invalid test. -->
+
+	<test id="Invalid Input -XXsetHWPrefetch=abc">
+		<command>$EXE$ -Xtrace:print={j9util.35-36} -XXsetHWPrefetch=abc $CLASS$</command>
+		<output regex="no" type="success">Parse error for -XXsetHWPrefetch=</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test Argument Ordering -XXsetHWPrefetch:none -XXsetHWPrefetch=2">
+		<command>$EXE$ -Xtrace:print={j9util.35-36} -XXsetHWPrefetch:none -XXsetHWPrefetch=2 $CLASS$</command>
+		<output regex="no" type="success">Fibonacci: iterations</output>
+		<output regex="no" type="required">j9util(j9vm).35       - setHWPrefetch return code = 0 and current value of DSCR = 2</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test Argument Ordering -XXsetHWPrefetch=3 -XXsetHWPrefetch:none">
+		<command>$EXE$ -Xtrace:print={j9util.35-36} -XXsetHWPrefetch=3 -XXsetHWPrefetch:none $CLASS$</command>
+		<output regex="no" type="success">Fibonacci: iterations</output>
+		<output regex="no" type="required">j9util(j9vm).35       - setHWPrefetch return code = 0 and current value of DSCR = 1</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Test Argument Ordering -XXsetHWPrefetch=1 -XXsetHWPrefetch=-3 -XXsetHWPrefetch=2">
+		<command>$EXE$ -Xtrace:print={j9util.35-36} -XXsetHWPrefetch=1 -XXsetHWPrefetch=-3 -XXsetHWPrefetch=2 $CLASS$</command>
+		<output regex="no" type="success">Fibonacci: iterations</output>
+		<output regex="no" type="required">j9util(j9vm).35       - setHWPrefetch return code = 0 and current value of DSCR = 2</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test Argument Ordering -XXsetHWPrefetch:none -XXsetHWPrefetch=2 -XXsetHWPrefetch:os-default">
+		<command>$EXE$ -Xtrace:print={j9util.35-36} -XXsetHWPrefetch:none -XXsetHWPrefetch=2 -XXsetHWPrefetch:os-default $CLASS$</command>
+		<output regex="no" type="success">Fibonacci: iterations</output>
+		<output regex="no" type="required">j9util(j9vm).35       - setHWPrefetch return code = 0 and current value of DSCR = 0</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test Argument Ordering -XXsetHWPrefetch:os-default -XXsetHWPrefetch:none -XXsetHWPrefetch:os-default">
+		<command>$EXE$ -Xtrace:print={j9util.35-36} -XXsetHWPrefetch:os-default -XXsetHWPrefetch:none -XXsetHWPrefetch:os-default $CLASS$</command>
+		<output regex="no" type="success">Fibonacci: iterations</output>
+		<output regex="no" type="required">j9util(j9vm).35       - setHWPrefetch return code = 0 and current value of DSCR = 0</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test Argument Ordering -XXsetHWPrefetch:none -XXsetHWPrefetch:os-default -XXsetHWPrefetch:none">
+		<command>$EXE$ -Xtrace:print={j9util.35-36} -XXsetHWPrefetch:none -XXsetHWPrefetch:os-default -XXsetHWPrefetch:none $CLASS$</command>
+		<output regex="no" type="success">Fibonacci: iterations</output>
+		<output regex="no" type="required">j9util(j9vm).35       - setHWPrefetch return code = 0 and current value of DSCR = 1</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+ 
+</suite>

--- a/test/functional/cmdLineTests/dscr/playlist.xml
+++ b/test/functional/cmdLineTests/dscr/playlist.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+  	<test>
+		<testCaseName>cmdLineTester_dscr</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)dscr.xml$(Q) -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<platformRequirements>os.aix</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+</playlist>

--- a/test/functional/cmdLineTests/locales/build.xml
+++ b/test/functional/cmdLineTests/locales/build.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="cmdLineTests" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests locales
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/locales" />
+	<property name="src" location="." />
+
+	<if>
+		<contains string="${SPEC}" substring="zos"/>
+		<then>
+			<property name="TEXT_ENCODING" value="IBM-1047"/>
+		</then>
+		<else>
+			<property name="TEXT_ENCODING" value="ISO-8859-1"/>
+		</else>
+	</if>
+
+	<target name="dist" description="generate the distribution">
+		<copy todir="${DEST}" outputencoding="${TEXT_ENCODING}">
+			<fileset dir="${src}" includes="*.xml"/>
+			<fileset dir="${src}" includes="*.sh"/>
+		</copy>
+	</target>
+
+	<target name="build" >
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/locales/locales.xml
+++ b/test/functional/cmdLineTests/locales/locales.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2016, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 Locales Command-Line Option Tests" timeout="2400">
+	<variable name="CLASS" value="-cp $UTILSJAR$ VMBench.FibBench" />
+	
+	<test id="locales">
+		<command>$EXE$ -Xlog:INFO -Xshareclasses:SILENT -Xjit:NUMINTERFACECALLCACHESLOTS=4 -Xtrace:iprint=j9vm.4 $CLASS$</command>
+		<output regex="no" type="success">Fibonacci: iterations</output> 
+		<output regex="no" type="failure">bad return code</output>
+		<output regex="no" type="failure">JVMJ9VM085</output>
+	</test>
+	
+</suite>

--- a/test/functional/cmdLineTests/locales/playlist.xml
+++ b/test/functional/cmdLineTests/locales/playlist.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+	<test>
+		<testCaseName>cmdLineTester_locales</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-DEXE=$(SQ)bash $(TEST_RESROOT)$(D)run_all_locales.sh $(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)locales.xml$(Q) -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<platformRequirements>^os.win</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<!-- temporarily disable this test on openj9; backlog issue 384 -->
+			<impl>ibm</impl>
+		</impls>
+	</test>
+</playlist>

--- a/test/functional/cmdLineTests/locales/run_all_locales.sh
+++ b/test/functional/cmdLineTests/locales/run_all_locales.sh
@@ -1,0 +1,60 @@
+#! /bin/bash
+
+#
+# Copyright (c) 2016, 2020 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+#
+
+# don't try ZOS xplink and lp64 locales
+# Various IBM-XXXX code pages cause java.io.UnsupportedEncodingsException on ZOS 
+# see CMVC 189169 and 189170
+for locale in `locale -a | grep -v -E "xplink|lp64|IBM"`;
+do
+  # vi_VN.tcvn currently causes problems in SLES10 and 11
+  # see CMVC 188505 and https://bugzilla.linux.ibm.com/show_bug.cgi?id=78610
+  if [[ "$locale" != "vi_VN.tcvn" && \
+  # hy_AM.armsc, ka_GE, ka_GE.georg, tg_TJ, tg_TJ.koi8t currently cause problems on Linux
+  # as of SDK.java7sr1hrt = 20120213_01
+  # see CMVC 188906
+	"$locale" != "Ar_AA" && \
+	"$locale" != "hy_AM.armscii8" && \
+	"$locale" != "ka_GE" && \
+	"$locale" != "ka_GE.georgianps" && \
+	"$locale" != "tg_TJ" && \
+	"$locale" != "tg_TJ.koi8t" ]]; then
+
+    echo
+    echo "Locale: " $locale;
+
+    # also print locale to stderr so it appears with the JAVA errors
+    echo 1>&2;
+    echo "Locale: " $locale 1>&2;
+    
+    export LC_ALL=$locale;
+    export LANG=$locale;
+    
+    # run first argument and pass remaining arguments
+    $1 "${@:2}";
+    
+    if [ "$?" != 0 ]; then
+      echo "bad return code"
+    fi
+  fi
+done

--- a/test/functional/cmdLineTests/reflectCache/build.xml
+++ b/test/functional/cmdLineTests/reflectCache/build.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="loadLibraryTest" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests reflectCache
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/reflectCache" />
+	<property name="src" location="./src"/>
+	<property name="build" location="./bin"/>
+
+	<target name="init">
+		<mkdir dir="${DEST}" />
+		<mkdir dir="${build}" />
+	</target>
+
+	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" />
+	</target>
+
+	<target name="dist" depends="compile" description="generate the distribution">
+		<jar jarfile="${DEST}/reflectCache.jar" filesonly="true">
+			<fileset dir="${build}" />
+			<fileset dir="${src}" />
+		</jar>
+		<copy todir="${DEST}">
+			<fileset dir="${src}/../" includes="*.xml" />
+		</copy>
+	</target>
+
+	<target name="clean" depends="dist" description="clean up">
+		<!-- Delete the ${build} directory trees -->
+		<delete dir="${build}" />
+	</target>
+
+	<target name="build" >
+		<antcall target="clean" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/reflectCache/playlist.xml
+++ b/test/functional/cmdLineTests/reflectCache/playlist.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+	<test>
+		<testCaseName>cmdLineTester_reflectCache</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DREFLECTCACHETESTJAR=$(Q)$(TEST_RESROOT)$(D)reflectCache.jar$(Q) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)reflectcache_test.xml$(Q) -explainExcludes \
+	-xids all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)reflectcache_exclude.xml$(Q) -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+</playlist>

--- a/test/functional/cmdLineTests/reflectCache/reflectcache_exclude.xml
+++ b/test/functional/cmdLineTests/reflectCache/reflectcache_exclude.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2016, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "excludes.dtd">
+<?xml:stylesheet type="text/xsl" href="excludes.xsl" ?>
+
+<suite id="J9 shared cache dbgext Tests">
+
+<!-- Define all the platforms that are supported by the J9 VM-->
+<!--none --> <platform id="none"/>
+<!--all --> <platform id="all"/>
+<!--j2se --> <platform id="j2se"/>
+<!--AIX --> <platform id="aix_ppc-32"/>
+<!--AIX64 --> <platform id="aix_ppc-64"/>
+<!--Linux Hammer --> <platform id="linux_x86-64"/>
+<!--Linux IA32 --> <platform id="linux_x86-32"/>
+<!--Linux PPC --> <platform id="linux_ppc-32"/>
+<!--Linux PPC 64bit --> <platform id="linux_ppc-64"/>
+<!--Linux S390 --> <platform id="linux_390-31"/>
+<!--Linux S390 64bit --> <platform id="linux_390-64"/>
+<!--Linux IA32 Realtime --> <platform id="linux_x86_rtj"/>
+<!--Win64 Hammer --> <platform id="win_x86-64"/>
+<!--Windows IA32 --> <platform id="win_x86-32"/>
+<!--z/OS S390 64bit JIT Modron --> <platform id="zos_390-64"/>
+<!--z/OS S390 JIT Modron --> <platform id="zos_390-31"/>
+
+</suite>

--- a/test/functional/cmdLineTests/reflectCache/reflectcache_test.xml
+++ b/test/functional/cmdLineTests/reflectCache/reflectcache_test.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2016, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="-Dreflect.cache Command-Line Option Tests" timeout="2400">
+ 
+	<test id="No reflect.cache cmdLine option. Reflect Cache test classes are in classpath.">
+		<command>$EXE$ -cp $Q$$REFLECTCACHETESTJAR$$Q$ test.reflectCache.Test_ReflectCache</command>
+		<output regex="no" type="success">testField is cached</output> 
+		<output regex="no" type="required">testMethod is cached</output> 
+		<output regex="no" type="failure">TEST FAILED</output>
+		<output regex="no" type="failure">JVMJ9VM085</output>
+	</test>
+
+	<test id="No reflect.cache cmdLine option. Reflect Cache test classes are in boot classpath.">
+		<command>$EXE$ -Xbootclasspath/a:$Q$$REFLECTCACHETESTJAR$$Q$ test.reflectCache.Test_ReflectCache</command>
+		<output regex="no" type="success">testField is cached</output> 
+		<output regex="no" type="required">testMethod is cached</output> 
+		<output regex="no" type="failure">TEST FAILED</output>
+		<output regex="no" type="failure">JVMJ9VM085</output>
+	</test>
+
+	<test id="-Dreflect.cache  Reflect Cache test classes are in classpath.">
+		<command>$EXE$ -Dreflect.cache -cp $Q$$REFLECTCACHETESTJAR$$Q$ test.reflectCache.Test_ReflectCache</command>
+		<output regex="no" type="success">testField is cached</output> 
+		<output regex="no" type="required">testMethod is cached</output> 
+		<output regex="no" type="failure">TEST FAILED</output>		
+		<output regex="no" type="failure">JVMJ9VM085</output>
+	</test>
+
+ 	<test id="-Dreflect.cache. Reflect Cache test classes are in boot classpath.">
+		<command>$EXE$ -Dreflect.cache -Xbootclasspath/a:$Q$$REFLECTCACHETESTJAR$$Q$ test.reflectCache.Test_ReflectCache</command>
+		<output regex="no" type="success">testField is cached</output> 
+		<output regex="no" type="required">testMethod is cached</output> 
+		<output regex="no" type="failure">TEST FAILED</output>
+		<output regex="no" type="failure">JVMJ9VM085</output>
+	</test>
+
+	<test id="-Dreflect.cache=false . Reflect Cache test classes are in classpath.">
+		<command>$EXE$ -Dreflect.cache=false -cp $Q$$REFLECTCACHETESTJAR$$Q$ test.reflectCache.Test_ReflectCache</command>
+  		<output regex="no" type="success">testField is not cached</output> 
+  		<output regex="no" type="required">testMethod is not cached</output> 
+  		<output regex="no" type="failure">TEST FAILED</output>
+  		<output regex="no" type="failure">JVMJ9VM085</output>
+	</test>
+ 
+	<test id="-Dreflect.cache=boot. Reflect Cache test classes are in boot classpath.">
+		<command>$EXE$ -Dreflect.cache=boot -Xbootclasspath/a:$Q$$REFLECTCACHETESTJAR$$Q$ test.reflectCache.Test_ReflectCache</command>
+		<output regex="no" type="success">testField is cached</output> 
+		<output regex="no" type="required">testMethod is cached</output> 
+		<output regex="no" type="failure">TEST FAILED</output>
+		<output regex="no" type="failure">JVMJ9VM085</output>
+	</test>
+
+	<test id="-Dreflect.cache=boot,app . Reflect Cache test classes are in boot classpath.">
+		<command>$EXE$ -Dreflect.cache=boot,app -Xbootclasspath/a:$Q$$REFLECTCACHETESTJAR$$Q$ test.reflectCache.Test_ReflectCache</command>
+		<output regex="no" type="success">testField is cached</output> 
+  		<output regex="no" type="required">testMethod is cached</output> 
+  		<output regex="no" type="failure">TEST FAILED</output>
+  		<output regex="no" type="failure">JVMJ9VM085</output>
+ 	</test>
+ 
+  	<test id="-Dreflect.cache=app . Reflect Cache test classes are in boot classpath.">
+		<command>$EXE$ -Dreflect.cache=app -Xbootclasspath/a:$Q$$REFLECTCACHETESTJAR$$Q$ test.reflectCache.Test_ReflectCache</command>
+   		<output regex="no" type="success">testField is not cached</output> 
+   		<output regex="no" type="required">testMethod is not cached</output> 
+   		<output regex="no" type="failure">TEST FAILED</output>
+   		<output regex="no" type="failure">JVMJ9VM085</output>
+ 	</test>
+
+  	<test id="-Dreflect.cache=app,boot . Reflect Cache test classes are in boot classpath.">
+		<command>$EXE$ -Dreflect.cache=app,boot -Xbootclasspath/a:$Q$$REFLECTCACHETESTJAR$$Q$ test.reflectCache.Test_ReflectCache</command>
+  		<output regex="no" type="success">testField is cached</output> 
+  		<output regex="no" type="required">testMethod is cached</output> 
+  		<output regex="no" type="failure">TEST FAILED</output>
+  		<output regex="no" type="failure">JVMJ9VM085</output>
+ 	</test>
+ 
+  	<test id="-Xaggressive . Reflect Cache test classes are in boot classpath.">
+		<command>$EXE$ -Xaggressive -Xbootclasspath/a:$Q$$REFLECTCACHETESTJAR$$Q$ test.reflectCache.Test_ReflectCache</command>
+  		<output regex="no" type="success">testField is cached</output> 
+  		<output regex="no" type="required">testMethod is cached</output> 
+  		<output regex="no" type="failure">TEST FAILED</output>
+  		<output regex="no" type="failure">JVMJ9VM085</output>
+	</test>
+ 
+ 	<test id="-Xaggressive -Dreflect.cache=app. Reflect Cache test classes are in boot classpath.">
+		<command>$EXE$ -Xaggressive -Dreflect.cache=app -Xbootclasspath/a:$Q$$REFLECTCACHETESTJAR$$Q$ test.reflectCache.Test_ReflectCache</command>
+		<output regex="no" type="success">testField is not cached</output> 
+		<output regex="no" type="required">testMethod is not cached</output> 
+		<output regex="no" type="failure">TEST FAILED</output>
+		<output regex="no" type="failure">JVMJ9VM085</output>
+	</test>
+ 	
+</suite>

--- a/test/functional/cmdLineTests/reflectCache/src/test/reflectCache/Test.java
+++ b/test/functional/cmdLineTests/reflectCache/src/test/reflectCache/Test.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package test.reflectCache;
+
+public class Test {
+	
+	public String testField;
+	
+	public Test() {}
+	public Test(String str) {}
+
+	public void testMethod(String str) {
+		
+	}
+}

--- a/test/functional/cmdLineTests/reflectCache/src/test/reflectCache/Test_ReflectCache.java
+++ b/test/functional/cmdLineTests/reflectCache/src/test/reflectCache/Test_ReflectCache.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package test.reflectCache;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * This class is used to test -Dreflect.cache options.  
+ * 
+ * If fields are cached, then their root field should be same. If they are not cached, then root is equal to null.
+ */
+public class Test_ReflectCache {
+
+	public static void main(String[] args) {
+		Class<?> testClass = Test.class;
+		try {
+			Field testField1 = testClass.getField("testField");
+			Field testFieldRoot = Field.class.getDeclaredField("root");
+			testFieldRoot.setAccessible(true);
+			Object rootObject1 = testFieldRoot.get(testField1);
+
+			Field testField2 = testClass.getField("testField");
+			Object rootObject2 = testFieldRoot.get(testField2);
+			
+			if (rootObject1 != rootObject2) {
+				System.out.println("TEST FAILED");
+				return;
+			} else {
+				if (rootObject1 == null) {
+					System.out.println("testField is not cached.");
+				} else {
+					System.out.println("testField is cached.");
+				}
+			}
+	
+			Method testMethod1 = testClass.getMethod("testMethod", String.class);
+			Field testMethodRoot = Method.class.getDeclaredField("root");
+			testMethodRoot.setAccessible(true);
+			rootObject1 = testMethodRoot.get(testMethod1);
+			
+			Method testMethod2 = testClass.getMethod("testMethod", String.class);
+			rootObject2 = testMethodRoot.get(testMethod2);
+			
+			if (rootObject1 != rootObject2) {
+				System.out.println("TEST FAILED");
+				return;
+			} else {
+				if (rootObject1 == null) {
+					System.out.println("testMethod is not cached.");
+				} else {
+					System.out.println("testMethod is cached.");
+				}
+			}
+			
+			Constructor<?> testConstructor1 = testClass.getConstructor();
+			Field testConstructorRoot = Constructor.class.getDeclaredField("root");
+			testConstructorRoot.setAccessible(true);
+			rootObject1 = testConstructorRoot.get(testConstructor1);
+			
+			Constructor<?> testConstructor2 = testClass.getConstructor();
+			rootObject2 = testConstructorRoot.get(testConstructor2);
+			
+			if (rootObject1 != rootObject2) {
+				System.out.println("TEST FAILED");
+				return;
+			} else {
+				if (rootObject1 == null) {
+					System.out.println("testConstructor is not cached.");
+				} else {
+					System.out.println("testConstructor is cached.");
+				}
+			}
+			
+			Constructor<?> testConstructorA = testClass.getConstructor(String.class);
+			rootObject1 = testConstructorRoot.get(testConstructorA);
+			Constructor<?> testConstructorB = testClass.getConstructor(String.class);
+			rootObject2 = testConstructorRoot.get(testConstructorB);
+			if (rootObject1 != rootObject2) {
+				System.out.println("TEST FAILED");
+				return;
+			} else {
+				if (null == rootObject1) {
+					System.out.println("testConstructor is not cached.");
+				} else {
+					System.out.println("testConstructor is cached.");
+				}
+			}
+		} catch (SecurityException e) {
+			e.printStackTrace();
+			System.out.println("TEST FAILED");
+		} catch (NoSuchFieldException e) {
+			e.printStackTrace();
+			System.out.println("TEST FAILED");
+		} catch (NoSuchMethodException e) {
+			e.printStackTrace();
+			System.out.println("TEST FAILED");
+		}catch (IllegalArgumentException e) {
+			e.printStackTrace();
+			System.out.println("TEST FAILED");
+		} catch (IllegalAccessException e) {
+			e.printStackTrace();
+			System.out.println("TEST FAILED");
+		}
+	}
+}

--- a/test/functional/cmdLineTests/shareClassTests/BadStackMap/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/BadStackMap/build.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="loadLibraryTest" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests badStackMap
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/shareClassTests/BadStackMap" />
+	<property name="src" location="./src"/>
+	<property name="build" location="./bin"/>
+
+	<target name="init">
+		<mkdir dir="${DEST}" />
+		<mkdir dir="${build}" />
+	</target>
+
+	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" />
+	</target>
+
+	<target name="dist" depends="compile" description="generate the distribution">
+		<jar jarfile="${DEST}/badStackMap.jar" filesonly="true">
+			<fileset dir="${build}" />
+			<fileset dir="${src}" />
+		</jar>
+		<copy todir="${DEST}">
+			<fileset dir="${src}/../" includes="*.xml" />
+		</copy>
+	</target>
+
+	<target name="clean" depends="dist" description="clean up">
+		<!-- Delete the ${build} directory trees -->
+		<delete dir="${build}" />
+	</target>
+
+	<target name="build" >
+		<antcall target="clean" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/shareClassTests/BadStackMap/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/BadStackMap/playlist.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+	<test>
+		<testCaseName>cmdLineTester_shareClassesBadStackMap</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DJARPATH=$(Q)$(TEST_RESROOT)$(D)badStackMap.jar$(Q) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)shareClassesBadStackMap.xml$(Q) -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+</playlist>

--- a/test/functional/cmdLineTests/shareClassTests/BadStackMap/shareClassesBadStackMap.xml
+++ b/test/functional/cmdLineTests/shareClassTests/BadStackMap/shareClassesBadStackMap.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2016, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 Java Command-Line Option Test for PMR 03266,756,000" timeout="300">
+	<variable name="JAR" value="-cp $JARPATH$ ShareClassesBadStackMapTest" />
+	
+	<test id="Attempt to destroy any pre-existing cache">
+		<command>$EXE$ -Xshareclasses:name=testSCBadStackMap,destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
+		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
+		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="-Xshareclasses:name=testSCBadStackMap ShareClassesBadStackMapTest Run 1">
+		<command>$EXE$ -Xshareclasses:name=testSCBadStackMap $JAR$</command>
+		<output type="success" regex="no">foo</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="-Xshareclasses:name=testSCBadStackMap ShareClassesBadStackMapTest Run 2">
+		<command>$EXE$ -Xshareclasses:name=testSCBadStackMap $JAR$</command>
+		<output type="success" regex="no">foo</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Cleanup cache">
+		<command>$EXE$ -Xshareclasses:name=testSCBadStackMap,destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
+		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+ 
+
+</suite>

--- a/test/functional/cmdLineTests/shareClassTests/BadStackMap/src/ShareClassesBadStackMapTest.java
+++ b/test/functional/cmdLineTests/shareClassTests/BadStackMap/src/ShareClassesBadStackMapTest.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+public class ShareClassesBadStackMapTest {
+	public static void main(String[] paramArrayOfString) {
+	  foo(Integer.valueOf(0));
+	}
+	
+	public static boolean foo(Object paramObject) {
+	  System.out.println("foo");
+	  return true;
+	}
+  }

--- a/test/functional/cmdLineTests/shareClassTests/StorageKey/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/StorageKey/build.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="cmdLineTests" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests locales
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/shareClassTests/StorageKey" />
+	<property name="src" location="." />
+
+	<target name="dist" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml"/>
+		</copy>
+	</target>
+
+	<target name="build" >
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/shareClassTests/StorageKey/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/StorageKey/playlist.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+	<test>
+		<testCaseName>cmdLineTester_shareClassesStorageKey</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)storageKey.xml$(Q) -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<platformRequirements>os.zos</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+</playlist> 

--- a/test/functional/cmdLineTests/shareClassTests/StorageKey/storageKey.xml
+++ b/test/functional/cmdLineTests/shareClassTests/StorageKey/storageKey.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2016, 2020 IBM Corp. and others
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 Shared Classes z/OS Storage Key Command-Line Option Tests" timeout="2400">
+	<variable name="CLASS" value="-cp $UTILSJAR$ VMBench.FibBench" />
+
+	<test id="Attempt to destroy any pre-existing cache created in storage protection key 2">
+		<command>$EXE$ -Xtrace:print={j9prt.1033-1035} -Xtrace:print={j9shr.2041} -Xshareclasses:nonpersistent,name=testSCstorageKey2,storageKey=2,destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
+		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
+		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Create a cache in storage protection key = 2">
+		<command>$EXE$ -Xtrace:print={j9prt.1033-1035} -Xtrace:print={j9shr.2041} -Xshareclasses:nonpersistent,name=testSCstorageKey2,storageKey=2 $CLASS$</command>
+		<output regex="no" type="success">Fibonacci: iterations</output>
+		<output regex="no" type="required">j9prt.1033     - Trc_PRT_shmem_j9shmem_createSharedMemory_storageKey</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Attempt to open a cache created in storage protection key 2 while running in storage key 8">
+		<command>$EXE$ -Xtrace:print={j9prt.1033-1035} -Xtrace:print={j9shr.2041} -Xshareclasses:nonpersistent,name=testSCstorageKey2,storageKey=8</command>
+		<output regex="no" type="success">JVMPORT034W Attempted to attach shared memory created in storage protection key 2, but currently running in key 8.</output>
+		<output regex="no" type="required">JVMSHRC336E Port layer error code = -525038</output>
+		<output regex="no" type="required">j9prt.1034     - Trc_PRT_shmem_j9shmem_openSharedMemory_storageKey</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Attempt to destroy cache created in storage protection key 2">
+		<command>$EXE$ -Xtrace:print={j9prt.1033-1035} -Xtrace:print={j9shr.2041} -Xshareclasses:nonpersistent,name=testSCstorageKey2,storageKey=2,destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
+		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Attempt to destroy any pre-existing cache created in storage protection key 9">
+		<command>$EXE$ -Xtrace:print={j9prt.1033-1035} -Xtrace:print={j9shr.2041} -Xshareclasses:nonpersistent,name=testSCstorageKey9,storageKey=9,destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
+		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
+		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Create a cache in storage protection key = 9">
+		<command>$EXE$ -Xtrace:print={j9prt.1033-1035} -Xtrace:print={j9shr.2041} -Xshareclasses:nonpersistent,name=testSCstorageKey9,storageKey=9 $CLASS$</command>
+		<output regex="no" type="success">Fibonacci: iterations</output>
+		<output regex="no" type="required">j9prt.1033     - Trc_PRT_shmem_j9shmem_createSharedMemory_storageKey</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Attempt to open a cache created in storage protection key 9 while running in storage key 8">
+		<command>$EXE$ -Xtrace:print={j9prt.1033-1035} -Xtrace:print={j9shr.2041} -Xshareclasses:nonpersistent,name=testSCstorageKey9,storageKey=8 $CLASS$</command>
+		<output regex="no" type="success">Fibonacci: iterations</output>
+		<output regex="no" type="required">j9prt.1034     - Trc_PRT_shmem_j9shmem_openSharedMemory_storageKey: Shared classes cache was created in storage protection key = 9 and the current key = 8</output>
+		<output regex="no" type="required">j9shr.2041     - OSCache::Cache is switched to readonly mode due to storage protection key incompatibility</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Attempt to destroy cache created in storage protection key 9">
+		<command>$EXE$ -Xtrace:print={j9prt.1033-1035} -Xtrace:print={j9shr.2041} -Xshareclasses:nonpersistent,name=testSCstorageKey9,storageKey=9,destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
+		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+
+</suite>


### PR DESCRIPTION
- issue: runtimes/backlog 373
- [ci skip]

 cmdLineTester_locales (disable on win, disable on OpenJ9 backlog 384)

 cmdLineTester_shareClassesStorageKey (only on zos)

 cmdLineTester_shareClassesBadStackMap

 cmdLineTester_dscr (only on aix)

 cmdLineTester_reflectCache

 cmdLineTester_bootStrapStaticVerify

 cmdLineTester_doProtectedAccessCheck

Signed-off-by: OscarQQ <Yixin.Qian@ibm.com>