### PR TITLE
Mask off unused cpu features

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8513,8 +8513,9 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
 #if defined(J9VM_OPT_JITSERVER)
          if (that->_methodBeingCompiled->isOutOfProcessCompReq())
             {
+            // Customize target.cpu based on the processor description fetched from the client
             OMRProcessorDesc JITClientProcessorDesc = TR::Compiler->target.cpu.getProcessorDescription();
-            target.cpu = TR::CPU(JITClientProcessorDesc);
+            target.cpu = TR::CPU::customize(JITClientProcessorDesc);
             }
          else
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1915,7 +1915,7 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
             }
          else
             {
-            TR::Compiler->relocatableTarget.cpu = TR::CPU(compInfo->reloRuntime()->getProcessorDescriptionFromSCC(fe, curThread));
+            TR::Compiler->relocatableTarget.cpu = TR::CPU::customize(compInfo->reloRuntime()->getProcessorDescriptionFromSCC(fe, curThread));
             }
          }
 

--- a/runtime/compiler/env/CPU.hpp
+++ b/runtime/compiler/env/CPU.hpp
@@ -29,11 +29,10 @@ namespace TR
 {
 class OMR_EXTENSIBLE CPU : public J9::CPUConnector
    {
-   public:
+public:
 
    CPU() : J9::CPUConnector() {}
    CPU(const OMRProcessorDesc& processorDescription) : J9::CPUConnector(processorDescription) {}
-
    };
 }
 

--- a/runtime/compiler/env/J9CPU.cpp
+++ b/runtime/compiler/env/J9CPU.cpp
@@ -29,8 +29,8 @@
 #include "env/CPU.hpp"
 #include "env/VMJ9.h"
 
-OMRProcessorDesc J9::CPU::_featureMasks = {OMR_PROCESSOR_UNDEFINED, OMR_PROCESSOR_UNDEFINED, {}};
-bool J9::CPU::_isFeatureMasksEnabled = false;
+OMRProcessorDesc J9::CPU::_supportedFeatureMasks = {OMR_PROCESSOR_UNDEFINED, OMR_PROCESSOR_UNDEFINED, {}};
+bool J9::CPU::_isSupportedFeatureMasksEnabled = false;
 
 OMRProcessorDesc
 J9::CPU::getProcessorDescription()
