### PR TITLE
Automate adding 'Snapshot' labeled issues to the project

### DIFF
--- a/.github/workflows/assign-to-snapshot-project.yml
+++ b/.github/workflows/assign-to-snapshot-project.yml
@@ -1,0 +1,16 @@
+name: Assign to snapshot project
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'Snapshot'
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.3.0
+        with:
+          project: Snapshot+Restore
+          column: To do
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/assign-to-snapshot-project.yml
+++ b/.github/workflows/assign-to-snapshot-project.yml
@@ -1,3 +1,25 @@
+###############################################################################
+# Copyright (c) 2020, 2020 Red Hat and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################/
+
 name: Assign to snapshot project
 
 on:

--- a/.github/workflows/assign-to-snapshot-project.yml
+++ b/.github/workflows/assign-to-snapshot-project.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   automate-project-columns:
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'Snapshot'
+    if: github.event.label.name == 'snapshot'
     steps:
       - uses: alex-page/github-project-automation-plus@v0.3.0
         with:


### PR DESCRIPTION
We have a template to allow creating 'Snapshot' issues.
Unfortunately, templates can't assign issues to a project
so we're trying to use github actions to do it instead.

The action is set to only trigger if an issue has the
snapshot label added to it.

Uses https://github.com/marketplace/actions/github-project-automation

Signed-off-by: Dan Heidinga <heidinga@redhat.com>