### PR TITLE
Use Compilation API for asking if recursive method target

### DIFF
--- a/runtime/compiler/p/codegen/J9PPCInstruction.cpp
+++ b/runtime/compiler/p/codegen/J9PPCInstruction.cpp
@@ -50,7 +50,7 @@ uint8_t *TR::PPCDepImmSymInstruction::generateBinaryEncoding()
       TR::ResolvedMethodSymbol *sym = getSymbolReference()->getSymbol()->getResolvedMethodSymbol();
       TR_ResolvedMethod *resolvedMethod = sym == NULL ? NULL : sym->getResolvedMethod();
       TR::LabelSymbol *label = getSymbolReference()->getSymbol()->getLabelSymbol();
-      bool callToSelf = resolvedMethod != NULL && resolvedMethod->isSameMethod(comp->getCurrentMethod()) && !comp->isDLT();
+      bool callToSelf = comp->isRecursiveMethodTarget(resolvedMethod);
 
       if (cg()->hasCodeCacheSwitched())
          {

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -2379,7 +2379,7 @@ void J9::Power::PrivateLinkage::buildVirtualDispatch(TR::Node                   
                   {
                   TR_ResolvedMethod *calleeMethod = chTable->findSingleAbstractImplementer(thisClass, methodSymRef->getOffset(), methodSymRef->getOwningMethod(comp()), comp());
                   if (calleeMethod &&
-                      ((calleeMethod->isSameMethod(comp()->getCurrentMethod()) && !comp()->isDLT()) ||
+                      (comp()->isRecursiveMethodTarget(calleeMethod) ||
                        !calleeMethod->isInterpreted() ||
                        calleeMethod->isJITInternalNative()))
                      {
@@ -2393,7 +2393,7 @@ void J9::Power::PrivateLinkage::buildVirtualDispatch(TR::Node                   
                   {
                   TR_ResolvedMethod *calleeMethod = methodSymRef->getOwningMethod(comp())->getResolvedVirtualMethod(comp(), refinedThisClass, methodSymRef->getOffset());
                   if (calleeMethod &&
-                      ((calleeMethod->isSameMethod(comp()->getCurrentMethod()) && !comp()->isDLT()) ||
+                      (comp()->isRecursiveMethodTarget(calleeMethod) ||
                        !calleeMethod->isInterpreted() ||
                        calleeMethod->isJITInternalNative()))
                      {
@@ -2444,7 +2444,7 @@ void J9::Power::PrivateLinkage::buildVirtualDispatch(TR::Node                   
                   resolvedMethodSymbol = methodSymbol->getResolvedMethodSymbol();
                   resolvedMethod = resolvedMethodSymbol->getResolvedMethod();
                   }
-               uintptr_t methodAddress = resolvedMethod->isSameMethod(comp()->getCurrentMethod()) && !comp()->isDLT() ? 0 : (uintptr_t)resolvedMethod->startAddressForJittedMethod();
+               uintptr_t methodAddress = comp()->isRecursiveMethodTarget(resolvedMethod) ? 0 : (uintptr_t)resolvedMethod->startAddressForJittedMethod();
                TR::Instruction *gcPoint = generateDepImmSymInstruction(cg(), TR::InstOpCode::bl, callNode, methodAddress,
                                                                                               new (trHeapMemory()) TR::RegisterDependencyConditions(0, 0, trMemory()), methodSymRef);
                generateDepLabelInstruction(cg(), TR::InstOpCode::label, callNode, doneLabel, dependencies);
@@ -2685,9 +2685,7 @@ void J9::Power::PrivateLinkage::buildDirectCall(TR::Node *callNode,
    TR::MethodSymbol *callSymbol    = callSymRef->getSymbol()->castToMethodSymbol();
    TR::ResolvedMethodSymbol *sym   = callSymbol->getResolvedMethodSymbol();
    TR_ResolvedMethod *vmm       = (sym==NULL)?NULL:sym->getResolvedMethod();
-   bool myself =
-      (vmm!=NULL && vmm->isSameMethod(comp()->getCurrentMethod()) && !comp()->isDLT()) ?
-      true : false;
+   bool myself = comp()->isRecursiveMethodTarget(vmm);
 
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
 

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1261,7 +1261,7 @@ void TR::X86CallSite::setupVirtualGuardInfo()
                {
                TR_ResolvedMethod * method = chTable->findSingleAbstractImplementer(thisClass, methodSymRef->getOffset(), methodSymRef->getOwningMethod(comp()), comp());
                if (method &&
-                   ((method->isSameMethod(comp()->getCurrentMethod()) && !comp()->isDLT()) ||
+                   (comp()->isRecursiveMethodTarget(method) ||
                     !method->isInterpreted() ||
                     method->isJITInternalNative()))
                   {
@@ -1276,7 +1276,7 @@ void TR::X86CallSite::setupVirtualGuardInfo()
                   {
                   TR_ResolvedMethod *calleeMethod = methodSymRef->getOwningMethod(comp())->getResolvedVirtualMethod(comp(), refinedThisClass, methodSymRef->getOffset());
                   if (calleeMethod &&
-                      ((calleeMethod->isSameMethod(comp()->getCurrentMethod()) && !comp()->isDLT()) ||
+                      (comp()->isRecursiveMethodTarget(calleeMethod) ||
                        !calleeMethod->isInterpreted() ||
                        calleeMethod->isJITInternalNative()))
                      {

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -1777,7 +1777,7 @@ J9::Z::PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDep
                      TR_ResolvedMethod * method = chTable->findSingleAbstractImplementer(thisClass, methodSymRef->getOffset(),
                                                                 methodSymRef->getOwningMethod(comp()), comp());
                      if (method &&
-                        ((method->isSameMethod(comp()->getCurrentMethod()) && !comp()->isDLT()) || !method->isInterpreted() || method->isJITInternalNative()))
+                        (comp()->isRecursiveMethodTarget(method) || !method->isInterpreted() || method->isJITInternalNative()))
                         {
                         performGuardedDevirtualization = true;
                         resolvedMethod = method;
@@ -1798,7 +1798,7 @@ J9::Z::PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDep
                         TR_ResolvedMethod * calleeMethod = methodSymRef->getOwningMethod(comp())->getResolvedVirtualMethod(comp(),
                                                                 refinedThisClass, methodSymRef->getOffset());
                         if (calleeMethod &&
-                           ((calleeMethod->isSameMethod(comp()->getCurrentMethod()) && !comp()->isDLT()) ||
+                           (comp()->isRecursiveMethodTarget(calleeMethod) ||
                            !calleeMethod->isInterpreted() ||
                            calleeMethod->isJITInternalNative()))
                            {
@@ -2340,7 +2340,7 @@ J9::Z::PrivateLinkage::buildDirectCall(TR::Node * callNode, TR::SymbolReference 
    TR_ResolvedMethod * fem = (sym == NULL) ? NULL : sym->getResolvedMethod();
    bool myself;
    bool isJitInduceOSR = callSymRef->isOSRInductionHelper();
-   myself = (fem != NULL && fem->isSameMethod(comp()->getCurrentMethod()) && !comp()->isDLT()) ? true : false;
+   myself = comp()->isRecursiveMethodTarget(fem);
 
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
 


### PR DESCRIPTION
Replace recursive method checks with `isRecursiveMethodTarget` Compilation query.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>