### PR TITLE
Reduce AOT load failures with SVM enabled

### DIFF
--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -49,6 +49,11 @@ TR::SymbolValidationManager::_systemClassesNotWorthRemembering[] = {
     */
    { "java/lang/Throwable", NULL, true },
 
+   /* Newer java code is moving towards using StringBuilder. Therefore, ignoring this class
+    * reduces load failures, while having minimal impact on steady state throughput.
+    */
+   { "java/lang/StringBuffer", NULL, false },
+
    /* Terminating entry */
    { NULL, NULL, false }
 };
@@ -156,7 +161,7 @@ TR::SymbolValidationManager::isClassWorthRemembering(TR_OpaqueClassBlock *clazz)
 void
 TR::SymbolValidationManager::populateWellKnownClasses()
    {
-#define WELL_KNOWN_CLASS_COUNT 10
+#define WELL_KNOWN_CLASS_COUNT 9
 #define REQUIRED_WELL_KNOWN_CLASS_COUNT 1
 
    // Classes must have names only allowed to be defined by the bootstrap loader
@@ -170,7 +175,6 @@ TR::SymbolValidationManager::populateWellKnownClasses()
       "java/lang/Runnable",
       "java/lang/String",
       "java/lang/StringBuilder",
-      "java/lang/StringBuffer",
       "java/lang/System",
       "java/lang/ref/Reference",
       "com/ibm/jit/JITHelpers",

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -38,7 +38,20 @@
 #define snprintf _snprintf
 #endif
 
-static const char * const jlthrowableName = "java/lang/Throwable";
+TR::SymbolValidationManager::SystemClassNotWorthRemembering
+TR::SymbolValidationManager::_systemClassesNotWorthRemembering[] = {
+
+   /* Generally, classes that inherit from java/lang/Throwable are used to indicate exception
+    * conditions; as such, they are not going be important for the performance of normal mainline
+    * code. Therefore, it is better for the AOT compiler to not be aware of these classes (and
+    * thereby lose the ability to optimize for them) rather than risk a load failure due to a code
+    * path that was unlikely to execute.
+    */
+   { "java/lang/Throwable", NULL, true },
+
+   /* Terminating entry */
+   { NULL, NULL, false }
+};
 
 TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_ResolvedMethod *compilee)
    : _symbolID(FIRST_ID),
@@ -64,8 +77,7 @@ TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_Reso
      _idToSymbolTable(_region),
      _seenSymbolsSet((SeenSymbolsComparator()), _region),
      _wellKnownClasses(_region),
