### PR TITLE
Exclude com.oracle.net.Sdp from ClassloadingTester

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/vmcheck/TestLoadingClassesFromJarfile.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/vmcheck/TestLoadingClassesFromJarfile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -151,7 +151,8 @@ public class TestLoadingClassesFromJarfile {
 			"sun.print",
 			"sun.reflect.misc.Trampoline",
 			"sun.security.tools.policytool",
-			"sun.swing"
+			"sun.swing",
+			"com.oracle.net"
 	}).stream().map(s -> s.replace('.', '/')).collect(Collectors.toList()));
 
 	private static boolean includeFile(String jarEntryName) {


### PR DESCRIPTION
Added package `com.oracle.net` into `excludedPackages` because `Class.forName("com.oracle.net.Sdp")` throws
`java.lang.NoSuchMethodException: java.net.SdpSocketImpl.<init>(boolean)`;

Note: `Class.forName("com.oracle.net.Sdp")` throws following error:
```
Exception in thread "main" java.lang.AssertionError: java.lang.NoSuchMethodException: java.net.SdpSocketImpl.<init>(boolean)
	at com.oracle.net.Sdp.<clinit>(Sdp.java:91)
	at java.lang.Class.forNameImpl(Native Method)
	at java.lang.Class.forName(Class.java:337)
Caused by: java.lang.NoSuchMethodException: java.net.SdpSocketImpl.<init>(boolean)
	at java.lang.Class.newNoSuchMethodException(Class.java:566)
	at java.lang.Class.getDeclaredConstructor(Class.java:738)
	at com.oracle.net.Sdp.<clinit>(Sdp.java:86)
	... 5 more
```

fixes #10294 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>