### PR TITLE
Store classes not worth remembering per client for JITServer

### DIFF
--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -29,6 +29,7 @@
 #include "net/ServerStream.hpp" // for JITServer::ServerStream
 #include "runtime/RuntimeAssumptions.hpp" // for TR_AddressSet
 #include "env/JITServerPersistentCHTable.hpp"
+#include "runtime/SymbolValidationManager.hpp"
 
 
 ClientSessionData::ClientSessionData(uint64_t clientUID, uint32_t seqNo) : 
@@ -66,6 +67,8 @@ ClientSessionData::ClientSessionData(uint64_t clientUID, uint32_t seqNo) :
       {
       TR_ASSERT_FATAL(false, "Failed to initialize JITServer class unload RWMutex");
       }
+
+   TR::SymbolValidationManager::populateSystemClassesNotWorthRemembering(this);
    }
 
 ClientSessionData::~ClientSessionData()

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -27,6 +27,7 @@
 #include "env/PersistentCollections.hpp" // for PersistentUnorderedMap
 #include "il/DataTypes.hpp" // for DataType
 #include "env/VMJ9.h" // for TR_StaticFinalData
+#include "runtime/SymbolValidationManager.hpp"
 
 class J9ROMClass;
 class J9Class;
@@ -434,6 +435,8 @@ class ClientSessionData
    void writeAcquireClassUnloadRWMutex();
    void writeReleaseClassUnloadRWMutex();
 
+   TR::SymbolValidationManager::SystemClassNotWorthRemembering *getSystemClassesNotWorthRemembering() { return _systemClassesNotWorthRemembering; }
+
    private:
    const uint64_t _clientUID;
    int64_t  _timeOfLastAccess; // in ms
@@ -481,6 +484,8 @@ class ClientSessionData
 
    omrthread_rwmutex_t _classUnloadRWMutex;
    volatile bool _bClassUnloadingAttempt;
+
+   TR::SymbolValidationManager::SystemClassNotWorthRemembering _systemClassesNotWorthRemembering[TR::SymbolValidationManager::SYSTEM_CLASSES_NOT_WORTH_REMEMBERING_COUNT];
    }; // class ClientSessionData
 
 

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -38,6 +38,10 @@
 #include "exceptions/AOTFailure.hpp"
 #include "runtime/J9Runtime.hpp"
 
+#if defined(J9VM_OPT_JITSERVER)
+class ClientSessionData;
+#endif
+
 #define SVM_ASSERT_LOCATION_INNER(line) __FILE__ ":" #line
 #define SVM_ASSERT_LOCATION(line) SVM_ASSERT_LOCATION_INNER(line)
 
@@ -637,9 +641,9 @@ public:
 
    struct SystemClassNotWorthRemembering
       {
-      const char * const _className;
+      const char *_className;
       TR_OpaqueClassBlock *_clazz;
-      const bool _checkIsSuperClass;
+      bool _checkIsSuperClass;
       };
 
    void populateWellKnownClasses();
@@ -764,10 +768,17 @@ public:
 
    static bool assertionsAreFatal();
 
+   static int getSystemClassesNotWorthRememberingCount();
+
 #if defined(J9VM_OPT_JITSERVER)
    std::string serializeSymbolToIDMap();
    void deserializeSymbolToIDMap(const std::string &symbolToIdStr);
+   static void populateSystemClassesNotWorthRemembering(ClientSessionData *clientData);
 #endif /* defined(J9VM_OPT_JITSERVER) */
+
+   SystemClassNotWorthRemembering *getSystemClassNotWorthRemembering(int idx);
+
+   static const int SYSTEM_CLASSES_NOT_WORTH_REMEMBERING_COUNT = 2;
 
 private:
 


### PR DESCRIPTION
PR #10644 added a static array of classes not worth remembering
to Symbol Validation Manager. JITServer, however, requires this array
to be stored on a per client bases, since pointers to J9 classes
are different between clients.
