### PR TITLE
Handle native OOM in catUTFToString4

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -3013,7 +3013,9 @@ illegalAccess:
 				J9UTF8_LENGTH(nameUTF),
 				J9UTF8_DATA(sigUTF),
 				J9UTF8_LENGTH(sigUTF));
-		setCurrentExceptionFromJIT(currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALACCESSEXCEPTION, detailMessage);
+		if (NULL != detailMessage) {
+			setCurrentExceptionFromJIT(currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALACCESSEXCEPTION, detailMessage);
+		}
 		goto done;
 	}
 

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1465,7 +1465,10 @@ obj:
 			}
 		}
 		updateVMStruct(REGISTER_ARGS);
-		setCurrentException(_currentThread, exception, (UDATA*)methodToString(_currentThread, _sendMethod));
+		j9object_t detailMessage = methodToString(_currentThread, _sendMethod);
+		if (NULL != detailMessage) {
+			setCurrentException(_currentThread, exception, (UDATA*)detailMessage);
+		}
 		VMStructHasBeenUpdated(REGISTER_ARGS);
 		return  GOTO_THROW_CURRENT_EXCEPTION;
 	}

--- a/runtime/vm/exceptionsupport.c
+++ b/runtime/vm/exceptionsupport.c
@@ -1101,7 +1101,10 @@ setRecursiveBindError(J9VMThread * currentThread, J9Method * method)
 void  
 setNativeNotFoundError(J9VMThread * currentThread, J9Method * method)
 {
-	setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGUNSATISFIEDLINKERROR, (UDATA*)methodToString(currentThread, method));
+	j9object_t detailMessage = methodToString(currentThread, method);
+	if (NULL != detailMessage) {
+		setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGUNSATISFIEDLINKERROR, (UDATA*)detailMessage);
+	}
 }
 
 

--- a/runtime/vm/resolvefield.cpp
+++ b/runtime/vm/resolvefield.cpp
@@ -147,7 +147,9 @@ findField(J9VMThread *vmStruct, J9Class *clazz, U_8 *fieldName, UDATA fieldNameL
 			(const U_8 *) ".", 1,
 			fieldName, fieldNameLength, 
 			NULL, 0);
-		setCurrentException(vmStruct, J9VMCONSTANTPOOL_JAVALANGNOSUCHFIELDERROR, (UDATA*)message);
+		if (NULL != message) {
+			setCurrentException(vmStruct, J9VMCONSTANTPOOL_JAVALANGNOSUCHFIELDERROR, (UDATA*)message);
+		}
 	}
 
 	return NULL;

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -1641,7 +1641,9 @@ resolveVirtualMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA c
 				if (0 == vTableOffset) {
 					if (throwException) {
 						j9object_t errorString = methodToString(vmStruct, method);
-						setCurrentException(vmStruct, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, (UDATA *)errorString);
+						if (NULL != errorString) {
+							setCurrentException(vmStruct, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, (UDATA *)errorString);
+						}
 					}
 				} else {
 					if (ramCPEntry != NULL) {

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -498,7 +498,9 @@ catUtfToString4(J9VMThread * vmThread, const U_8 *data1, UDATA length1, const U_
 	j9object_t result = NULL;
 	UDATA totalLength = length1 + length2 + length3 + length4;
 	U_8 *buffer = (U_8*)j9mem_allocate_memory(totalLength, OMRMEM_CATEGORY_VM);
-	if (NULL != buffer) {
+	if (NULL == buffer) {
+		vmThread->javaVM->internalVMFunctions->setNativeOutOfMemoryError(vmThread, 0, 0);
+	} else {
 		U_8 *ptr = buffer;
 		memcpy(ptr, data1, length1);
 		ptr += length1;


### PR DESCRIPTION
catUTFToString4 will now set native OOM if it fails to allocate memory,
so that an exception will always be pending if NULL is returned. Update
callers to respect the OOM.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>