### PR TITLE
Add 'self()` to address extensible class warning

### DIFF
--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -341,7 +341,7 @@ J9::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
                                               void *preferredStartAddress)
    {
    if (TR::Options::getCmdLineOptions()->getOption(TR_ForceGenerateReadOnlyCode))
-      return allocateCodeCacheWithDataSegmentRO(segmentSize, codeCacheSizeToAllocate, preferredStartAddress);
+      return self()->allocateCodeCacheWithDataSegmentRO(segmentSize, codeCacheSizeToAllocate, preferredStartAddress);
 
    J9JavaVM *javaVM = this->javaVM();
    J9JITConfig *jitConfig = this->jitConfig();


### PR DESCRIPTION
Signed-off-by: Dan Heidinga <heidinga@redhat.com>