### PR TITLE
Remove the unnecessary platform check for PortableAOT

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8516,7 +8516,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
          else
 #endif /* defined(J9VM_OPT_JITSERVER) */
             {
-            if (vm->needRelocatableTarget() && target.cpu.isX86())
+            if (vm->needRelocatableTarget())
                {
                target = TR::Compiler->relocatableTarget;
                }


### PR DESCRIPTION
When Portable AOT is off, `TR::Compiler->relocatableTarget` will be the same as `TR::Compiler->target`. Therefore it works without the platform check even for platforms that does not have Portable AOT support.

Signed-off-by: Harry Yu <harryyu1994@gmail.com>