### PR TITLE
Add --with-freetype option for JDK8 to OSX platforms

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -573,7 +573,7 @@ def build_all() {
                 timeout(time: 5, unit: 'HOURS') {
                     try {
                         // Cleanup in case an old build left anything behind
-                        cleanWs()
+                        cleanWs disableDeferredWipeout: true, deleteDirs: true
                         add_node_to_description()
                         // Setup Artifactory now that we are on a node. This determines which server(s) we push to.
                         variableFile.set_artifactory_config(BUILD_IDENTIFIER)

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -566,7 +566,7 @@ x86-64_mac:
     8: 'macosx-x86_64-normal-server-release'
     11: 'macosx-x86_64-normal-server-release'
   extra_configure_options:
-    8: '--with-toolchain-type=clang'
+    8: '--with-toolchain-type=clang --with-freetype=/usr/local/freetype-2.9.1'
   freemarker: '/Users/jenkins/freemarker.jar'
   openjdk_reference_repo: '/Users/jenkins/openjdk_cache'
   node_labels:


### PR DESCRIPTION
Build JDK8 with freetype 2.9.1 on OSX 10.14.
Disable deferred wipeout when cleaning the build workspace at the
beginning of the build to avoid hang ups on macOS.

[ci skip]
Fixes https://github.com/eclipse/openj9/issues/10375

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>