@@ -49,19 +49,19 @@ void
 J9::CPU::enableFeatureMasks()
    {
    // Assume all features will be utilized by default
-   memset(_featureMasks.features, ~0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
-   _isFeatureMasksEnabled = true;
+   memset(_supportedFeatureMasks.features, ~0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
+   _isSupportedFeatureMasksEnabled = true;
    }
 
 TR::CPU
 J9::CPU::customize(OMRProcessorDesc processorDescription)
    {
-   if (_isFeatureMasksEnabled)
+   if (_isSupportedFeatureMasksEnabled)
       {
       // mask out any cpu features that the compiler doesn't care about
       for (size_t i = 0; i < OMRPORT_SYSINFO_FEATURES_SIZE; i++)
          {
-         processorDescription.features[i] &= _featureMasks.features[i];
+         processorDescription.features[i] &= _supportedFeatureMasks.features[i];
          }
       }
    return TR::CPU(processorDescription);
@@ -84,9 +84,9 @@ J9::CPU::supportsFeature(uint32_t feature)
    OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
 
    static bool disableCPUDetectionTest = feGetEnv("TR_DisableCPUDetectionTest");
-   if (!disableCPUDetectionTest && _isFeatureMasksEnabled)
+   if (!disableCPUDetectionTest && _isSupportedFeatureMasksEnabled)
       {
-      TR_ASSERT_FATAL(TRUE == omrsysinfo_processor_has_feature(&_featureMasks, feature), "New processor feature usage detected, please add feature %d to _featureMasks via TR::CPU::enableFeatureMasks()\n", feature);
+      TR_ASSERT_FATAL(TRUE == omrsysinfo_processor_has_feature(&_supportedFeatureMasks, feature), "New processor feature usage detected, please add feature %d to _supportedFeatureMasks via TR::CPU::enableFeatureMasks()\n", feature);
       }
 
    return TRUE == omrsysinfo_processor_has_feature(&_processorDescription, feature);

--- a/runtime/compiler/env/J9CPU.hpp
+++ b/runtime/compiler/env/J9CPU.hpp
@@ -48,12 +48,12 @@ protected:
    /**
     * @brief Contain the list of processor features utlizied by the compiler, initialized via TR::CPU::initializeFeatureMasks()
     */
-   static OMRProcessorDesc _featureMasks;
+   static OMRProcessorDesc _supportedFeatureMasks;
 
    /**
-    * @brief _isFeatureMasksEnabled tells you whether _featureMasks was used for masking out unused processor features
+    * @brief _isSupportedFeatureMasksEnabled tells you whether _supportedFeatureMasks was used for masking out unused processor features
     */
-   static bool _isFeatureMasksEnabled;
+   static bool _isSupportedFeatureMasksEnabled;
 
 public:
 
@@ -72,7 +72,7 @@ public:
    static TR::CPU customize(OMRProcessorDesc processorDescription);
 
    /**
-    * @brief Intialize _featureMasks to the list of processor features that will be utilized by the compiler and set _isFeatureMasksEnabled to true
+    * @brief Intialize _supportedFeatureMasks to the list of processor features that will be utilized by the compiler and set _isSupportedFeatureMasksEnabled to true
     * @return void
     */
    static void enableFeatureMasks();

--- a/runtime/compiler/env/J9CPU.hpp
+++ b/runtime/compiler/env/J9CPU.hpp
@@ -45,12 +45,43 @@ protected:
    CPU() : OMR::CPUConnector() {}
    CPU(const OMRProcessorDesc& processorDescription) : OMR::CPUConnector(processorDescription) {}
 
+   /**
+    * @brief Contain the list of processor features utlizied by the compiler, initialized via TR::CPU::initializeFeatureMasks()
+    */
+   static OMRProcessorDesc _featureMasks;
+
+   /**
+    * @brief _isFeatureMasksEnabled tells you whether _featureMasks was used for masking out unused processor features
+    */
+   static bool _isFeatureMasksEnabled;
+
 public:
+
+   /** 
+    * @brief Returns the processor type and features that will be used by JIT and AOT compilations
+    * @param[in] omrPortLib : the port library
+    * @return TR::CPU
+    */
+   static TR::CPU detect(OMRPortLibrary * const omrPortLib);
+
+   /** 
+    * @brief Disable processor features based on input processor description, user options and whether they are utilized by the compiler
+    * @param[in] OMRProcessorDesc : the processor description
+    * @return TR::CPU
+    */
+   static TR::CPU customize(OMRProcessorDesc processorDescription);
+
+   /**
+    * @brief Intialize _featureMasks to the list of processor features that will be utilized by the compiler and set _isFeatureMasksEnabled to true
+    * @return void
+    */
+   static void enableFeatureMasks();
 
    const char *getProcessorVendorId() { TR_ASSERT(false, "Vendor ID not defined for this platform!"); return NULL; }
    uint32_t getProcessorSignature() { TR_ASSERT(false, "Processor Signature not defined for this platform!"); return 0; }
 
    OMRProcessorDesc getProcessorDescription();
+   bool supportsFeature(uint32_t feature);
    };
 }
 

--- a/runtime/compiler/env/J9CPU.hpp
+++ b/runtime/compiler/env/J9CPU.hpp
@@ -46,7 +46,7 @@ protected:
    CPU(const OMRProcessorDesc& processorDescription) : OMR::CPUConnector(processorDescription) {}
 
    /**
-    * @brief Contain the list of processor features utlizied by the compiler, initialized via TR::CPU::initializeFeatureMasks()
+    * @brief Contains the list of processor features exploited by the compiler, initialized via TR::CPU::initializeFeatureMasks()
     */
    static OMRProcessorDesc _supportedFeatureMasks;
 
@@ -58,21 +58,21 @@ protected:
 public:
 
    /** 
-    * @brief Returns the processor type and features that will be used by JIT and AOT compilations
+    * @brief A factory method used to construct a CPU object based on the underlying hardware
     * @param[in] omrPortLib : the port library
     * @return TR::CPU
     */
    static TR::CPU detect(OMRPortLibrary * const omrPortLib);
 
    /** 
-    * @brief Disable processor features based on input processor description, user options and whether they are utilized by the compiler
+    * @brief A factory method used to construct a CPU object based on user customized processorDescription
     * @param[in] OMRProcessorDesc : the processor description
     * @return TR::CPU
     */
    static TR::CPU customize(OMRProcessorDesc processorDescription);
 
    /**
-    * @brief Intialize _supportedFeatureMasks to the list of processor features that will be utilized by the compiler and set _isSupportedFeatureMasksEnabled to true
+    * @brief Intialize _supportedFeatureMasks to the list of processor features that will be exploited by the compiler and set _isSupportedFeatureMasksEnabled to true
     * @return void
     */
    static void enableFeatureMasks();

--- a/runtime/compiler/p/env/J9CPU.cpp
+++ b/runtime/compiler/p/env/J9CPU.cpp
@@ -55,12 +55,12 @@ J9::Power::CPU::enableFeatureMasks()
                                         OMR_FEATURE_PPC_HTM, OMR_FEATURE_PPC_HAS_VSX};
 
 
