### PR TITLE
Fix isConstructor for value type factory method

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -5122,7 +5122,10 @@ TR_ResolvedJ9Method::methodModifiers()
 bool
 TR_ResolvedJ9Method::isConstructor()
    {
-   return nameLength()==6 && !strncmp(nameChars(), "<init>", 6);
+   if (!TR::Compiler->om.areValueTypesEnabled())
+      return (nameLength()==6 && !strncmp(nameChars(), "<init>", 6));
+   else
+      return (nameLength()==6 && !isStatic() && (returnType()==TR::NoType) && !strncmp(nameChars(), "<init>", 6));
    }
 
 bool TR_ResolvedJ9Method::isStatic()            { return methodModifiers() & J9AccStatic ? true : false; }

--- a/runtime/compiler/il/J9SymbolReference.cpp
+++ b/runtime/compiler/il/J9SymbolReference.cpp
@@ -62,15 +62,10 @@ SymbolReference::SymbolReference(
       symRefTab->comp()->registerResolvedMethodSymbolReference(self());
 
    //Check for init method
-   if (sym->isMethod())
+   if (sym->isMethod() &&
+       sym->castToMethodSymbol()->getMethod()->isConstructor())
       {
-      char *name         = sym->castToMethodSymbol()->getMethod()->nameChars();
-      int   nameLen      = sym->castToMethodSymbol()->getMethod()->nameLength();
-      if ((nameLen == 6) &&
-          !strncmp(name, "<init>", 6))
-         {
-         self()->setInitMethod();
-         }
+      self()->setInitMethod();
       }
 
    symRefTab->checkImmutable(self());


### PR DESCRIPTION
Inline class values are created with static factory methods with method name `<init>`. `<init>` is also the method name for identity class constructor name. `isConstructor()` should return false for inline class value factory method.

Thanks to @hzongaro for helping find the incorrect return type info setup. 