### PR TITLE
Fix compiler warnings with clang 12

### DIFF
--- a/runtime/redirector/redirector.c
+++ b/runtime/redirector/redirector.c
@@ -681,15 +681,14 @@ chooseJVM(JavaVMInitArgs *args, char *retBuffer, size_t bufferLength)
 		fprintf(stdout, "does not exist.\n");
 
 		/* direct user to OpenJ9 build configurations to properly generate the requested build. */
-		if (OPENJ9_NOCR_JVM_DIR == basePointer) {
+		if (0 == strcmp(OPENJ9_NOCR_JVM_DIR, basePointer)) {
 			fprintf(stdout,
 					"This JVM package only includes the '-Xcompressedrefs' configuration. Please run "
 					"the VM without specifying the '-Xnocompressedrefs' option or by specifying the "
 					"'-Xcompressedrefs' option.\nTo compile the other configuration, please run configure "
 					"with '--with-noncompressedrefs.\n"
 			);
-		}
-		if (OPENJ9_CR_JVM_DIR == basePointer) {
+		} else if (0 == strcmp(OPENJ9_CR_JVM_DIR, basePointer)) {
 			fprintf(stdout,
 					"This JVM package only includes the '-Xnocompressedrefs' configuration. Please run "
 					"the VM without specifying the '-Xcompressedrefs' option or by specifying the "


### PR DESCRIPTION
Xcode 12 includes a newer version of clang:
```
$ clang --version
Apple clang version 12.0.0 (clang-1200.0.32.2)
Target: x86_64-apple-darwin19.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```
That new compiler complains:
```
redirector.c:684:27: error: result of comparison against a string literal is unspecified (use an explicit string comparison function instead) [-Werror,-Wstring-compare]
                if (OPENJ9_NOCR_JVM_DIR == basePointer) {
                    ~~~~~~~~~~~~~~~~~~~ ^
```