### PR TITLE
Changing the JDK folder name specifically for JDK11 z/OS build.

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -302,7 +302,14 @@ def archive_sdk() {
             def archiveCmd = SPEC.contains('zos') ? 'pax -wvz -p x' : 'tar -cvz -T -'
             // Filter out unwanted files (most of which are available in the debug-image).
             def filterCmd = "sed -e '/\\.dbg\$/d' -e '/\\.debuginfo\$/d' -e '/\\.diz\$/d' -e '/\\.dSYM\\//d' -e '/\\.map\$/d' -e '/\\.pdb\$/d'"
-            sh "( cd ${buildDir} && find ${JDK_FOLDER} -type f | ${filterCmd} | ${archiveCmd} ) > ${SDK_FILENAME}"
+            // Rename the top level directory for JDK11 z/OS to J11.0_64.
+            def ZOS_JDK_FOLDER = "J11.0_64"
+            if (SPEC.contains('zos')) {
+                sh "( cd ${buildDir} && mv ${JDK_FOLDER} ${ZOS_JDK_FOLDER} )"
+                sh "( cd ${buildDir} && find ${ZOS_JDK_FOLDER} -type f | ${filterCmd} | ${archiveCmd} ) > ${SDK_FILENAME}"
+            } else {
+                sh "( cd ${buildDir} && find ${JDK_FOLDER} -type f | ${filterCmd} | ${archiveCmd} ) > ${SDK_FILENAME}"
+            }
             // test if the test natives directory is present, only in JDK11+
             if (fileExists("${buildDir}${testDir}")) {
                 if (SPEC.contains('zos')) {

--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -619,7 +619,7 @@ def set_build_variables() {
 
 def set_sdk_variables() {
     DATESTAMP = get_date()
-    SDK_FILE_EXT = SPEC.contains('zos') ? '.pax' : '.tar.gz'
+    SDK_FILE_EXT = SPEC.contains('zos') ? '.pax.Z' : '.tar.gz'
     SDK_FILENAME =  "OpenJ9-JDK${SDK_VERSION}-${SPEC}-${DATESTAMP}${SDK_FILE_EXT}"
     TEST_FILENAME = "test-images.tar.gz"
     JAVADOC_FILENAME = "OpenJ9-JDK${SDK_VERSION}-Javadoc-${SPEC}-${DATESTAMP}.tar.gz"


### PR DESCRIPTION
This is required for creating the z/OS SMP/E packages for JDK11 builds with OpenJ9.

Signed-off-by: Surya Narkedimilli <snarkedi@in.ibm.com>