### PR TITLE
Introduce instanceHasRefs flag

### DIFF
--- a/runtime/gc_glue_java/ObjectModel.hpp
+++ b/runtime/gc_glue_java/ObjectModel.hpp
@@ -202,7 +202,11 @@ public:
 		}
 		case OBJECT_HEADER_SHAPE_POINTERS:
 			if (J9_IS_J9CLASS_FLATTENED(clazz)) {
-				result = SCAN_FLATTENED_ARRAY_OBJECT;
+				if (J9CLASS_HAS_REFERENCES(((J9ArrayClass *)clazz)->leafComponentType)) {
+					result = SCAN_FLATTENED_ARRAY_OBJECT;
+				} else {
+					result = SCAN_PRIMITIVE_ARRAY_OBJECT;
+				}
 			} else {
 				result = SCAN_POINTER_ARRAY_OBJECT;
 			}

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -81,6 +81,7 @@
 #define J9ClassIsExemptFromValidation 0x2000
 #define J9ClassContainsUnflattenedFlattenables 0x4000
 #define J9ClassCanSupportFastSubstitutability 0x8000
+#define J9ClassHasReferences 0x10000
 
 /* @ddr_namespace: map_to_type=J9FieldFlags */
 
@@ -3107,6 +3108,12 @@ typedef struct J9Class {
 
 #define J9ARRAYCLASS_SET_STRIDE(clazz, strideLength) ((clazz)->flattenedClassCache) = (J9FlattenedClassCache*)(UDATA)(strideLength)
 #define J9ARRAYCLASS_GET_STRIDE(clazz) ((UDATA)((clazz)->flattenedClassCache))
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#define J9CLASS_HAS_REFERENCES(clazz) (J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassHasReferences))
+#else
+#define J9CLASS_HAS_REFERENCES(clazz) TRUE
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 typedef struct J9ArrayClass {
 	UDATA eyecatcher;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -523,7 +523,11 @@ getJimModules(J9VMThread *currentThread);
 * @return void
 */
 void
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+calculateInstanceDescription( J9VMThread *vmThread, J9Class *ramClass, J9Class *ramSuperClass, UDATA *storage, J9ROMFieldOffsetWalkState *walkState, J9ROMFieldOffsetWalkResult *walkResult, BOOLEAN hasReferences);
+#else /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 calculateInstanceDescription( J9VMThread *vmThread, J9Class *ramClass, J9Class *ramSuperClass, UDATA *storage, J9ROMFieldOffsetWalkState *walkState, J9ROMFieldOffsetWalkResult *walkResult);
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
 #define NO_LOCKWORD_NEEDED (UDATA) -1
 #define LOCKWORD_NEEDED		(UDATA) -2


### PR DESCRIPTION
Introduce instanceHasRefs flag

There is an issue with instance description bits with respect to
flattened types. See https://github.com/eclipse/openj9/issues/10070.
Currently, there is a mistach between the layout of a type on its own,
and when it is flattened. This is due to the pre-padding required for
standalone valuetypes on compressedrefs mode. The `backfill` has been
used to track pre-padding. This is an error prone approach and has cause
bugs in the past.

The only cases where pre-padding is needed is on compressedRefs where
there is at least one double-slot sized field. A better solution (to
backfill approach) is, instead of pre-padding, insert a single slot
field in the spot where the padding would be. This this means that if a
type (in compressedrefs mode) has at least one single slot or ref field
the pre-padding is not needed. This leaves fields with only double slot
fields. In these cases, we do not need to track the padding because
double-slot fields cannot be references, so there is no mismatch with
the instance description bits between the standalone layout and the
flattened layout.

This PR is the first step in solving this problem. This PR introduces a
flag on the J9Class that indicates whether the type has instances field
which are references. In these cases the barrier API for copying
instance fields doesn't need to scan the instance description bits to
apply barrier loads/stores. It can simply use a slot sized load/store
for the operation.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>