### PR TITLE
Enable portable AOT on Power

### DIFF
--- a/runtime/compiler/p/env/J9CPU.cpp
+++ b/runtime/compiler/p/env/J9CPU.cpp
@@ -29,8 +29,15 @@
 bool
 J9::Power::CPU::isCompatible(const OMRProcessorDesc& processorDescription)
    {
-   OMRProcessorArchitecture targetProcessor = self()->getProcessorDescription().processor;
-   OMRProcessorArchitecture processor = processorDescription.processor;
+   const OMRProcessorArchitecture& targetProcessor = self()->getProcessorDescription().processor;
+   const OMRProcessorArchitecture& processor = processorDescription.processor;
+
+   for (int i = 0; i < OMRPORT_SYSINFO_FEATURES_SIZE; i++)
+      {
+      if ((processorDescription.features[i] & self()->getProcessorDescription().features[i]) != processorDescription.features[i])
+         return false;
+      }
+
    // Backwards compatibility only applies to p4,p5,p6,p7 and onwards
    // Looks for equality otherwise
    if ((processor == OMR_PROCESSOR_PPC_GP

--- a/runtime/compiler/p/env/J9CPU.cpp
+++ b/runtime/compiler/p/env/J9CPU.cpp
@@ -26,6 +26,25 @@
 #include "j9.h"
 #include "j9port.h"
 
+TR::CPU
+J9::Power::CPU::detectRelocatable(OMRPortLibrary * const omrPortLib)
+   {
+   if (omrPortLib == NULL)
+      return TR::CPU();
+
+   OMRPORT_ACCESS_FROM_OMRPORT(omrPortLib);
+   OMRProcessorDesc portableProcessorDescription;
+   omrsysinfo_get_processor_description(&portableProcessorDescription);
+   
+   if (portableProcessorDescription.processor > OMR_PROCESSOR_PPC_P8)
+      {
+      portableProcessorDescription.processor = OMR_PROCESSOR_PPC_P8;
+      portableProcessorDescription.physicalProcessor = OMR_PROCESSOR_PPC_P8;
+      }
+
+   return TR::CPU::customize(portableProcessorDescription);
+   }
+
 bool
 J9::Power::CPU::isCompatible(const OMRProcessorDesc& processorDescription)
    {

--- a/runtime/compiler/p/env/J9CPU.hpp
+++ b/runtime/compiler/p/env/J9CPU.hpp
@@ -60,6 +60,13 @@ public:
     */
    static void enableFeatureMasks();
 
+   /** 
+    * @brief A factory method used to construct a CPU object for portable AOT compilations
+    * @param[in] omrPortLib : the port library
+    * @return TR::CPU
+    */
+   static TR::CPU detectRelocatable(OMRPortLibrary * const omrPortLib);
+   
    bool isCompatible(const OMRProcessorDesc& processorDescription);
    };
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1698,10 +1698,10 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				IDATA argIndex9 = 0;
 				BOOLEAN sharedClassDisabled = FALSE;
 
-#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390)
+#if (defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390) || defined(J9VM_ARCH_POWER))
 				IDATA argIndexXXPortableSharedCache = 0;
 				IDATA argIndexXXNoPortableSharedCache = 0;
-#endif /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390) */
+#endif /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390) || defined(J9VM_ARCH_POWER)*/
 
 				vm->sharedClassPreinitConfig = NULL;
 
@@ -1730,10 +1730,10 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				argIndex8 = FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, VMOPT_XSCMAXJITDATA, NULL);
 				argIndex9 = FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, VMOPT_XXSHARED_CACHE_HARD_LIMIT_EQUALS, NULL);
 
-#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390)
+#if (defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390) || defined(J9VM_ARCH_POWER))
 				argIndexXXPortableSharedCache = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXPORTABLESHAREDCACHE, NULL);
 				argIndexXXNoPortableSharedCache = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXNOPORTABLESHAREDCACHE, NULL);
-#endif /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390) */
+#endif /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390) || defined(J9VM_ARCH_POWER) */
 
 				if (((!J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm)) && (argIndex < 0))
 					|| (TRUE == sharedClassDisabled)
@@ -1815,7 +1815,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 					vm->sharedClassPreinitConfig = piConfig;
 
 					if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_AOT)) {
-#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390)
+#if (defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390) || defined(J9VM_ARCH_POWER))
 						if (argIndexXXPortableSharedCache > argIndexXXNoPortableSharedCache) {
 							vm->extendedRuntimeFlags2 |= J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE;
 						} else if (argIndexXXPortableSharedCache == argIndexXXNoPortableSharedCache) {
@@ -1827,7 +1827,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 								vm->extendedRuntimeFlags2 |= J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE;
 							}
 						}
-#endif /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390) */
+#endif /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390) || defined(J9VM_ARCH_POWER) */
 					}
 				}
 


### PR DESCRIPTION
- Use `OMR_PROCESSOR_PPC_P8` as the portable cpu processor on Power
- AOT compilation will use `OMR_PROCESSOR_PPC_P8` when Portable AOT is enabled and will use host cpu when Portable AOT is not enabled
- Enable Portable AOT on Power, compressed reference shift on Power will be fixed to 3 if Portable AOT is enabled
- Portable AOT is controlled by [+|-]PortableSharedCache (enabled by default in containers and disabled by default outside of containers)

Signed-off-by: Harry Yu <harryyu1994@gmail.com>