### PR TITLE
Update travis git cache to fetch snapshot branch

### DIFF
--- a/buildenv/travis/build-on-travis.sh
+++ b/buildenv/travis/build-on-travis.sh
@@ -97,7 +97,11 @@ if test "x$RUN_BUILD" = "xyes" ; then
   pushd $TRAVIS_BUILD_DIR
   git remote set-branches origin 'snapshot'
   git fetch --depth 50 origin snapshot
+  git remote -v
+  git branch -v
   popd
+
+
 
   cd openj9-openjdk-jdk11 && bash get_source.sh -openj9-repo=$TRAVIS_BUILD_DIR -openj9-branch=$TRAVIS_BRANCH -openj9-sha=$OPENJ9_SHA -omr-branch=snapshot
 

--- a/buildenv/travis/build-on-travis.sh
+++ b/buildenv/travis/build-on-travis.sh
@@ -91,6 +91,14 @@ if test "x$RUN_BUILD" = "xyes" ; then
     echo "Warning using SHA $OPENJ9_SHA instead of $TRAVIS_COMMIT."
   fi
 
+  # Travis uses --depth=50 which implies --single-branch.  To get the snapshot branch, we
+  # need to add the ref and fetch it explicitly before the get_source.sh can use it as it
+  # is "fetching" from the local checkout
+  pushd $TRAVIS_BUILD_DIR
+  git remote set-branches origin 'snapshot'
+  git fetch --depth 50 origin snapshot
+  popd
+
   cd openj9-openjdk-jdk11 && bash get_source.sh -openj9-repo=$TRAVIS_BUILD_DIR -openj9-branch=$TRAVIS_BRANCH -openj9-sha=$OPENJ9_SHA -omr-branch=snapshot
 
   # Limit number of jobs to work around g++ internal compiler error.

--- a/buildenv/travis/build-on-travis.sh
+++ b/buildenv/travis/build-on-travis.sh
@@ -96,7 +96,7 @@ if test "x$RUN_BUILD" = "xyes" ; then
   # is "fetching" from the local checkout
   pushd $TRAVIS_BUILD_DIR
   git remote set-branches origin 'snapshot'
-  git fetch --depth 50 origin snapshot
+  git fetch --depth 50 origin snapshot:snapshot
   git remote -v
   git branch -v
   popd


### PR DESCRIPTION
travis, by default, clones the repo with:
```
git clone --depth=50
```
which implies `--single-branch`.  For the snapshot builds,
we need the snapshot branch to be present in the local git
repo.

To make that work, we need to add the remote reference for
the snapshot branch and then fetch it with the depth of 50.

Signed-off-by: Dan Heidinga <heidinga@redhat.com>