### PR TITLE
Adding `stalltimems` in `gc-end` stanza

### DIFF
--- a/runtime/gc_stats/VLHGCIncrementStats.hpp
+++ b/runtime/gc_stats/VLHGCIncrementStats.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -116,6 +116,14 @@ public:
 		_workPacketStats.merge(&stats->_workPacketStats);
 		_copyForwardStats.merge(&stats->_copyForwardStats);
 		_irrsStats.merge(&stats->_irrsStats);
+	}
+
+	/**
+	 * Get total stall time 
+	 */
+	uint64_t getTotalStallTime()
+	{
+		return _copyForwardStats.getStallTime() + _markStats.getStallTime() + _sweepStats.idleTime + _workPacketStats.getStallTime() + _compactStats._moveStallTime + _compactStats._rebuildStallTime;
 	}
 };
 


### PR DESCRIPTION
Attribute `stalltimems` is added to `gc-end` to report time spent in stalling (in ms).
omr:https://github.com/eclipse/omr/pull/5560

- New API `getTotalStallTime()` introduced for `MM_VLHGCIncrementStats`, which sums up stall times of following stats structure:
```
_copyForwardStats.getStallTime() 
_markStats.getStallTime()
_sweepStats.idleTime
_workPacketStats.getStallTime()
_compactStats._moveStallTime
_compactStats._rebuildStallTime;
```
- Move clearing of `_vlhgcIncrementStats` from `MM_IncrementalGenerationalGC::globalMarkPhase` to `MM_IncrementalGenerationalGC::setupBeforeGlobalGC` to force increment stats cleared at start of each global increment..
- Add assertions to guarantee correctness of increments stats.
- Set collection stats `stalltime` for verbose GC increment end event

Signed-off-by: Enson Guo <enson.guo@ibm.com>