### PR TITLE
Unify LinkageInfo word initialization

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -1540,27 +1540,8 @@ void J9::ARM64::PrivateLinkage::performPostBinaryEncoding()
                    "Expecting the return type info instruction to be created");
 
    TR::ARM64ImmInstruction *linkageInfoWordInstruction = cg()->getReturnTypeInfoInstruction();
-   uint32_t linkageInfoWord = linkageInfoWordInstruction->getSourceImmediate();
-
-   intptr_t jittedMethodEntryAddress = reinterpret_cast<intptr_t>(getJittedMethodEntryPoint()->getBinaryEncoding());
-   intptr_t interpretedMethodEntryAddress = reinterpret_cast<intptr_t>(getInterpretedMethodEntryPoint()->getBinaryEncoding());
-
-   linkageInfoWord = (static_cast<uint32_t>(jittedMethodEntryAddress - interpretedMethodEntryAddress) << 16) | linkageInfoWord;
+   uint32_t linkageInfoWord = cg()->initializeLinkageInfo(linkageInfoWordInstruction->getBinaryEncoding());
    linkageInfoWordInstruction->setSourceImmediate(linkageInfoWord);
-
-   *(uint32_t *)(linkageInfoWordInstruction->getBinaryEncoding()) = linkageInfoWord;
-
-   // Set recompilation info
-   //
-   TR::Recompilation *recomp = comp()->getRecompilationInfo();
-   if (recomp != NULL && recomp->couldBeCompiledAgain())
-      {
-      J9::PrivateLinkage::LinkageInfo *lkInfo = J9::PrivateLinkage::LinkageInfo::get(cg()->getCodeStart());
-      if (recomp->useSampling())
-         lkInfo->setSamplingMethodBody();
-      else
-         lkInfo->setCountingMethodBody();
-      }
    }
 
 int32_t J9::ARM64::HelperLinkage::buildArgs(TR::Node *callNode,

--- a/runtime/compiler/arm/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/arm/codegen/J9CodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -283,19 +283,8 @@ void J9::ARM::CodeGenerator::doBinaryEncoding()
       cursorInstruction = cursorInstruction->getNext();
       if (isPrivateLinkage && cursorInstruction == j2jEntryInstruction)
          {
-         uint32_t magicWord = ((self()->getBinaryBufferCursor()-self()->getCodeStart())<<16) | static_cast<uint32_t>(comp->getReturnInfo());
-         TR_ASSERT(_returnTypeInfoInstruction && _returnTypeInfoInstruction->getOpCodeValue() == ARMOp_dd, "assertion failure");
-         ((TR::ARMImmInstruction *)_returnTypeInfoInstruction)->setSourceImmediate(magicWord);
-         *(uint32_t *)(_returnTypeInfoInstruction->getBinaryEncoding()) = magicWord;
-
-         if (recomp != NULL && recomp->couldBeCompiledAgain())
-            {
-            J9::PrivateLinkage::LinkageInfo *lkInfo = J9::PrivateLinkage::LinkageInfo::get(self()->getCodeStart());
-            if (recomp->useSampling())
-               lkInfo->setSamplingMethodBody();
-            else
-               lkInfo->setCountingMethodBody();
-            }
+         uint32_t linkageInfoWord = self()->initializeLinkageInfo(_returnTypeInfoInstruction->getBinaryEncoding());
+         ((TR::ARMImmInstruction *)_returnTypeInfoInstruction)->setSourceImmediate(linkageInfoWord);
          }
       }
    // Create exception table entries for outlined instructions.

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -5297,6 +5297,25 @@ J9::CodeGenerator::generatePoisonNode(TR::Block *currentBlock, TR::SymbolReferen
    return storeNode;
    }
 
+uint32_t
+J9::CodeGenerator::initializeLinkageInfo(void *linkageInfoPtr)
+   {
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = (J9::PrivateLinkage::LinkageInfo *)linkageInfoPtr;
+
+   TR::Recompilation * recomp = self()->comp()->getRecompilationInfo();
+   if (recomp && recomp->couldBeCompiledAgain())
+      {
+      if (recomp->useSampling())
+         linkageInfo->setSamplingMethodBody();
+      else
+         linkageInfo->setCountingMethodBody();
+      }
+
+   linkageInfo->setReservedWord((self()->getBinaryBufferCursor() - self()->getCodeStart()));
+   linkageInfo->setReturnInfo(self()->comp()->getReturnInfo());
+
+   return linkageInfo->getWord();
+   }
 
 // I need to preserve the type information for monitorenter/exit through
 // code generation, but the secondChild is being used for other monitor

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -577,6 +577,15 @@ public:
     */
    bool supportsStackAllocations() { return false; }
 
+   /**
+    * \brief Initializes the Linkage Info word found before the interpreter entry point.
+    *
+    * \param[in] linkageInfo : pointer to the linkage info word
+    *
+    * \return Linkage Info word
+    */
+   uint32_t initializeLinkageInfo(void *linkageInfoPtr);
+
 private:
 
    enum // Flags

--- a/runtime/compiler/codegen/PrivateLinkage.hpp
+++ b/runtime/compiler/codegen/PrivateLinkage.hpp
@@ -25,6 +25,7 @@
 
 #include "codegen/Linkage.hpp"
 #include "env/jittypes.h"
+#include "compile/CompilationTypes.hpp"
 #include "infra/Assert.hpp"
 
 namespace TR { class CodeGenerator; }
@@ -85,6 +86,11 @@ public:
 
       inline uint16_t getReservedWord() { return (_word & ReservedMask) >> 16; }
       inline void setReservedWord(uint16_t w) { _word |= ((w << 16) & ReservedMask); }
+
+      inline TR_ReturnInfo getReturnInfo() { return (TR_ReturnInfo)(_word & ReturnInfoMask); }
+      inline void setReturnInfo(TR_ReturnInfo w) { _word |= (w & ReturnInfoMask); }
+
+      inline uint32_t getWord() { return _word; }
 
       int32_t getJitEntryOffset()
          {


### PR DESCRIPTION
The Linkage Info word is a 32-bit piece of memory right before the start PC of a compiled body that holds flags describing the body (sampling body, etc) as well as the offset describing the distance between the the Interpreter Entry Point and the JIT Entry Point. The initialization of this word has been done in a very raw manner, dealing directly with the memory rather than using the `J9::PrivateLinkage::LinkageInfo` abstraction. This PR cleans up this code.

Depends on https://github.com/eclipse/omr/pull/5583