### PR TITLE
CMake: make nlsgen output depend on the .nls files

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -137,15 +137,18 @@ add_custom_target(j9vm_hookgen
 )
 
 # Generate NLS headers
+file(GLOB_RECURSE nls_files "${CMAKE_CURRENT_SOURCE_DIR}/nls/*.nls")
 add_custom_command(
-	OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/java.properties"
-	DEPENDS j9nls
+	OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/nls.stamp"
+	DEPENDS j9nls ${nls_files}
 	COMMAND "${Java_JAVA_EXECUTABLE}" -cp "$<TARGET_PROPERTY:j9nls,JAR_FILE>" com.ibm.oti.NLSTool.J9NLS -source "${CMAKE_CURRENT_SOURCE_DIR}"
+	COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/nls.stamp"
+	COMMENT "Generating NLS files"
 	VERBATIM
 )
 add_custom_target(j9vm_nlsgen
 	DEPENDS
-		"${CMAKE_CURRENT_BINARY_DIR}/java.properties"
+		"${CMAKE_CURRENT_BINARY_DIR}/nls.stamp"
 )
 
 set(J9VM_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/include")


### PR DESCRIPTION
fixes #10539

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>