### PR TITLE
Don't sign extend compressed string bytes

### DIFF
--- a/runtime/gc_modron_standard/StandardAccessBarrier.cpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.cpp
@@ -517,7 +517,7 @@ MM_StandardAccessBarrier::jniGetStringCritical(J9VMThread* vmThread, jstring str
 				jint i;
 				
 				for (i = 0; i < length; i++) {
-					data[i] = (jchar)J9JAVAARRAYOFBYTE_LOAD(vmThread, (j9object_t)valueObject, i) & (jchar)0xFF;
+					data[i] = (jchar)(U_8)J9JAVAARRAYOFBYTE_LOAD(vmThread, (j9object_t)valueObject, i);
 				}
 			} else {
 				if (J9_ARE_ANY_BITS_SET(javaVM->runtimeFlags, J9_RUNTIME_STRING_BYTE_ARRAY)) {

--- a/runtime/gc_realtime/RealtimeAccessBarrier.cpp
+++ b/runtime/gc_realtime/RealtimeAccessBarrier.cpp
@@ -506,7 +506,7 @@ MM_RealtimeAccessBarrier::jniGetStringCritical(J9VMThread* vmThread, jstring str
 				jint i;
 				
 				for (i = 0; i < length; i++) {
-					data[i] = (jchar)J9JAVAARRAYOFBYTE_LOAD(vmThread, (j9object_t)valueObject, i) & (jchar)0xFF;
+					data[i] = (jchar)(U_8)J9JAVAARRAYOFBYTE_LOAD(vmThread, (j9object_t)valueObject, i);
 				}
 			} else {
 				if (J9_ARE_ANY_BITS_SET(javaVM->runtimeFlags, J9_RUNTIME_STRING_BYTE_ARRAY)) {

--- a/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
+++ b/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
@@ -450,7 +450,7 @@ MM_VLHGCAccessBarrier::copyStringCritical(J9VMThread *vmThread, GC_ArrayObjectMo
 	} else {
 		if (isCompressed) {
 			for (jint i = 0; i < length; i++) {
-				*data[i] = (jchar)J9JAVAARRAYOFBYTE_LOAD(vmThread, (j9object_t)valueObject, i) & (jchar)0xFF;
+				*data[i] = (jchar)(U_8)J9JAVAARRAYOFBYTE_LOAD(vmThread, (j9object_t)valueObject, i);
 			}
 		} else {
 			if (J9_ARE_ANY_BITS_SET(javaVM->runtimeFlags, J9_RUNTIME_STRING_BYTE_ARRAY)) {

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corp. and others
+ * Copyright (c) 2012, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -709,7 +709,7 @@ getStringChars(JNIEnv *env, jstring string, jboolean *isCopy)
 
 			if (IS_STRING_COMPRESSED(currentThread, stringObject)) {
 				for (UDATA i = 0; i < length; ++i) {
-					((jchar*)chars)[i] = (jchar)J9JAVAARRAYOFBYTE_LOAD(currentThread, charArray, i);
+					((jchar*)chars)[i] = (jchar)(U_8)J9JAVAARRAYOFBYTE_LOAD(currentThread, charArray, i);
 				}
 			} else {
 				VM_ArrayCopyHelpers::memcpyFromArray(currentThread, charArray, (UDATA)1, 0, length, (void*)chars);
@@ -945,7 +945,7 @@ outOfBounds:
 		JAVA_OFFLOAD_SWITCH_ON_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_REGION, byteCount);
 		if (IS_STRING_COMPRESSED(currentThread, stringObject)) {
 			for (jsize i = 0; i < len; ++i) {
-				buf[i] = (jchar)J9JAVAARRAYOFBYTE_LOAD(currentThread, charArray, i + start);
+				buf[i] = (jchar)(U_8)J9JAVAARRAYOFBYTE_LOAD(currentThread, charArray, i + start);
 			}
 		} else {
 			/* No guarantee of native memory alignment, so copy byte-wise */


### PR DESCRIPTION
When converting elements of a byte array to jchar, cast through U_8
first (the array load macro evaluates to an I_8) to avoid sign
extending.

Fixes: #10692

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>