### PR TITLE
Improve jextract for ELF core files

### DIFF
--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/jvm/j9/dump/extract/Main.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/jvm/j9/dump/extract/Main.java
@@ -350,6 +350,14 @@ public class Main {
 			}
 			report("jextract complete."); //$NON-NLS-1$
 		}
+
+		if (dumper._dump != null) {
+			try {
+				dumper._dump.releaseResources();
+			} catch (IOException e) {
+				// ignore
+			}
+		}
 	}
 
 	private static void ensure(boolean condition, String errorMessage) {
@@ -567,8 +575,7 @@ public class Main {
 			byte[] buffer = new byte[ZIP_BUFFER_SIZE];
 			while (fileNames.hasNext()) {
 				String name = fileNames.next();
-				try {
-					ClosingFileReader in = fileResolver.openFile(name);
+				try (ClosingFileReader in = fileResolver.openFile(name)) {
 					boolean mvsfile = in.isMVSFile();
 					String absolute = in.getAbsolutePath();
 					if (mvsfile || absolute.equals(new File(name).getAbsolutePath())) {


### PR DESCRIPTION
This is a further improvement over #10625 for #9549: Attempt to un-resolve symbolic links so `jdmpview` can find files by soname.

For example, a recent Linux distribution includes the following for soname 'libc.so.6':
```
  /lib/x86_64-linux-gnu/libc-2.31.so
  /lib/x86_64-linux-gnu/libc.so.6
```
with the latter being a symbolic link to the former.

Close files.