-   memset(_featureMasks.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
+   memset(_supportedFeatureMasks.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
    OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
    for (size_t i = 0; i < sizeof(utilizedFeatures)/sizeof(uint32_t); i++)
       {
-      omrsysinfo_processor_set_feature(&_featureMasks, utilizedFeatures[i], TRUE);
+      omrsysinfo_processor_set_feature(&_supportedFeatureMasks, utilizedFeatures[i], TRUE);
       }
    
-   _isFeatureMasksEnabled = true;
+   _isSupportedFeatureMasksEnabled = true;
    }

--- a/runtime/compiler/p/env/J9CPU.cpp
+++ b/runtime/compiler/p/env/J9CPU.cpp
@@ -48,60 +48,19 @@ J9::Power::CPU::isCompatible(const OMRProcessorDesc& processorDescription)
    }
 
 void
-J9::Power::CPU::applyUserOptions()
+J9::Power::CPU::enableFeatureMasks()
    {
-   // P10 support is not yet well-tested, so it's currently gated behind an environment
-   // variable to prevent it from being used by accident by users who use old versions of
-   // OMR once P10 chips become available.
-   if (_processorDescription.processor == OMR_PROCESSOR_PPC_P10)
+   // Only enable the features that compiler currently uses
+   const uint32_t utilizedFeatures [] = {OMR_FEATURE_PPC_HAS_ALTIVEC, OMR_FEATURE_PPC_HAS_DFP,
+                                        OMR_FEATURE_PPC_HTM, OMR_FEATURE_PPC_HAS_VSX};
+
+
+   memset(_featureMasks.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
+   OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
+   for (size_t i = 0; i < sizeof(utilizedFeatures)/sizeof(uint32_t); i++)
       {
-      static bool enableP10 = feGetEnv("TR_EnableExperimentalPower10Support");
-      if (!enableP10)
-         {
-         _processorDescription.processor = OMR_PROCESSOR_PPC_P9;
-         _processorDescription.physicalProcessor = OMR_PROCESSOR_PPC_P9;
-         }
+      omrsysinfo_processor_set_feature(&_featureMasks, utilizedFeatures[i], TRUE);
       }
-
-   if (debug("rios1"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_RIOS1;
-   else if (debug("rios2"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_RIOS2;
-   else if (debug("pwr403"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_PWR403;
-   else if (debug("pwr405"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_PWR405;
-   else if (debug("pwr601"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_PWR601;
-   else if (debug("pwr603"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_PWR603;
-   else if (debug("pwr604"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_PWR604;
-   else if (debug("pwr630"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_PWR630;
-   else if (debug("pwr620"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_PWR620;
-   else if (debug("nstar"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_NSTAR;
-   else if (debug("pulsar"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_PULSAR;
-   else if (debug("gp"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_GP;
-   else if (debug("gpul"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_GPUL;
-   else if (debug("gr"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_GR;
-   else if (debug("p6"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_P6;
-   else if (debug("p7"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_P7;
-   else if (debug("p8"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_P8;
-   else if (debug("p9"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_P9;
-   else if (debug("440GP"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_PWR440;
-   else if (debug("750FX"))
-      _processorDescription.processor = OMR_PROCESSOR_PPC_7XX;
+   
+   _isFeatureMasksEnabled = true;
    }
-

--- a/runtime/compiler/p/env/J9CPU.hpp
+++ b/runtime/compiler/p/env/J9CPU.hpp
@@ -55,7 +55,7 @@ protected:
 public:
 
    /**
-    * @brief Intialize _featureMasks to the list of processor features that will be utilized by the compiler and set _isFeatureMasksEnabled to true
+    * @brief Intialize _supportedFeatureMasks to the list of processor features that will be utilized by the compiler and set _isSupportedFeatureMasksEnabled to true
     * @return void
     */
    static void enableFeatureMasks();

--- a/runtime/compiler/p/env/J9CPU.hpp
+++ b/runtime/compiler/p/env/J9CPU.hpp
@@ -54,8 +54,13 @@ protected:
 
 public:
 
+   /**
+    * @brief Intialize _featureMasks to the list of processor features that will be utilized by the compiler and set _isFeatureMasksEnabled to true
+    * @return void
+    */
+   static void enableFeatureMasks();
+
    bool isCompatible(const OMRProcessorDesc& processorDescription);
-   void applyUserOptions();
    };
 
 }

--- a/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
+++ b/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
@@ -232,7 +232,6 @@ uint8_t* TR::X86AllocPrefetchSnippet::emitSharedBody(uint8_t* prefetchSnippetBuf
    //
    for (int32_t lineOffset = 0; lineOffset < numLines; ++lineOffset)
       {
-      TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || TR::CodeGenerator::getX86ProcessorInfo().isAMD15h() == comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H), "OMR_PROCESSOR_X86_AMDFAMILY15H\n");
       prefetchSnippetBuffer[0] = 0x0F;
       if (comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H))
          prefetchSnippetBuffer[1] = 0x0D;

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -503,7 +503,6 @@ J9::X86::CodeGenerator::nopsAlsoProcessedByRelocations()
 bool
 J9::X86::CodeGenerator::enableAESInHardwareTransformations()
    {
-   TR_ASSERT_FATAL(self()->comp()->compileRelocatableCode() || self()->comp()->isOutOfProcessCompilation() || self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AESNI) == TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI(), "supportsAESNI() failed\n");
    if (self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AESNI) && !self()->comp()->getOption(TR_DisableAESInHardware) && !self()->comp()->getCurrentMethod()->isJNINative())
       return true;
    else

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -4662,7 +4662,6 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
          }
       }
 
-   TR_ASSERT_FATAL(cg->comp()->compileRelocatableCode() || cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed\n");
    if (cg->comp()->target().is64Bit() && cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
       {
       TR::LabelSymbol *JITMonitorEntrySnippetLabel = generateLabelSymbol(cg);
@@ -4718,14 +4717,12 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
    if (cg->comp()->target().is64Bit() && !fej9->generateCompressedLockWord())
       {
       op = cg->comp()->target().isSMP() ? LCMPXCHG8MemReg : CMPXCHG8MemReg;
-      TR_ASSERT_FATAL(cg->comp()->compileRelocatableCode() || cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
       if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
          op = cg->comp()->target().isSMP() ? XALCMPXCHG8MemReg : XACMPXCHG8MemReg;
       }
    else
       {
       op = cg->comp()->target().isSMP() ? LCMPXCHG4MemReg : CMPXCHG4MemReg;
-      TR_ASSERT_FATAL(cg->comp()->compileRelocatableCode() || cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
       if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
          op = cg->comp()->target().isSMP() ? XALCMPXCHG4MemReg : XACMPXCHG4MemReg;
       }
@@ -5552,7 +5549,6 @@ TR::Register
 
    if (!node->isReadMonitor() && !reservingLock)
       {
-      TR_ASSERT_FATAL(cg->comp()->compileRelocatableCode() || cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
       if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
          generateMemImmInstruction(XRSMemImm4(gen64BitInstr),
             node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), 0, cg);
@@ -9122,7 +9118,6 @@ static TR::Register* inlineStringHashCode(TR::Node* node, bool isCompressed, TR:
       generateRegMemInstruction(LEARegMem(), node, tmp, generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, isCompressed ? MASKCOMPRESSED : MASKDECOMPRESSED), cg), cg);
 
       auto mr = generateX86MemoryReference(tmp, index, shift, 0, cg);
-      TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || cg->getX86ProcessorInfo().supportsAVX() == comp->target().cpu.supportsAVX(), "supportsAVX() failed\n");
       if (comp->target().cpu.supportsAVX())
          {
          generateRegMemInstruction(PANDRegMem, node, hashXMM, mr, cg);
@@ -9534,7 +9529,6 @@ inlineCompareAndSwapNative(
       }
    else
       {
-      TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8) == cg->getX86ProcessorInfo().supportsCMPXCHG8BInstruction(), "supportsCMPXCHG8BInstruction() failed\n");
       if (!comp->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8))
          return false;
 
@@ -9957,7 +9951,6 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
 
          case TR::java_util_concurrent_atomic_Fences_orderAccesses:
             {
-            TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.supportsMFence() == cg->getX86ProcessorInfo().supportsMFence(), "supportsMFence() failed\n");
             if (comp->target().cpu.supportsMFence())
                {
                TR_X86OpCode fenceOp;
@@ -9971,9 +9964,6 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
 
          case TR::java_util_concurrent_atomic_Fences_orderReads:
             {
-            TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.requiresLFence() == cg->getX86ProcessorInfo().requiresLFENCE(), "requiresLFence() failed\n");
-            TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.supportsLFence() == cg->getX86ProcessorInfo().supportsLFence(), "supportsLFence() failed\n");
-
             if (comp->target().cpu.requiresLFence() &&
                 comp->target().cpu.supportsLFence())
                {
@@ -9988,8 +9978,6 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
 
          case TR::java_util_concurrent_atomic_Fences_orderWrites:
             {
-            TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.supportsSFence() == cg->getX86ProcessorInfo().supportsSFence(), "supportsSFence() failed\n");
-
             if (comp->target().cpu.supportsSFence())
                {
                TR_X86OpCode fenceOp;

--- a/runtime/compiler/x/env/J9CPU.cpp
+++ b/runtime/compiler/x/env/J9CPU.cpp
@@ -81,13 +81,13 @@ J9::X86::CPU::enableFeatureMasks()
                                         OMR_FEATURE_X86_AESNI, OMR_FEATURE_X86_OSXSAVE, OMR_FEATURE_X86_AVX,
                                         OMR_FEATURE_X86_FMA, OMR_FEATURE_X86_HLE, OMR_FEATURE_X86_RTM};
 
-   memset(_featureMasks.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
+   memset(_supportedFeatureMasks.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
    OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
    for (size_t i = 0; i < sizeof(utilizedFeatures)/sizeof(uint32_t); i++)
       {
-      omrsysinfo_processor_set_feature(&_featureMasks, utilizedFeatures[i], TRUE);
+      omrsysinfo_processor_set_feature(&_supportedFeatureMasks, utilizedFeatures[i], TRUE);
       }
-   _isFeatureMasksEnabled = true;
+   _isSupportedFeatureMasksEnabled = true;
    }
 
 
@@ -153,7 +153,7 @@ J9::X86::CPU::supportsFeature(uint32_t feature)
    if (!disableCPUDetectionTest)
       {
       TR_ASSERT_FATAL(self()->supports_feature_test(feature), "Old API and new API did not match: processor feature %d\n", feature);
-      TR_ASSERT_FATAL(TRUE == omrsysinfo_processor_has_feature(&_featureMasks, feature), "New processor feature usage detected, please add feature %d to _featureMasks via TR::CPU::enableFeatureMasks()\n", feature);
+      TR_ASSERT_FATAL(TRUE == omrsysinfo_processor_has_feature(&_supportedFeatureMasks, feature), "New processor feature usage detected, please add feature %d to _supportedFeatureMasks via TR::CPU::enableFeatureMasks()\n", feature);
       }
       
    return TRUE == omrsysinfo_processor_has_feature(&_processorDescription, feature);

--- a/runtime/compiler/x/env/J9CPU.hpp
+++ b/runtime/compiler/x/env/J9CPU.hpp
@@ -51,12 +51,22 @@ protected:
    CPU(const OMRProcessorDesc& processorDescription) : J9::CPU(processorDescription) {}
 
 public:
+
    /** 
     * @brief Returns the processor type and features that will be used by portable AOT compilations
     * @param[in] omrPortLib : the port library
     * @return TR::CPU
     */
    static TR::CPU detectRelocatable(OMRPortLibrary * const omrPortLib);
+
+   /**
+    * @brief Intialize _featureMasks to the list of processor features that will be utilized by the compiler and set _isFeatureMasksEnabled to true
+    * @return void
+    */
+   static void enableFeatureMasks();
+
+   bool is(OMRProcessorArchitecture p);
+   bool supportsFeature(uint32_t feature);
 
    TR_X86CPUIDBuffer *queryX86TargetCPUID();
    const char * getProcessorVendorId();
@@ -66,6 +76,7 @@ public:
    bool hasPopulationCountInstruction();
 
    bool isCompatible(const OMRProcessorDesc& processorDescription);
+
    uint32_t getX86ProcessorFeatureFlags();
    uint32_t getX86ProcessorFeatureFlags2();
    uint32_t getX86ProcessorFeatureFlags8();

--- a/runtime/compiler/x/env/J9CPU.hpp
+++ b/runtime/compiler/x/env/J9CPU.hpp
@@ -60,7 +60,7 @@ public:
    static TR::CPU detectRelocatable(OMRPortLibrary * const omrPortLib);
 
    /**
-    * @brief Intialize _featureMasks to the list of processor features that will be utilized by the compiler and set _isFeatureMasksEnabled to true
+    * @brief Intialize _supportedFeatureMasks to the list of processor features that will be utilized by the compiler and set _isSupportedFeatureMasksEnabled to true
     * @return void
     */
    static void enableFeatureMasks();

--- a/runtime/compiler/x/env/J9CPU.hpp
+++ b/runtime/compiler/x/env/J9CPU.hpp
@@ -53,14 +53,14 @@ protected:
 public:
 
    /** 
-    * @brief Returns the processor type and features that will be used by portable AOT compilations
+    * @brief A factory method used to construct a CPU object for portable AOT compilations
     * @param[in] omrPortLib : the port library
     * @return TR::CPU
     */
    static TR::CPU detectRelocatable(OMRPortLibrary * const omrPortLib);
 
    /**
-    * @brief Intialize _supportedFeatureMasks to the list of processor features that will be utilized by the compiler and set _isSupportedFeatureMasksEnabled to true
+    * @brief Intialize _supportedFeatureMasks to the list of processor features that will be exploited by the compiler and set _isSupportedFeatureMasksEnabled to true
     * @return void
     */
    static void enableFeatureMasks();

--- a/runtime/compiler/z/env/J9CPU.cpp
+++ b/runtime/compiler/z/env/J9CPU.cpp
@@ -121,12 +121,12 @@ J9::Z::CPU::customize(OMRProcessorDesc processorDescription)
          }
       }
 
-   if (_isFeatureMasksEnabled)
+   if (_isSupportedFeatureMasksEnabled)
       {
       // mask out any cpu features that the compiler doesn't care about
       for (size_t i = 0; i < OMRPORT_SYSINFO_FEATURES_SIZE; i++)
          {
-         processorDescription.features[i] &= _featureMasks.features[i];
+         processorDescription.features[i] &= _supportedFeatureMasks.features[i];
          }
       }
 
@@ -147,13 +147,13 @@ J9::Z::CPU::enableFeatureMasks()
                                          OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_3,
                                          OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY};
 
-   memset(_featureMasks.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
+   memset(_supportedFeatureMasks.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
    OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
    for (size_t i = 0; i < sizeof(utilizedFeatures)/sizeof(uint32_t); i++)
       {
-      omrsysinfo_processor_set_feature(&_featureMasks, utilizedFeatures[i], TRUE);
+      omrsysinfo_processor_set_feature(&_supportedFeatureMasks, utilizedFeatures[i], TRUE);
       }
-   _isFeatureMasksEnabled = true;
+   _isSupportedFeatureMasksEnabled = true;
    }
 
 bool

--- a/runtime/compiler/z/env/J9CPU.hpp
+++ b/runtime/compiler/z/env/J9CPU.hpp
@@ -69,7 +69,7 @@ public:
    static TR::CPU customize(OMRProcessorDesc processorDescription);
 
    /**
-    * @brief Intialize _featureMasks to the list of processor features that will be utilized by the compiler and set _isFeatureMasksEnabled to true
+    * @brief Intialize _supportedFeatureMasks to the list of processor features that will be utilized by the compiler and set _isSupportedFeatureMasksEnabled to true
     * @return void
     */
    static void enableFeatureMasks();

--- a/runtime/compiler/z/env/J9CPU.hpp
+++ b/runtime/compiler/z/env/J9CPU.hpp
@@ -53,19 +53,28 @@ protected:
    CPU(const OMRProcessorDesc& processorDescription) : J9::CPU(processorDescription) {}
 
 public:
+
    /**
     * @brief Returns the processor type and features that will be used by portable AOT compilations
     * @param[in] omrPortLib : the port library
     * @return TR::CPU
     */
    static TR::CPU detectRelocatable(OMRPortLibrary * const omrPortLib);
+
+   /** 
+    * @brief Disable processor features based on input processor description, user options and whether they are utilized by the compiler
+    * @param[in] OMRProcessorDesc : the processor description
+    * @return TR::CPU
+    */
+   static TR::CPU customize(OMRProcessorDesc processorDescription);
+
+   /**
+    * @brief Intialize _featureMasks to the list of processor features that will be utilized by the compiler and set _isFeatureMasksEnabled to true
+    * @return void
+    */
+   static void enableFeatureMasks();
    
-   void applyUserOptions();
    bool isCompatible(const OMRProcessorDesc& processorDescription);
-
-private:
-
-   static void adjustProcessorFeatures(OMRProcessorDesc& processorDescription);
    };
 
 }

--- a/runtime/compiler/z/env/J9CPU.hpp
+++ b/runtime/compiler/z/env/J9CPU.hpp
@@ -54,22 +54,22 @@ protected:
 
 public:
 
-   /**
-    * @brief Returns the processor type and features that will be used by portable AOT compilations
+   /** 
+    * @brief A factory method used to construct a CPU object for portable AOT compilations
     * @param[in] omrPortLib : the port library
     * @return TR::CPU
     */
    static TR::CPU detectRelocatable(OMRPortLibrary * const omrPortLib);
 
    /** 
-    * @brief Disable processor features based on input processor description, user options and whether they are utilized by the compiler
+    * @brief A factory method used to construct a CPU object based on user customized processorDescription
     * @param[in] OMRProcessorDesc : the processor description
     * @return TR::CPU
     */
    static TR::CPU customize(OMRProcessorDesc processorDescription);
 
    /**
-    * @brief Intialize _supportedFeatureMasks to the list of processor features that will be utilized by the compiler and set _isSupportedFeatureMasksEnabled to true
+    * @brief Intialize _supportedFeatureMasks to the list of processor features that will be exploited by the compiler and set _isSupportedFeatureMasksEnabled to true
     * @return void
     */
    static void enableFeatureMasks();

--- a/runtime/port/linuxs390/j9ri.c
+++ b/runtime/port/linuxs390/j9ri.c
@@ -104,7 +104,7 @@ j9ri_params_init(struct J9PortLibrary *portLibrary, struct J9RIParameters *riPar
 
 /**
  * Register a signalHandler for RI real-time signals
- * This is called once from the JIT during J9::Z::CPU::applyUserOptions().
+ * This is called once from the JIT during J9::Z::CPU::customize().
  * If the registration fails, RI will not be used.
  */
 int32_t


### PR DESCRIPTION
- Guard cpu feature tests against old version cpu feature detection on x86 with an environment variable.
- Remove redundant assertion tests on x86.
- Eliminate `applyUserOptions()`. 
  - Disassociate the options from `TR::CPU`. 
  - Issue with `applyUserOptions()` is that the options are not initialized when `TR::CPU` is initialized which means if the user calls `applyUserOptions()` at the incorrect place the options queries that it contains will either crash the program or not take effect. I want to eliminate this risk of incorrect usage.
- Introduce new API called `TR::CPU::customize(OMRProcessorDesc processorDescription)`
  - it's a static factory method that takes in an `OMRProcessorDesc` from user and output a `TR::CPU` object
  - The design is that we do not give user to ability to modify the fields of TR::CPU object in place. You will need to go through a factory method to change TR::CPU. This makes it easier for us to keep track where TR::CPU is modified and eliminate any unintentional illegal TR::CPU modifications from user which can be disastrous.
- Introduce new API called `TR::CPU::enableFeatureMasks()`
  - You can turn on "featureMasks" support using this API
  - Once "featureMasks" support is turned on, we will mask out all cpu features that are not used by the current compiler from the OMRProcessorDesc struct in TR::CPU which allows to do CPU compatibility checks for AOT more correctly
  - For each platform, we keep track of the utilized cpu features inside `TR::CPU::enableFeatureMasks()`
  - If developer utilizes a previously unused feature, they need to add it to `TR::CPU::enableFeatureMasks()`
  - We have assert tests in place to detect queries to unused feature
    - The purpose of this detection is to minimize the risk of masking out cpu features that are being used.
- Summary of current design:
  - `TR::CPU::detect(omrPortLib)`: static factory method that gives you the TR::CPU object based on port library
  - `TR::CPU::customize(processorDescription)`: static factory method that gives you the TR::CPU object based on a processorDescription provided by user

Issue: https://github.com/eclipse/openj9/issues/10683

Signed-off-by: Harry Yu <harryyu1994@gmail.com>