### PR TITLE
Use Start PC from isCompiled API

### DIFF
--- a/runtime/compiler/control/CompilationController.cpp
+++ b/runtime/compiler/control/CompilationController.cpp
@@ -613,7 +613,7 @@ TR::DefaultCompilationStrategy::processJittedSample(TR_MethodEvent *event)
       fe->acquireCompilationLock();
       bool isAlreadyBeingCompiled;
       TR_OpaqueMethodBlock *j9m = methodInfo->getMethodInfo();
-      void *currentStartPC = TR::CompilationInfo::isCompiled((J9Method*)j9m) ? (void *)TR::Compiler->mtd.startPC(j9m) : NULL;
+      void *currentStartPC = TR::CompilationInfo::getPCIfCompiled((J9Method*)j9m);
 
       // See if the method has already been compiled but we get a sample in the old body
       if (currentStartPC != startPC) // rare case

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -457,6 +457,14 @@ public:
    static JITServer::ServerStream *getStream();
 #endif /* defined(J9VM_OPT_JITSERVER) */
    static bool isInterpreted(J9Method *method) { return !isCompiled(method); }
+
+   /**
+    * @brief Determines if a J9Method is compiled
+    *
+    * @param method pointer to the J9Method
+    *
+    * @return true if compiled, false otherwise
+    */
    static bool isCompiled(J9Method *method)
       {
 #if defined(J9VM_OPT_JITSERVER)
@@ -466,8 +474,34 @@ public:
          return std::get<0>(stream->read<bool>());
          }
 #endif /* defined(J9VM_OPT_JITSERVER) */
-      return (((uintptr_t)method->extra) & J9_STARTPC_NOT_TRANSLATED) == 0;
+
+      return (getPCIfCompiled(method) != NULL);
       }
