### PR TITLE
BytecodeInterpreter changes to adopt OpenJDK MethodHandles

### DIFF
--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -176,6 +176,12 @@ typedef enum {
 	J9_BCLOOP_SEND_TARGET_CLASS_ARRAY_TYPE_IMPL,
 	J9_BCLOOP_SEND_TARGET_CLASS_IS_RECORD,
 	J9_BCLOOP_SEND_TARGET_CLASS_IS_SEALED,
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	J9_BCLOOP_SEND_TARGET_METHODHANDLE_INVOKEBASIC,
+	J9_BCLOOP_SEND_TARGET_METHODHANDLE_LINKTOSTATICSPECIAL,
+	J9_BCLOOP_SEND_TARGET_METHODHANDLE_LINKTOVIRTUAL,
+	J9_BCLOOP_SEND_TARGET_METHODHANDLE_LINKTOINTERFACE,
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 } VM_SendTarget;
 
 typedef enum {
@@ -331,7 +337,7 @@ public:
 
 	/**
 	 * @brief Return whether an exception is pending or not
-	 * 
+	 *
 	 * @param currentThread the J9VMThread to check
 	 * @return true if an exception is pending, otherwise false.
 	 */
@@ -785,7 +791,7 @@ done:
 	 * Perform a non-instrumentable allocation of an indexable flattened or unflattened class.
 	 *
 	 * Unflattened array classes that contain the J9ClassContainsUnflattenedFlattenables flag will return NULL
-	 * 
+	 *
 	 * @param currentThread[in] the current J9VMThread
 	 * @param objectAllocate[in] instance of MM_ObjectAllocationAPI created on the current thread
 	 * @param arrayClass[in] the indexable J9Class to instantiate
@@ -1082,7 +1088,7 @@ done:
 		}
 		return hash;
 	}
-	
+
 	/**
 	 * Determines whether the UTF8 string is an ASCII string.
 	 *
@@ -1441,7 +1447,7 @@ done:
 
 		return (jobject)ref;
 	}
-	
+
 	static VMINLINE U_32
 	lookupVarHandleMethodTypeCacheIndex(J9ROMClass *romClass, UDATA cpIndex)
 	{

--- a/runtime/vm/initsendtarget.cpp
+++ b/runtime/vm/initsendtarget.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,6 +29,59 @@
 #include <string.h>
 
 extern "C" {
+
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+static VMINLINE bool
+initializeMethodRunAddressMethodHandle(J9Method *method)
+{
+	void *methodRunAddress = NULL;
+	J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
+	U_32 const modifiers = romMethod->modifiers;
+
+	/* The methods that require the special send target are all native. */
+	if (J9_ARE_ALL_BITS_SET(modifiers, J9AccNative)) {
+		J9UTF8 *classNameUTF = J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(method)->romClass);
+		if (J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(classNameUTF), J9UTF8_LENGTH(classNameUTF), "java/lang/invoke/MethodHandle")) {
+			J9UTF8 *methodNameUTF = J9ROMMETHOD_NAME(romMethod);
+			UDATA methodNameLength = J9UTF8_LENGTH(methodNameUTF);
+			U_8 *methodName = J9UTF8_DATA(methodNameUTF);
+
+			switch (methodNameLength) {
+			case 11:
+				if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "invokeBasic")) {
+					methodRunAddress = J9_BCLOOP_ENCODE_SEND_TARGET(J9_BCLOOP_SEND_TARGET_METHODHANDLE_INVOKEBASIC);
+				}
+				break;
+			case 12:
+				if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "linkToStatic")) {
+					methodRunAddress = J9_BCLOOP_ENCODE_SEND_TARGET(J9_BCLOOP_SEND_TARGET_METHODHANDLE_LINKTOSTATICSPECIAL);
+				}
+				break;
+			case 13:
+				if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "linkToSpecial")) {
+					methodRunAddress = J9_BCLOOP_ENCODE_SEND_TARGET(J9_BCLOOP_SEND_TARGET_METHODHANDLE_LINKTOSTATICSPECIAL);
+				} else if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "linkToVirtual")) {
+					methodRunAddress = J9_BCLOOP_ENCODE_SEND_TARGET(J9_BCLOOP_SEND_TARGET_METHODHANDLE_LINKTOVIRTUAL);
+				}
+				break;
+			case 15:
+				if (J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "linkToInterface")) {
+					methodRunAddress = J9_BCLOOP_ENCODE_SEND_TARGET(J9_BCLOOP_SEND_TARGET_METHODHANDLE_LINKTOINTERFACE);
+				}
+				break;
+			default:
+				break;
+			}
+
+			if (NULL != methodRunAddress) {
+				method->methodRunAddress = methodRunAddress;
+			}
+		}
+	}
+
+	return (NULL != methodRunAddress);
+}
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 static VMINLINE bool
 initializeMethodRunAddressVarHandle(J9Method *method)
