### PR TITLE
Use a separate mutex for small freed block lists of persistent allocator

### DIFF
--- a/runtime/compiler/env/PersistentAllocator.cpp
+++ b/runtime/compiler/env/PersistentAllocator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,9 @@ PersistentAllocator::PersistentAllocator(const PersistentAllocatorKit &creationK
    _freeBlocks(),
    _segments(SegmentContainerAllocator(RawAllocator(&creationKit.javaVM)))
    {
+   j9thread_monitor_init_with_name(&_smallBlockListsMonitor, 0, "JIT-SmallBlockListsMonitor");
+   if (!_smallBlockListsMonitor)
+      throw std::bad_alloc();
    }
 
 PersistentAllocator::~PersistentAllocator() throw()
@@ -44,20 +47,14 @@ PersistentAllocator::~PersistentAllocator() throw()
       _segments.pop_front();
       _segmentAllocator.deallocate(segment);
       }
+   j9thread_monitor_destroy(_smallBlockListsMonitor);
+   _smallBlockListsMonitor = NULL;
    }
 
 void *
 PersistentAllocator::allocate(size_t size, const std::nothrow_t tag, void * hint) throw()
    {
-   if (::memoryAllocMonitor)
-      ::memoryAllocMonitor->enter();
-
-   void * result = allocateLocked(size);
-
-   if (::memoryAllocMonitor)
-      ::memoryAllocMonitor->exit();
-
-   return result;
+   return allocateInternal(size);
    }
 
 void *
@@ -68,66 +65,130 @@ PersistentAllocator::allocate(size_t size, void *hint)
    return alloc;
    }
 
+PersistentAllocator::Block *
+PersistentAllocator::allocateFromVariableSizeListLocked(size_t allocSize)
+   {
+   Block * block = NULL;
+   Block * prev = NULL;
+   for (block = _freeBlocks[LARGE_BLOCK_LIST_INDEX]; block && block->_size < allocSize; prev = block, block = prev->next())
+      {}
+
+   if (block)
+      {
+      if (prev)
+         prev->_next = block->next();
+      else
+         _freeBlocks[LARGE_BLOCK_LIST_INDEX] = block->next();
+
+      block->_next = NULL;
+      }
+   return block;
+   }
+
 void *