+
+   /**
+    * @brief Returns the PC of a method that is compiled
+    *
+    * @param method pointer to the J9Method
+    *
+    * @return The start PC if compiled, NULL otherwise
+    */
+   static void* getPCIfCompiled(J9Method *method)
+      {
+#if defined(J9VM_OPT_JITSERVER)
+      if (auto stream = getStream())
+         {
+         stream->write(JITServer::MessageType::CompInfo_getPCIfCompiled, method);
+         return std::get<0>(stream->read<void *>());
+         }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+      /* Read extra field only once */
+      void *extra = method->extra;
+
+      /* Return extra field if compiled, NULL otherwise */
+      return ((uintptr_t)extra & J9_STARTPC_NOT_TRANSLATED) == 0 ? extra : NULL;
+      }
+
    static bool isJNINative(J9Method *method)
       {
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -4495,9 +4495,9 @@ TR::CompilationInfoPerThread::shouldPerformCompilation(TR_MethodToBeCompiled &en
          {
          TR_ASSERT(entry._reqFromSecondaryQueue == TR_MethodToBeCompiled::REASON_UPGRADE, "wrong reason for upgrade");
          // This method might have failed compilation or have been rejected due to filters
-         if (TR::CompilationInfo::isCompiled(method))
+         void *startPC = TR::CompilationInfo::getPCIfCompiled(method);
+         if (startPC)
             {
-            void *startPC = TR::CompilationInfo::getJ9MethodStartPC(method);
             // A compilation attempt might have already happened for this method
             // (and failed or succeeded)
             J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
@@ -5420,14 +5420,13 @@ void *TR::CompilationInfo::startPCIfAlreadyCompiled(J9VMThread * vmThread, TR::I
       // first compilation of the method: J9Method would be updated if the
       // compilation has already taken place
       //
-      if (isCompiled(method))
-         startPC = getJ9MethodStartPC(method);
+      startPC = getPCIfCompiled(method);
       }
    else
       {
       J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(oldStartPC);
-      if (linkageInfo->recompilationAttempted() && isCompiled(method))
-         startPC = getJ9MethodStartPC(method);
+      if (linkageInfo->recompilationAttempted())
+         startPC = getPCIfCompiled(method);
       }
    return startPC;
    }
@@ -5652,10 +5651,10 @@ void *TR::CompilationInfo::compileMethod(J9VMThread * vmThread, TR::IlGeneratorM
          } // if
       else if (!oldStartPC && !details.isMethodInProgress())
          {
-         if (isCompiled(method))
+         startPC = getPCIfCompiled(method);
+         if (startPC)
             {
             debugPrint("\tcompile request already done", method); //, vmThread, entry->getMethodDetails());
-            startPC = getJ9MethodStartPC(method);
             needCompile = false;
             }
          } // if
@@ -5666,9 +5665,9 @@ void *TR::CompilationInfo::compileMethod(J9VMThread * vmThread, TR::IlGeneratorM
             J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(oldStartPC);
             if (linkageInfo->recompilationAttempted())
                {
-               startPC = getJ9MethodStartPC(method); // provide the new startPC
+               startPC = getPCIfCompiled(method); // provide the new startPC
                // must look like a compiled method
-               if (isCompiled(method))
+               if (startPC)
                   {
                   debugPrint("\tcompile request already done", method); //, vmThread, entry->getMethodDetails());
                   needCompile = false;
@@ -7512,10 +7511,14 @@ TR::CompilationInfoPerThreadBase::postCompilationTasks(J9VMThread * vmThread,
    else // compilation will not be retried, either because it succeeded or because we don't want to
       {
       TR_PersistentJittedBodyInfo *bodyInfo;
+      void *extra = NULL;
       // JITServer: Can not acquire the jitted body info on the server
-      if (!entry->isOutOfProcessCompReq() && entry->isDLTCompile() && !startPC && TR::CompilationInfo::isCompiled(method) && // DLT compilation that failed too many times
-         (bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(method->extra)))  // do not use entry->_oldStartPC which is probably 0. Use the most up-to-date startPC
+      if (!entry->isOutOfProcessCompReq() && entry->isDLTCompile() && !startPC &&
+          (extra = TR::CompilationInfo::getPCIfCompiled(method)) && // DLT compilation that failed too many times
+          (bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(extra)))  // do not use entry->_oldStartPC which is probably 0. Use the most up-to-date startPC
+         {
          bodyInfo->getMethodInfo()->setHasFailedDLTCompRetrials(true);
+         }
 
       startPC = TR::CompilationInfo::compilationEnd(
          vmThread,
@@ -11487,10 +11490,9 @@ TR::CompilationInfo::triggerOrderedCompiles(TR_FrontEnd * f, intptr_t tickCount)
       // For a compiled method, mark it for recompilation if it is currently
       // being sampled. If it is being profiled leave it to run its course.
       //
-      if (isCompiled(ramMethod))
+      void *startPC = getPCIfCompiled(ramMethod);
+      if (startPC)
          {
-         void *startPC = TR::CompilationInfo::getJ9MethodStartPC(ramMethod);
-
          J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
 
          if (linkageInfo->isRecompMethodBody())

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -721,9 +721,10 @@ static TR_YesNoMaybe shouldInitiateDLT(J9DLTInformationBlock *dltInfo, int32_t i
    if (hitCount>=triggerCount)
       return TR_maybe;
 
-   if(!TR::Options::getCmdLineOptions()->getOption(TR_DisableFastDLTOnLongRunningInterpreter) && TR::CompilationInfo::isCompiled(currentMethod))
+   void *extra = TR::CompilationInfo::getPCIfCompiled(currentMethod);
+   if(extra && !TR::Options::getCmdLineOptions()->getOption(TR_DisableFastDLTOnLongRunningInterpreter))
       {
-      TR_PersistentJittedBodyInfo *bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(currentMethod->extra);
+      TR_PersistentJittedBodyInfo *bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(extra);
       if (bodyInfo && bodyInfo->isLongRunningInterpreted())
          return TR_yes;
       }
@@ -846,6 +847,7 @@ void DLTLogic(J9VMThread* vmThread, TR::CompilationInfo *compInfo)
    int32_t    idx = dltBlock->cursor + 1;
    J9ROMMethod *romMethod = NULL;
    bool         bcRepeats;
+   void        *extra = NULL;
 
    if (startPC!=(uint8_t *)-1 &&  walkState.method!=0)
       romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(walkState.method);
@@ -864,9 +866,9 @@ void DLTLogic(J9VMThread* vmThread, TR::CompilationInfo *compInfo)
       dltBlock->methods[idx] = 0;
       return;
       }
-   else if (TR::CompilationInfo::isCompiled(walkState.method))
+   else if (extra = TR::CompilationInfo::getPCIfCompiled(walkState.method))
       {
-      TR_PersistentJittedBodyInfo *bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(walkState.method->extra);
+      TR_PersistentJittedBodyInfo *bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(extra);
       if (bodyInfo && bodyInfo->getMethodInfo()->hasFailedDLTCompRetrials())
          {
          dltBlock->methods[idx] = 0;
@@ -2312,9 +2314,8 @@ void jitClassesRedefined(J9VMThread * currentThread, UDATA classCount, J9JITRede
             TR::CodeCacheManager::instance()->onClassRedefinition(reinterpret_cast<TR_OpaqueMethodBlock *>(staleMethod),
                                                                   reinterpret_cast<TR_OpaqueMethodBlock *>(freshMethod));
             // Step 2 invalidate methods that are already compiled and trigger a new compilation.
-            if (staleMethod && freshMethod && compInfo->isCompiled(staleMethod))
+            if (staleMethod && freshMethod && (startPC = compInfo->getPCIfCompiled(staleMethod)))
                {
-               startPC = TR::CompilationInfo::getJ9MethodStartPC(staleMethod);
                // Update the ram method information in PersistentMethodInfo
                TR_PersistentJittedBodyInfo *bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(startPC);
                if (bodyInfo)
@@ -6094,10 +6095,9 @@ void jitHookJNINativeRegistered(J9HookInterface **hookInterface, UDATA eventNum,
    TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
    getOutOfIdleStates(TR::CompilationInfo::SAMPLER_DEEPIDLE, compInfo, "JNI registered");
 
-   if (TR::CompilationInfo::isCompiled(method))
+   uint8_t *thunkStartPC = (uint8_t *)TR::CompilationInfo::getPCIfCompiled(method);
+   if (thunkStartPC)
       {
-      uint8_t *thunkStartPC = (uint8_t*) TR::CompilationInfo::getJ9MethodStartPC(method);
-
       // The address in the word immediately before the linkage info
       uintptr_t **addressSlot = (uintptr_t **)(thunkStartPC - (4 + sizeof(uintptr_t)));
 

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1984,6 +1984,12 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, TR::CompilationInfo::isCompiled(method));
          }
          break;
+      case MessageType::CompInfo_getPCIfCompiled:
+         {
+         J9Method *method = std::get<0>(client->getRecvData<J9Method *>());
+         client->write(response, TR::CompilationInfo::getPCIfCompiled(method));
+         }
+         break;
       case MessageType::CompInfo_getJ9MethodExtra:
          {
          J9Method *method = std::get<0>(client->getRecvData<J9Method *>());

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -102,7 +102,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 10;
+   static const uint16_t MINOR_NUMBER = 11;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -207,6 +207,7 @@ enum MessageType : uint16_t
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled, // 171
+   CompInfo_getPCIfCompiled,
    CompInfo_getInvocationCount,
    CompInfo_setInvocationCount,
    CompInfo_getJ9MethodExtra,
@@ -219,7 +220,7 @@ enum MessageType : uint16_t
    CompInfo_getJ9MethodStartPC,
 
    // For J9::ClassEnv Methods
-   ClassEnv_classFlagsValue, // 182
+   ClassEnv_classFlagsValue, // 183
    ClassEnv_classDepthOf,
    ClassEnv_classInstanceSize,
    ClassEnv_superClassesOf,
@@ -232,13 +233,13 @@ enum MessageType : uint16_t
    ClassEnv_getROMClassRefName,
 
    // For TR_J9SharedCache
-   SharedCache_getClassChainOffsetInSharedCache, // 193
+   SharedCache_getClassChainOffsetInSharedCache, // 194
    SharedCache_rememberClass,
    SharedCache_addHint,
    SharedCache_storeSharedData,
 
    // For runFEMacro
-   runFEMacro_invokeCollectHandleNumArgsToCollect, // 197
+   runFEMacro_invokeCollectHandleNumArgsToCollect, // 198
    runFEMacro_invokeExplicitCastHandleConvertArgs,
    runFEMacro_targetTypeL,
    runFEMacro_invokeILGenMacrosInvokeExactAndFixup,
@@ -264,24 +265,24 @@ enum MessageType : uint16_t
    runFEMacro_invokeCollectHandleAllocateArray,
 
    // for JITServerPersistentCHTable
-   CHTable_getAllClassInfo, // 221
+   CHTable_getAllClassInfo, // 222
    CHTable_getClassInfoUpdates,
    CHTable_commit,
    CHTable_clearReservable,
 
    // for JITServerIProfiler
-   IProfiler_profilingSample, // 225
+   IProfiler_profilingSample, // 226
    IProfiler_searchForMethodSample,
    IProfiler_getMaxCallCount,
    IProfiler_setCallCount,
 
-   Recompilation_getExistingMethodInfo, // 229
+   Recompilation_getExistingMethodInfo, // 230
    Recompilation_getJittedBodyInfoFromPC,
 
    ClassInfo_getRemoteROMString,
 
    // for KnownObjectTable
-   KnownObjectTable_getOrCreateIndex, // 232
+   KnownObjectTable_getOrCreateIndex, // 233
    KnownObjectTable_getOrCreateIndexAt,
    KnownObjectTable_getPointer,
    KnownObjectTable_getExistingIndexAt,
@@ -295,7 +296,7 @@ enum MessageType : uint16_t
    KnownObjectTable_invokeDirectHandleDirectCall,
    KnownObjectTable_getKnownObjectTableDumpInfo,
 
-   ClassEnv_isClassRefValueType, // 244
+   ClassEnv_isClassRefValueType, // 245
    MessageType_MAXTYPE
    };
 
@@ -475,6 +476,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "VM_stackWalkerMaySkipFramesSVM",
    "VM_getFields",
    "CompInfo_isCompiled", // 171
+   "CompInfo_getPCIfCompiled",
    "CompInfo_getInvocationCount",
    "CompInfo_setInvocationCount",
    "CompInfo_getJ9MethodExtra",
@@ -485,7 +487,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "CompInfo_setInvocationCountAtomic",
    "CompInfo_isClassSpecial",
    "CompInfo_getJ9MethodStartPC",
-   "ClassEnv_classFlagsValue", // 182
+   "ClassEnv_classFlagsValue", // 183
    "ClassEnv_classDepthOf",
    "ClassEnv_classInstanceSize",
    "ClassEnv_superClassesOf",
@@ -496,11 +498,11 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "ClassEnv_getITable",
    "ClassEnv_classHasIllegalStaticFinalFieldModification",
    "ClassEnv_getROMClassRefName",
-   "SharedCache_getClassChainOffsetInSharedCache", // 193
+   "SharedCache_getClassChainOffsetInSharedCache", // 194
    "SharedCache_rememberClass",
    "SharedCache_addHint",
    "SharedCache_storeSharedData",
-   "runFEMacro_invokeCollectHandleNumArgsToCollect", // 197
+   "runFEMacro_invokeCollectHandleNumArgsToCollect", // 198
    "runFEMacro_invokeExplicitCastHandleConvertArgs",
    "runFEMacro_targetTypeL",
    "runFEMacro_invokeILGenMacrosInvokeExactAndFixup",
@@ -524,15 +526,15 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "runFEMacro_invokeFilterArgumentsWithCombinerHandleFilterPosition",
    "runFEMacro_invokeFilterArgumentsWithCombinerHandleArgumentIndices",
    "runFEMacro_invokeCollectHandleAllocateArray",
-   "CHTable_getAllClassInfo", // 221
+   "CHTable_getAllClassInfo", // 222
    "CHTable_getClassInfoUpdates",
    "CHTable_commit",
    "CHTable_clearReservable",
-   "IProfiler_profilingSample", // 225
+   "IProfiler_profilingSample", // 226
    "IProfiler_searchForMethodSample",
    "IProfiler_getMaxCallCount",
    "IProfiler_setCallCount",
-   "Recompilation_getExistingMethodInfo", // 229
+   "Recompilation_getExistingMethodInfo", // 230
    "Recompilation_getJittedBodyInfoFromPC",
    "ClassInfo_getRemoteROMString",
    "KnownObjectTable_getOrCreateIndex", // 232
@@ -547,7 +549,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "KnownObjectTable_getReferenceField",
    "KnownObjectTable_invokeDirectHandleDirectCall",
    "KnownObjectTable_getKnownObjectTableDumpInfo",
-   "ClassEnv_isClassRefValueType", // 244
+   "ClassEnv_isClassRefValueType", // 245
    };
    }; // namespace JITServer
 #endif // MESSAGE_TYPES_HPP

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3485,7 +3485,7 @@ typedef struct J9Method {
 	U_8* bytecodes;
 	struct J9ConstantPool* constantPool;
 	void* methodRunAddress;
-	void* extra;
+	void* volatile extra;
 } J9Method;
 
 typedef struct J9JNIMethodID {


### PR DESCRIPTION
Because the extra field of a J9Method is a global that can be modified by another thread (and accesses to it aren't locked), it is possible to read the value once, make a decision based on it, read it again and then be in an invalid state. This PR 

1. makes J9Method.extra volatile
2. adds the getPCIfCompiled API in TR::CompilationInfo to return the Start PC if the method is compiled, and NULL otherwise; this allows callers to use the returned start PC rather than read the extra field again.
3. modifies callers of isCompiled to use getPCIfCompiled rather than read the extra field of the J9Method again if the method is compiled.

Fixes https://github.com/eclipse/openj9/issues/10623
Closes https://github.com/eclipse/openj9/issues/10673