### PR TITLE
Change default -Xthr:spin1 value for PPC64BE

### DIFF
--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -509,7 +509,9 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 	vm->thrDeflationPolicy = J9VM_DEFLATION_POLICY_ASAP;
 
 	if (cpus > 1) {
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (defined(LINUXPPC)) && !defined(J9VM_ENV_LITTLE_ENDIAN)
+		vm->thrMaxSpins1BeforeBlocking = 151;
+#elif defined(AIXPPC) || defined(LINUXPPC)
 		vm->thrMaxSpins1BeforeBlocking = 96;
 #else /* defined(AIXPPC) || defined(LINUXPPC) */
 		vm->thrMaxSpins1BeforeBlocking = 256;


### PR DESCRIPTION
Currently, the xlC compiler generates a bunch of extra nops in the spinOnFlatLock routine, throwing off the spinning timing and causing a ~5% regression. This change modifies the default spin count to 151 for PPC64BE (previously 96 for all PPC machines), which restores the proper timing and fixes the regression.

Signed-off-by: Jackie Midroni <jackie.midroni@mail.utoronto.ca>