-PersistentAllocator::allocateLocked(size_t requestedSize)
+PersistentAllocator::allocateInternal(size_t requestedSize)
    {
    TR_ASSERT( sizeof(Block) == mem_round( sizeof(Block) ),"Persistent block size will prevent us from properly aligning allocations.");
    size_t const dataSize = mem_round(requestedSize);
    size_t const allocSize = sizeof(Block) + dataSize;
+   void * allocation = NULL;
 
-   TR::AllocatedMemoryMeter::update_allocated(allocSize, persistentAlloc);
+   if (TR::AllocatedMemoryMeter::_enabled & persistentAlloc)
+      {
+      // Use _smallBlockListsMonitor to protect TR::AllocatedMemoryMeter::update_allocated
+      // because accessing the variable-size-block list protected by ::memoryAllocMonitor
+      // takes longer and we may be penalizing access to fixed size block which should be very fast
+      j9thread_monitor_enter(_smallBlockListsMonitor);
+      TR::AllocatedMemoryMeter::update_allocated(allocSize, persistentAlloc);
+      j9thread_monitor_exit(_smallBlockListsMonitor);
+      }
 
    // If this is a small block try to allocate it from the appropriate
    // fixed-size-block chain.
    //
    size_t const index = freeBlocksIndex(allocSize);
-   Block * block = 0;
-   Block * prev = 0;
-   for (
-      block = _freeBlocks[index];
-      block && block->_size < allocSize;
-      prev = block, block = prev->next()
-      )
-      { TR_ASSERT(index == 0, "Iterating through a fixed-size block bin."); }
-
-   if (block)
+   if (index != LARGE_BLOCK_LIST_INDEX) // fixed-size-block chain
       {
-
-      TR_ASSERT(
-         ( index == 0 ) || ( block->_size == allocSize ),
-         "block %p in chain for index %d has size %d (not %d)\n",
-         block,
-         index,
-         block->_size,
-         (index * sizeof(void *)) + sizeof(Block)
-         );
-
-      if (prev)
-         prev->_next = block->next();
-      else
-         _freeBlocks[index] = block->next();
-
-      block->_next = NULL;
-
-      size_t const excess = block->_size - allocSize;
-
-      if (excess > sizeof(Block))
+      j9thread_monitor_enter(_smallBlockListsMonitor);
+      Block * block = _freeBlocks[index];
+      if (block)
          {
-         block->_size = allocSize;
-         freeBlock( new (pointer_cast<uint8_t *>(block) + allocSize) Block(excess) );
+         _freeBlocks[index] = block->next();
+         block->_next = NULL;
+         j9thread_monitor_exit(_smallBlockListsMonitor);
+         allocation = block + 1; // Return pointer after the header
          }
+      else // Couldn't find suitable free block; need to allocate from segment
+         {
+         j9thread_monitor_exit(_smallBlockListsMonitor);
 
-      return block + 1;
+         // Find the first persistent segment with enough free space
+         if (::memoryAllocMonitor)
+            ::memoryAllocMonitor->enter();
+         allocation = allocateFromSegmentLocked(allocSize);
+         if (::memoryAllocMonitor)
+            ::memoryAllocMonitor->exit();
+         }
       }
+   else // Variable size block allocation
+      {
+      if (::memoryAllocMonitor)
+         ::memoryAllocMonitor->enter();
+      Block * block = allocateFromVariableSizeListLocked(allocSize);
+      if (block)
+         {
+         // If the block I found is bigger than what I need,
+         // split it and put the remaining block back onto the free list
+         size_t const excess = block->_size - allocSize;
+         if (excess > sizeof(Block))
+            {
+            block->_size = allocSize;
+            const size_t excessIndex = freeBlocksIndex(excess);
+            if (excessIndex > LARGE_BLOCK_LIST_INDEX)
+               {
+               // Exit the variable size list monitor and grab a fixed size list monitor
+               if (::memoryAllocMonitor)
+                  ::memoryAllocMonitor->exit();
 
-   // Find the first persistent segment with enough free space
-   //
+               j9thread_monitor_enter(_smallBlockListsMonitor);
+               freeFixedSizeBlock( new (pointer_cast<uint8_t *>(block) + allocSize) Block(excess) );
+               j9thread_monitor_exit(_smallBlockListsMonitor);
+               }
+            else
+               {
+               freeVariableSizeBlock( new (pointer_cast<uint8_t *>(block) + allocSize) Block(excess) );
+               if (::memoryAllocMonitor)
+                  ::memoryAllocMonitor->exit();
+               }
+            }
+         else // No block splitting required; just release memoryAllocMonitor
+            {
+            if (::memoryAllocMonitor)
+               ::memoryAllocMonitor->exit();
+            }
+         allocation = block + 1; // Return pointer after the header
+         }
+      else // Must allocate block from segment
+         {
+         // memoryAllocMonitor is already acquired
+         allocation = allocateFromSegmentLocked(allocSize);
+         if (::memoryAllocMonitor)
+            ::memoryAllocMonitor->exit();
+         }
+      }
+   return allocation;
+   }
+
+void *
+PersistentAllocator::allocateFromSegmentLocked(size_t allocSize)
+   {
    J9MemorySegment *segment = findUsableSegment(allocSize);
    if (!segment)
       {
       size_t const segmentSize = allocSize < _minimumSegmentSize ? _minimumSegmentSize : allocSize;
       segment = _segmentAllocator.allocate(segmentSize, std::nothrow);
-      if (!segment) return 0;
+      if (!segment) 
+         return NULL;
       try
          {
          _segments.push_front(TR::ref(*segment));
@@ -135,11 +196,11 @@ PersistentAllocator::allocateLocked(size_t requestedSize)
       catch(const std::exception &e)
          {
          _segmentAllocator.deallocate(*segment);
-         return 0;
+         return NULL;
          }
       }
    TR_ASSERT(segment && remainingSpace(*segment) >= allocSize, "Failed to acquire a segment");
-   block = new(operator new(allocSize, *segment)) Block(allocSize);
+   Block * block = new(operator new(allocSize, *segment)) Block(allocSize);
    return block + 1;
    }
 
@@ -164,26 +225,33 @@ PersistentAllocator::remainingSpace(J9MemorySegment &segment) throw()
    }
 
 void
