### PR TITLE
Use global JITConfig in CH Table

### DIFF
--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -325,6 +325,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
                   }
 
                jitConfig = vm->jitConfig;
+               ::jitConfig = jitConfig;
 
                if (!jitConfig)
                   {

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1681,12 +1681,12 @@ onLoadInternal(
 #if defined(J9VM_OPT_JITSERVER)
       if (persistentMemory->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
          {
-         chtable = new (PERSISTENT_NEW) JITClientPersistentCHTable(persistentMemory, jitConfig);
+         chtable = new (PERSISTENT_NEW) JITClientPersistentCHTable(persistentMemory);
          }
       else
 #endif
          {
-         chtable = new (PERSISTENT_NEW) TR_PersistentCHTable(persistentMemory, jitConfig);
+         chtable = new (PERSISTENT_NEW) TR_PersistentCHTable(persistentMemory);
          }
       if (chtable == NULL)
          return -1;

--- a/runtime/compiler/env/JITServerPersistentCHTable.cpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.cpp
@@ -30,8 +30,8 @@
 #include "runtime/JITClientSession.hpp"
 
 
-JITServerPersistentCHTable::JITServerPersistentCHTable(TR_PersistentMemory *trMemory, J9JITConfig *jitConfig)
-   : TR_PersistentCHTable(trMemory, jitConfig),
+JITServerPersistentCHTable::JITServerPersistentCHTable(TR_PersistentMemory *trMemory)
+   : TR_PersistentCHTable(trMemory),
    _classMap(decltype(_classMap)::allocator_type(TR::Compiler->persistentAllocator()))
    {
    _chTableMonitor = TR::Monitor::create("JIT-JITServerCHTableMonitor");
@@ -397,8 +397,8 @@ FlatPersistentClassInfo::deserializeHierarchy(const std::string& data)
 // JITClient
 // TODO: check for race conditions with _dirty/_remove
 
-JITClientPersistentCHTable::JITClientPersistentCHTable(TR_PersistentMemory *trMemory, J9JITConfig *jitConfig)
-   : TR_PersistentCHTable(trMemory, jitConfig)
+JITClientPersistentCHTable::JITClientPersistentCHTable(TR_PersistentMemory *trMemory)
+   : TR_PersistentCHTable(trMemory)
    , _dirty(decltype(_dirty)::allocator_type(TR::Compiler->persistentAllocator()))
    , _remove(decltype(_remove)::allocator_type(TR::Compiler->persistentAllocator()))
    {

--- a/runtime/compiler/env/JITServerPersistentCHTable.hpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.hpp
@@ -55,7 +55,7 @@ class JITServerPersistentCHTable : public TR_PersistentCHTable
 public:
    TR_ALLOC(TR_Memory::PersistentCHTable)
 
-   JITServerPersistentCHTable(TR_PersistentMemory *, J9JITConfig *);
+   JITServerPersistentCHTable(TR_PersistentMemory *);
    ~JITServerPersistentCHTable();
 
    bool isInitialized() { return !_classMap.empty(); } // needs CHTable monitor in hand
@@ -102,7 +102,7 @@ class JITClientPersistentCHTable : public TR_PersistentCHTable
 public:
    TR_ALLOC(TR_Memory::PersistentCHTable)
 
-   JITClientPersistentCHTable(TR_PersistentMemory *, J9JITConfig *);
+   JITClientPersistentCHTable(TR_PersistentMemory *);
 
    std::pair<std::string, std::string> serializeUpdates();
 

--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -50,7 +50,7 @@
 
 class TR_OpaqueClassBlock;
 
-TR_PersistentCHTable::TR_PersistentCHTable(TR_PersistentMemory *trPersistentMemory, J9JITConfig *jitConfig)
+TR_PersistentCHTable::TR_PersistentCHTable(TR_PersistentMemory *trPersistentMemory)
    : _trPersistentMemory(trPersistentMemory)
    {
    /*
@@ -66,7 +66,7 @@ TR_PersistentCHTable::TR_PersistentCHTable(TR_PersistentMemory *trPersistentMemo
    _classes = static_cast<TR_LinkHead<TR_PersistentClassInfo> *>(static_cast<void *>(_buffer));
 
 #if defined(J9VM_OPT_SNAPSHOTS)
-   if (IS_RESTORE_RUN(jitConfig->javaVM))
+   if (IS_RESTORE_RUN(::jitConfig->javaVM))
       {
       resetStatus();
       }

--- a/runtime/compiler/env/PersistentCHTable.hpp
+++ b/runtime/compiler/env/PersistentCHTable.hpp
@@ -69,7 +69,7 @@ class TR_PersistentCHTable
    public:
    TR_ALLOC(TR_Memory::PersistentCHTable)
 
-   TR_PersistentCHTable(TR_PersistentMemory *, J9JITConfig *);
+   TR_PersistentCHTable(TR_PersistentMemory *);
 
    virtual TR_PersistentClassInfo * findClassInfo(TR_OpaqueClassBlock * classId);
 


### PR DESCRIPTION
In order to minimize merge conflicts with master, use the global
JITConfig in the constructor of the Persistent CH Table.

Signed-off-by: Irwin D'Souza <dsouzai.gh@gmail.com>