@@ -156,6 +209,12 @@ initializeMethodRunAddress(J9VMThread *vmThread, J9Method *method)
 	J9JavaVM* vm = vmThread->javaVM;
 
 	method->extra = (void *) J9_STARTPC_NOT_TRANSLATED;
+
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	if (initializeMethodRunAddressMethodHandle(method)) {
+		return;
+	}
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 	if (initializeMethodRunAddressVarHandle(method)) {
 		return;


### PR DESCRIPTION
1. **New INLs:**
	i. **invokeBasic**: [Virtual] this.invokeBasic(args, ...,  mn)
	The MH receiver is located before the arguments.
	```
	  -- java_lang_invoke_MethodHandle::form -> LambdaForm
	  --- java_lang_invoke_LambdaForm::vmentry -> MemberName
	  ---- java_lang_invoke_MemberName::vmtarget -> J9Method*
	  ----- invoke_target(vmtarget)
	```
	ii. **linkToStaticSpecial**: [Static] MH.linkToStaticSpecial(this, args ..., mn)
	The object at the top of the stack is a MemberName instance.
	```
	  -- java_lang_invoke_MemberName::vmtarget -> J9Method*
	  --- invoke_target(vmtarget)
	```

	iii. **linkToVirtual**: [Static] MH.linkTo*(this, args ..., mn)
	The object at the top of the stack is a MemberName instance.
	```
	  -- java_lang_invoke_MemberName::vmtarget -> J9JNIMethodID*
	  --- invoke_target(receiverClass + vmtarget->vTableIndex)
	```
	iv. **linkToInterface**: [Static] MH.linkTo*(this, args ..., mn)
	The object at the top of the stack is a MemberName instance.
	```
	  -- java_lang_invoke_MemberName::vmtarget -> J9JNIMethodID*
	  --- iTable query to find the vTableOffset
	  ---- invoke_target(receiverClass + vTableOffset)
	```
	**For INL invocations from the JIT,**
	- invokeBasic: JIT return address is restored and j2i transition is
	invoked.
	- linkTo*: the MemberName object is moved in front of the first
	argument before the JIT return address is restored and j2i transition is
	invoked.

2. **Rewrite invokedynamic to work with OpenJDK MethodHandles.**
	The execution bytecode has changed to GOTO_RUN_METHOD.

	The resolution method has changed. MethodHandleNatives.linkCallSite is
	called for resolution. It returns two items: 1) MemberName object and 2)
	MethodHandle object.

	The _sendMethod is derived from the MemberName object:
	java_lang_invoke_MemberName::vmtarget -> J9Method*.

	The MethodHandle object is pushed on top of the stack since it is the
	last argument for the _sendMethod.

	Then, the _sendMethod is invoked.

3. **Rewrite invokehandle to work with OpenJDK MethodHandles.**
	The execution bytecode has changed to GOTO_RUN_METHOD.

	The resolution method has changed. MethodHandleNatives.linkMethod is
	called for resolution. It returns two items: 1) MemberName object and 2)
	MethodHandle object.

	The _sendMethod is derived from the MemberName object:
	java_lang_invoke_MemberName::vmtarget -> J9Method*.

	The MethodHandle object is pushed on top of the stack since it is the
	last argument for the _sendMethod.

	Then, the _sendMethod is invoked.

4. **invokehandlegeneric is unused with OpenJDK MethodHandles**
	For OpenJDK MethodHandles (MH), MH.invoke and MH.invokeExact both share
	common functionality. So, they are both translated to invokehandle.

	Thus, invokehandlegeneric stays unused with OpenJDK MethodHandles.

Related: #7352

Co-authored-by: Jack Lu <Jack.S.Lu@ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>