### PR TITLE
JITServer: Eliminate cpu.getProcessorDescription() remote override

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8514,7 +8514,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
          if (that->_methodBeingCompiled->isOutOfProcessCompReq())
             {
             // Customize target.cpu based on the processor description fetched from the client
-            OMRProcessorDesc JITClientProcessorDesc = TR::Compiler->target.cpu.getProcessorDescription();
+            OMRProcessorDesc JITClientProcessorDesc = that->getClientData()->getOrCacheVMInfo(that->_methodBeingCompiled->_stream)->_processorDescription;
             target.cpu = TR::CPU::customize(JITClientProcessorDesc);
             }
          else

--- a/runtime/compiler/env/J9CPU.cpp
+++ b/runtime/compiler/env/J9CPU.cpp
@@ -24,25 +24,25 @@
 #pragma csect(STATIC,"J9J9CPU#S")
 #pragma csect(TEST,"J9J9CPU#T")
 
-#include "control/CompilationRuntime.hpp"
-#include "env/CompilerEnv.hpp"
 #include "env/CPU.hpp"
 #include "env/VMJ9.h"
+#include "infra/Assert.hpp"                         // for TR_ASSERT
 
 OMRProcessorDesc J9::CPU::_supportedFeatureMasks = {OMR_PROCESSOR_UNDEFINED, OMR_PROCESSOR_UNDEFINED, {}};
 bool J9::CPU::_isSupportedFeatureMasksEnabled = false;
 
-OMRProcessorDesc
-J9::CPU::getProcessorDescription()
+const char *
+J9::CPU::getProcessorVendorId() 
    {
-#if defined(J9VM_OPT_JITSERVER)
-   if (auto stream = TR::CompilationInfo::getStream())
-      {
-      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
-      return vmInfo->_processorDescription;
-      }
-#endif /* defined(J9VM_OPT_JITSERVER) */
-   return _processorDescription;
+   TR_ASSERT_FATAL(false, "Vendor ID not defined for this platform!");
+   return NULL;
+   }
+
+uint32_t 
+J9::CPU::getProcessorSignature()
+   {
+   TR_ASSERT_FATAL(false, "Processor Signature not defined for this platform!"); 
+   return 0;
    }
 
 void

--- a/runtime/compiler/env/J9CPU.hpp
+++ b/runtime/compiler/env/J9CPU.hpp
@@ -33,8 +33,6 @@ namespace J9 { typedef CPU CPUConnector; }
 #endif
 
 #include "env/OMRCPU.hpp"
-#include "j9port.h"
-#include "infra/Assert.hpp"                         // for TR_ASSERT
 
 namespace J9
 {
@@ -77,13 +75,11 @@ public:
     */
    static void enableFeatureMasks();
 
-   const char *getProcessorVendorId() { TR_ASSERT(false, "Vendor ID not defined for this platform!"); return NULL; }
-   uint32_t getProcessorSignature() { TR_ASSERT(false, "Processor Signature not defined for this platform!"); return 0; }
-
-   OMRProcessorDesc getProcessorDescription();
    bool supportsFeature(uint32_t feature);
+   
+   const char *getProcessorVendorId();
+   uint32_t getProcessorSignature();
    };
 }
-
 
 #endif


### PR DESCRIPTION
Currently there is an inconsistency in the design where `cpu.getProcessorDescription()` always goes to `vmInfo` to grab processor info in JITServer mode. With the cross-compilation design in place, `cpu` should already contain what's needed in its member fields. I want to eliminate this inconsistency by removing the "JITServer remote override" to `cpu.getProcessorDescription()` and follow what has been done for the cross-compilation design. Additional benefit of this is that it also eliminates the thread local read performed by the "JITServer remote override"

Signed-off-by: Harry Yu <harryyu1994@gmail.com>