-PersistentAllocator::freeBlock(Block * block)
+PersistentAllocator::freeFixedSizeBlock(Block * block)
    {
+   // Appropriate lock should have been obtained
    TR_ASSERT(block->_size > 0, "Block size is non-positive");
-   TR_ASSERT(block->_next == NULL, "In-use persistent memory block @ belongs to a free block chain.", block);
-   block->_next = NULL;
-
-   // If this is a small block, add it to the appropriate fixed-size-block
-   // chain. Otherwise add it to the variable-size-block chain which is in
-   // ascending size order.
-   //
    size_t const index = freeBlocksIndex(block->_size);
-   Block * blockIterator = _freeBlocks[index];
+   TR_ASSERT(index != LARGE_BLOCK_LIST_INDEX, "freeFixedSizeBlock should be used for small blocks, so index cannot be LARGE_BLOCK_LIST_INDEX");
+   block->_next = _freeBlocks[index];
+   _freeBlocks[index] = block;
+   }
+
+void
+PersistentAllocator::freeVariableSizeBlock(Block * block)
+   {
+   // Appropriate lock should have been obtained
+   TR_ASSERT(block->_size > 0, "Block size is non-positive");
+   block->_next = NULL;
+   // Add block to the variable-size-block chain which is in ascending size order.
+   //
+   TR_ASSERT(freeBlocksIndex(block->_size) == LARGE_BLOCK_LIST_INDEX, "freeVariableSizeBlock should be used for large blocks, so index should be LARGE_BLOCK_LIST_INDEX");
+   Block * blockIterator = _freeBlocks[LARGE_BLOCK_LIST_INDEX];
    if (!blockIterator || !(blockIterator->_size < block->_size) )
       {
-      block->_next = _freeBlocks[index];
-      _freeBlocks[index] = block;
+      block->_next = _freeBlocks[LARGE_BLOCK_LIST_INDEX];
+      _freeBlocks[LARGE_BLOCK_LIST_INDEX] = block;
       }
    else
       {
-      TR_ASSERT(index == 0, "Iterating through what should be fixed-size blocks.");
       while (blockIterator->next() && blockIterator->next()->_size < block->_size)
          {
          blockIterator = blockIterator->next();
@@ -194,25 +262,49 @@ PersistentAllocator::freeBlock(Block * block)
    }
 
 void
-PersistentAllocator::deallocate(void * mem, size_t) throw()
+PersistentAllocator::freeBlock(Block * block)
    {
-   if (::memoryAllocMonitor)
-      ::memoryAllocMonitor->enter();
+   TR_ASSERT(block->_size > 0, "Block size is non-positive");
 
-
-   Block * block = static_cast<Block *>(mem) - 1;
-
-   // adjust the used persistent memory here and not in freePersistentmemory(block, size)
+   // Adjust the used persistent memory here and not in freePersistentmemory(block, size)
    // because that call is also used to free memory that wasn't actually committed
-   TR::AllocatedMemoryMeter::update_freed(block->_size, persistentAlloc);
-
-   freeBlock(block);
-
-   if (::memoryAllocMonitor)
-      ::memoryAllocMonitor->exit();
+   if (TR::AllocatedMemoryMeter::_enabled & persistentAlloc)
+      {
+      j9thread_monitor_enter(_smallBlockListsMonitor);
+      TR::AllocatedMemoryMeter::update_freed(block->_size, persistentAlloc);
+      j9thread_monitor_exit(_smallBlockListsMonitor);
+      }
+  
+   // If this is a small block, add it to the appropriate fixed-size-block
+   // chain. Otherwise add it to the variable-size-block chain which is in
+   // ascending size order.
+   //
+   size_t const index = freeBlocksIndex(block->_size);
+   if (index > LARGE_BLOCK_LIST_INDEX)
+      {
+      j9thread_monitor_enter(_smallBlockListsMonitor);
+      freeFixedSizeBlock(block);
+      j9thread_monitor_exit(_smallBlockListsMonitor);
+      }
+   else
+      {
+      if (::memoryAllocMonitor)
+         ::memoryAllocMonitor->enter();
+      freeVariableSizeBlock(block);
+      if (::memoryAllocMonitor)
+         ::memoryAllocMonitor->exit();
+      }
    }
 
-}
+void
+PersistentAllocator::deallocate(void * mem, size_t) throw()
+   {
+   Block * block = static_cast<Block *>(mem) - 1;
+   TR_ASSERT_FATAL(block->_next == NULL, "Freeing a block that is already on the free list. block=%p next=%p", block, block->_next);
+   freeBlock(block);
+   }
+
+} // namespace J9
 
 void *
 operator new(size_t size, J9::PersistentAllocator &persistentAllocator)

