### PR TITLE
Loosen well known classes restriction

### DIFF
--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -198,7 +198,7 @@ void
 TR::SymbolValidationManager::populateWellKnownClasses()
    {
 #define WELL_KNOWN_CLASS_COUNT 9
-#define REQUIRED_WELL_KNOWN_CLASS_COUNT 1
+#define REQUIRED_WELL_KNOWN_CLASS_COUNT 0
 
    // Classes must have names only allowed to be defined by the bootstrap loader
    // The first REQUIRED_WELL_KNOWN_CLASS_COUNT entries are required - if any is
@@ -284,6 +284,7 @@ TR::SymbolValidationManager::populateWellKnownClasses()
       _wellKnownClassChainOffsets != NULL,
       "Failed to store well-known classes' class chains");
 
+#undef REQUIRED_WELL_KNOWN_CLASS_COUNT
 #undef WELL_KNOWN_CLASS_COUNT
    }
 


### PR DESCRIPTION
When the SVM is enabled, there is a restriction that when building up
the list of well known classes, the compiler has to be able to
generate the class chains of the first N well known classes. N was
previously set to 1, which meant that regardless whether the class chain
existed for the remaining classes in the list of well known classes, the
class chain of the first class in the list had to exist. The first class
in the list is java/lang/Class.

It isn't clear why the restriction exists however. As it turns out,
jvmti agents exist that can redefine java/lang/Class, which means the
class chain for the redefined java/lang/Class may not exist if a new
J9ROMClass is created for the redefined class. The consequence of this
is that all AOT compilations will fail.

The well known classes are an optimization which reduces the number of
validation records needed. Therefore, by loosening the restriction of
needing the class chains of the first N well known classes to exist
allows AOT compilations in workloads where an agent may redefine some of
these classes.