-     _loadersOkForWellKnownClasses(_region),
-     _jlthrowable(_fej9->getSystemClassFromClassName(jlthrowableName, (int32_t)strlen(jlthrowableName)))
+     _loadersOkForWellKnownClasses(_region)
    {
    assertionsAreFatal(); // Acknowledge the env var whether or not assertions fail
 
@@ -108,25 +120,37 @@ TR::SymbolValidationManager::defineGuaranteedID(void *symbol, TR::SymbolType typ
 bool
 TR::SymbolValidationManager::isClassWorthRemembering(TR_OpaqueClassBlock *clazz)
    {
-   if (!_jlthrowable)
-      _jlthrowable = _fej9->getSystemClassFromClassName(jlthrowableName, (int32_t)strlen(jlthrowableName));
+   bool worthRemembering = true;
 
-   /* This heuristic checks whether the class being considered is, or inherits from, java/lang/Throwable.
-    * If it is, the class is deemed not worth remembering. The reason for this is to reduce the chances
-    * of an AOT load failure. Generally, classes that inherit from java/lang/Throwable are used to indicate
-    * exception conditions; as such, they are not going be important for the performance of normal mainline
-    * code. Therefore, it is better for the compiler to not be aware of these classes (and thereby lose the
-    * ability to optimize for them) rather than risk a load failure due to a code path that was unlikely to
-    * execute.
-    */
-   if (_jlthrowable && _fej9->isSameOrSuperClass((J9Class *)_jlthrowable, (J9Class *)clazz))
+   for (int i = 0; worthRemembering && _systemClassesNotWorthRemembering[i]._className; i++)
       {
-      if (_comp->getOption(TR_TraceRelocatableDataCG))
-         traceMsg(_comp, "isClassWorthRemembering: clazz %p is or inherits from jlthrowable\n", clazz);
-      return false;
+      SystemClassNotWorthRemembering *systemClassNotWorthRemembering = &_systemClassesNotWorthRemembering[i];
+      if (!systemClassNotWorthRemembering->_clazz)
+         {
+         systemClassNotWorthRemembering->_clazz = _fej9->getSystemClassFromClassName(
+                  systemClassNotWorthRemembering->_className,
+                  (int32_t)strlen(systemClassNotWorthRemembering->_className));
+         }
+
+      if (systemClassNotWorthRemembering->_checkIsSuperClass)
+         {
+         if (systemClassNotWorthRemembering->_clazz &&
+             _fej9->isSameOrSuperClass((J9Class *)systemClassNotWorthRemembering->_clazz, (J9Class *)clazz))
+            {
+            if (_comp->getOption(TR_TraceRelocatableDataCG))
+               traceMsg(_comp, "isClassWorthRemembering: clazz %p is or inherits from %s (%p)\n",
+                        clazz, systemClassNotWorthRemembering->_className, systemClassNotWorthRemembering->_clazz);
+
+            worthRemembering = false;
+            }
+         }
+      else
+         {
+         worthRemembering = (clazz != systemClassNotWorthRemembering->_clazz);
+         }
       }
 
-   return true;
+   return worthRemembering;
    }
 
 void

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -629,8 +629,11 @@ TR::SymbolValidationManager::addMultipleArrayRecords(TR_OpaqueClassBlock *compon
 bool
 TR::SymbolValidationManager::addMethodRecord(TR::MethodValidationRecord *record)
    {
-   if (shouldNotDefineSymbol(record->_method))
+   if (shouldNotDefineSymbol(record->_method)
+       || !isClassWorthRemembering(_fej9->getClassOfMethod(record->_method)))
+      {
       return abandonRecord(record);
+      }
 
    if (recordExists(record))
       {
@@ -972,6 +975,9 @@ TR::SymbolValidationManager::addStackWalkerMaySkipFramesRecord(TR_OpaqueMethodBl
 bool
 TR::SymbolValidationManager::addClassInfoIsInitializedRecord(TR_OpaqueClassBlock *clazz, bool isInitialized)
    {
+   if (!isClassWorthRemembering(clazz))
+      return false;
+
    SVM_ASSERT_ALREADY_VALIDATED(this, clazz);
    return addVanillaRecord(clazz, new (_region) ClassInfoIsInitialized(clazz, isInitialized));
    }

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -635,6 +635,13 @@ public:
 
    SymbolValidationManager(TR::Region &region, TR_ResolvedMethod *compilee);
 
+   struct SystemClassNotWorthRemembering
+      {
+      const char * const _className;
+      TR_OpaqueClassBlock *_clazz;
+      const bool _checkIsSuperClass;
+      };
+
    void populateWellKnownClasses();
    bool validateWellKnownClasses(const uintptr_t *wellKnownClassChainOffsets);
    bool isWellKnownClass(TR_OpaqueClassBlock *clazz);
@@ -904,7 +911,7 @@ private:
    typedef std::set<ClassFromAnyCPIndex, LessClassFromAnyCPIndex, ClassFromAnyCPIndexAlloc> ClassFromAnyCPIndexSet;
    ClassFromAnyCPIndexSet _classesFromAnyCPIndex;
 
-   TR_OpaqueClassBlock *_jlthrowable;
+   static SystemClassNotWorthRemembering _systemClassesNotWorthRemembering[];
    };
 
 }


### PR DESCRIPTION
https://github.com/eclipse/openj9/issues/4897

This PR introduces some improvements to the SVM to reduce AOT load failures caused by validation failures:

1. Refactor `isClassWorthRemembering` to facilitate adding more classes in the future
2. Add `java/lang/StringBuffer` to the list of classes not worth remembering. The motivation behind this is newer java code is moving towards using StringBuilder. Therefore, ignoring this class reduces load failures, while having minimal impact on steady state throughput.
3. Check if the class is worth remembering in the `addMethodRecord` and `addClassInfoIsInitialized` before creating the validation records. In the case of the former, several validation failures were related to the `<init>` method of exception classes; exception classes are already part of the classes not worth remembering, so the `<init>` method follows suit.

With these changes, the number of AOT load failures with the SVM reduces by more than half; however, no SVM AOT still has less load failures (~50). Additionally, the startup regression between JDK11 SVM compared to the default JDK11 NoSVM is reduced to as much as 1.5% (though this seems to vary depending on the day). The throughput hit for these changes is ~1% - this isn't the throughput of a default run, but rather, the code quality of SVM AOT reduces by ~1% (this is mostly due to the StringBuffer change).