--- a/runtime/compiler/env/PersistentAllocator.hpp
+++ b/runtime/compiler/env/PersistentAllocator.hpp
@@ -81,7 +81,7 @@ private:
       Block * next() { return reinterpret_cast<Block *>( (reinterpret_cast<uintptr_t>(_next) & ~0x1)); }
       };
 
-   static const size_t PERSISTANT_BLOCK_SIZE_BUCKETS = 12;
+   static const size_t PERSISTANT_BLOCK_SIZE_BUCKETS = 16;
    static size_t freeBlocksIndex(size_t const blockSize)
       {
       size_t const adjustedBlockSize = blockSize - sizeof(Block);

--- a/runtime/compiler/env/PersistentAllocator.hpp
+++ b/runtime/compiler/env/PersistentAllocator.hpp
@@ -81,17 +81,30 @@ private:
       Block * next() { return reinterpret_cast<Block *>( (reinterpret_cast<uintptr_t>(_next) & ~0x1)); }
       };
 
+   // Monitor to protect access to the linked lists of (small) fixed-size blocks
+   // The variable-size block list (which takes longer to access) will continue
+   // to be protected by memoryAllocMonitor. This arrangement prevents a fast
+   // fixed-size block list access to be delayed by a slow variable-size block
+   // list access
+   J9ThreadMonitor * _smallBlockListsMonitor;
+
    static const size_t PERSISTANT_BLOCK_SIZE_BUCKETS = 16;
+   // first list/bucket is for large blocks of variable size
+   static const size_t LARGE_BLOCK_LIST_INDEX = 0;
    static size_t freeBlocksIndex(size_t const blockSize)
       {
       size_t const adjustedBlockSize = blockSize - sizeof(Block);
       size_t const candidateBucket = adjustedBlockSize / sizeof(void *);
       return candidateBucket < PERSISTANT_BLOCK_SIZE_BUCKETS ?
          candidateBucket :
-         0;
+         LARGE_BLOCK_LIST_INDEX;
       }
 
-   void * allocateLocked(size_t);
+   void * allocateInternal(size_t);
+   Block * allocateFromVariableSizeListLocked(size_t allocSize);
+   void * allocateFromSegmentLocked(size_t allocSize);
+   void freeFixedSizeBlock(Block * block);
+   void freeVariableSizeBlock(Block * block);
    void freeBlock(Block *);
 
    J9MemorySegment * findUsableSegment(size_t requiredSize);


### PR DESCRIPTION
Small freed memory blocks using persistent memory are kept in some
linked lists, where each list only contains blocks of same size.
This allows the JIT to rapidly allocate/deallocate a small block
of memory by detaching the head (or adding to the head) of an
appropriate such list.
Larger freed blocks are kept in a separate list where blocks are
ordered by size. The overhead to access this list can sometimes be
quite large, depending on the number of entries in this list (we
need to traverse the list to find the right location for adding
to or deleting from it).
Currently, all these lists are protected by the same monitor:
`memoryAllocMonitor`. In order to avoid a fast allocation or
deallocation of a small block to be delayed by a concurrent access
to the large-block list (which can take time), this commit
introduces a dedicated mutex for the set of small-freed-block
lists, called `_smallBlockListsMonitor`.
Some refactoring of the code has also been performed.
Also, the number of small-freed-block lists has been increased
from 11 to 15.


Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>
