### PR TITLE
JDK15 Load native libraries via jdk.internal.loader.NativeLibraries

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -437,6 +437,9 @@ K0644="Caller-sensitive method called StackWalker.getCallerClass()"
 #java.lang.ClassLoader
 K0645="The given class loader name can't be empty."
 K0646="Late attach connection to self disabled. Set jdk.attach.allowAttachSelf=true"
+K0647="Can't load {0}"
+K0648="Not an absolute path: {0}"
+K0649="{0} ({1})"
 
 #jdk.internal.misc.Unsafe
 K0700="Update spans the word, not supported"

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -724,9 +724,20 @@ public static int identityHashCode(Object anObject) {
 @CallerSensitive
 public static void load(String pathName) {
 	SecurityManager smngr = System.getSecurityManager();
-	if (smngr != null)
+	if (smngr != null) {
 		smngr.checkLink(pathName);
+	}
+/*[IF Java15]*/
+	File fileName = new File(pathName);
+	if (fileName.isAbsolute()) {
+		ClassLoader.loadLibrary(getCallerClass(), fileName);
+	} else {
+		/*[MSG "K0648", "Not an absolute path: {0}"]*/
+		throw new UnsatisfiedLinkError(com.ibm.oti.util.Msg.getString("K0648", pathName));//$NON-NLS-1$
+	}
+/*[ELSE]
 	ClassLoader.loadLibraryWithPath(pathName, ClassLoader.callerClassLoader(), null);
+/*[ENDIF] Java15 */
 }
 
 /**
@@ -739,7 +750,11 @@ public static void load(String pathName) {
  */
 @CallerSensitive
 public static void loadLibrary(String libName) {
+/*[IF Java15]*/
+	ClassLoader.loadLibrary(getCallerClass(), libName);
+/*[ELSE]*/
 	ClassLoader.loadLibraryWithClassLoader(libName, ClassLoader.callerClassLoader());
+/*[ENDIF] Java15 */
 }
 
 /**

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2312,12 +2312,27 @@ JVM_SuspendThread(jint arg0, jint arg1)
 }
 
 
-
-jobject JNICALL
-JVM_UnloadLibrary(jint arg0)
+/* NOTE this is required by JDK15+ jdk.internal.loader.NativeLibraries.unload().
+ */
+#if JAVA_SPEC_VERSION >= 15
+void JNICALL JVM_UnloadLibrary(void *handle)
+#else /* JAVA_SPEC_VERSION >= 15 */
+jobject JNICALL JVM_UnloadLibrary(jint arg0)
+#endif /* JAVA_SPEC_VERSION >= 15 */
 {
+#if JAVA_SPEC_VERSION >= 15
+	Trc_SC_UnloadLibrary_Entry(handle);
+#if defined(WIN32)
+	FreeLibrary((HMODULE)handle);
+#elif defined(J9UNIX) || defined(J9ZOS390) /* defined(WIN32) */
+	dlclose(handle);
+#else /* defined(WIN32) */
+#error "Please implement J7vmi.c:JVM_UnloadLibrary(void *handle)"
+#endif /* defined(WIN32) */
+#else /* JAVA_SPEC_VERSION >= 15 */
 	assert(!"JVM_UnloadLibrary() stubbed!");
 	return NULL;
+#endif /* JAVA_SPEC_VERSION >= 15 */
 }
 
 

--- a/runtime/j9vm/j9scar.tdf
+++ b/runtime/j9vm/j9scar.tdf
@@ -343,3 +343,8 @@ TraceEntry=Trc_SC_GetExtendedNPEMessage_Entry Overhead=1 Level=3 Template="JVM_G
 TraceEntry=Trc_SC_GetExtendedNPEMessage_Entry2 Overhead=1 Level=1 Template="JVM_GetExtendedNPEMessage - throwableObj(0x%p)"
 TraceEvent=Trc_SC_GetExtendedNPEMessage_Null_NPE_MSG Overhead=1 Level=1 Template="JVM_GetExtendedNPEMessage - returns a NULL NPE message : romClass (0x%p) && romMethod (0x%p) bytecodeOffset (%d)"
 TraceExit=Trc_SC_GetExtendedNPEMessage_Exit Overhead=1 Level=3 Template="JVM_GetExtendedNPEMessage - returns msgObjectRef(0x%p)"
+
+TraceEntry=Trc_SC_UnloadLibrary_Entry NoEnv Overhead=1 Level=2 Template="JVM_UnloadLibrary(handle=%p)"
+TraceEvent=Trc_SC_LoadLibrary_BootStrap NoEnv Overhead=1 Level=3 Template="JVM_LoadLibrary(name=%s) Bootstrap library"
+TraceEvent=Trc_SC_LoadLibrary_OpenShared NoEnv Overhead=1 Level=3 Template="JVM_LoadLibrary(name=%s) j9sl_open_shared_library"
+TraceEvent=Trc_SC_LoadLibrary_OpenShared_Decorate NoEnv Overhead=1 Level=3 Template="JVM_LoadLibrary(name=%s) j9sl_open_shared_library J9PORT_SLOPEN_DECORATE"

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -191,7 +191,10 @@ _X(JVM_SetThreadPriority,JNICALL,true,void,JNIEnv* env, jobject thread, jint pri
 _X(JVM_StartThread,JNICALL,true,void ,JNIEnv* jniEnv, jobject newThread)
 _X(JVM_StopThread,JNICALL,true,jobject ,jint arg0, jint arg1, jint arg2)
 _X(JVM_SuspendThread,JNICALL,true,jobject ,jint arg0, jint arg1)
-_X(JVM_UnloadLibrary,JNICALL,true,jobject ,jint arg0)
+_IF([JAVA_SPEC_VERSION < 15],
+	[_X(JVM_UnloadLibrary, JNICALL, true, jobject, jint arg0)])
+_IF([JAVA_SPEC_VERSION >= 15],
+	[_X(JVM_UnloadLibrary, JNICALL, true, void, void* handle)])
 _X(JVM_Yield,JNICALL,true,jobject ,jint arg0, jint arg1)
 _X(JVM_SetSockOpt,JNICALL,true,jint ,jint fd, int level, int optname, const char *optval, int optlen)
 _X(JVM_GetSockOpt,JNICALL,true,jint ,jint fd, int level, int optname, char *optval, int *optlen)

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -798,3 +798,22 @@ TraceException=Trc_VM_CreateRAMClassFromROMClass_circularity2 noEnv Overhead=1 L
 
 TraceException=Trc_VM_CreateRAMClassFromROMClass_classIsNotPermittedBySealedSuperclass Overhead=1 Level=1 Template="Superclass (RAM class=%p) does not include %.*s in PermittedSubclasses list"
 TraceException=Trc_VM_CreateRAMClassFromROMClass_classIsNotPermittedBySealedSuperinterface Overhead=1 Level=1 Template="Superinterface (RAM class=%p) does not include %.*s in PermittedSubclasses list"
+
+TraceEntry=Trc_VM_bindNative_Entry Overhead=1 Level=3 Template="bindNative - nativeMethod (%p) longJNI (%s) shortJNI (%s) bindJNINative (%llu)"
+TraceEvent=Trc_VM_bindNative_NativeLibrary_Success Overhead=1 Level=3 Template="bindNative success - nativeMethod (%p) nativeLibrary (%p) longJNI (%s) shortJNI (%s) bindJNINative (%llu)"
+TraceEvent=Trc_VM_bindNative_NativeLibrary_OOM Overhead=1 Level=3 Template="bindNative OOM - nativeMethod (%p) nativeLibrary (%p) longJNI (%s) shortJNI (%s) bindJNINative (%llu)"
+TraceEvent=Trc_VM_bindNative_NullNativeLibrary_Success Overhead=1 Level=3 Template="bindNative success (NULL Native Library) - nativeMethod (%p) longJNI (%s) shortJNI (%s) bindJNINative (%llu)"
+TraceEvent=Trc_VM_bindNative_NullNativeLibrary_OOM Overhead=1 Level=3 Template="bindNative OOM (NULL Native Library) - nativeMethod (%p) longJNI (%s) shortJNI (%s) bindJNINative (%llu)"
+TraceEvent=Trc_VM_bindNative_JVMTIAgent_Success Overhead=1 Level=3 Template="bindNative success (JVMTI Agent) - nativeMethod (%p) longJNI (%s) shortJNI (%s)"
+TraceEvent=Trc_VM_bindNative_Fail Overhead=1 Level=3 Template="bindNative fail - nativeMethod (%p) longJNI (%s) shortJNI (%s) bindJNINative (%llu)"
+TraceEntry=Trc_VM_lookupJNINative_Entry Overhead=1 Level=3 Template="lookupJNINative - nativeLibrary (%p) nativeMethod (%p) symbolName (%s) signature (%s)"
+TraceEvent=Trc_VM_lookupJNINative_NullNativeLibrary Overhead=1 Level=3 Template="lookupJNINative (null native library) - nativeMethod (%p) symbolName (%s) signature (%s) functionAddress (%p)"
+TraceExit=Trc_VM_lookupJNINative_Exit Overhead=1 Level=3 Template="lookupJNINative - nativeLibrary (%p) nativeMethod (%p) nativeMethod->extra (%p) symbolName (%s) signature (%s) lookupResult (%llu)"
+TraceEntry=Trc_VM_lookupNativeAddress_Entry Overhead=1 Level=3 Template="lookupNativeAddress - nativeLibrary (%p) nativeMethod (%p) longJNI (%s) shortJNI (%s) functionArgCount (%llu) bindJNINative (%llu)"
+TraceExit=Trc_VM_lookupNativeAddress_inlIntercept_Exit Overhead=1 Level=3 Template="lookupNativeAddress - nativeLibrary (%p) nativeMethod (%p) longJNI (%s) rc (%llu)"
+TraceExit=Trc_VM_lookupNativeAddress_bindmethod_shortJNI_Exit Overhead=1 Level=3 Template="lookupNativeAddress - nativeLibrary (%p) nativeMethod (%p) shortJNI (%s) argSignature (%s)"
+TraceExit=Trc_VM_lookupNativeAddress_bindmethod_longJNI_Exit Overhead=1 Level=3 Template="lookupNativeAddress - nativeLibrary (%p) nativeMethod (%p) longJNI (%s) argSignature (%s)"
+TraceExit=Trc_VM_lookupNativeAddress_fail_Exit Overhead=1 Level=3 Template="lookupNativeAddress - nativeLibrary (%p) nativeMethod (%p) argSignature (%s)"
+
+TraceEntry=Trc_VM_registerBootstrapLibrary_Entry Overhead=1 Level=3 Template="registerBootstrapLibrary - libName (%s) libraryPtr (%p)"
+TraceExit=Trc_VM_registerBootstrapLibrary_Exit Overhead=1 Level=3 Template="registerBootstrapLibrary - libName (%s) libraryPtr (%p) result (%llu)"

--- a/test/functional/cmdLineTests/loadLibraryTest/loadLibraryTest.xml
+++ b/test/functional/cmdLineTests/loadLibraryTest/loadLibraryTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2013, 2018 IBM Corp. and others
+  Copyright (c) 2013, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,7 @@
 		<output type="success" regex="no" showMatch="yes">Not found in java.library.path</output>
 		<!-- Accept "The specified network name is no longer available" as pass, since this test fails on win8 intermittently with follow message. For more detail, please see JAZZ103 69396 -->
 		<output type="success" regex="no" showMatch="yes">The specified network name is no longer available</output>
+		<output type="success" regex="no" showMatch="yes">java.lang.UnsatisfiedLinkError: Can't load abcdef</output>
 
 		<output type="failure" caseSensitive="no" regex="no">The specified path is invalid</output>
 		<output type="failure" caseSensitive="no" regex="no">Could not find or load main class Files</output>


### PR DESCRIPTION
* JDK15 `bindNative()` first search the nativeLibrary associated with the classloader (like pre-jdk15 levels) for `systemClassLoader`; if that didn't succeed or the `classloader` is not `systemClassLoader`, `lookupNativeAddress()` is invoked with a `NULL` nativeLibrary;
* When the incoming nativeLibrary is `NULL`, `lookupNativeAddress()` calls into `java.lang.ClassLoader.findNative()` to get native method functionAddress;
* After a successful binding, `classLoaderRegisterLibrary()` skips `JNI_Onload()` which is going to be invoked by `NativeLibraries.load()` instead;
* `JVM_LoadLibrary()` invokes `registerBootstrapLibrary()` for early bootstrap, and `j9sl_open_shared_library` for later class loading;
* Changed `System.load/loadLibrary` to invoke `ClassLoader.loadLibrary(caller, fileName)`;
* Added `JVM_UnloadLibrary()` implementation;

closes: https://github.com/eclipse/openj9/issues/9018
closes: https://github.com/eclipse/openj9/issues/9442

Signed-off-by: Jason Feng <fengj@ca.ibm.com>