### PR TITLE
Add a check for romclass in iterateStackTrace()

### DIFF
--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -355,6 +355,16 @@ inlinedEntry:
 								 * by the bootstrap classloader.
 								 */
 								ramClass = peekClassHashTable(vmThread, vm->applicationClassLoader, J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
+								if (NULL != ramClass) {
+									if (romClass != ramClass->romClass) {
+										/**
+										 * It is possible this romClass is not loaded by app class loader.
+										 * There is another class loader that loads a different class with the same name,
+										 * Do not return the ramClass from app loader in this case.
+										 */
+										ramClass = NULL;
+									}
+								}
 							}
 						}
 


### PR DESCRIPTION
It is possible that app class loader and another class 
loader load 2 different classes with the same name. 
When using peekClassHashTable() with app classLoader, it is 
possible that the current romClass is loaded by another 
loader with the same name. Add a check for romClass
before returning the ramClass.

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>