### PR TITLE
Move MethodType static helpers to new helper Class

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -4842,7 +4842,7 @@ SecurityException {
 	 * @return field descriptor of Class instance
 	 */
 	public String descriptorString() {
-		/* see MethodType.getBytecodeStringName */
+		/* see MethodTypeHelper.getBytecodeStringName */
 
 		if (this.isPrimitive()) {
 			if (this == int.class) {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ConvertHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ConvertHandle.java
@@ -98,9 +98,9 @@ abstract class ConvertHandle extends MethodHandle {
 					continue;
 				} else {
 					// fromClass is reference type { Object, Number, Boolean, Byte, Integer, etc }
-					Class<?> unwrappedFromClass = MethodType.unwrapPrimitive(fromClass);
+					Class<?> unwrappedFromClass = MethodTypeHelper.unwrapPrimitive(fromClass);
 					if ((toClass == unwrappedFromClass) ||
-						fromClass.isAssignableFrom(MethodType.wrapPrimitive(toClass)) ||
+						fromClass.isAssignableFrom(MethodTypeHelper.wrapPrimitive(toClass)) ||
 						FilterHelpers.checkIfWideningPrimitiveConversion(unwrappedFromClass, toClass)) {
 						continue;
 					}
@@ -110,7 +110,7 @@ abstract class ConvertHandle extends MethodHandle {
 		
 			// toClass is reference type
 			// primitive wrapper is subclass of fromClass
-			if (toClass.isAssignableFrom(MethodType.wrapPrimitive(fromClass))) {
+			if (toClass.isAssignableFrom(MethodTypeHelper.wrapPrimitive(fromClass))) {
 				requiresBoxing = true;
 				continue;
 			}
@@ -233,8 +233,8 @@ abstract class ConvertHandle extends MethodHandle {
 			MethodHandle filter = cachedReturnFilters.get(type);
 			if (filter == null) {
 				MethodHandle previous;
-				String to = MethodType.getBytecodeStringName(toClass);
-				String from = MethodType.getBytecodeStringName(type.parameterType(0));
+				String to = MethodTypeHelper.getBytecodeStringName(toClass);
+				String from = MethodTypeHelper.getBytecodeStringName(type.parameterType(0));
 				filter = privilegedLookup.findStatic(FilterHelpers.class, from + "2" + to, type); //$NON-NLS-1$
 				if ((previous = cachedReturnFilters.putIfAbsent(type, filter)) != null) {
 					filter = previous;
@@ -254,7 +254,7 @@ abstract class ConvertHandle extends MethodHandle {
 		 * Constructors of the Wrapper type provide the filter.
 		 */
 		static MethodHandle getBoxingReturnFilter(MethodType type) throws IllegalAccessException, NoSuchMethodException {
-			Class<?> wrapper = MethodType.wrapPrimitive(type.parameterType(0));
+			Class<?> wrapper = MethodTypeHelper.wrapPrimitive(type.parameterType(0));
 			if (!type.returnType().isAssignableFrom(wrapper)) {
 				throw new WrongMethodTypeException();
 			}
@@ -283,22 +283,22 @@ abstract class ConvertHandle extends MethodHandle {
 				} else {
 					methodName = "object2"; //$NON-NLS-1$
 				}
-				methodName += MethodType.getBytecodeStringName(returnType);
+				methodName += MethodTypeHelper.getBytecodeStringName(returnType);
 				return privilegedLookup.findStatic(FilterHelpers.class, methodName, MethodType.methodType(returnType, Object.class));
 			
 			} else if (toUnbox.equals(Number.class)) {
 				/* Widening conversions need to validate the conversion at runtime */
 				if (!isExplicitCast) {
 					if ((returnType != boolean.class) || (returnType != char.class)) {
-						return privilegedLookup.findStatic(FilterHelpers.class, "number2" + MethodType.getBytecodeStringName(returnType), MethodType.methodType(returnType, Number.class)); //$NON-NLS-1$
+						return privilegedLookup.findStatic(FilterHelpers.class, "number2" + MethodTypeHelper.getBytecodeStringName(returnType), MethodType.methodType(returnType, Number.class)); //$NON-NLS-1$
 					}
 				} else {
 					/* special case these - can't be handled by the <type>Value() methods on Number */
 					if ((returnType == boolean.class) || (returnType == char.class)) {
-						String methodName = "explicitNumber2"  + MethodType.getBytecodeStringName(returnType); //$NON-NLS-1$
+						String methodName = "explicitNumber2"  + MethodTypeHelper.getBytecodeStringName(returnType); //$NON-NLS-1$
 						return privilegedLookup.findStatic(FilterHelpers.class, methodName, MethodType.methodType(returnType, Number.class));
 					}
-					String methodName = MethodType.getBytecodeStringName(returnType) + "Value"; //$NON-NLS-1$
+					String methodName = MethodTypeHelper.getBytecodeStringName(returnType) + "Value"; //$NON-NLS-1$
 					return privilegedLookup.findVirtual(Number.class, methodName, MethodType.methodType(returnType));
 				}
 			
@@ -321,9 +321,9 @@ abstract class ConvertHandle extends MethodHandle {
 				/* widen the return if possible */
 				return MethodHandles.filterReturnValue(filter, getPrimitiveReturnFilter(MethodType.methodType(returnType, char.class), isExplicitCast));
 			
-			} else if (MethodType.WRAPPER_SET.contains(toUnbox)) {
+			} else if (MethodTypeHelper.WRAPPER_SET.contains(toUnbox)) {
 				/* remaining wrappers may have widening conversions - can be handled by toUnbox#'type'Value() methods (ie: Number subclasses)*/
-				Class<?> unwrapped = MethodType.unwrapPrimitive(toUnbox);
+				Class<?> unwrapped = MethodTypeHelper.unwrapPrimitive(toUnbox);
 				boolean justUnwrap = returnType.equals(unwrapped);
 				if (justUnwrap || isExplicitCast || checkIfWideningPrimitiveConversion(unwrapped, returnType)) {
 					

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FieldHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FieldHandle.java
@@ -66,7 +66,7 @@ abstract class FieldHandle extends PrimitiveHandle {
 	}
 
 	final Class<?> finishFieldInitialization(Class<?> accessClass) throws IllegalAccessException, NoSuchFieldException {
-		String signature = MethodType.getBytecodeStringName(fieldClass);
+		String signature = MethodTypeHelper.getBytecodeStringName(fieldClass);
 		try {
 			boolean isStaticLookup = ((KIND_GETSTATICFIELD == this.kind) || (KIND_PUTSTATICFIELD == this.kind)); 
 			return lookupField(referenceClass, name, signature, isStaticLookup, accessClass);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
@@ -61,7 +61,7 @@ abstract class FieldVarHandle extends VarHandle {
 		int header = (isStatic ? 0 : VM.OBJECT_HEADER_SIZE);
 
 		/* The native lookupField method also modifies the definingClass field. */
-		this.vmslot = lookupField(definingClass, fieldName, MethodType.getBytecodeStringName(fieldType), fieldType, isStatic, accessClass) + header;
+		this.vmslot = lookupField(definingClass, fieldName, MethodTypeHelper.getBytecodeStringName(fieldType), fieldType, isStatic, accessClass) + header;
 
 		checkSetterFieldFinality(handleTable);
 	}
@@ -141,7 +141,7 @@ abstract class FieldVarHandle extends VarHandle {
 	 * 
 	 * @param lookupClass The class where we start the lookup of the field
 	 * @param name The field name
-	 * @param signature Equivalent of the String returned by MethodType.getBytecodeStringName
+	 * @param signature Equivalent of the String returned by MethodTypeHelper.getBytecodeStringName
 	 * @param type The exact type of the field. This must match the signature.
 	 * @param isStatic A boolean value indicating whether the field is static.
 	 * @param accessClass The class being used to look up the field.

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleResolver.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleResolver.java
@@ -217,7 +217,7 @@ final class MethodHandleResolver {
 			Object internalRamClass = access.createInternalRamClass(j9class);
 			Class<?> classObject = getClassFromJ9Class(j9class);
 			
-			type = MethodType.vmResolveFromMethodDescriptorString(methodDescriptor, access.getClassloader(classObject), null);
+			type = MethodTypeHelper.vmResolveFromMethodDescriptorString(methodDescriptor, access.getClassloader(classObject), null);
 			final MethodHandles.Lookup lookup = new MethodHandles.Lookup(classObject, false);
 			try {
 				lookup.accessCheckArgRetTypes(type);
@@ -325,27 +325,27 @@ final class MethodHandleResolver {
 				result = lookup.findStaticSetter(referenceClazz, name, resolveFieldHandleHelper(typeDescriptor, lookup, loader));
 				break;
 			case 5: /* invokeVirtual */
-				type = MethodType.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
+				type = MethodTypeHelper.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
 				lookup.accessCheckArgRetTypes(type);
 				result = lookup.findVirtual(referenceClazz, name, type);
 				break;
 			case 6: /* invokeStatic */
-				type = MethodType.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
+				type = MethodTypeHelper.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
 				lookup.accessCheckArgRetTypes(type);
 				result = lookup.findStatic(referenceClazz, name, type);
 				break;
 			case 7: /* invokeSpecial */ 
-				type = MethodType.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
+				type = MethodTypeHelper.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
 				lookup.accessCheckArgRetTypes(type);
 				result = lookup.findSpecial(referenceClazz, name, type, currentClass);
 				break;
 			case 8: /* newInvokeSpecial */
-				type = MethodType.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
+				type = MethodTypeHelper.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
 				lookup.accessCheckArgRetTypes(type);
 				result = lookup.findConstructor(referenceClazz, type);
 				break;
 			case 9: /* invokeInterface */
-				type = MethodType.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
+				type = MethodTypeHelper.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
 				lookup.accessCheckArgRetTypes(type);
 				result = lookup.findVirtual(referenceClazz, name, type);
 				break;
@@ -366,7 +366,7 @@ final class MethodHandleResolver {
 	 * a valid field descriptor so adding the "()V" around it is valid.
 	 */
 	private static final Class<?> resolveFieldHandleHelper(String typeDescriptor, Lookup lookup, ClassLoader loader) throws Throwable {
-		MethodType mt = MethodType.vmResolveFromMethodDescriptorString("(" + typeDescriptor + ")V", loader, null); //$NON-NLS-1$ //$NON-NLS-2$
+		MethodType mt = MethodTypeHelper.vmResolveFromMethodDescriptorString("(" + typeDescriptor + ")V", loader, null); //$NON-NLS-1$ //$NON-NLS-2$
 		lookup.accessCheckArgRetTypes(mt);
 		return mt.parameterType(0);
 	}
@@ -399,7 +399,7 @@ final class MethodHandleResolver {
 		char[] signature = new char[length];
 		fieldDescriptor.getChars(0, length, signature, 0);
 
-		MethodType.parseIntoClass(signature, 0, classList, classLoader, fieldDescriptor);
+		MethodTypeHelper.parseIntoClass(signature, 0, classList, classLoader, fieldDescriptor);
 
 		return classList.get(0);
 	}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2952,7 +2952,7 @@ public class MethodHandles {
 			if (constantValue == null) {
 				throw new IllegalArgumentException();
 			}
-			Class<?> unwrapped = MethodType.unwrapPrimitive(constantValue.getClass());
+			Class<?> unwrapped = MethodTypeHelper.unwrapPrimitive(constantValue.getClass());
 			if ((returnType != unwrapped) && !FilterHelpers.checkIfWideningPrimitiveConversion(unwrapped, returnType)) {
 				throw new ClassCastException();
 			}
@@ -3998,7 +3998,7 @@ public class MethodHandles {
 			}
 			if (clazz.isPrimitive()) {
 				Objects.requireNonNull(value);
-				Class<?> unwrapped = MethodType.unwrapPrimitive(valueClazz);
+				Class<?> unwrapped = MethodTypeHelper.unwrapPrimitive(valueClazz);
 				if ((clazz != unwrapped) && !FilterHelpers.checkIfWideningPrimitiveConversion(unwrapped, clazz)) {
 					clazz.cast(value);	// guaranteed to throw ClassCastException
 				}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -75,33 +75,11 @@ public final class MethodType implements Serializable
 /*[ENDIF]*/
 {
 	static final Class<?>[] EMTPY_PARAMS = new Class<?>[0];
-	static final Set<Class<?>> WRAPPER_SET;
-	static {
-		Class<?>[] wrappers = {Byte.class, Character.class, Double.class, Float.class, Integer.class, Long.class, Short.class, Boolean.class };
-		WRAPPER_SET = Collections.unmodifiableSet(new HashSet<Class<?>>(Arrays.asList(wrappers)));
-	}
 
 /*[IF Sidecar19-SE-OpenJ9]*/	
 	private MethodTypeForm form;
 /*[ENDIF]*/	
-	
-	/*[IF ]*/
-	/* Do not include 'primitives.put("V", void.class)' as void.class is not yet loaded when
-	 * MethodType gets loaded and this will cause the VM not to start.  See the code
-	 * in Class#getPrimitiveClass() for the issue. */
-	/*[ENDIF]*/
-	static final Class<?>[] primitivesArray = new Class<?>[26];
-	static {
-		primitivesArray['B' - 'A'] = byte.class;
-		primitivesArray['C' - 'A'] = char.class;
-		primitivesArray['D' - 'A'] = double.class;
-		primitivesArray['F' - 'A'] = float.class;
-		primitivesArray['I' - 'A'] = int.class;
-		primitivesArray['J' - 'A'] = long.class;
-		primitivesArray['S' - 'A'] = short.class;
-		primitivesArray['Z' - 'A'] = boolean.class;
-	}
-	
+
 	private static Map<MethodType, WeakReference<MethodType>> internTable = Collections.synchronizedMap(new WeakHashMap<MethodType, WeakReference<MethodType>>());
 	// lock object to control insertion of new MTs
 	static final class InternTableAddLock { }
@@ -135,7 +113,6 @@ public final class MethodType implements Serializable
 	private static final ObjectStreamField[] serialPersistentFields = new ObjectStreamField[0];
 	private static final long serialVersionUID = 292L;
 	private DeserializedFieldsHolder deserializedFields;
-
 
 	/**
 	 * Holder for the deserialized arguments[] and returnType values
@@ -227,7 +204,6 @@ public final class MethodType implements Serializable
 		}
 		return ints;
 	}
-
 
 	/**
 	 * Convenience method to create a new MethodType with only the parameter at 
@@ -410,32 +386,6 @@ public final class MethodType implements Serializable
 		
 		return methodType(returnType, types);
 	}
-	
-	/**
-	 * This helper calls MethodType.fromMethodDescriptorString(...) or 
-	 * MethodType.fromMethodDescriptorStringAppendArg(...) but throws 
-	 * NoClassDefFoundError instead of TypeNotPresentException during 
-	 * the VM resolve stage.
-	 *
-	 * @param methodDescriptor - the method descriptor string
-	 * @param loader - the ClassLoader to be used
-	 * @param appendArgumentType - an extra argument type
-	 *
-	 * @return a MethodType object representing the method descriptor string
-	 *
-	 * @throws IllegalArgumentException - if the string is not well-formed
-	 * @throws NoClassDefFoundError - if a named type cannot be found
-	 */
-	static final MethodType vmResolveFromMethodDescriptorString(String methodDescriptor, ClassLoader loader, Class<?> appendArgumentType) throws Throwable {
-		try {
-			if (null == appendArgumentType) {
-				return MethodType.fromMethodDescriptorString(methodDescriptor, loader);
-			}
-			return MethodType.fromMethodDescriptorStringAppendArg(methodDescriptor, loader, appendArgumentType);
-		} catch (TypeNotPresentException e) {
-			throw throwNoClassDefFoundError(e);
-		}
-	}
 
 	/**
 	 * Helper method to throw NoClassDefFoundError if the cause of TypeNotPresentException 
@@ -456,72 +406,6 @@ public final class MethodType implements Serializable
 			throw noClassDefFoundError;
 		}
 		throw e;
-	}
-	
-	/*
-	 * Convert the string from bytecode format to the format needed for ClassLoader#loadClass().
-	 * Change all '/' to '.'.
-	 * Remove the 'L' & ';' from objects, unless they are array classes.
-	 */
-	private static final Class<?> nonPrimitiveClassFromString(String name, ClassLoader classLoader) {
-		try {
-			name = name.replace('/', '.');
-			if (name.indexOf('L') == 0) {
-				// Remove the 'L' and ';'
-				name = name.substring(1, name.length() - 1);
-			}
-			return Class.forName(name, false, classLoader);
-		} catch(ClassNotFoundException e){
-			throw new TypeNotPresentException(name, e);
-		}
-	}
-
-	/*
-	 * Parses the first parameter in a descriptor string into a Class object.
-	 * The Class object is append to given ArrayList and the current string index is returned.
-	 */
-	static final int parseIntoClass(char[] signature, int index, ArrayList<Class<?>> args, ClassLoader classLoader, String descriptor) {
-		char current = signature[index];
-		Class<?> c;			
-		
-		if ((current == 'L') || (current == '[')) {
-			int start = index;
-			while(signature[index] == '[') {
-				index++;
-			}
-			String name;
-			if (signature[index] != 'L') {
-				name = descriptor.substring(start, index + 1);
-			} else { 
-				int end = descriptor.indexOf(';', index);
-				if (end == -1) {
-					/*[MSG "K05d6", "malformed method descriptor: {0}"]*/
-					throw new IllegalArgumentException(Msg.getString("K05d6", descriptor)); //$NON-NLS-1$
-				}
-				name = descriptor.substring(start, end + 1);
-				index = end;
-			}
-			c = nonPrimitiveClassFromString(name, classLoader);
-		} else {
-			try {
-				c = primitivesArray[current - 'A'];
-			} catch(ArrayIndexOutOfBoundsException e) {
-				c = null;
-			}
-			if (c == null) {
-				if (current == 'V') {
-					// lazily add 'V' to work around load ordering issues
-					primitivesArray['V' - 'A'] = void.class;
-					c = void.class;
-				} else {
-					/*[MSG "K05d7", "not a primitive: {0}"]*/
-					throw new IllegalArgumentException(Msg.getString("K05d7", current)); //$NON-NLS-1$
-				}
-			}
-		}
-		args.add(c);
-
-		return index;
 	}
 
 	/*
@@ -560,7 +444,7 @@ public final class MethodType implements Serializable
 				continue;
 			}
 
-			index = parseIntoClass(signature, index, args, classLoader, methodDescriptor);
+			index = MethodTypeHelper.parseIntoClass(signature, index, args, classLoader, methodDescriptor);
 			index++;
 		}
 		return args;
@@ -624,11 +508,11 @@ public final class MethodType implements Serializable
 	 * @return whether the MethodType contains any wrapper types
 	 */
 	public boolean hasWrappers() {
-		if (WRAPPER_SET.contains(returnType) || (returnType == Void.class)){
+		if (MethodTypeHelper.WRAPPER_SET.contains(returnType) || (returnType == Void.class)){
 			return true;
 		}
 		for(Class<?> c : arguments){
-			if (WRAPPER_SET.contains(c)){
+			if (MethodTypeHelper.WRAPPER_SET.contains(c)){
 				return true;
 			}
 		}
@@ -975,10 +859,10 @@ public final class MethodType implements Serializable
 	private String createMethodDescriptorString(){
 		StringBuilder sb= new StringBuilder("("); //$NON-NLS-1$
 		for (Class<?> c : arguments){
-			sb.append(getBytecodeStringName(c));
+			sb.append(MethodTypeHelper.getBytecodeStringName(c));
 		}
 		sb.append(")"); //$NON-NLS-1$
-		sb.append(getBytecodeStringName(returnType));
+		sb.append(MethodTypeHelper.getBytecodeStringName(returnType));
 		return sb.toString();
 	}
 	
@@ -1014,10 +898,10 @@ public final class MethodType implements Serializable
 	public MethodType unwrap(){
 		Class<?>[] args = arguments.clone();
 		for(int i = 0; i < args.length; i++){
-			args[i] = unwrapPrimitive(args[i]);
+			args[i] = MethodTypeHelper.unwrapPrimitive(args[i]);
 		}
-		Class<?> unwrappedReturnType = unwrapPrimitive(returnType);
-		if (unwrapPrimitive(returnType) == Void.class) {
+		Class<?> unwrappedReturnType = MethodTypeHelper.unwrapPrimitive(returnType);
+		if (MethodTypeHelper.unwrapPrimitive(returnType) == Void.class) {
 			unwrappedReturnType = void.class;
 		}
 		return methodType(unwrappedReturnType, args, false);
@@ -1034,9 +918,9 @@ public final class MethodType implements Serializable
 	public MethodType wrap(){
 		Class<?>[] args = arguments.clone();
 		for(int i = 0; i < args.length; i++){
-			args[i] = wrapPrimitive(args[i]);
+			args[i] = MethodTypeHelper.wrapPrimitive(args[i]);
 		}
-		return methodType(wrapPrimitive(returnType), args, false);
+		return methodType(MethodTypeHelper.wrapPrimitive(returnType), args, false);
 	}
 	
 	/**
@@ -1070,129 +954,7 @@ public final class MethodType implements Serializable
 		combinedParameters.addAll(classes);
 		return methodType(returnType, combinedParameters);
 	}
-	
-	/**
-	 * Returns the appropriate wrapper class or the original class
-	 * @param primitiveClass The class to convert to a wrapper class
-	 * @return The wrapper class or the original class if no wrapper is available
-	 */
-	static Class<?> wrapPrimitive(Class<?> primitveClass) {
-		if (primitveClass.isPrimitive()) {
-			if (int.class == primitveClass){ //I
-				return Integer.class;
-			}
-			if (long.class == primitveClass){ //J
-				return Long.class;
-			}
-			if (byte.class == primitveClass){	//B
-				return Byte.class;
-			}
-			if (char.class == primitveClass){ //C
-				return Character.class;
-			}
-			if (double.class == primitveClass){ //D
-				return Double.class;
-			}
-			if (float.class == primitveClass){ //F
-				return Float.class;
-			}
-			if (boolean.class == primitveClass){ //Z
-				return Boolean.class;
-			}
-			if (void.class == primitveClass) {
-				return Void.class;
-			}
-			if (short.class == primitveClass){ //S
-				return Short.class;
-			}
-		}
-		return primitveClass;
-	}
-	
-	
-	/**
-	 * Takes a class and returns the corresponding primitive if one exists.
-	 * @param wrapperClass The class to check for primitive classes.
-	 * @return The corresponding primitive class or the input class.
-	 */
-	/*[IF ]*/
-	/* Note that Void.class is not handled by this method as it is only viewed as a
-	 * wrapper when it is the return class.
-	 */
-	/*[ENDIF]*/
-	static Class<?> unwrapPrimitive(Class<?> wrapperClass){
-		if (Integer.class == wrapperClass) { //I
-			return int.class;
-		}
-		if (Long.class == wrapperClass) { //J
-			return long.class;
-		}
-		if (Byte.class == wrapperClass) {	//B
-			return byte.class;
-		}
-		if (Character.class == wrapperClass) { //C
-			return char.class;
-		}
-		if (Double.class == wrapperClass) { //D
-			return double.class;
-		}
-		if (Float.class == wrapperClass) { //F
-			return float.class;
-		}
-		if (Short.class == wrapperClass) { //S
-			return short.class;
-		}
-		if (Boolean.class == wrapperClass) { //Z
-			return boolean.class;
-		}
-		return wrapperClass;
-	}
-	
-	/* The string returned by this method should be in sync with Class.descriptorString() */
-	static String getBytecodeStringName(Class<?> c){
-		if (c.isPrimitive()) {
-			if (c == int.class) {
-				return "I"; //$NON-NLS-1$
-			} else if (c == long.class) {
-				return "J"; //$NON-NLS-1$
-			} else if (c == byte.class) {
-				return "B"; //$NON-NLS-1$
-			} else if (c == boolean.class) {
-				return "Z"; //$NON-NLS-1$
-			} else if (c == void.class) {
-				return "V"; //$NON-NLS-1$
-			} else if (c == char.class) {
-				return "C"; //$NON-NLS-1$
-			} else if (c == double.class) {
-				return "D"; //$NON-NLS-1$
-			} else if (c == float.class) {
-				return "F"; //$NON-NLS-1$
-			} else if (c == short.class) {
-				return "S"; //$NON-NLS-1$
-			}
-		}
-		Class<?> clazz = c;
-		if (c.isArray()) {
-			clazz = c.getComponentType();
-			while (clazz.isArray()) {
-				clazz = clazz.getComponentType();
-			}
-		}
-		String name = c.getName().replace('.', '/');
-		/*[IF Java15]*/
-		if (clazz.isHidden()) {
-			/* keep the last "." before romaddress for hidden classes */
-			int index = name.lastIndexOf('/');
-			name = name.substring(0, index) + '.' + name.substring(index + 1,name.length());
-		}
-		/*[ENDIF] Java15 */
-		
-		if (c.isArray()) {
-			return name;
-		}
-		return "L"+ name + ";"; //$NON-NLS-1$ //$NON-NLS-2$
-	}
-	
+
 	/*
 	 * Implements JSR 292 serialization spec.
 	 * Write the MethodType without writing the field names.

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodTypeHelper.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodTypeHelper.java
@@ -1,0 +1,281 @@
+/*[INCLUDE-IF Sidecar18-SE]*/
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package java.lang.invoke;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.ibm.oti.util.Msg;
+
+/**
+ * MethodTypeHelper - static methods
+ *
+ * @since Java 11
+ */
+final class MethodTypeHelper {
+	static final Set<Class<?>> WRAPPER_SET;
+	static {
+		Class<?>[] wrappers = {Byte.class, Character.class, Double.class, Float.class, Integer.class, Long.class, Short.class, Boolean.class };
+		WRAPPER_SET = Collections.unmodifiableSet(new HashSet<Class<?>>(Arrays.asList(wrappers)));
+	}
+
+	/*[IF ]*/
+	/* Do not include 'primitives.put("V", void.class)' as void.class is not yet loaded when
+	 * MethodType gets loaded and this will cause the VM not to start.  See the code
+	 * in Class#getPrimitiveClass() for the issue. */
+	/*[ENDIF]*/
+	static final Class<?>[] primitivesArray = new Class<?>[26];
+	static {
+		primitivesArray['B' - 'A'] = byte.class;
+		primitivesArray['C' - 'A'] = char.class;
+		primitivesArray['D' - 'A'] = double.class;
+		primitivesArray['F' - 'A'] = float.class;
+		primitivesArray['I' - 'A'] = int.class;
+		primitivesArray['J' - 'A'] = long.class;
+		primitivesArray['S' - 'A'] = short.class;
+		primitivesArray['Z' - 'A'] = boolean.class;
+	}
+
+	/**
+	 * Returns the appropriate wrapper class or the original class
+	 * @param primitiveClass The class to convert to a wrapper class
+	 * @return The wrapper class or the original class if no wrapper is available
+	 */
+	static Class<?> wrapPrimitive(Class<?> primitveClass) {
+		if (primitveClass.isPrimitive()) {
+			if (int.class == primitveClass) { //I
+				return Integer.class;
+			}
+			if (long.class == primitveClass) { //J
+				return Long.class;
+			}
+			if (byte.class == primitveClass) { //B
+				return Byte.class;
+			}
+			if (char.class == primitveClass) { //C
+				return Character.class;
+			}
+			if (double.class == primitveClass) { //D
+				return Double.class;
+			}
+			if (float.class == primitveClass) { //F
+				return Float.class;
+			}
+			if (boolean.class == primitveClass) { //Z
+				return Boolean.class;
+			}
+			if (void.class == primitveClass) {
+				return Void.class;
+			}
+			if (short.class == primitveClass) { //S
+				return Short.class;
+			}
+		}
+		return primitveClass;
+	}
+
+	/**
+	 * Takes a class and returns the corresponding primitive if one exists.
+	 * @param wrapperClass The class to check for primitive classes.
+	 * @return The corresponding primitive class or the input class.
+	 */
+	/*[IF ]*/
+	/* Note that Void.class is not handled by this method as it is only viewed as a
+	 * wrapper when it is the return class.
+	 */
+	/*[ENDIF]*/
+	static Class<?> unwrapPrimitive(Class<?> wrapperClass) {
+		if (Integer.class == wrapperClass) { //I
+			return int.class;
+		}
+		if (Long.class == wrapperClass) { //J
+			return long.class;
+		}
+		if (Byte.class == wrapperClass) { //B
+			return byte.class;
+		}
+		if (Character.class == wrapperClass) { //C
+			return char.class;
+		}
+		if (Double.class == wrapperClass) { //D
+			return double.class;
+		}
+		if (Float.class == wrapperClass) { //F
+			return float.class;
+		}
+		if (Short.class == wrapperClass) { //S
+			return short.class;
+		}
+		if (Boolean.class == wrapperClass) { //Z
+			return boolean.class;
+		}
+		return wrapperClass;
+	}
+
+	/* The string returned by this method should be in sync with Class.descriptorString() */
+	static String getBytecodeStringName(Class<?> c) {
+		if (c.isPrimitive()) {
+			if (c == int.class) {
+				return "I"; //$NON-NLS-1$
+			} else if (c == long.class) {
+				return "J"; //$NON-NLS-1$
+			} else if (c == byte.class) {
+				return "B"; //$NON-NLS-1$
+			} else if (c == boolean.class) {
+				return "Z"; //$NON-NLS-1$
+			} else if (c == void.class) {
+				return "V"; //$NON-NLS-1$
+			} else if (c == char.class) {
+				return "C"; //$NON-NLS-1$
+			} else if (c == double.class) {
+				return "D"; //$NON-NLS-1$
+			} else if (c == float.class) {
+				return "F"; //$NON-NLS-1$
+			} else if (c == short.class) {
+				return "S"; //$NON-NLS-1$
+			}
+		}
+		Class<?> clazz = c;
+		if (c.isArray()) {
+			clazz = c.getComponentType();
+			while (clazz.isArray()) {
+				clazz = clazz.getComponentType();
+			}
+		}
+		String name = c.getName().replace('.', '/');
+		/*[IF Java15]*/
+		if (clazz.isHidden()) {
+			/* keep the last "." before romaddress for hidden classes */
+			int index = name.lastIndexOf('/');
+			name = name.substring(0, index) + '.' + name.substring(index + 1,name.length());
+		}
+		/*[ENDIF] Java15 */
+
+		if (c.isArray()) {
+			return name;
+		}
+		return "L"+ name + ";"; //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	/*
+	 * Convert the string from bytecode format to the format needed for ClassLoader#loadClass().
+	 * Change all '/' to '.'.
+	 * Remove the 'L' & ';' from objects, unless they are array classes.
+	 */
+	private static final Class<?> nonPrimitiveClassFromString(String name, ClassLoader classLoader) {
+		try {
+			name = name.replace('/', '.');
+			if (name.indexOf('L') == 0) {
+				// Remove the 'L' and ';'
+				name = name.substring(1, name.length() - 1);
+			}
+			return Class.forName(name, false, classLoader);
+		} catch(ClassNotFoundException e) {
+			throw new TypeNotPresentException(name, e);
+		}
+	}
+
+	/*
+	 * Parses the first parameter in a descriptor string into a Class object.
+	 * The Class object is append to given ArrayList and the current string index is returned.
+	 */
+	static final int parseIntoClass(char[] signature, int index, ArrayList<Class<?>> args, ClassLoader classLoader, String descriptor) {
+		char current = signature[index];
+		Class<?> c;
+
+		if ((current == 'L') || (current == '[')) {
+			int start = index;
+			while(signature[index] == '[') {
+				index++;
+			}
+			String name;
+			if (signature[index] != 'L') {
+				name = descriptor.substring(start, index + 1);
+			} else {
+				int end = descriptor.indexOf(';', index);
+				if (end == -1) {
+					/*[MSG "K05d6", "malformed method descriptor: {0}"]*/
+					throw new IllegalArgumentException(Msg.getString("K05d6", descriptor)); //$NON-NLS-1$
+				}
+				name = descriptor.substring(start, end + 1);
+				index = end;
+			}
+			c = nonPrimitiveClassFromString(name, classLoader);
+		} else {
+			try {
+				c = primitivesArray[current - 'A'];
+			} catch(ArrayIndexOutOfBoundsException e) {
+				c = null;
+			}
+			if (c == null) {
+				if (current == 'V') {
+					// lazily add 'V' to work around load ordering issues
+					primitivesArray['V' - 'A'] = void.class;
+					c = void.class;
+				} else {
+					/*[MSG "K05d7", "not a primitive: {0}"]*/
+					throw new IllegalArgumentException(Msg.getString("K05d7", current)); //$NON-NLS-1$
+				}
+			}
+		}
+		args.add(c);
+
+		return index;
+	}
+
+	/**
+	 * This helper calls MethodType.fromMethodDescriptorString(...) or
+	 * MethodType.fromMethodDescriptorStringAppendArg(...) but throws
+	 * NoClassDefFoundError instead of TypeNotPresentException during
+	 * the VM resolve stage.
+	 *
+	 * @param methodDescriptor - the method descriptor string
+	 * @param loader - the ClassLoader to be used
+	 * @param appendArgumentType - an extra argument type
+	 *
+	 * @return a MethodType object representing the method descriptor string
+	 *
+	 * @throws IllegalArgumentException - if the string is not well-formed
+	 * @throws NoClassDefFoundError - if a named type cannot be found
+	 */
+	static final MethodType vmResolveFromMethodDescriptorString(String methodDescriptor, ClassLoader loader, Class<?> appendArgumentType) throws Throwable {
+		try {
+			MethodType result = MethodType.fromMethodDescriptorString(methodDescriptor, loader);
+			if (null != appendArgumentType) {
+				result = result.appendParameterTypes(appendArgumentType);
+			}
+			return result;
+		} catch (TypeNotPresentException e) {
+			Throwable cause = e.getCause();
+			if (cause instanceof ClassNotFoundException) {
+				NoClassDefFoundError noClassDefFoundError = new NoClassDefFoundError(cause.getMessage());
+				noClassDefFoundError.initCause(cause);
+				throw noClassDefFoundError;
+			}
+			throw e;
+		}
+	}
+}

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -133,11 +133,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<classref name="java/lang/invoke/MethodType" flags="opt_methodHandleCommon"/>
 	<classref name="java/lang/invoke/MethodHandle" flags="opt_methodHandleCommon"/>
 	<classref name="java/lang/invoke/WrongMethodTypeException" flags="opt_methodHandleCommon"/>
+	<classref name="java/lang/invoke/MethodTypeHelper" flags="opt_methodHandleCommon"/>
 	<classref name="java/lang/invoke/MethodHandleResolver" flags="opt_methodHandleCommon"/>
 	
 	<!-- Class references needed to support OpenJDK MethodHandles. -->
 	<classref name="java/lang/invoke/MemberName" flags="opt_openjdkMethodhandle"/>
-	<classref name="java/lang/invoke/MethodTypeHelper" flags="opt_openjdkMethodhandle"/>
 	<classref name="java/lang/invoke/MethodTypeForm" flags="opt_openjdkMethodhandle"/>
 	<classref name="java/lang/invoke/LambdaForm" flags="opt_openjdkMethodhandle"/>
 	
@@ -389,7 +389,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<staticmethodref class="java/lang/J9VMInternals" name="threadCleanup" signature="(Ljava/lang/Thread;)V"/>
 	<staticmethodref class="java/lang/J9VMInternals" name="newInstanceImpl" signature="(Ljava/lang/Class;)Ljava/lang/Object;" flags="jit_newInstancePrototype"/>
 	<staticmethodref class="java/lang/J9VMInternals" name="formatNoSuchMethod" signature="(Ljava/lang/String;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/String;"/>
-	<staticmethodref class="java/lang/invoke/MethodType" name="vmResolveFromMethodDescriptorString" signature="(Ljava/lang/String;Ljava/lang/ClassLoader;Ljava/lang/Class;)Ljava/lang/invoke/MethodType;" flags="opt_methodHandle"/>
 	<staticmethodref class="java/lang/invoke/MethodHandle" name="invokeWithArgumentsHelper" signature="(Ljava/lang/invoke/MethodHandle;[Ljava/lang/Object;)Ljava/lang/Object;" flags="opt_methodHandle"/>
 	<specialmethodref class="java/lang/invoke/MethodHandle" name="forGenericInvoke" signature="(Ljava/lang/invoke/MethodType;Z)Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/>
 	<specialmethodref class="java/lang/invoke/MethodHandle" name="returnFilterPlaceHolder" signature="()Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/>
@@ -408,13 +407,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<staticmethodref class="java/lang/J9VMInternals" name="recordInitializationFailure" signature="(Ljava/lang/Class;Ljava/lang/Throwable;)V"/>
 
 	<!-- Static method references needed to support OpenJ9 and OpenJDK MethodHandles. -->
+	<staticmethodref class="java/lang/invoke/MethodTypeHelper" name="vmResolveFromMethodDescriptorString" signature="(Ljava/lang/String;Ljava/lang/ClassLoader;Ljava/lang/Class;)Ljava/lang/invoke/MethodType;" flags="opt_methodHandleCommon"/>
 	<staticmethodref class="java/lang/invoke/MethodHandleResolver" name="sendResolveMethodHandle" signature="(ILjava/lang/Class;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;Ljava/lang/ClassLoader;)Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandleCommon"/>
 	<staticmethodref class="java/lang/invoke/MethodHandleResolver" name="resolveInvokeDynamic" signature="(JLjava/lang/String;Ljava/lang/String;J)Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandleCommon"/>
 	<staticmethodref class="java/lang/invoke/MethodHandleResolver" name="resolveConstantDynamic" signature="(JLjava/lang/String;Ljava/lang/String;J)Ljava/lang/Object;" versions="11-" flag="opt_methodHandleCommon"/>
 	<staticmethodref class="java/lang/invoke/MethodHandleResolver" name="constructorPlaceHolder" signature="(Ljava/lang/Object;)Ljava/lang/Object;" flags="opt_methodHandleCommon"/>
 
 	<!-- Static method references needed to support OpenJDK MethodHandles. -->
-	<staticmethodref class="java/lang/invoke/MethodTypeHelper" name="vmResolveFromMethodDescriptorString" signature="(Ljava/lang/String;Ljava/lang/ClassLoader;Ljava/lang/Class;)Ljava/lang/invoke/MethodType;" flags="opt_openjdkMethodhandle"/>
 	<staticmethodref class="java/lang/invoke/MethodHandleResolver" name="resolveMethodHandle" signature="(Ljava/lang/Class;ILjava/lang/Class;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/Object;" flags="opt_openjdkMethodhandle"/>
 
 	<!-- Security manager check -->

--- a/runtime/vm/callin.cpp
+++ b/runtime/vm/callin.cpp
@@ -880,7 +880,7 @@ sendFromMethodDescriptorString(J9VMThread *currentThread, J9UTF8 *descriptor, J9
 			*--currentThread->sp = (UDATA)classLoader->classLoaderObject;
 			*--currentThread->sp = (UDATA)J9VM_J9CLASS_TO_HEAPCLASS(appendArgType);
 			currentThread->returnValue = J9_BCLOOP_RUN_METHOD;
-			currentThread->returnValue2 = (UDATA)J9VMJAVALANGINVOKEMETHODTYPE_VMRESOLVEFROMMETHODDESCRIPTORSTRING_METHOD(vm);
+			currentThread->returnValue2 = (UDATA)J9VMJAVALANGINVOKEMETHODTYPEHELPER_VMRESOLVEFROMMETHODDESCRIPTORSTRING_METHOD(vm);
 			c_cInterpreter(currentThread);
 		}
 		restoreCallInFrame(currentThread);


### PR DESCRIPTION
static methods:
- vmResolveFromMethodDescriptorString()
- parseIntoClass()
- nonPrimitiveClassFromString()
- getBytecodeStringName()
- unwrapPrimitive()
- wrapPrimitive()

static fields:
- primitivesArray
- WRAPPER_SET

Related: #7352 
Depends: #10637 

Co-authored-by: Babneet Singh <sbabneet@ca.ibm.com>
Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>