### PR TITLE
Detect incomplete ELF core files

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELF32FileReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELF32FileReader.java
@@ -56,14 +56,14 @@ import com.ibm.j9ddr.corereaders.InvalidDumpFormatException;
 
 public class ELF32FileReader extends ELFFileReader {
 
-	public ELF32FileReader(File file, ByteOrder byteOrder, long offset)
+	public ELF32FileReader(File file, ByteOrder byteOrder)
 			throws IOException, InvalidDumpFormatException {
-		super(file, byteOrder, offset);
+		super(file, byteOrder);
 	}
 
-	public ELF32FileReader(ImageInputStream in, long offset)
+	public ELF32FileReader(ImageInputStream in, long offset, long limit)
 			throws IOException, InvalidDumpFormatException {
-		super(in, offset);
+		super(in, offset, limit);
 	}
 
 	public boolean validDump(byte[] data, long filesize) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELF32FileReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELF32FileReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2014 IBM Corp. and others
+ * Copyright (c) 2004, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,6 @@
 package com.ibm.j9ddr.corereaders.elf;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -34,48 +33,45 @@ import javax.imageio.stream.ImageInputStream;
 import com.ibm.j9ddr.corereaders.InvalidDumpFormatException;
 
 /*
- * 32-bit Elf header
+ * ELF 32-bit header
  *
- *	typedef struct
- *	{
- *	  unsigned char e_ident[EI_NIDENT];     // Magic number and other info
- *	  Elf32_Half    e_type;                 // Object file type
- *	  Elf32_Half    e_machine;              // Architecture
- *	  Elf32_Word    e_version;              // Object file version
- *	  Elf32_Addr    e_entry;                // Entry point virtual address
- *	  Elf32_Off     e_phoff;                // Program header table file offset
- *	  Elf32_Off     e_shoff;                // Section header table file offset
- *	  Elf32_Word    e_flags;                // Processor-specific flags
- *	  Elf32_Half    e_ehsize;               // ELF header size in bytes
- *	  Elf32_Half    e_phentsize;            // Program header table entry size
- *	  Elf32_Half    e_phnum;                // Program header table entry count
- *	  Elf32_Half    e_shentsize;            // Section header table entry size
- *	  Elf32_Half    e_shnum;                // Section header table entry count
- *	  Elf32_Half    e_shstrndx;             // Section header string table index
- *	} Elf32_Ehdr;
+ * typedef struct
+ * {
+ *   unsigned char e_ident[EI_NIDENT]; // Magic number and other info
+ *   Elf32_Half    e_type;             // Object file type
+ *   Elf32_Half    e_machine;          // Architecture
+ *   Elf32_Word    e_version;          // Object file version
+ *   Elf32_Addr    e_entry;            // Entry point virtual address
+ *   Elf32_Off     e_phoff;            // Program header table file offset
+ *   Elf32_Off     e_shoff;            // Section header table file offset
+ *   Elf32_Word    e_flags;            // Processor-specific flags
+ *   Elf32_Half    e_ehsize;           // ELF header size in bytes
+ *   Elf32_Half    e_phentsize;        // Program header table entry size
+ *   Elf32_Half    e_phnum;            // Program header table entry count
+ *   Elf32_Half    e_shentsize;        // Section header table entry size
+ *   Elf32_Half    e_shnum;            // Section header table entry count
+ *   Elf32_Half    e_shstrndx;         // Section header string table index
+ * } Elf32_Ehdr;
  */
 
-public class ELF32FileReader extends ELFFileReader
-{
+public class ELF32FileReader extends ELFFileReader {
 
-	public ELF32FileReader(File f, ByteOrder byteOrder, long offset) throws FileNotFoundException, IOException, InvalidDumpFormatException
-	{
-		super(f, byteOrder, offset);
+	public ELF32FileReader(File file, ByteOrder byteOrder, long offset)
+			throws IOException, InvalidDumpFormatException {
+		super(file, byteOrder, offset);
 	}
 
-	public ELF32FileReader(ImageInputStream in, long offset) throws IOException, InvalidDumpFormatException
-	{
+	public ELF32FileReader(ImageInputStream in, long offset)
+			throws IOException, InvalidDumpFormatException {
 		super(in, offset);
 	}
-	
-	public boolean validDump(byte[] data, long filesize)
-	{
-		return (0x7F == data[0] && 0x45 == data[1] && 0x4C == data[2]
-				&& 0x46 == data[3] && ELFCLASS32 == data[4]);
+
+	public boolean validDump(byte[] data, long filesize) {
+		return (0x7F == data[0] && 0x45 == data[1] && 0x4C == data[2] && 0x46 == data[3] && ELFCLASS32 == data[4]);
 	}
 
-	protected ProgramHeaderEntry readProgramHeaderEntry() throws IOException
-	{
+	@Override
+	protected ProgramHeaderEntry readProgramHeaderEntry() throws IOException {
 		int type = is.readInt();
 		long fileOffset = unsigned(is.readInt());
 		long virtualAddress = unsigned(is.readInt());
@@ -84,49 +80,46 @@ public class ELF32FileReader extends ELFFileReader
 		long memorySize = unsigned(is.readInt());
 		int flags = is.readInt();
 		long alignment = unsigned(is.readInt());
-		return new ProgramHeaderEntry(type, fileOffset, fileSize,
-				virtualAddress, physicalAddress, memorySize, flags, alignment,
-				this);
+		return new ProgramHeaderEntry(type, fileOffset, fileSize, virtualAddress, physicalAddress, memorySize, flags,
+				alignment, this);
 	}
 
-	private long unsigned(int i)
-	{
+	private static long unsigned(int i) {
 		return i & 0xffffffffL;
 	}
 
-	protected long padToWordBoundary(long l)
-	{
-		return ((l + 3) / 4) * 4;
+	@Override
+	protected long padToWordBoundary(long l) {
+		return (l + 3) & ~3;
 	}
 
-	protected long readElfWord() throws IOException
-	{
+	@Override
+	protected long readElfWord() throws IOException {
 		return is.readInt() & 0xffffffffL;
 	}
 
-	protected Address readElfWordAsAddress() throws IOException
-	{
+	@Override
+	protected Address readElfWordAsAddress() throws IOException {
 		return new Address32(is.readInt());
 	}
 
-	protected int addressSizeBits()
-	{
+	@Override
+	protected int addressSizeBits() {
 		return 32;
 	}
 
-	protected List<ELFSymbol> readSymbolsAt(SectionHeaderEntry entry)
-			throws IOException {
+	@Override
+	protected List<ELFSymbol> readSymbolsAt(SectionHeaderEntry entry) throws IOException {
 		// The size of an entry is 16 bytes, entry.size must be a multiple of that
 		// or we know this SectionHeaderEntry is corrupt.
-		if (0 != entry.size % 16l) {
+		if (0 != entry.size % 16L) {
 			return Collections.emptyList();
 		}
 		seek(entry.offset);
-		long count = entry.size / 16l;
 		// maximum 8096 symbols, for protection against excessive or infinite
 		// loops in corrupt dumps, catch corrupt negative counts with abs.
-		count = Math.min(Math.abs(count), 8096);
-		List<ELFSymbol> symbols = new ArrayList<ELFSymbol>((int)count);
+		int count = (int) Math.min(Math.abs(entry.size / 16L), 8096);
+		List<ELFSymbol> symbols = new ArrayList<>(count);
 		for (long i = 0; i < count; i++) {
 			long name = is.readInt() & 0xffffffffL;
 			long value = is.readInt() & 0xffffffffL;
@@ -134,9 +127,9 @@ public class ELF32FileReader extends ELFFileReader
 			byte info = is.readByte();
 			byte other = is.readByte();
 			int sectionIndex = is.readShort() & 0xffff;
-			symbols.add(new ELFSymbol(name, value, size, info, other,
-					sectionIndex));
+			symbols.add(new ELFSymbol(name, value, size, info, other, sectionIndex));
 		}
 		return symbols;
 	}
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELF64FileReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELF64FileReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 IBM Corp. and others
+ * Copyright (c) 2009, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,6 @@
 package com.ibm.j9ddr.corereaders.elf;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -34,53 +33,49 @@ import javax.imageio.stream.ImageInputStream;
 import com.ibm.j9ddr.corereaders.InvalidDumpFormatException;
 
 /*
- * Elf 64-bit header
- * 
- *	typedef struct
- *	{
- *	  unsigned char e_ident[EI_NIDENT];     // Magic number and other info
- *	  Elf64_Half    e_type;                 // Object file type
- *	  Elf64_Half    e_machine;              // Architecture
- *	  Elf64_Word    e_version;              // Object file version
- *	  Elf64_Addr    e_entry;                // Entry point virtual address
- *	  Elf64_Off     e_phoff;                // Program header table file offset
- *	  Elf64_Off     e_shoff;                // Section header table file offset
- *	  Elf64_Word    e_flags;                // Processor-specific flags
- *	  Elf64_Half    e_ehsize;               // ELF header size in bytes
- *	  Elf64_Half    e_phentsize;            // Program header table entry size
- *	  Elf64_Half    e_phnum;                // Program header table entry count
- *	  Elf64_Half    e_shentsize;            // Section header table entry size
- *	  Elf64_Half    e_shnum;                // Section header table entry count
- *	  Elf64_Half    e_shstrndx;             // Section header string table index
- *	} Elf64_Ehdr;
+ * ELF 64-bit header
+ *
+ * typedef struct
+ * {
+ *   unsigned char e_ident[EI_NIDENT]; // Magic number and other info
+ *   Elf64_Half    e_type;             // Object file type
+ *   Elf64_Half    e_machine;          // Architecture
+ *   Elf64_Word    e_version;          // Object file version
+ *   Elf64_Addr    e_entry;            // Entry point virtual address
+ *   Elf64_Off     e_phoff;            // Program header table file offset
+ *   Elf64_Off     e_shoff;            // Section header table file offset
+ *   Elf64_Word    e_flags;            // Processor-specific flags
+ *   Elf64_Half    e_ehsize;           // ELF header size in bytes
+ *   Elf64_Half    e_phentsize;        // Program header table entry size
+ *   Elf64_Half    e_phnum;            // Program header table entry count
+ *   Elf64_Half    e_shentsize;        // Section header table entry size
+ *   Elf64_Half    e_shnum;            // Section header table entry count
+ *   Elf64_Half    e_shstrndx;         // Section header string table index
+ * } Elf64_Ehdr;
  */
 
-public class ELF64FileReader extends ELFFileReader
-{
+public class ELF64FileReader extends ELFFileReader {
 
-	public ELF64FileReader(File f, ByteOrder byteOrder, long offset) throws FileNotFoundException, IOException, InvalidDumpFormatException
-	{
-		super(f,byteOrder, offset);
-	}
-	
-	public ELF64FileReader(File f, ByteOrder byteOrder) throws FileNotFoundException, IOException, InvalidDumpFormatException
-	{
-		super(f,byteOrder, 0);
+	public ELF64FileReader(File file, ByteOrder byteOrder, long offset)
+			throws IOException, InvalidDumpFormatException {
+		super(file, byteOrder, offset);
 	}
 
-	public ELF64FileReader(ImageInputStream in, long offset) throws IOException, InvalidDumpFormatException
-	{
+	public ELF64FileReader(File file, ByteOrder byteOrder)
+			throws IOException, InvalidDumpFormatException {
+		super(file, byteOrder, 0);
+	}
+
+	public ELF64FileReader(ImageInputStream in, long offset) throws IOException, InvalidDumpFormatException {
 		super(in, offset);
 	}
-	
-	public boolean validDump(byte[] data, long filesize)
-	{
-		return (0x7F == data[0] && 0x45 == data[1] && 0x4C == data[2]
-				&& 0x46 == data[3] && ELFCLASS64 == data[4]);
+
+	public boolean validDump(byte[] data, long filesize) {
+		return (0x7F == data[0] && 0x45 == data[1] && 0x4C == data[2] && 0x46 == data[3] && ELFCLASS64 == data[4]);
 	}
 
-	protected ProgramHeaderEntry readProgramHeaderEntry() throws IOException
-	{
+	@Override
+	protected ProgramHeaderEntry readProgramHeaderEntry() throws IOException {
 		int type = is.readInt();
 		int flags = is.readInt();
 		long fileOffset = is.readLong();
@@ -89,44 +84,41 @@ public class ELF64FileReader extends ELFFileReader
 		long fileSize = is.readLong();
 		long memorySize = is.readLong();
 		long alignment = is.readLong();
-		return new ProgramHeaderEntry(type, fileOffset, fileSize,
-				virtualAddress, physicalAddress, memorySize, flags, alignment,
-				this);
+		return new ProgramHeaderEntry(type, fileOffset, fileSize, virtualAddress, physicalAddress, memorySize, flags,
+				alignment, this);
 	}
 
-	protected long padToWordBoundary(long l)
-	{
-		return ((l + 7) / 8) * 8;
+	@Override
+	protected long padToWordBoundary(long l) {
+		return (l + 7) & ~7;
 	}
 
-	protected long readElfWord() throws IOException
-	{
+	@Override
+	protected long readElfWord() throws IOException {
 		return is.readLong();
 	}
 
-	protected Address readElfWordAsAddress() throws IOException
-	{
+	@Override
+	protected Address readElfWordAsAddress() throws IOException {
 		return new Address64(is.readLong());
 	}
 
-	protected int addressSizeBits()
-	{
+	@Override
+	protected int addressSizeBits() {
 		return 64;
 	}
 
-	protected List<ELFSymbol> readSymbolsAt(SectionHeaderEntry entry)
-			throws IOException {
+	protected List<ELFSymbol> readSymbolsAt(SectionHeaderEntry entry) throws IOException {
 		// The size of an entry is 24 bytes, entry.size must be a multiple of that
 		// or we know this SectionHeaderEntry is corrupt.
-		if (0 != entry.size % 24l) {
+		if (0 != entry.size % 24L) {
 			return Collections.emptyList();
 		}
 		seek(entry.offset);
-		long count = (int) (entry.size / 24l);
 		// maximum 8096 symbols, for protection against excessive or infinite
 		// loops in corrupt dumps, catch corrupt negative counts with abs.
-		count = Math.min(Math.abs(count), 8096);
-		List<ELFSymbol> symbols = new ArrayList<ELFSymbol>((int)count);
+		int count = (int) Math.min(Math.abs(entry.size / 24L), 8096);
+		List<ELFSymbol> symbols = new ArrayList<>(count);
 		for (long i = 0; i < count; i++) {
 			long name = is.readInt() & 0xffffffffL;
 			byte info = is.readByte();
@@ -134,9 +126,9 @@ public class ELF64FileReader extends ELFFileReader
 			int sectionIndex = is.readShort() & 0xffff;
 			long value = is.readLong();
 			long size = is.readLong();
-			symbols.add(new ELFSymbol(name, value, size, info, other,
-					sectionIndex));
+			symbols.add(new ELFSymbol(name, value, size, info, other, sectionIndex));
 		}
 		return symbols;
 	}
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELF64FileReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELF64FileReader.java
@@ -56,18 +56,14 @@ import com.ibm.j9ddr.corereaders.InvalidDumpFormatException;
 
 public class ELF64FileReader extends ELFFileReader {
 
-	public ELF64FileReader(File file, ByteOrder byteOrder, long offset)
-			throws IOException, InvalidDumpFormatException {
-		super(file, byteOrder, offset);
-	}
-
 	public ELF64FileReader(File file, ByteOrder byteOrder)
 			throws IOException, InvalidDumpFormatException {
-		super(file, byteOrder, 0);
+		super(file, byteOrder);
 	}
 
-	public ELF64FileReader(ImageInputStream in, long offset) throws IOException, InvalidDumpFormatException {
-		super(in, offset);
+	public ELF64FileReader(ImageInputStream in, long offset, long limit)
+			throws IOException, InvalidDumpFormatException {
+		super(in, offset, limit);
 	}
 
 	public boolean validDump(byte[] data, long filesize) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFDumpReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFDumpReader.java
@@ -43,10 +43,12 @@ import static com.ibm.j9ddr.corereaders.elf.ELFFileReader.NT_PRPSINFO;
 import static com.ibm.j9ddr.corereaders.elf.ELFFileReader.NT_PRSTATUS;
 import static java.util.logging.Level.FINER;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -88,27 +90,25 @@ import com.ibm.j9ddr.corereaders.osthread.OSStackFrame;
 import com.ibm.j9ddr.corereaders.osthread.Register;
 
 /**
- * 
- * 
  * @author andhall
- *
  */
-public abstract class ELFDumpReader implements ILibraryDependentCore
-{
-	private static final Logger logger = Logger.getLogger(com.ibm.j9ddr.corereaders.ICoreFileReader.J9DDR_CORE_READERS_LOGGER_NAME);
-	
+public abstract class ELFDumpReader implements ILibraryDependentCore {
+
+	private static final Logger logger = Logger
+			.getLogger(com.ibm.j9ddr.corereaders.ICoreFileReader.J9DDR_CORE_READERS_LOGGER_NAME);
+
 	/**
 	 * Setting this system property (to anything) will cause the dump reader
 	 * to only search for libraries that are present in the core file because
 	 * the process loaded them and not to use any that are separately on disk
 	 * *OR* attached to the end of the core file by the diagnostics collector.
-	 * 
+	 *
 	 * The system property name matches the field name, so it can be set with:
 	 * -Dcom.ibm.j9ddr.corereaders.elf.ELFDumpReader.USELOADEDLIBRARIES=true
 	 * at the command line.
-	 */ 
+	 */
 	public static final String USELOADEDLIBRARIES = "com.ibm.j9ddr.corereaders.elf.ELFDumpReader.USELOADEDLIBRARIES";
-	
+
 	/**
 	 * Setting this system property will cause the dump reader to retry searches
 	 * for Linux libraries without fully qualified names by prepending the specified
@@ -118,65 +118,63 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 	 * jextracted zip file.
 	 */
 	public static final String KNOWNLIBPATHS_PROPERTY = "com.ibm.j9ddr.corereaders.elf.ELFDumpReader.KNOWNLIBPATHS";
-	public static final String[] KNOWNLIBPATHS_DEFAULT_32 = {"/lib", "/usr/lib", "/usr/local/lib"};
-	public static final String[] KNOWNLIBPATHS_DEFAULT_64 = {"/lib64", "/usr/lib64", "/usr/local/lib64"};
-	
+	public static final String[] KNOWNLIBPATHS_DEFAULT_32 = { "/lib", "/usr/lib", "/usr/local/lib" };
+	public static final String[] KNOWNLIBPATHS_DEFAULT_64 = { "/lib64", "/usr/lib64", "/usr/local/lib64" };
+
 	private static final String[] KNOWNLIBPATHSGLOBAL;
 	private final String[] knownLibPaths;
-	
+
 	static {
 		String paths = System.getProperty(KNOWNLIBPATHS_PROPERTY);
-		if( paths != null ) {
+		if (paths != null) {
 			KNOWNLIBPATHSGLOBAL = paths.split(File.pathSeparator);
 		} else {
 			KNOWNLIBPATHSGLOBAL = null;
 		}
 	}
-	
+
 	protected final ELFFileReader _reader;
 	protected final LinuxProcessAddressSpace _process;
 	protected final ILibraryResolver _resolver;
-	
-	private List<DataEntry> _processEntries = new ArrayList<DataEntry>();
-	private List<DataEntry> _threadEntries = new ArrayList<DataEntry>();
-	private List<DataEntry> _auxiliaryVectorEntries = new ArrayList<DataEntry>();
-	private List<DataEntry> _highwordRegisterEntries = new ArrayList<DataEntry>();
+
+	private final List<DataEntry> _processEntries = new ArrayList<>();
+	private final List<DataEntry> _threadEntries = new ArrayList<>();
+	private final List<DataEntry> _auxiliaryVectorEntries = new ArrayList<>();
+	private final List<DataEntry> _highwordRegisterEntries = new ArrayList<>();
 	private int _pid;
 	private String _executableFileName;
 	private String _commandLine;
 	private String _executablePathOverride;
 	private int _signalNumber = -1;
-	
+
 	private IModule _executable;
 	private List<IModule> _modules;
 	private CorruptDataException _modulesException;
-	
-	private long _platformIdAddress = 0;
-	
-	private boolean useLoadedLibraries = false;
-	
-	//list to keep track of all the files that have been opened by this dump reader
-	private ArrayList<ELFFileReader> openFileTracker = new ArrayList<ELFFileReader>(); 
 
-	private Unwind unwinder = null;
-	
-	protected ELFDumpReader(ELFFileReader reader) throws IOException, InvalidDumpFormatException
-	{
+	private long _platformIdAddress;
+	private boolean useLoadedLibraries;
+
+	// list to keep track of all the files that have been opened by this dump reader
+	private ArrayList<ELFFileReader> openFileTracker = new ArrayList<>();
+
+	private Unwind unwinder;
+
+	protected ELFDumpReader(ELFFileReader reader) throws IOException, InvalidDumpFormatException {
 		_reader = reader;
 		_process = new LinuxProcessAddressSpace(_reader.addressSizeBits() / 8, _reader.getByteOrder(), this);
 		unwinder = new Unwind(_process);
-		if(reader.getFile() == null) {
+		if (reader.getFile() == null) {
 			_resolver = LibraryResolverFactory.getResolverForCoreFile(reader.getStream());
 		} else {
 			_resolver = LibraryResolverFactory.getResolverForCoreFile(reader.getFile());
 		}
-		
+
 		useLoadedLibraries = (System.getProperty(USELOADEDLIBRARIES) != null);
-		
-		if( KNOWNLIBPATHSGLOBAL != null ) {
+
+		if (KNOWNLIBPATHSGLOBAL != null) {
 			knownLibPaths = KNOWNLIBPATHSGLOBAL;
 		} else {
-			knownLibPaths = _reader.is64Bit()?KNOWNLIBPATHS_DEFAULT_64:KNOWNLIBPATHS_DEFAULT_32;
+			knownLibPaths = _reader.is64Bit() ? KNOWNLIBPATHS_DEFAULT_64 : KNOWNLIBPATHS_DEFAULT_32;
 		}
 		processProgramHeader();
 		processAuxiliaryHeader();
@@ -185,116 +183,110 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 			_executablePathOverride = System.getProperty(SYSTEM_PROP_EXE_PATH);
 			readModules();
 		} catch (Exception e) {
-			//Store it to throw later
+			// Store it to throw later
 			_modulesException = new CorruptDataException(e);
 		}
 	}
-	
+
 	public void close() throws IOException {
-		//close the handle to the dump
+		// close the handle to the dump
 		_reader.close();
-		//now close any open module handles
-		if((_executable != null) && (_executable instanceof ELFFileReader)) {
+		// now close any open module handles
+		if (_executable instanceof ELFFileReader) {
 			((ELFFileReader) _executable).is.close();
 		}
-		for(IModule module : _modules) {
-			if(module instanceof ELFFileReader) {
+		for (IModule module : _modules) {
+			if (module instanceof ELFFileReader) {
 				((ELFFileReader) module).is.close();
 			}
 		}
-		//close any tracked open files
-		for(ELFFileReader reader : openFileTracker) {
-			if(reader != null) {
+		// close any tracked open files
+		for (ELFFileReader reader : openFileTracker) {
+			if (reader != null) {
 				reader.close();
 			}
 		}
-		//release any resources acquired for library resolution
+		// release any resources acquired for library resolution
 		_resolver.dispose();
 	}
-	
-	public static ELFDumpReader getELFDumpReader(ELFFileReader reader) throws IOException, InvalidDumpFormatException
-	{		
+
+	public static ELFDumpReader getELFDumpReader(ELFFileReader reader) throws IOException, InvalidDumpFormatException {
 		switch (reader.getMachineType()) {
-		case (ARCH_IA32) :
+		case (ARCH_IA32):
 			return new ELFIA32DumpReader(reader);
-		case (ARCH_AMD64) :
+		case (ARCH_AMD64):
 			return new ELFAMD64DumpReader(reader);
-		case (ARCH_PPC32) :
+		case (ARCH_PPC32):
 			return new ELFPPC32DumpReader(reader);
-		case (ARCH_PPC64) :
+		case (ARCH_PPC64):
 			return new ELFPPC64DumpReader(reader);
-		case (ARCH_S390)  :
-			if(reader.is64Bit()) {
+		case (ARCH_S390):
+			if (reader.is64Bit()) {
 				return new ELFS39064DumpReader(reader);
 			} else {
 				return new ELFS39031DumpReader(reader);
 			}
-		case (ARCH_ARM) :
+		case (ARCH_ARM):
 			return new ELFARM32DumpReader(reader);
-		case (ARCH_AARCH64) :
+		case (ARCH_AARCH64):
 			return new ELFAArch64DumpReader(reader);
-		case (ARCH_RISCV64) :
+		case (ARCH_RISCV64):
 			return new ELFRISCV64DumpReader(reader);
 		default:
 			throw new IOException("Unrecognised machine type: " + reader.getMachineType());
 		}
 	}
-	
-	public static ELFDumpReader getELFDumpReader(File file) throws IOException, InvalidDumpFormatException
-	{
+
+	public static ELFDumpReader getELFDumpReader(File file) throws IOException, InvalidDumpFormatException {
 		ELFFileReader reader = ELFFileReader.getELFFileReader(file);
 		return getELFDumpReader(reader);
 	}
 
-	public static ELFDumpReader getELFDumpReader(ImageInputStream in) throws IOException, InvalidDumpFormatException
-	{
+	public static ELFDumpReader getELFDumpReader(ImageInputStream in) throws IOException, InvalidDumpFormatException {
 		ELFFileReader reader = ELFFileReader.getELFFileReader(in);
 		return getELFDumpReader(reader);
 	}
 
-	
-	public List<IAddressSpace> getAddressSpaces()
-	{
-		return Collections.singletonList((IAddressSpace)_process);
+	@Override
+	public List<IAddressSpace> getAddressSpaces() {
+		return Collections.singletonList((IAddressSpace) _process);
 	}
 
-	public String getDumpFormat()
-	{
+	@Override
+	public String getDumpFormat() {
 		return "ELF";
 	}
 
-	public Platform getPlatform()
-	{
+	@Override
+	public Platform getPlatform() {
 		return Platform.LINUX;
 	}
 
-	public Properties getProperties()
-	{
+	@Override
+	public Properties getProperties() {
 		Properties props = new Properties();
-		
+
 		props.setProperty(ICore.SYSTEM_TYPE_PROPERTY, "Linux");
-		props.setProperty(ICore.PROCESSOR_TYPE_PROPERTY,getProcessorType());
-		props.setProperty(ICore.PROCESSOR_SUBTYPE_PROPERTY,getProcessorSubType());
-		
+		props.setProperty(ICore.PROCESSOR_TYPE_PROPERTY, getProcessorType());
+		props.setProperty(ICore.PROCESSOR_SUBTYPE_PROPERTY, getProcessorSubType());
+
 		return props;
 	}
 
-	public String getCommandLine() throws CorruptDataException
-	{
+	public String getCommandLine() throws CorruptDataException {
 		return _commandLine;
 	}
 
-	private void readProcessData() throws IOException
-	{
+	private void readProcessData() throws IOException {
 		if (_processEntries.size() == 0) {
 			throw new IOException("No process entries found in Elf file.");
 		} else if (_processEntries.size() != 1) {
-			throw new IOException("Unexpected number of process entries found in ELF file. Expected 1, found " + _processEntries.size());
+			throw new IOException("Unexpected number of process entries found in ELF file. Expected 1, found "
+					+ _processEntries.size());
 		}
-		
+
 		DataEntry entry = _processEntries.get(0);
-		
-		
+
 		_reader.seek(entry.offset);
 		_reader.readByte(); // Ignore state
 		_reader.readByte(); // Ignore sname
@@ -305,151 +297,149 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 		readUID(); // Ignore uid
 		readUID(); // Ignore gid
 		_pid = _reader.readInt();
-				
+
 		_reader.readInt(); // Ignore ppid
 		_reader.readInt(); // Ignore pgrp
 		_reader.readInt(); // Ignore sid
-		
+
 		// Ignore filler. Command-line is last 80 bytes (defined by ELF_PRARGSZ
 		// in elfcore.h).
 		// Command-name is 16 bytes before command-line.
 		_reader.seek(entry.offset + entry.size - 96);
-		_executableFileName = new String(_reader.readBytes(16), "ASCII").trim(); // Ignore command
-		try {	
-			_commandLine = new String(_reader.readBytes(ELF_PRARGSZ),"ASCII").trim();
-		} catch (UnsupportedEncodingException ex) {
-			throw new RuntimeException(ex);
-		}
+		_executableFileName = new String(_reader.readBytes(16), StandardCharsets.US_ASCII).trim(); // Ignore command
+		_commandLine = new String(_reader.readBytes(ELF_PRARGSZ), StandardCharsets.US_ASCII).trim();
 	}
 
 	/**
 	 * Read all modules in the core file, where "modules" = the executable and all
 	 * shared libraries. Put the executable into _executable and the libraries without
-	 * the executable into _modules. 
+	 * the executable into _modules.
 	 * <p>
 	 * Find libraries by two methods: iterating through all the segments in the core
-	 * file looking for which are libraries and iterating through the debug information 
-	 * within the executable. We may find the executable either on disk, within the 
-	 * core file as one of the loaded segments, or appended to the core file by 
-	 * library collections. Consolidate the list of libraries that we find from the 
-	 * debug information with the list from the core file to build the best list possible. 
+	 * file looking for which are libraries and iterating through the debug information
+	 * within the executable. We may find the executable either on disk, within the
+	 * core file as one of the loaded segments, or appended to the core file by
+	 * library collections. Consolidate the list of libraries that we find from the
+	 * debug information with the list from the core file to build the best list possible.
 	 * <p>
-	 * When constructing the module objects, use the best available data. This means using 
-	 * the section header information from the collected libraries if present since this 
-	 * is always more reliable than that in the core file.  
+	 * When constructing the module objects, use the best available data. This means using
+	 * the section header information from the collected libraries if present since this
+	 * is always more reliable than that in the core file.
 	 *
 	 * @throws IOException
 	 */
 
 	/* In a second comment to avoid it appearing in hovertext
-	 * 
+	 *
 	 * This method is called under at least two completely different circumstances:
-	 * 
+	 *
 	 * Circumstance 1 - called during library collection when there are not yet any collected libraries
-	 * appended to the core file. In this case all that is really wanted is a list of the 
-	 * names of the libraries to guide the collection but this method does not discriminate and 
-	 * constructs everything possible, reading section header tables and symbol tables and so on. 
-	 * In this case the aim is to return the most complete list of modules, examining both the 
-	 * modules within the core file and the list that can be found from the debug data in the 
-	 * executable. 
-	 *  
+	 * appended to the core file. In this case all that is really wanted is a list of the
+	 * names of the libraries to guide the collection but this method does not discriminate and
+	 * constructs everything possible, reading section header tables and symbol tables and so on.
+	 * In this case the aim is to return the most complete list of modules, examining both the
+	 * modules within the core file and the list that can be found from the debug data in the
+	 * executable.
+	 *
 	 * Circumstance 2 - called when it is important to have the best possible information about
-	 * each module - as for example when called from jdmpview. In this case the collected libraries 
-	 * may or may not be appended to the core file but if they are then the section header information 
-	 * is always better when taken from the collected library so the modules should be constructed 
-	 * from the them. 
-	 * 
+	 * each module - as for example when called from jdmpview. In this case the collected libraries
+	 * may or may not be appended to the core file but if they are then the section header information
+	 * is always better when taken from the collected library so the modules should be constructed
+	 * from the them.
+	 *
 	 * The reason it is important to keep an eye on both circumstances is that they affect one another.
 	 * In circumstance 1, some of the constructed modules are of poor quality because the original library is not
 	 * available. In circumstance 2, whether or not the library will be found appended to the core file
-	 * depends on whether it was found and returned in circumstance 1. 
-	 * 
-	 * TODO refactor so that the code paths for the two circumstances are not so entwined. Separate out the 
+	 * depends on whether it was found and returned in circumstance 1.
+	 *
+	 * TODO refactor so that the code paths for the two circumstances are not so entwined. Separate out the
 	 * two functions of gathering the list of names of which libraries exist, needed for both circumstances, and constructing
-	 * the best possible image of each library, using core and collected library, only needed for the second circumstance. 
-	 * 
-	 * There are three sorts of module, too. 
+	 * the best possible image of each library, using core and collected library, only needed for the second circumstance.
+	 *
+	 * There are three sorts of module, too.
 	 * 1. Those found only via the program header table of the core file. This includes most of the system
-	 * libraries e.g. ld-linux.so.2. These only have the library name, no path, because they are found from 
+	 * libraries e.g. ld-linux.so.2. These only have the library name, no path, because they are found from
 	 * the SOname within the module.
 	 * 2. Those found only via the debug data in the executable. This can include several of the j9 libraries.
 	 * They are present within the core file but the route to the SOname is broken somehow
-	 * 3. Those found both ways - most of the j9 libraries are in this case. However note that the 
-	 * names will be different because the names found via the debug data are full pathnames and the 
+	 * 3. Those found both ways - most of the j9 libraries are in this case. However note that the
+	 * names will be different because the names found via the debug data are full pathnames and the
 	 * names found via the SOname is just the library name. However they can be matched up via the load
-	 * address which is available on both routes. 
-	 * 
+	 * address which is available on both routes.
+	 *
 	 * There are a some oddities too:
 	 * 1. the executable always appears in the core file with a SOname of "lib.so"
-	 * 2. The core file always contains a library called linux-gate.so which does not correspond to 
+	 * 2. The core file always contains a library called linux-gate.so which does not correspond to
 	 * a file on disk
-	 * 3. Sometimes the same file - e.g. libvmi.so, and the executable itself - will be mapped into memory 
-	 * twice or more at different addresses so the same name will appear more than once in the 
+	 * 3. Sometimes the same file - e.g. libvmi.so, and the executable itself - will be mapped into memory
+	 * twice or more at different addresses so the same name will appear more than once in the
 	 * list from the core file.
 	 */
-	
-	private void readModules() throws IOException
-	{
+
+	private void readModules() throws IOException {
 		if (_executable == null || _executable instanceof MissingFileModule) {
 			_modulesException = null;
-			_modules = new LinkedList<IModule>();
+			_modules = new LinkedList<>();
 			readProcessData();
-			// Try to find the executable image either on disk or appended to the core file by library collection. 
-			// If we can we will probably also find the libraries on disk or appended to the core file and will 
-			// therefore get good section header tables. 
+			// Try to find the executable image either on disk or appended to the core file by library collection.
+			// If we can we will probably also find the libraries on disk or appended to the core file and will
+			// therefore get good section header tables.
 			// Otherwise use the copy of the executable within the core file. It may contain some of the library info
 			// so it makes a good fallback.
 			LibraryDataSource executableFile = findExecutableOnDiskOrAppended();
 			ELFFileReader executableELF = null;
 
-			if (executableFile != null && executableFile.getType() != LibraryDataSource.Source.NOT_FOUND && !useLoadedLibraries) {
+			if (executableFile != null && executableFile.getType() != LibraryDataSource.Source.NOT_FOUND
+					&& !useLoadedLibraries) {
 				try {
 					executableELF = getELFReaderFromDataSource(executableFile);
 				} catch (InvalidDumpFormatException e) {
-					//Not an ELF file.
+					// Not an ELF file.
 				}
 				if (null != executableELF) {
 					createAllModules(executableELF, executableFile.getName());
 				}
-			} else if( _executable instanceof MissingFileModule) {
+			} else if (_executable instanceof MissingFileModule) {
 				logger.log(Level.FINE, "Libraries unavailable, falling back to loaded modules within the core file.");
 				executableELF = getELFReaderForExecutableWithinCoreFile();
 				if (null != executableELF) {
 					createAllModules(executableELF, _executablePathOverride);
 				} else {
-					_executable = new MissingFileModule(_process, _executableFileName, Collections.<IMemoryRange>emptyList());
+					_executable = new MissingFileModule(_process, _executableFileName,
+							Collections.<IMemoryRange>emptyList());
 				}
 			} else {
-				_executable = new MissingFileModule(_process, _executableFileName, Collections.<IMemoryRange>emptyList());
+				_executable = new MissingFileModule(_process, _executableFileName,
+						Collections.<IMemoryRange>emptyList());
 			}
 		}
 	}
 
 	/**
-	 * Gather all of the information about all of the modules in the core file and fill in the _executable and _modules 
-	 * instance variables. 
+	 * Gather all of the information about all of the modules in the core file and fill in the _executable and _modules
+	 * instance variables.
 	 * <p>
-	 *  The name and a reader for the executable need to be passed in as there is special handling for the executable: not only must it
-	 *  be removed from the list of libraries since it is special, but also the name is needed so that when we come across a modules
-	 *  with a name of "lib.so" the name of the executable can be put in instead. 
+	 * The name and a reader for the executable need to be passed in as there is special handling for the executable: not only must it
+	 * be removed from the list of libraries since it is special, but also the name is needed so that when we come across a modules
+	 * with a name of "lib.so" the name of the executable can be put in instead.
 	 * <p>
-	 * Gather the full set of libraries using both the debug data in the executable and the list of segments from 
-	 * the program header table in the core file. 
+	 * Gather the full set of libraries using both the debug data in the executable and the list of segments from
+	 * the program header table in the core file.
 	 * <p>
 	 * When constructing the module objects, use the copies of the module from disk or appended to the core file for their
 	 * section info, if it is available. It is invariably better than that in the core file which may have been overwritten.
 	 * <p>
 	 * When constructing the module objects, use the name of the module from the debug data if there is a choice, since
-	 * the debug data always has full path names. Full path names are needed for accurate library collection. 
+	 * the debug data always has full path names. Full path names are needed for accurate library collection.
 	 * <p>
-	 * During library collection or when using jdmpview with a core file which does not have libraries appended, the best module 
-	 * object will be constructed using data from both sources: the full path name from the 
-	 * debug data but the section and symbol information from what is available in the core file. 
+	 * During library collection or when using jdmpview with a core file which does not have libraries appended, the best module
+	 * object will be constructed using data from both sources: the full path name from the
+	 * debug data but the section and symbol information from what is available in the core file.
 	 * <p>
 	 * The overall logic is to gather all of the names from the debug data and to gather readers for all of the library files
-	 * within the core file, all indexed and sorted by virtual address, then to do a two-way merge on address and 
-	 * create the module objects with the best data available. 
-	 *  
+	 * within the core file, all indexed and sorted by virtual address, then to do a two-way merge on address and
+	 * create the module objects with the best data available.
+	 *
 	 * @param ELFFileReader for the executable
 	 * @param executable name
 	 * @throws IOException
@@ -460,25 +450,25 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 		 * while loading but not once loaded. If we have a disk version of the library we can pull in the
 		 * section header table from that (as well as the symbols as those sections may not be loaded either).
 		 */
-		List<IModule> allModules = new LinkedList<IModule>();
+		List<IModule> allModules = new LinkedList<>();
 		long executableBaseAddress = executableELF.getBaseAddress();
-		
+
 		Map<Long, ELFFileReader> inCoreReaders = getElfReadersForModulesWithinCoreFile(executableELF, executableName);
-		Map<Long, String> libraryNamesFromDebugData = readLibraryNamesFromDebugData(executableELF,
-				inCoreReaders, executableELF);
-		
-		for( Map.Entry<Long, ELFFileReader> entry: inCoreReaders.entrySet() ) {
+		Map<Long, String> libraryNamesFromDebugData = readLibraryNamesFromDebugData(executableELF, inCoreReaders,
+				executableELF);
+
+		for (Map.Entry<Long, ELFFileReader> entry : inCoreReaders.entrySet()) {
 			long coreFileAddress = entry.getKey();
 			ELFFileReader inCoreReader = entry.getValue();
 			String moduleName = inCoreReader.readSONAME(_reader);
 			/* A module name of lib.so apparently really means the executable. */
-			if( "lib.so".equals(moduleName) ) {
+			if ("lib.so".equals(moduleName)) {
 				moduleName = executableName;
 			}
 			String debugName = libraryNamesFromDebugData.get(coreFileAddress);
 			ELFFileReader readerForModuleOnDiskOrAppended = null;
 			/* Is there an entry in the debug data for this module? */
-			if( debugName != null ) {
+			if (debugName != null) {
 				moduleName = debugName;
 				readerForModuleOnDiskOrAppended = getReaderForModuleOnDiskOrAppended(debugName);
 			} else {
@@ -487,38 +477,40 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 			/* Patch up this modules section header table with the one from the disk version before we
 			 * create the module.
 			 */
-			if ( !inCoreReader.isCompatibleWith( readerForModuleOnDiskOrAppended ) ) {
+			if (!inCoreReader.isCompatibleWith(readerForModuleOnDiskOrAppended)) {
 				// Can we use the on disk reader so we can use it to get missing data.
 				readerForModuleOnDiskOrAppended = null;
 			}
-			IModule module = createModuleFromElfReader(coreFileAddress , moduleName, inCoreReader, readerForModuleOnDiskOrAppended);
-			if( module != null ) {
-				allModules.add(module);				
+			IModule module = createModuleFromElfReader(coreFileAddress, moduleName, inCoreReader,
+					readerForModuleOnDiskOrAppended);
+			if (module != null) {
+				allModules.add(module);
 			}
 		}
-		
+
 		// TODO - Sort modules. For the sake of tidiness.
 		_modules.addAll(allModules);
 		ELFFileReader readerForExectuableOnDiskOrAppended = getReaderForModuleOnDiskOrAppended(executableName);
-		_executable = createModuleFromElfReader(executableBaseAddress, executableName, executableELF, readerForExectuableOnDiskOrAppended);
+		_executable = createModuleFromElfReader(executableBaseAddress, executableName, executableELF,
+				readerForExectuableOnDiskOrAppended);
 	}
-	
+
 	/**
 	 * Make a best effort to find the program header table entry in the core file for the executable.
-	 * Do this by working through all the loadable entries, looking for the first  
-	 * one that says in the elf header that it is for an executable. 
-	 *  
+	 * Do this by working through all the loadable entries, looking for the first
+	 * one that says in the elf header that it is for an executable.
+	 *
 	 * @return a reader for the executable
 	 */
 	private ELFFileReader getELFReaderForExecutableWithinCoreFile() {
 		for (ProgramHeaderEntry entry : _reader.getProgramHeaderEntries()) {
-			if( !entry.isLoadable() ) {
+			if (!entry.isLoadable()) {
 				continue;
 			}
 			ELFFileReader elfReader;
 			try {
 				elfReader = ELFFileReader.getELFFileReaderWithOffset(_reader.getStream(), entry.fileOffset);
-				if( elfReader.isExecutable() ) {
+				if (elfReader.isExecutable()) {
 					return elfReader;
 				}
 			} catch (IOException e) {
@@ -529,68 +521,71 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Iterate through the program header table of the core file constructing an ELFFileReader for
 	 * everything that is loadable and is in ELF format. Insert each into a map where they are indexed by base address.
-	 * 
+	 *
 	 * @return map BaseAddress -> ELFFileReader
 	 */
-	private TreeMap<Long, ELFFileReader> getElfReadersForModulesWithinCoreFile(ELFFileReader executableELF, String executableName) {
-		TreeMap<Long,ELFFileReader> moduleReadersByBaseAddress = new TreeMap<Long,ELFFileReader>();
-//		System.out.println("dumping program header table");
-//		for (ProgramHeaderEntry entry : _reader.getProgramHeaderEntries()) {
-//			System.out.printf("offset %x address %x, type %d\n",entry.fileOffset,entry.virtualAddress, entry._type);
-//		}
-		
+	private TreeMap<Long, ELFFileReader> getElfReadersForModulesWithinCoreFile(ELFFileReader executableELF,
+			String executableName) {
+		TreeMap<Long, ELFFileReader> moduleReadersByBaseAddress = new TreeMap<>();
+		// System.out.println("dumping program header table");
+		// for (ProgramHeaderEntry entry : _reader.getProgramHeaderEntries()) {
+		//     System.out.printf("offset %x address %x, type %d\n",entry.fileOffset,entry.virtualAddress, entry._type);
+		// }
+
 		for (ProgramHeaderEntry entry : _reader.getProgramHeaderEntries()) {
-			if( !entry.isLoadable() || entry.fileSize == 0 ) {
+			if (!entry.isLoadable() || entry.fileSize == 0) {
 				continue;
 			}
 			try {
-//				System.err.printf("Getting internal reader for %s, virtual address 0x%x, file offset 0x%x\n", executableName, entry.virtualAddress, entry.fileOffset );
+				// System.err.printf("Getting internal reader for %s, virtual address 0x%x, file offset 0x%x\n", executableName, entry.virtualAddress, entry.fileOffset );
 				ELFFileReader loadedElf = getReaderFromOffsetWithinCoreFile(_reader.getStream(), entry.fileOffset);
 				if (loadedElf != null) {
-					moduleReadersByBaseAddress.put(entry.virtualAddress,loadedElf);						
+					moduleReadersByBaseAddress.put(entry.virtualAddress, loadedElf);
 				}
 			} catch (IOException e) {
-				logger.log(Level.FINER,"IOException reading module from: " + _reader.getSourceName()
-						+ " @ " + Long.toHexString(entry.fileOffset));
-			}				
+				logger.log(Level.FINER, "IOException reading module from: " + _reader.getSourceName() + " @ "
+						+ Long.toHexString(entry.fileOffset));
+			}
 		}
 		return moduleReadersByBaseAddress;
 	}
-	
-	private ELFFileReader getELFReaderFromDataSource(LibraryDataSource source) throws IOException, InvalidDumpFormatException {
+
+	private ELFFileReader getELFReaderFromDataSource(LibraryDataSource source)
+			throws IOException, InvalidDumpFormatException {
 		ELFFileReader executableELF = null;
-		switch(source.getType()) {
-			case FILE :
-				executableELF = ELFFileReader.getELFFileReader(source.getFile());
-				break;
-			case STREAM :
-				executableELF = ELFFileReader.getELFFileReader(source.getStream());
-				break;
+		switch (source.getType()) {
+		case FILE:
+			executableELF = ELFFileReader.getELFFileReader(source.getFile());
+			break;
+		case STREAM:
+			executableELF = ELFFileReader.getELFFileReader(source.getStream());
+			break;
+		default:
+			break;
 		}
 		openFileTracker.add(executableELF);
 		return executableELF;
 	}
-	
+
 	/**
-	 * Use the debug data pointed at by the executable's dynamic table to get a list of the libraries. 
-	 * The debug data is supposed to point to all the libraries that the executable uses. 
+	 * Use the debug data pointed at by the executable's dynamic table to get a list of the libraries.
+	 * The debug data is supposed to point to all the libraries that the executable uses.
 	 * <p>
 	 * @param executableELF a reader to the executable - could be on disk, could be appended to the core file, could be within the core file
 	 * @param map of base Address to readers for the modules within the core file
 	 * @param reader for the core file as a whole
-	 * @return TreeMap of Long -> String - map from base address to the library name 
+	 * @return TreeMap of Long -> String - map from base address to the library name
 	 * @throws IOException
 	 */
-	private Map<Long, String> readLibraryNamesFromDebugData(ELFFileReader executableELF, 
-			Map<Long, ELFFileReader> coreModulesMap,
-			ELFFileReader coreFileReader) throws IOException {
-		
+	private Map<Long, String> readLibraryNamesFromDebugData(ELFFileReader executableELF,
+			Map<Long, ELFFileReader> coreModulesMap, ELFFileReader coreFileReader) throws IOException {
+
 		// Create the method return value
-		TreeMap<Long,String> libraryNamesByBaseAddress = new TreeMap<Long, String>();		
+		TreeMap<Long, String> libraryNamesByBaseAddress = new TreeMap<>();
 
 		ProgramHeaderEntry dynamic = executableELF.getDynamicTableEntry();
 		if (dynamic == null) {
@@ -601,21 +596,21 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 		if (!isReadableAddress(dynamicTableAddress)) {
 			return libraryNamesByBaseAddress;
 		}
-		
+
 		// Seek to the start of the dynamic section
 		// WARNING: there is a surprising gotcha here. To read the dynamic table and debug data
-		// it is essential to use the reader for the core file as a whole, _reader, 
-		// and not the elfReader that was passed in. 
-		// The reason is that the executable is loaded into memory twice, and the 
-		// entry for the dynamic table in the program header table of the first points at the 
-		// dynamic table in the second. For example, the executable is loaded at both 0x8048000 and 
-		// 8049000. Both have a program header table where the dynamic entry points at the 
-		// dynamic table in the one loaded at 8049000. If you slip up, by the way, and look at 
-		// the dynamic table in one loaded at 8048000 you find the debug entry is 0.  
-		// It is essential to use _reader because elfReader that is passed in will be 
-		// for the 8048000 executable and will not be able to resolve addresses in the 8049000+ range - 
-		// it does not have the program header table entries to do so. 
-		// The reader for the core file as a whole though can do so. 
+		// it is essential to use the reader for the core file as a whole, _reader,
+		// and not the elfReader that was passed in.
+		// The reason is that the executable is loaded into memory twice, and the
+		// entry for the dynamic table in the program header table of the first points at the
+		// dynamic table in the second. For example, the executable is loaded at both 0x8048000 and
+		// 8049000. Both have a program header table where the dynamic entry points at the
+		// dynamic table in the one loaded at 8049000. If you slip up, by the way, and look at
+		// the dynamic table in one loaded at 8048000 you find the debug entry is 0.
+		// It is essential to use _reader because elfReader that is passed in will be
+		// for the 8048000 executable and will not be able to resolve addresses in the 8049000+ range -
+		// it does not have the program header table entries to do so.
+		// The reader for the core file as a whole though can do so.
 		_reader.seekToAddress(dynamicTableAddress);
 
 		// Loop reading the dynamic section tag-value/pointer pairs until a 'debug'
@@ -625,57 +620,57 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 
 		do {
 			// Read the tag and the value/pointer (only used after the loop has terminated)
-			tag     = _reader.readElfWord();
+			tag = _reader.readElfWord();
 			address = _reader.readElfWord();
-			
+
 			// Check that the tag is valid. As there may be some debate about the
 			// set of valid values, a message will be issued but reading will continue
 			/*
 			 * CMVC 161449 - SVT:70:jextract invalid tag error
 			 * The range of valid values in the header has been expanded, so increasing the valid range
 			 * http://refspecs.freestandards.org/elf/gabi4+/ch5.dynamic.html
-			 * DT_RUNPATH 			29 	d_val 	optional 	optional
-			 * DT_FLAGS 			30 	d_val 	optional 	optional
-			 * DT_ENCODING 			32 	unspecified 	unspecified 	unspecified
-			 * DT_PREINIT_ARRAY 	32 	d_ptr 	optional 	ignored
-			 * DT_PREINIT_ARRAYSZ 	33 	d_val 	optional 	ignored
+			 * DT_RUNPATH          29  d_val        optional     optional
+			 * DT_FLAGS            30  d_val        optional     optional
+			 * DT_ENCODING         32  unspecified  unspecified  unspecified
+			 * DT_PREINIT_ARRAY    32  d_ptr        optional     ignored
+			 * DT_PREINIT_ARRAYSZ  33  d_val        optional     ignored
 			 */
-			if ( !((tag >= 0         ) && (tag <= 33        )) &&
-			     !((tag >= 0x60000000) && (tag <= 0x6FFFFFFF)) &&
-			     !((tag >= 0x70000000) && (tag <= 0x7FFFFFFF))    ) {
-				logger.log(Level.WARNING,
-					"Error reading dynamic section. Invalid tag value '0x" + 
-					Long.toHexString(tag) +
-					"'. The core file is invalid and the results may unpredictable"
-				);
+			if (   !((tag >=          0) && (tag <=         33))
+				&& !((tag >= 0x60000000) && (tag <= 0x6FFFFFFF))
+				&& !((tag >= 0x70000000) && (tag <= 0x7FFFFFFF))
+			) {
+				logger.log(Level.WARNING, "Error reading dynamic section. Invalid tag value '0x" + Long.toHexString(tag)
+						+ "'. The core file is invalid and the results may unpredictable");
 			}
-			
+
 			// System.err.println("Found dynamic section tag 0x" + Long.toHexString(tag));
 		} while ((tag != DT_NULL) && (tag != DT_DEBUG));
 
 		// If there is no debug section, there is nothing to do
-		if ( tag != DT_DEBUG) {
+		if (tag != DT_DEBUG) {
 			return libraryNamesByBaseAddress;
 		}
 
-		// Seek to the start of the debug data		
+		// Seek to the start of the debug data
 		_reader.seekToAddress(address);
-			
+
 		// NOTE the rendezvous structure is described in /usr/include/link.h
-		//	struct r_debug {
-		//		int r_version;
-		//		struct link_map *r_map;
-		//		ElfW(Addr) r_brk;		/* Really a function pointer */
-		//		enum { ... } r_state;
-		//		ElfW(Addr) r_ldbase;
-		//	};
-		//	struct link_map {
-		   //		ElfW(Addr) l_addr;		/* Base address shared object is loaded at.  */
-		   //		char *l_name;			/* Absolute file name object was found in.  */
-		   //		ElfW(Dyn) *l_ld;		/* Dynamic section of the shared object.  */
-		   //		struct link_map *l_next, *l_prev;	/* Chain of loaded objects.  */
-		//	};
-			
+		// struct r_debug
+		// {
+		//     int r_version;
+		//     struct link_map *r_map;
+		//     ElfW(Addr) r_brk;       /* Really a function pointer */
+		//     enum { ... } r_state;
+		//     ElfW(Addr) r_ldbase;
+		// };
+		// struct link_map
+		// {
+		//     ElfW(Addr) l_addr;      /* Base address shared object is loaded at.  */
+		//     char *l_name;           /* Absolute file name object was found in.  */
+		//     ElfW(Dyn) *l_ld;        /* Dynamic section of the shared object.  */
+		//     struct link_map *l_next, *l_prev; /* Chain of loaded objects.  */
+		// };
+
 		_reader.readElfWord(); // Ignore version (and alignment padding)
 		long next = _reader.readElfWord();
 		while (0 != next) {
@@ -687,7 +682,7 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 			if (0 != baseAddress) {
 				// NOTE There is an apparent bug in the link editor on Linux x86-64.
 				// The loadedBaseAddress for libnuma.so is invalid, although it is
-				// correctly loaded and its symbols are resolved.  The library is loaded
+				// correctly loaded and its symbols are resolved. The library is loaded
 				// around 0x2a95c4f000 but its base is recorded in the link map as
 				// 0xfffffff09f429000.
 
@@ -695,27 +690,27 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 				try {
 					name = _process.readStringAt(nameAddress);
 				} catch (MemoryFault e1) {
-					//Do nothing
+					// Do nothing
 				}
-				// If we have a valid link_map entry, open up the actual library file to get the symbols and 
+				// If we have a valid link_map entry, open up the actual library file to get the symbols and
 				// library sections.
-				// Note: on SLES 10 we have seen a link_map entry with a null name, in non-corrupt dumps, so we now 
+				// Note: on SLES 10 we have seen a link_map entry with a null name, in non-corrupt dumps, so we now
 				// ignore link_map entries with null names rather than report them as corrupt. See defect 132140
 				// Check for zero-length name - sometimes we get empty name even for valid modules. See defect 182917
 				// Note : on SLES 11 we have seen a link_map entry with a module name of "7". Using the base address and correlating
-				// with the libraries we find by iterating through the program header table of the core file, we know that 
-				// this is in fact linux-vdso64.so.1 
+				// with the libraries we find by iterating through the program header table of the core file, we know that
+				// this is in fact linux-vdso64.so.1
 				// Detect this by spotting that the name does not begin with "/" - the names should
-				// always be full pathnames. In this case just ignore this one.   
-				// See defect CMVC 184115 
+				// always be full pathnames. In this case just ignore this one.
+				// See defect CMVC 184115
 				if (null != name && name.length() != 0) {
 					if (name.startsWith("/")) { // normal case - full pathname
-						libraryNamesByBaseAddress.put(baseAddress,name);											
+						libraryNamesByBaseAddress.put(baseAddress, name);
 					} else {
 						ELFFileReader moduleWithinCoreFile = coreModulesMap.get(baseAddress);
 						if (moduleWithinCoreFile != null) {
-							String SONameForModuleAtThisAddress = moduleWithinCoreFile.readSONAME(coreFileReader);				
-							libraryNamesByBaseAddress.put(baseAddress,SONameForModuleAtThisAddress);
+							String SONameForModuleAtThisAddress = moduleWithinCoreFile.readSONAME(coreFileReader);
+							libraryNamesByBaseAddress.put(baseAddress, SONameForModuleAtThisAddress);
 						}
 					}
 				}
@@ -726,18 +721,19 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 	}
 
 	/**
-	 * Given an ELF reader, read the symbols, memory ranges and properties from the module 
+	 * Given an ELF reader, read the symbols, memory ranges and properties from the module
 	 * and construct a Module object. The ELF reader may point to a segment within the core file
-	 * or may point to a copy of the module on disk or appended to the core file. 
-	 * 
+	 * or may point to a copy of the module on disk or appended to the core file.
+	 *
 	 * @param loadedBaseAddress of the module
 	 * @param name of the module
 	 * @param elfReader to the module
-	 * 
+	 *
 	 * @return IModule
 	 * @throws IOException
 	 */
-	private IModule createModuleFromElfReader(final long loadedBaseAddress, String name, ELFFileReader inCoreReader, ELFFileReader diskReader) {
+	private IModule createModuleFromElfReader(final long loadedBaseAddress, String name, ELFFileReader inCoreReader,
+			ELFFileReader diskReader) {
 		if (name == null) {
 			return null;
 		}
@@ -745,13 +741,13 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 			return new MissingFileModule(_process, name, Collections.<IMemoryRange>emptyList());
 		}
 		List<? extends ISymbol> symbols = null;
-		Map<Long, String> sectionHeaderStringTable = null; 
+		Map<Long, String> sectionHeaderStringTable = null;
 		List<SectionHeaderEntry> sectionHeaderEntries = null;
 		Properties properties;
 		Collection<? extends IMemorySource> declaredRanges;
-		
+
 		ProgramHeaderEntry ehFrameEntry = null;
-		
+
 		// Create the unwind data from the program header with the type GNU_UNWIND.
 		// We could look for the .eh_frame section header but section headers aren't
 		// guaranteed to be loaded. (More accurately they shouldn't be but sometimes
@@ -760,31 +756,31 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 		// If we don't find the entry, we are probably on a platform which
 		// doesn't require it or reading a library that was compiled not to use it
 		// so don't raise an error if it isn't present.
-		for( ProgramHeaderEntry ph: inCoreReader.getProgramHeaderEntries() ) {
-			if( ph.isEhFrame() ) {
+		for (ProgramHeaderEntry ph : inCoreReader.getProgramHeaderEntries()) {
+			if (ph.isEhFrame()) {
 				ehFrameEntry = ph;
 			}
 		}
 		try {
-			if( ehFrameEntry != null ) {
+			if (ehFrameEntry != null) {
 				unwinder.addCallFrameInformation(loadedBaseAddress, ehFrameEntry, name);
 			}
 		} catch (MemoryFault mf) {
 			// We get known memory faults for ld-linux-x86-64.so.2 in AMD64 dumps (at the first address it's loaded at)
 			// and linux-vdso.so.1. The first of these turns up again at a location that works, the second is
 			// "magic" so we don't worry about them. We want this code to be as resilient as possible.
-			logger.log(Level.FINER,"MemoryFault reading GNU_EH_FRAME data for module with name " + name + " and base address "
-					+ Long.toHexString(loadedBaseAddress));
+			logger.log(Level.FINER, "MemoryFault reading GNU_EH_FRAME data for module with name " + name
+					+ " and base address " + Long.toHexString(loadedBaseAddress));
 		} catch (CorruptDataException cde) {
-			logger.log(Level.FINER,"CorruptDataException reading GNU_EH_FRAME data for module with name " + name + " and base address "
-					+ Long.toHexString(loadedBaseAddress));
+			logger.log(Level.FINER, "CorruptDataException reading GNU_EH_FRAME data for module with name " + name
+					+ " and base address " + Long.toHexString(loadedBaseAddress));
 		} catch (IOException e) {
-			logger.log(Level.FINER,"IOException reading GNU_EH_FRAME data for module with name " + name + " and base address "
-					+ Long.toHexString(loadedBaseAddress));
+			logger.log(Level.FINER, "IOException reading GNU_EH_FRAME data for module with name " + name
+					+ " and base address " + Long.toHexString(loadedBaseAddress));
 		}
-		
+
 		try {
-			if( diskReader != null ) {
+			if (diskReader != null) {
 				symbols = diskReader.getSymbols(loadedBaseAddress, true);
 				sectionHeaderStringTable = diskReader.getSectionHeaderStringTable();
 				sectionHeaderEntries = diskReader.getSectionHeaderEntries();
@@ -798,31 +794,32 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 			// But we can use the section headers and string table from the disk or zipped library
 			// to navigate. (Section headers are redundant once the library is loaded so may not
 			// be in memory.)
-			declaredRanges = inCoreReader.getMemoryRanges(loadedBaseAddress, sectionHeaderEntries, sectionHeaderStringTable);
+			declaredRanges = inCoreReader.getMemoryRanges(loadedBaseAddress, sectionHeaderEntries,
+					sectionHeaderStringTable);
 		} catch (IOException e) {
-			logger.log(Level.FINER,"Error generating module with name " + name + " and base address "
+			logger.log(Level.FINER, "Error generating module with name " + name + " and base address "
 					+ Long.toHexString(loadedBaseAddress));
 			return null;
 		}
-		
-		//Of the declared memory ranges, some will already be in core (i.e. .data) others will have been declared
-		//in the core, but not backed.
-		List<IMemoryRange> ranges = new ArrayList<IMemoryRange>(declaredRanges.size());
-		
+
+		// Of the declared memory ranges, some will already be in core (i.e. .data) others will have been declared
+		// in the core, but not backed.
+		List<IMemoryRange> ranges = new ArrayList<>(declaredRanges.size());
+
 		for (IMemorySource source : declaredRanges) {
 			IMemorySource coreSource = _process.getRangeForAddress(source.getBaseAddress());
-			
+
 			/**
-			 * The following test skips sections that originally had an address of 0 
-			 * the section header table. 
-			 * 
-			 * Explanation follows - see also the example section header table at the top 
-			 * of SectionHeaderEntry.java  
-			 * 
-			 * Some of the later sections in the section header table have an address field 
+			 * The following test skips sections that originally had an address of 0
+			 * the section header table.
+			 *
+			 * Explanation follows - see also the example section header table at the top
+			 * of SectionHeaderEntry.java
+			 *
+			 * Some of the later sections in the section header table have an address field
 			 * 0. That is a relative address, relative to the base address of the module.
 			 * They are usually the sections from .comment onwards.
-			 *  
+			 *
 			 * When the entry is constructed the code that creates the entry creates it with
 			 * address (base address of the module) + (address field in the SHT) hence those
 			 * that had an address of 0 will have an address == base address of the module.
@@ -830,27 +827,27 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 			 * not safe to create them as sections - they were there in the on-disk version of
 			 * the library but often not in memory. The code above that called elfReader.getMemoryRanges
 			 * may have been reading the version of the module from disk (which is good, it means
-			 * you get a good section header string table so you get good names for all the 
+			 * you get a good section header string table so you get good names for all the
 			 * sections) but not all the sections exist in memory. The danger of adding them
 			 * as memory ranges is that they start to overlay the segments in the core file
-			 * that come immediately afterwards; that is, they cause jdmpview, for example, to 
-			 * believe that the contents of these later areas of memory are backed by the  
-			 * contents of the library on disk when they are not.  
+			 * that come immediately afterwards; that is, they cause jdmpview, for example, to
+			 * believe that the contents of these later areas of memory are backed by the
+			 * contents of the library on disk when they are not.
 			 * See CMVC 185753
-			 * 
-			 * So, don't add sections that originally had address 0. 
-			 * 
+			 *
+			 * So, don't add sections that originally had address 0.
+			 *
 			 */
 			if (source.getBaseAddress() == loadedBaseAddress) { // must have originally had address 0 in the section header table
 				continue;
 			}
-			
+
 			if (null != coreSource) {
 				if (coreSource.isBacked()) {
 					// Range already exists
 				} else {
-					//The range exists but isn't backed. We need to replace the in-core memory range with the one
-					//from the library
+					// The range exists but isn't backed. We need to replace the in-core memory range with the one
+					// from the library
 					if (source.getSize() > 0) {
 						_process.removeMemorySource(coreSource);
 						_process.addMemorySource(source);
@@ -863,7 +860,7 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 			}
 			ranges.add(source);
 		}
-		return new Module(_process,name,symbols, ranges, loadedBaseAddress, properties);
+		return new Module(_process, name, symbols, ranges, loadedBaseAddress, properties);
 
 	}
 
@@ -883,62 +880,69 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 			return false;
 		}
 	}
-	
-	private LibraryDataSource findExecutableOnDiskOrAppended()
-	{
-		//Three sources for executable data. The command line (limit 80 chars), the executable file name (no path info, limit 16 chars),
-		//and the executablePathOverride (passed down from higher layers, not necessarily set).
-		
+
+	private LibraryDataSource findExecutableOnDiskOrAppended() {
+		// Three sources for executable data. The command line (limit 80 chars), the executable file name (no path info, limit 16 chars),
+		// and the executablePathOverride (passed down from higher layers, not necessarily set).
+
 		if (_executablePathOverride != null) {
 			try {
 				LibraryDataSource libSource = _resolver.getLibrary(_executablePathOverride, false);
 				return libSource;
 			} catch (FileNotFoundException e) {
 				logger.fine("Could not resolve executable, have the native libraries been collected ?");
-				logger.logp(FINER,"com.ibm.j9ddr.corereaders.elf.ELFDumpReader","findExecutableOnDiskOrAppended","IOException resolving library", e);	
+				logger.logp(FINER, "com.ibm.j9ddr.corereaders.elf.ELFDumpReader", "findExecutableOnDiskOrAppended",
+						"IOException resolving library", e);
 			}
 		}
-		
-		//Try the command line
-		int spaceIndex = _commandLine.indexOf(" ");
-		
+
+		// Try the command line
+		int spaceIndex = _commandLine.indexOf(' ');
+
 		if (spaceIndex != -1) {
 			String executablePath = _commandLine.substring(0, spaceIndex);
-			
+
 			try {
 				LibraryDataSource libSource = _resolver.getLibrary(executablePath, true);
 				return libSource;
 			} catch (IOException e) {
-				//Do nothing
+				// Do nothing
 			}
 		}
-		
-		//Try the executable
+
+		// Try the executable
 		try {
 			LibraryDataSource libSource = _resolver.getLibrary(_executableFileName, true);
 			return libSource;
 		} catch (IOException e) {
-			//Do nothing
+			// Do nothing
 		}
-		
+
 		return new LibraryDataSource(_executableFileName);
 	}
 
-	//Architecture-specific template methods:
+	// Architecture-specific template methods:
 	protected abstract long readUID() throws IOException;
-	protected abstract String getProcessorType();
-	protected abstract SortedMap<String, Number> readRegisters() throws IOException;
-	protected abstract String getStackPointerRegisterName();
-	protected abstract long getBasePointerFrom(Map<String, Number> registers);
-	protected abstract long getInstructionPointerFrom(Map<String, Number> registers);
-	protected abstract long getLinkRegisterFrom(Map<String, Number> registers);
-	protected abstract void readHighwordRegisters(DataEntry entry, Map<String, Number> registers) throws IOException, InvalidDumpFormatException;
 
-	protected long getStackPointerFrom(Map<String, Number> registers)
-	{
+	protected abstract String getProcessorType();
+
+	protected abstract SortedMap<String, Number> readRegisters() throws IOException;
+
+	protected abstract String getStackPointerRegisterName();
+
+	protected abstract long getBasePointerFrom(Map<String, Number> registers);
+
+	protected abstract long getInstructionPointerFrom(Map<String, Number> registers);
+
+	protected abstract long getLinkRegisterFrom(Map<String, Number> registers);
+
+	protected abstract void readHighwordRegisters(DataEntry entry, Map<String, Number> registers)
+			throws IOException, InvalidDumpFormatException;
+
+	protected long getStackPointerFrom(Map<String, Number> registers) {
 		return registers.get(getStackPointerRegisterName()).longValue();
 	}
-	
+
 	/*
 	 * The offset of the instruction pointer from the base pointer within a stack frame.
 	 * (Generally 1 word, except on PPC 64 where it's 2 words because of the status register.)
@@ -950,7 +954,7 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 	protected String getProcessorSubType() {
 		try {
 			String proc = readStringAt(_platformIdAddress);
-			if(proc == null) {
+			if (proc == null) {
 				return "unknown";
 			} else {
 				return proc;
@@ -959,48 +963,47 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 			return "unknown";
 		}
 	}
-	
-	public String readStringAt(long address) throws IOException
-	{
-		String toReturn = null;
-		
+
+	public String readStringAt(long address) throws IOException {
 		if (isReadableAddress(address)) {
-			StringBuffer buf = new StringBuffer();
 			_reader.seekToAddress(address);
-			byte b = _reader.readByte();
-			while (0 != b) {
-				buf.append(new String(new byte[] { b }, "ASCII"));
-				b = _reader.readByte();
+
+			for (ByteArrayOutputStream buffer = new ByteArrayOutputStream();;) {
+				byte ascii = _reader.readByte();
+
+				if (ascii != 0) {
+					buffer.write(ascii);
+				} else {
+					return new String(buffer.toByteArray(), StandardCharsets.US_ASCII);
+				}
 			}
-			toReturn = buf.toString();
-		} 
-		return toReturn;
+		}
+
+		return null;
 	}
-	
-	private void processProgramHeader() throws IOException
-	{
+
+	private void processProgramHeader() throws IOException {
 		for (ProgramHeaderEntry entry : _reader.getProgramHeaderEntries()) {
 			if (entry.isNote()) {
 				readNotes(entry);
 			}
 			IMemorySource range = entry.asMemorySource();
-			//Range gets declared covering entire 64 bit address space. This messes up the overlapping ranges logic 
-			//in AbstractMemory so is explicitly filtered here.
-			if (! (range.getTopAddress() == 0xffffffffffffffffL && range.getBaseAddress() == 0)) {
+			// Range gets declared covering entire 64 bit address space.
+			// This messes up the overlapping ranges logic
+			// in AbstractMemory so is explicitly filtered here.
+			if (!(range.getTopAddress() == 0xffffffffffffffffL && range.getBaseAddress() == 0)) {
 				_process.addMemorySource(range);
 			}
 		}
 	}
 
-	private void processAuxiliaryHeader() throws IOException
-	{
+	private void processAuxiliaryHeader() throws IOException {
 		for (DataEntry entry : _auxiliaryVectorEntries) {
 			readAuxiliaryVector(entry);
 		}
 	}
-	
-	private void readNotes(ProgramHeaderEntry entry) throws IOException
-	{
+
+	private void readNotes(ProgramHeaderEntry entry) throws IOException {
 		long offset = entry.fileOffset;
 		long limit = offset + entry.fileSize;
 		while (offset >= entry.fileOffset && offset < limit) {
@@ -1008,9 +1011,9 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 		}
 	}
 
-	private long readNote(long offset) throws IOException
-	{
+	private long readNote(long offset) throws IOException {
 		_reader.seek(offset);
+
 		long nameLength = padToIntBoundary(_reader.readInt());
 		long dataSize = _reader.readInt();
 		long type = _reader.readInt();
@@ -1018,27 +1021,27 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 
 		long dataOffset = offset + ELF_NOTE_HEADER_SIZE + nameLength;
 
-		if (NT_PRSTATUS == type)
+		if (NT_PRSTATUS == type) {
 			_threadEntries.add(new DataEntry(dataOffset, dataSize));
-		else if (NT_PRPSINFO == type)
+		} else if (NT_PRPSINFO == type) {
 			_processEntries.add(new DataEntry(dataOffset, dataSize));
-		else if (NT_AUXV == type)
+		} else if (NT_AUXV == type) {
 			_auxiliaryVectorEntries.add(new DataEntry(dataOffset, dataSize));
-		else if (NT_HGPRS == type )
+		} else if (NT_HGPRS == type) {
 			_highwordRegisterEntries.add(new DataEntry(dataOffset, dataSize));
-		
+		}
+
 		return dataOffset + padToIntBoundary(dataSize);
 	}
-	
+
 	/* The ELF NOTES section is padded to 4 byte boundaries.
 	 * (Not word size!)
 	 */
-	private static long padToIntBoundary(long l) {
-		return ((l + 3) / 4) * 4;
+	private static long padToIntBoundary(long value) {
+		return (value + 3) & ~3;
 	}
-	
-	private void readAuxiliaryVector(DataEntry entry) throws IOException
-	{
+
+	private void readAuxiliaryVector(DataEntry entry) throws IOException {
 		_reader.seek(entry.offset);
 		if (0 != entry.size) {
 			long type = _reader.readElfWord();
@@ -1056,46 +1059,42 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 		}
 	}
 
-	public IModule getExecutable() throws CorruptDataException
-	{
+	public IModule getExecutable() throws CorruptDataException {
 		if (_modulesException != null) {
 			throw _modulesException;
 		}
 		return _executable;
 	}
 
-	public List<? extends IModule> getModules() throws CorruptDataException
-	{
+	public List<? extends IModule> getModules() throws CorruptDataException {
 		if (_modulesException != null) {
 			throw _modulesException;
 		}
 		return _modules;
 	}
 
-	public long getProcessId()
-	{
+	public long getProcessId() {
 		return _pid;
 	}
 
-	public List<? extends IOSThread> getThreads()
-	{
-		List<IOSThread> threads = new ArrayList<IOSThread>(_threadEntries.size());
-		
+	public List<? extends IOSThread> getThreads() {
+		List<IOSThread> threads = new ArrayList<>(_threadEntries.size());
+
 		for (DataEntry entry : _threadEntries) {
 			try {
 				threads.add(readThread(entry));
 			} catch (IOException ex) {
-				//TODO handle
+				// TODO handle
 			}
 		}
-		
+
 		return threads;
 	}
-	
+
 	// Reads the prstatus structure.
 	private IOSThread readThread(DataEntry entry) throws IOException {
 		_reader.seek(entry.offset);
-		_signalNumber = _reader.readInt(); //  signalNumber
+		_signalNumber = _reader.readInt(); // signalNumber
 		_reader.readInt(); // Ignore code
 		_reader.readInt(); // Ignore errno
 		_reader.readShort(); // Ignore cursig
@@ -1106,25 +1105,25 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 		_reader.readInt(); // Ignore ppid
 		_reader.readInt(); // Ignore pgroup
 		_reader.readInt(); // Ignore session
-		
-		long utimeSec   = _reader.readElfWord(); // utime_sec
-		long utimeUSec  = _reader.readElfWord(); // utime_usec
-		long stimeSec   = _reader.readElfWord(); // stime_sec
-		long stimeUSec  = _reader.readElfWord(); // stime_usec
+
+		long utimeSec = _reader.readElfWord(); // utime_sec
+		long utimeUSec = _reader.readElfWord(); // utime_usec
+		long stimeSec = _reader.readElfWord(); // stime_sec
+		long stimeUSec = _reader.readElfWord(); // stime_usec
 		_reader.readElfWord(); // Ignore cutime_sec
 		_reader.readElfWord(); // Ignore cutime_usec
 		_reader.readElfWord(); // Ignore cstime_sec
 		_reader.readElfWord(); // Ignore cstime_usec
-		
+
 		// Registers are in a elf_gregset_t (which is defined per platform).
-		SortedMap<String, Number> registers = readRegisters();
+		Map<String, Number> registers = readRegisters();
 		Properties properties = new Properties();
 		properties.setProperty("Thread user time secs", Long.toString(utimeSec));
 		properties.setProperty("Thread user time usecs", Long.toString(utimeUSec));
 		properties.setProperty("Thread sys time secs", Long.toString(stimeSec));
 		properties.setProperty("Thread sys time usecs", Long.toString(stimeUSec));
-		
-		if (pid == _pid ) { // main thread (in Linux JVM fork&abort case this is the only thread) 
+
+		if (pid == _pid) { // main thread (in Linux JVM fork&abort case this is the only thread)
 			for (DataEntry registerEntry : _highwordRegisterEntries) {
 				try {
 					readHighwordRegisters(registerEntry, registers);
@@ -1133,58 +1132,53 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 				}
 			}
 		}
-	
+
 		return new LinuxThread(pid, registers, properties);
 	}
-	
-	protected class LinuxThread implements IOSThread
-	{
+
+	protected class LinuxThread implements IOSThread {
 		private final Map<String, Number> registers;
-		
+
 		private final Properties properties;
-		
+
 		private final long tid;
-		
-		private final List<IMemoryRange> memoryRanges = new LinkedList<IMemoryRange>();
-		
-		private final List<IOSStackFrame> stackFrames = new LinkedList<IOSStackFrame>();
-		
+
+		private final List<IMemoryRange> memoryRanges = new LinkedList<>();
+
+		private final List<IOSStackFrame> stackFrames = new LinkedList<>();
+
 		private boolean stackWalked = false;
-		
-		private LinuxThread(long tid, Map<String, Number> registers, Properties properties)
-		{
+
+		private LinuxThread(long tid, Map<String, Number> registers, Properties properties) {
 			this.registers = registers;
 			this.properties = properties;
 			this.tid = tid;
 		}
-		
-		public Collection<? extends IMemoryRange> getMemoryRanges()
-		{
+
+		public Collection<? extends IMemoryRange> getMemoryRanges() {
 			// Get stack frames will ensure the memory ranges for the stack
 			// are populated. (And checks if the stack has already been walked.)
 			getStackFrames();
-			
+
 			return memoryRanges;
 		}
 
-		public Properties getProperties()
-		{
+		public Properties getProperties() {
 			return properties;
 		}
 
-		public List<? extends IRegister> getRegisters()
-		{
-			List<IRegister> regList = new ArrayList<IRegister>(registers.size());
-			
+		public List<? extends IRegister> getRegisters() {
+			List<IRegister> regList = new ArrayList<>(registers.size());
+
 			for (String regName : registers.keySet()) {
-				Number value  = registers.get(regName);
-				
-				regList.add(new Register(regName,value));
+				Number value = registers.get(regName);
+
+				regList.add(new Register(regName, value));
 			}
-			
+
 			return regList;
 		}
-		
+
 		public long getInstructionPointer() {
 			if (registers != null) {
 				return getInstructionPointerFrom(registers);
@@ -1193,8 +1187,7 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 			}
 		}
 
-		public List<? extends IOSStackFrame> getStackFrames()
-		{
+		public List<? extends IOSStackFrame> getStackFrames() {
 			if (!stackWalked) {
 				walkStack();
 				stackWalked = true;
@@ -1203,7 +1196,6 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 		}
 
 		public void walkStack() {
-
 			long stackPointer = getStackPointerFrom(registers);
 			long basePointer = getBasePointerFrom(registers);
 			long instructionPointer = maskInstructionPointer(getInstructionPointerFrom(registers));
@@ -1212,33 +1204,28 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 				instructionPointer = maskInstructionPointer(getLinkRegisterFrom(registers));
 			}
 
-			if ((0 != instructionPointer)
-				&& isValidAddress(instructionPointer)
-				&& isValidAddress(stackPointer)
-			) {
+			if ((0 != instructionPointer) && isValidAddress(instructionPointer) && isValidAddress(stackPointer)) {
 				IMemoryRange range = _process.getRangeForAddress(stackPointer);
 				memoryRanges.add(new MemoryRange(_process.getAddressSpace(), range, "stack"));
 				UnwindTable unwindTable = null;
 
 				try {
-					
 					/* Attempt to obtain the unwind information for this ip. */
 					if (unwinder == null) {
 						unwinder = new Unwind(_process);
 					}
 					// dumpRegisters(registers);
-					unwindTable = unwinder
-							.getUnwindTableForInstructionAddress(instructionPointer);
+					unwindTable = unwinder.getUnwindTableForInstructionAddress(instructionPointer);
 					// If we couldn't find any unwind data, the the ip and base pointer are valid.
 					Map<String, Number> nextRegisters = registers;
 					if (unwindTable != null) {
 						// Apply the unwind data based on this ip to generate the first frame.
-//						System.err.printf("Using dwarf unwind for top frame 0\n");
-						
+						// System.err.printf("Using dwarf unwind for top frame 0\n");
+
 						nextRegisters = unwindTable.apply(nextRegisters, getDwarfRegisterKeys());
-						
+
 						// dumpRegisters(nextRegisters);
-						
+
 						long newStackPointer = unwindTable.getFrameAddress();
 						// System.err.printf("Replacing %s:0x%x with %s:0x%x as stack pointer\n", stackPointerName, nextRegisters.get(stackPointerName), stackPointerName, newStackPointer);
 						nextRegisters.put(getStackPointerRegisterName(), newStackPointer);
@@ -1251,12 +1238,12 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 					// Loop through stack frames, starting from current frame base pointer
 					// Maximum 256 frames, for protection against excessive or infinite loops in corrupt dumps
 					int loops = 0;
-//					System.err.printf("Instruction pointer is 0x%x, unwind table is: %s\n", instructionPointer, unwindTable);
+					// System.err.printf("Instruction pointer is 0x%x, unwind table is: %s\n", instructionPointer, unwindTable);
 					while (instructionPointer != 0x0 && isValidAddress(instructionPointer) && loops++ < 256) {
 
 						if (unwindTable != null) {
-//							System.err.printf("Using dwarf unwind for frame %d\n", loops);
-							
+							// System.err.printf("Using dwarf unwind for frame %d\n", loops);
+
 							nextRegisters = unwindTable.apply(nextRegisters, getDwarfRegisterKeys());
 
 							// dumpRegisters(nextRegisters);
@@ -1272,9 +1259,9 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 							// basePointer = newStackPointer;
 
 						} else if (basePointer != 0) {
-//							 System.err.printf("Using basic unwind for frame %d, ip: 0x%x\n", loops, instructionPointer);
+							// System.err.printf("Using basic unwind for frame %d, ip: 0x%x\n", loops, instructionPointer);
 							// previousBasePointer = basePointer;
-							if( isValidAddress(instructionPointer) ) {
+							if (isValidAddress(instructionPointer)) {
 								stackFrames.add(new OSStackFrame(basePointer, instructionPointer));
 							}
 							long ptr = basePointer;
@@ -1287,44 +1274,44 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 							logger.log(Level.FINER, "Base pointer is zero");
 						}
 
-//						System.err.printf("Instruction pointer is 0x%x, unwind table is: %s\n", instructionPointer, unwindTable);
+						// System.err.printf("Instruction pointer is 0x%x, unwind table is: %s\n", instructionPointer, unwindTable);
 
 					}
 				} catch (MemoryFault ex) {
-					logger.log(Level.FINER,"MemoryFault reading stack @ " + String.format("0x%x", ex.getAddress())
+					logger.log(Level.FINER, "MemoryFault reading stack @ " + String.format("0x%x", ex.getAddress())
 							+ " for thread " + tid);
 				} catch (CorruptDataException e) {
-					logger.log(Level.FINER,"CorruptDataException reading stack from: " + _reader.getSourceName()
+					logger.log(Level.FINER, "CorruptDataException reading stack from: " + _reader.getSourceName()
 							+ " for thread " + tid);
 				} catch (IOException e) {
-					logger.log(Level.FINER,"IOException reading stack from: " + _reader.getSourceName()
-							+ " for thread " + tid);
+					logger.log(Level.FINER,
+							"IOException reading stack from: " + _reader.getSourceName() + " for thread " + tid);
 				}
 			}
 		}
-		
+
+		@SuppressWarnings("unused" /* debugging aid */ )
 		private void dumpRegisters(Map<String, Number> registers) {
 			System.err.printf("-------------------------\n");
 			int rcount = 0;
-			List<String> keys = new LinkedList<String>();
-			for( String key : registers.keySet() ) {
-				if(key != null ) {
+			List<String> keys = new LinkedList<>();
+			for (String key : registers.keySet()) {
+				if (key != null) {
 					keys.add(key);
 				}
 			}
 			Collections.sort(keys);
-			for( String key: keys  ) {
+			for (String key : keys) {
 				System.err.printf("%s = 0x%x (%d) ", key, registers.get(key), registers.get(key));
 				rcount++;
-				if( rcount % 4 == 0) {
+				if (rcount % 4 == 0) {
 					System.err.println();
 				}
 			}
 			System.err.println();
 		}
 
-		public long getThreadId() throws CorruptDataException
-		{
+		public long getThreadId() throws CorruptDataException {
 			return tid;
 		}
 
@@ -1335,11 +1322,10 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 		public long getStackPointer() {
 			return getStackPointerFrom(registers);
 		}
-		
+
 	}
 
-	public int getSignalNumber()
-	{
+	public int getSignalNumber() {
 		if (_signalNumber == -1) {
 			getThreads();
 		}
@@ -1356,26 +1342,26 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 	 * numbers.
 	 */
 	protected abstract String[] getDwarfRegisterKeys();
-	
+
 	/* Overridden for z/Linux 31 as the top bit needs to be masked out. */
 	protected long maskInstructionPointer(long pointer) {
 		return pointer;
 	}
-	
-	public void executablePathHint(String path)
-	{
+
+	@Override
+	public void executablePathHint(String path) {
 		_executablePathOverride = path;
 		try {
 			readModules();
 		} catch (IOException e) {
-			//TODO handle
+			// TODO handle
 		}
 	}
 
 	/**
 	 * Create an ELFReader to a module at a given offset within the core file. Return null if this is not
-	 * possible - usually this is because the offset does not point to something in ELF format.  
-	 * 
+	 * possible - usually this is because the offset does not point to something in ELF format.
+	 *
 	 * @param in stream for the core file
 	 * @param offset
 	 * @return reader to the module or null if not possible
@@ -1384,14 +1370,13 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 	private ELFFileReader getReaderFromOffsetWithinCoreFile(ImageInputStream in, long offset) throws IOException {
 		ELFFileReader loadedElf = null;
 		try {
-			loadedElf = ELFFileReader
-					.getELFFileReaderWithOffset(in, offset);
+			loadedElf = ELFFileReader.getELFFileReaderWithOffset(in, offset);
 		} catch (InvalidDumpFormatException e) {
 			// This is usually thrown because the given program header entry
 			// points to a segment within the core file that does not start with an ELF header.
-			// This is not an error and is quite common: many of the segments within the core file are 
-			// not ELF-format modules. For example the segment that contains information about 
-			// the process, or segments to represent thread are not 
+			// This is not an error and is quite common: many of the segments within the core file are
+			// not ELF-format modules. For example the segment that contains information about
+			// the process, or segments to represent thread are not
 			// ELF-format modules and do not start with an ELF header.
 			return null;
 		}
@@ -1404,15 +1389,15 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 	 * <p>
 	 * Typically this will only be called with a full path library name e.g. /usr/lib/libnuma.so
 	 * however it attempts to search well known locations if the library isn't found.
-	 * 
+	 *
 	 * @param name
 	 * @return ElfFileReader to the module or null if could not be created
-	 * 
+	 *
 	 * @throws IOException
 	 * @throws InvalidDumpFormatException
 	 */
-	private ELFFileReader getReaderForModuleOnDiskOrAppended(String name)	throws IOException {
-		if (name != null) { 
+	private ELFFileReader getReaderForModuleOnDiskOrAppended(String name) throws IOException {
+		if (name != null) {
 			try {
 				LibraryDataSource libsource = _resolver.getLibrary(name);
 				if (libsource != null && LibraryDataSource.Source.NOT_FOUND != libsource.getType()) {
@@ -1427,24 +1412,21 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 				// not an error, just continue
 			}
 
-			if( !name.startsWith("/") ) {
+			if (!name.startsWith("/")) {
 				// Failed to find the library but it's a non-absolute unix path.
 				// Retry with some well known locations.
-				for( String path: knownLibPaths ) {
-					String fullPath = path.endsWith("/")?path+name:path+"/"+name;
+				for (String path : knownLibPaths) {
+					String fullPath = path.endsWith("/") ? path + name : path + "/" + name;
 					try {
-						//System.err.println("Looking for library " + name + " at " + fullPath);
+						// System.err.println("Looking for library " + name + " at " + fullPath);
 						LibraryDataSource libsource = _resolver.getLibrary(fullPath);
 						if (libsource != null && LibraryDataSource.Source.NOT_FOUND != libsource.getType()) {
 							ELFFileReader loadedElf = getELFReaderFromDataSource(libsource);
 							// Useful for identifying which library was with which full path using which type of stream (file or zip).
-							//System.err.println("Found library " + name + " at " + fullPath + " using " + loadedElf.getStream() );
+							// System.err.println("Found library " + name + " at " + fullPath + " using " + loadedElf.getStream() );
 							return loadedElf;
 						}
-					} catch (FileNotFoundException e) {
-						// in this circumstance it simply means that there is no collected version to be found
-						// not an error, just continue
-					} catch (InvalidDumpFormatException e) {
+					} catch (FileNotFoundException | InvalidDumpFormatException e) {
 						// in this circumstance it simply means that there is no collected version to be found
 						// not an error, just continue
 					}
@@ -1453,23 +1435,24 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 		}
 		return null;
 	}
-	
-	public class RegisterComparator implements Comparator<String> {
+
+	public static class RegisterComparator implements Comparator<String> {
 		public int compare(String s1, String s2) {
 			// Pad trailing single digit register names, eg gpr1 to gpr01 to sort nicely
-			int last = s1.length()-1;
+			int last = s1.length() - 1;
 			if (last >= 1) {
-				if (Character.isDigit(s1.charAt(last)) && Character.isLetter(s1.charAt(last-1))) {
-					s1 = s1.substring(0,last) + "0" + s1.substring(last);
+				if (Character.isDigit(s1.charAt(last)) && Character.isLetter(s1.charAt(last - 1))) {
+					s1 = s1.substring(0, last) + "0" + s1.substring(last);
 				}
 			}
-			last = s2.length()-1;
+			last = s2.length() - 1;
 			if (last >= 1) {
-				if (Character.isDigit(s2.charAt(last)) && Character.isLetter(s2.charAt(last-1))) {
-					s2 = s2.substring(0,last) + "0" + s2.substring(last);
+				if (Character.isDigit(s2.charAt(last)) && Character.isLetter(s2.charAt(last - 1))) {
+					s2 = s2.substring(0, last) + "0" + s2.substring(last);
 				}
 			}
 			return s1.compareTo(s2);
 		}
 	}
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFFileReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFFileReader.java
@@ -21,10 +21,11 @@
  *******************************************************************************/
 package com.ibm.j9ddr.corereaders.elf;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -50,12 +51,12 @@ import com.ibm.j9ddr.corereaders.memory.Symbol;
 
 /**
  * @author matthew
- *
  */
-public abstract class ELFFileReader 
-{
-	private static final Logger logger = Logger.getLogger(com.ibm.j9ddr.corereaders.ICoreFileReader.J9DDR_CORE_READERS_LOGGER_NAME);
-	
+public abstract class ELFFileReader {
+
+	private static final Logger logger = Logger
+			.getLogger(com.ibm.j9ddr.corereaders.ICoreFileReader.J9DDR_CORE_READERS_LOGGER_NAME);
+
 	public static final int ELF_NOTE_HEADER_SIZE = 12; // 3 32-bit words
 	public static final int EI_NIDENT = 16;
 	public static final byte ELFDATA2LSB = 1;
@@ -91,10 +92,7 @@ public abstract class ELFFileReader
 	// these are unsigned values so the constants can't be shorts
 	public final static int ET_LOOS = 0xfe00; /* OS-specific range start */
 	public final static int ET_HIOS = 0xfeff; /* OS-specific range end */
-	public final static int ET_LOPROC = 0xff00; /*
-												 * Processor-specific range
-												 * start
-												 */
+	public final static int ET_LOPROC = 0xff00; /* Processor-specific range start */
 	public final static int ET_HIPROC = 0xffff; /* Processor-specific range end */
 
 	public static final int NT_PRSTATUS = 1; // prstatus_t
@@ -108,50 +106,46 @@ public abstract class ELFFileReader
 	public static final int AT_NULL = 0; // End of vector
 	public static final int AT_ENTRY = 9; // Entry point of program
 	public static final int AT_PLATFORM = 15; // String identifying platform
-	public static final int AT_HWCAP = 16; // Machine dependent hints about
-											// processor capabilities
+	public static final int AT_HWCAP = 16; // Machine dependent hints about processor capabilities
 
 	private long _programHeaderOffset = -1;
 	private long _sectionHeaderOffset = -1;
-	private short _programHeaderEntrySize = 0;
-	private short _programHeaderCount = 0;
-	private short _sectionHeaderEntrySize = 0;
-	private short _sectionHeaderCount = 0;
+	private short _programHeaderEntrySize;
+	private short _programHeaderCount;
+	private short _sectionHeaderEntrySize;
+	private short _sectionHeaderCount;
 
-	private short _objectType = 0;
-	private int _version = 0;
-	private int _e_flags = 0;
+	private short _objectType;
+	private int _version;
+	private int _e_flags;
 	private short _machineType;
-	
-	private long baseOffset = 0;
+
+	private long baseOffset;
 
 	private final File _file;
-	
-	private List<ProgramHeaderEntry> _programHeaderEntries = new LinkedList<ProgramHeaderEntry>();
-	private List<SectionHeaderEntry> _sectionHeaderEntries = new LinkedList<SectionHeaderEntry>();
-	
 
-	protected abstract long padToWordBoundary(long l);
+	private final List<ProgramHeaderEntry> _programHeaderEntries = new LinkedList<>();
+	private final List<SectionHeaderEntry> _sectionHeaderEntries = new LinkedList<>();
 
-	protected abstract ProgramHeaderEntry readProgramHeaderEntry()
-			throws IOException;
+	protected abstract long padToWordBoundary(long address);
+
+	protected abstract ProgramHeaderEntry readProgramHeaderEntry() throws IOException;
 
 	protected abstract long readElfWord() throws IOException;
 
 	protected abstract Address readElfWordAsAddress() throws IOException;
 
-	protected abstract List<ELFSymbol> readSymbolsAt(SectionHeaderEntry entry)
-			throws IOException;
+	protected abstract List<ELFSymbol> readSymbolsAt(SectionHeaderEntry entry) throws IOException;
 
 	protected abstract int addressSizeBits();
-	
+
 	protected ImageInputStream is;
-	
+
 	protected String sourceName;
 
-	//Use openELFFile to get an ELFFile instance.
-	protected ELFFileReader(File file, ByteOrder byteOrder, long offset) throws IOException, FileNotFoundException, InvalidDumpFormatException
-	{
+	// Use openELFFile to get an ELFFile instance.
+	protected ELFFileReader(File file, ByteOrder byteOrder, long offset)
+			throws IOException, InvalidDumpFormatException {
 		try {
 			is = new FileImageInputStream(file);
 			is.setByteOrder(byteOrder);
@@ -159,99 +153,90 @@ public abstract class ELFFileReader
 			sourceName = file.getAbsolutePath();
 			this.baseOffset = offset;
 			initializeReader(offset);
-		} catch ( IOException e ) {
+		} catch (IOException | InvalidDumpFormatException e) {
 			// Don't leak file handles if we fail to create this reader.
-			if( is != null ) {
-				is.close();
-			}
-			throw e;
-		} catch ( InvalidDumpFormatException e ) {
-			// Don't leak file handles if we fail to create this reader.
-			if( is != null ) {
-				is.close();
-			}
+			close();
 			throw e;
 		}
 	}
-	
+
 	public void close() throws IOException {
-		if(is != null) {
+		if (is != null) {
 			is.close();
 		}
 	}
-	
-	protected ELFFileReader(ImageInputStream in, long offset)  throws IOException, InvalidDumpFormatException {
+
+	protected ELFFileReader(ImageInputStream in, long offset) throws IOException, InvalidDumpFormatException {
 		_file = null;
 		is = in;
 		this.baseOffset = offset;
 		sourceName = "internal data stream";
 		initializeReader(offset);
 	}
-	
+
 	public String getSourceName() {
 		return sourceName;
 	}
-	
+
 	private void initializeReader(long offset) throws IOException, InvalidDumpFormatException {
 		is.seek(offset);
 		readHeader();
 		readSectionHeader();
 		readProgramHeader();
 	}
-	
+
 	// ELF files can be either Big Endian (for example on Linux/PPC) or Little
 	// Endian (Linux/IA).
 	// Let's check whether it's actually an ELF file. We'll sort out the byte
 	// order later.
 
-	public static ELFFileReader getELFFileReaderWithOffset(File f, long offset) throws IOException, InvalidDumpFormatException
-	{
-		//Figure out which combination of bitness and architecture we are
+	public static ELFFileReader getELFFileReaderWithOffset(File f, long offset)
+			throws IOException, InvalidDumpFormatException {
+		// Figure out which combination of bitness and architecture we are
 		ImageInputStream in = new FileImageInputStream(f);
-		
-		if (! isFormatValid(in)) {
+
+		if (!isFormatValid(in)) {
 			throw new InvalidDumpFormatException("File " + f.getAbsolutePath() + " is not an ELF file");
 		}
 		int bitness = in.read();
 		ByteOrder byteOrder = getByteOrder(in);
-		in.close();							//no longer need the input stream as passing the File descriptor into the reader
+		in.close(); // no longer need the input stream as passing the File descriptor into the reader
 		if (ELFCLASS64 == bitness) {
-			return new ELF64FileReader(f, byteOrder, offset); 
+			return new ELF64FileReader(f, byteOrder, offset);
 		} else {
 			return new ELF32FileReader(f, byteOrder, offset);
 		}
 	}
 
-	
-	public static ELFFileReader getELFFileReader(File f) throws IOException, InvalidDumpFormatException
-	{
+	public static ELFFileReader getELFFileReader(File f) throws IOException, InvalidDumpFormatException {
 		return getELFFileReaderWithOffset(f, 0);
 	}
-	
+
 	public static ELFFileReader getELFFileReader(ImageInputStream in) throws IOException, InvalidDumpFormatException {
 		return getELFFileReaderWithOffset(in, 0);
 	}
-	
-	public static ELFFileReader getELFFileReaderWithOffset(ImageInputStream in, long offset) throws IOException, InvalidDumpFormatException {
-		in.mark();							//mark the stream as the validation and bitsize determinations move the underlying pointer
+
+	public static ELFFileReader getELFFileReaderWithOffset(ImageInputStream in, long offset)
+			throws IOException, InvalidDumpFormatException {
+		in.mark(); // mark the stream as the validation and bitsize determinations move the underlying pointer
 		in.seek(offset);
-		if (! isFormatValid(in)) {
+		if (!isFormatValid(in)) {
 			throw new InvalidDumpFormatException("The input stream is not an ELF file");
 		}
 		int bitness = in.read();
 		ByteOrder byteOrder = getByteOrder(in);
 		in.setByteOrder(byteOrder);
-		in.reset();							//reset the stream so that the reader reads from the start
+		in.reset(); // reset the stream so that the reader reads from the start
 		if (ELFCLASS64 == bitness) {
-			return new ELF64FileReader(in, offset); 
+			return new ELF64FileReader(in, offset);
 		} else {
 			return new ELF32FileReader(in, offset);
 		}
 	}
-		
+
 	private static ByteOrder getByteOrder(ImageInputStream in) throws IOException {
 		int endian = in.read();
-		ByteOrder byteOrder = null;
+		ByteOrder byteOrder;
 		if (ELFDATA2MSB == endian) {
 			byteOrder = ByteOrder.BIG_ENDIAN;
 		} else {
@@ -259,23 +244,20 @@ public abstract class ELFFileReader
 		}
 		return byteOrder;
 	}
-	
+
 	private static boolean isFormatValid(ImageInputStream in) throws IOException {
 		byte[] headerData = new byte[4];
 		in.readFully(headerData);
-		
+
 		return isELF(headerData);
 	}
-	
-	public static boolean isELF(byte[] signature)
-	{
+
+	public static boolean isELF(byte[] signature) {
 		// 0x7F, 'E', 'L', 'F'
-		return (0x7F == signature[0] && 0x45 == signature[1]
-				&& 0x4C == signature[2] && 0x46 == signature[3]);
+		return (0x7F == signature[0] && 0x45 == signature[1] && 0x4C == signature[2] && 0x46 == signature[3]);
 	}
 
-	private String _nameForFileType(short type)
-	{
+	private String _nameForFileType(short type) {
 		String fileType = "Unknown";
 		int typeAsInt = 0xFFFF & type;
 
@@ -294,27 +276,25 @@ public abstract class ELFFileReader
 		} else if ((ET_LOOS <= typeAsInt) && (typeAsInt <= ET_HIOS)) {
 			fileType = "OS-specific (" + Integer.toHexString(typeAsInt) + ")";
 		} else if ((ET_LOPROC <= typeAsInt) && (typeAsInt <= ET_HIPROC)) {
-			fileType = "Processor-specific (" + Integer.toHexString(typeAsInt)
-					+ ")";
+			fileType = "Processor-specific (" + Integer.toHexString(typeAsInt) + ")";
 		}
 		return fileType;
 	}
 
-	private void readHeader() throws IOException, InvalidDumpFormatException
-	{
+	private void readHeader() throws IOException, InvalidDumpFormatException {
 		byte[] signature = readBytes(EI_NIDENT);
-		
-		if (! isELF(signature)) {
+
+		if (!isELF(signature)) {
 			throw new InvalidDumpFormatException("Missing ELF magic number");
 		}
-		
-		_objectType = is.readShort(); // objectType
+
+		_objectType = is.readShort();
 		_machineType = is.readShort();
-		_version = is.readInt(); // Ignore version
+		_version = is.readInt();
 		readElfWord(); // Ignore entryPoint
 		_programHeaderOffset = readElfWord();
 		_sectionHeaderOffset = readElfWord();
-		_e_flags = is.readInt(); // e_flags
+		_e_flags = is.readInt();
 		is.readShort(); // Ignore elfHeaderSize
 		_programHeaderEntrySize = is.readShort();
 		_programHeaderCount = is.readShort();
@@ -323,8 +303,7 @@ public abstract class ELFFileReader
 		is.readShort(); // Ignore stringTable
 	}
 
-	private SectionHeaderEntry readSectionHeaderEntry() throws IOException
-	{
+	private SectionHeaderEntry readSectionHeaderEntry() throws IOException {
 		long name = is.readInt() & 0xffffffffL;
 		long type = is.readInt() & 0xffffffffL;
 		long flags = readElfWord();
@@ -333,42 +312,40 @@ public abstract class ELFFileReader
 		long size = readElfWord();
 		long link = is.readInt() & 0xffffffffL;
 		long info = is.readInt() & 0xffffffffL;
-		return new SectionHeaderEntry(name, type, flags, address, offset, size,
-				link, info);
+		return new SectionHeaderEntry(name, type, flags, address, offset, size, link, info);
 	}
 
 	/**
 	 * Read the section header table but being careful about whether the data we are reading looks valid or
-	 * whether we might just have been pointed at junk.  
+	 * whether we might just have been pointed at junk.
 	 * <p>
-	 * The ELF spec says that the section header table is optional and we often find that in a core file many of the 
-	 * modules do not have valid section header tables. In the ELF header there is a plausible count of the number of 
-	 * entries and a pointer to a plausible address in an area near the bottom of the module, but the 
+	 * The ELF spec says that the section header table is optional and we often find that in a core file many of the
+	 * modules do not have valid section header tables. In the ELF header there is a plausible count of the number of
+	 * entries and a pointer to a plausible address in an area near the bottom of the module, but the
 	 * data is not valid. The modules on disk do have valid section header tables but some parts of the section header
 	 * tables are often overwritten once the module is loaded into memory.
 	 * <p>
-	 * However the ELF header does not tell you this - it just points at the place in memory where the table 
+	 * However the ELF header does not tell you this - it just points at the place in memory where the table
 	 * should be (perhaps was, once) and says how many entries should be there. So we test whether it
 	 * looks valid. The likely scenarios are:
-	 * 1. we are pointing at non-zero junk. The first entry in the section header table should be zeros so we just return if that is 
-	 * not the case. 
+	 * 1. we are pointing at non-zero junk. The first entry in the section header table should be zeros so we just return if that is
+	 * not the case.
 	 * 2. we are pointing at a block of 0s. Look at the second entry also and return if the size field is zero.
 	 * If we pass these two tests, all well and good, go ahead and read in the rest.
 	 * <p>
-	 * This not the final line of defence though. It is fairly common that the first 
+	 * This not the final line of defence though. It is fairly common that the first
 	 * part of the section header table is fine but the later entries have been overwritten.
-	 * Later on, in getMemoryRanges, we see if we can find the section header string table and 
-	 * get a valid name for it Since the section header string table is one of the last sections 
-	 * this is usually a good indicator as to whether the section table is valid.  
-	 *     
+	 * Later on, in getMemoryRanges, we see if we can find the section header string table and
+	 * get a valid name for it Since the section header string table is one of the last sections
+	 * this is usually a good indicator as to whether the section table is valid.
+	 *
 	 * @throws IOException
 	 */
-	private void readSectionHeader() throws IOException
-	{
+	private void readSectionHeader() throws IOException {
 		if (_sectionHeaderCount < 3) {
 			return; // not enough entries to even check what we have got
-			// one special time this happens but is absolutely fine is when opening the 
-			// core file itself - it has no section table and the header count is 0 
+			// one special time this happens but is absolutely fine is when opening the
+			// core file itself - it has no section table and the header count is 0
 		}
 		seek(_sectionHeaderOffset);
 		SectionHeaderEntry firstEntry = readSectionHeaderEntry();
@@ -379,9 +356,9 @@ public abstract class ELFFileReader
 		SectionHeaderEntry secondEntry = readSectionHeaderEntry();
 		if (secondEntry.size == 0) {
 			return; // second entry should not have zero size
-		}	
-		_sectionHeaderEntries.add(firstEntry);	
-		_sectionHeaderEntries.add(secondEntry);	
+		}
+		_sectionHeaderEntries.add(firstEntry);
+		_sectionHeaderEntries.add(secondEntry);
 		// read in the third and subsequent entries - hence start the for loop with i = 2
 		for (int i = 2; i < _sectionHeaderCount; i++) {
 			seek(_sectionHeaderOffset + (i * _sectionHeaderEntrySize));
@@ -390,31 +367,29 @@ public abstract class ELFFileReader
 		}
 	}
 
-	private void readProgramHeader() throws IOException
-	{
+	private void readProgramHeader() throws IOException {
 		for (int i = 0; i < _programHeaderCount; i++) {
 			seek(_programHeaderOffset + i * _programHeaderEntrySize);
 			_programHeaderEntries.add(readProgramHeaderEntry());
 		}
 	}
-	
+
 	/**
 	 * Seek to the point in the ELF file that corresponds to the given memory address.
-	 * <p>	 
+	 * <p>
 	 * Note that it uses the first program header table entry that will resolve the address.
 	 * There may be more than one - it is quite common to have two or more
 	 * entries which can resolve an address - e.g. when called with the address
 	 * of the dynamic table, it is quite common to find that the first matching entry
-	 * is the entry for the dynamic table itself (it usually has its own entry) 
-	 * and a later entry with a broader range also encompasses the address; 
+	 * is the entry for the dynamic table itself (it usually has its own entry)
+	 * and a later entry with a broader range also encompasses the address;
 	 * however they invariably resolve to the same file offset so it does not matter
-	 * which you use. 
-	 * 
+	 * which you use.
+	 *
 	 * @param address
 	 * @throws IOException
 	 */
-	void seekToAddress(long address) throws IOException
-	{
+	void seekToAddress(long address) throws IOException {
 		ProgramHeaderEntry matchedEntry = null;
 
 		for (ProgramHeaderEntry element : _programHeaderEntries) {
@@ -426,48 +401,40 @@ public abstract class ELFFileReader
 		if (null == matchedEntry) {
 			throw new IOException("No ProgramHeaderEntry found for address");
 		} else {
-			seek(matchedEntry.fileOffset
-					+ (address - matchedEntry.virtualAddress));
+			seek(matchedEntry.fileOffset + (address - matchedEntry.virtualAddress));
 		}
 	}
-	
+
 	/**
 	 * Search the program header table to see whether it can successfully
 	 * resolve an address into a file offset.
 	 * <p>
-	 * If it returns true then it will be safe to call seekToAddress without an 
-	 * IOException being thrown. If it returns false, it will not. 
-	 * 
+	 * If it returns true then it will be safe to call seekToAddress without an
+	 * IOException being thrown. If it returns false, it will not.
+	 *
 	 * @param address virtual address
 	 * @return true or false according to whether the address will resolve
 	 */
 	public boolean canResolveAddress(long address) {
-		ProgramHeaderEntry matchedEntry = null;
-
 		for (ProgramHeaderEntry element : _programHeaderEntries) {
 			if (element.contains(address)) {
-				matchedEntry = element;
-				break;
+				return true;
 			}
 		}
-		if (null == matchedEntry) {
-			return false;
-		} else {
-			return true;
-		}
-	}	
-	
+		return false;
+	}
+
 	/** Obtain the symbols from a core reader, offset by baseAddress.
-	 *  
+	 *
 	 * @param baseAddress the base address to offset symbols from.
 	 * @param useUnallocatedSections whether to include symbols from unallocated sections. (true if reading from a library on disk, false if from a loaded library in the core file.)
 	 * @return
 	 * @throws IOException
 	 */
-	public List<? extends ISymbol> getSymbols(long baseAddress, boolean useUnallocatedSections ) throws IOException {
-		List<ISymbol> symbols = new LinkedList<ISymbol>();
+	public List<? extends ISymbol> getSymbols(long baseAddress, boolean useUnallocatedSections) throws IOException {
+		List<ISymbol> symbols = new LinkedList<>();
 		for (SectionHeaderEntry entry : _sectionHeaderEntries) {
-			if( useUnallocatedSections ||  entry.isAllocated() ) {
+			if (useUnallocatedSections || entry.isAllocated()) {
 				if (entry.isSymbolTable()) {
 					symbols.addAll(readSymbolsFrom(entry, baseAddress));
 				}
@@ -475,40 +442,40 @@ public abstract class ELFFileReader
 		}
 		return symbols;
 	}
-	
+
 	/**
 	 * Iterate through the sections that were already loaded and create a list of memory source objects for them.
 	 * Abandon the process if it is not possible to find the section header string table. This is one of the last
 	 * sections and if it cannot be found it is a good indicator that at least part of the section header table
-	 * has been overwritten. Since it is usually impossible to say where the overwriting starts it is safest to 
+	 * has been overwritten. Since it is usually impossible to say where the overwriting starts it is safest to
 	 * abandon it all. This is only an issue when working with a dump that does not have the original library files
-	 * attached to it.  
-	 *  
+	 * attached to it.
+	 *
 	 * @param baseAddress
 	 * @return List of memory sources
 	 * @throws IOException
 	 */
-	public Collection<? extends IMemorySource> getMemoryRanges(long baseAddress, List<SectionHeaderEntry> sectionHeaderEntries, Map<Long, String> sectionHeaderStringTable) throws IOException
-	{
-		List<IMemorySource> sections = new LinkedList<IMemorySource>();
-		if (sectionHeaderStringTable == null  || sectionHeaderEntries == null) {
+	public Collection<? extends IMemorySource> getMemoryRanges(long baseAddress,
+			List<SectionHeaderEntry> sectionHeaderEntries, Map<Long, String> sectionHeaderStringTable)
+			throws IOException {
+		List<IMemorySource> sections = new LinkedList<>();
+		if (sectionHeaderStringTable == null || sectionHeaderEntries == null) {
 			return sections; // abandon the process, return empty list
 		}
-		
+
 		// Loop through the section header entries building a module section for each one
 		// NB : If the core file is invalid, the method readString() may return null.
 		for (SectionHeaderEntry entry : sectionHeaderEntries) {
-			
+
 			// - Sections are only loaded if they are contained in a program header.
 			// - NOBITS sections (.bss) occupy space in memory but not in the library
 			//   (since they define sections that are generally initialized to 0's).
 			// - entry.address == 0 (sh_addr) also indicates a section that isn't loaded
 			// - entry.size == 0 is always true for the first (null) section header
-			if (!sectionHeaderMapsToProgramHeader(entry) || entry.isNoBits()
-					|| entry.address == 0 || entry.size == 0) {
+			if (!sectionHeaderMapsToProgramHeader(entry) || entry.isNoBits() || entry.address == 0 || entry.size == 0) {
 				continue;
 			}
-			
+
 			String name = sectionHeaderStringTable.get(entry._name);
 
 			// We may have read this section header from the core or the library
@@ -518,29 +485,28 @@ public abstract class ELFFileReader
 		}
 		return sections;
 	}
-	
+
 	public boolean sectionHeaderMapsToProgramHeader(SectionHeaderEntry section) {
-		
 		// To check if a section loaded you need to find out if it's in a range
 		// covered by a program header.
 		// (The readelf output for section to segment mappings only lists the
 		// sections that fall in a header. The others aren't actually loaded.)
-		for( ProgramHeaderEntry phe: _programHeaderEntries ) {
+		for (ProgramHeaderEntry phe : _programHeaderEntries) {
 			long headerBase = phe.fileOffset;
-			long headerTop = phe.fileOffset+phe.fileSize;
-			if( section.offset >= headerBase && section.offset < headerTop ) {
+			long headerTop = phe.fileOffset + phe.fileSize;
+			if (section.offset >= headerBase && section.offset < headerTop) {
 				return true;
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 	public Map<Long, String> getSectionHeaderStringTable() throws IOException {
 		SectionHeaderEntry shstrtabEntry = null;
-		
-		// Find the section header string table by looking for a section header entry of type string  
-		// table which, when resolved against itself, has the name ".shstrtab". 
+
+		// Find the section header string table by looking for a section header entry of type string
+		// table which, when resolved against itself, has the name ".shstrtab".
 		// NB : If the core file is invalid, the method stringFromBytesAt() may return null.
 		for (SectionHeaderEntry entry : _sectionHeaderEntries) {
 			if (entry.isStringTable()) {
@@ -551,25 +517,26 @@ public abstract class ELFFileReader
 						shstrtabEntry = entry;
 					}
 				} else {
-					logger.log(Level.FINER, "Error reading section header name. The core file is invalid and the results may unpredictable");
+					logger.log(Level.FINER,
+							"Error reading section header name. The core file is invalid and the results may unpredictable");
 				}
 			}
 		}
-		
+
 		if (shstrtabEntry == null) {
 			return null;
 		}
-		
-		Map<Long, String> sectionHeaderStringTable =  new HashMap<Long, String>();
+
+		Map<Long, String> sectionHeaderStringTable = new HashMap<>();
 		for (SectionHeaderEntry entry : _sectionHeaderEntries) {
-			
 			if (null != shstrtabEntry) {
 				String name = "";
 				seek(shstrtabEntry.offset + entry._name);
 				name = readString();
-				sectionHeaderStringTable.put(entry._name, name);					
+				sectionHeaderStringTable.put(entry._name, name);
 				if (name == null) {
-					logger.log(Level.FINER, "Error reading section header name. The core file is invalid and the results may unpredictable");
+					logger.log(Level.FINER,
+							"Error reading section header name. The core file is invalid and the results may unpredictable");
 				}
 			}
 		}
@@ -579,29 +546,30 @@ public abstract class ELFFileReader
 	/**
 	 * Given a section header table entry that points to a symbol table, construct a list
 	 * of the symbols.
-	 * 
+	 *
 	 * The previous code here was adding the base address to everything. However,
-	 * the symbols for the executable and system libraries are absolute addresses not 
-	 * relative so they should not have the base address added to them. 
+	 * the symbols for the executable and system libraries are absolute addresses not
+	 * relative so they should not have the base address added to them.
 	 * The symbols for the j9 shared libraries though look like offsets though whether they are
 	 * offsets from the base address or offsets from the section that contains them is
 	 * hard to say: interpreting symbols is hard - see the System V ABI abi386-4.pdf
 	 * One thing is pretty sure, though which is that if the symbol table value is already
 	 * greater than the base address, it is probably already a virtual address. Do not add the base address,
 	 * which is an improvement on the previous code.
-
+	 *
 	 * @param entry - section header table entry
 	 * @param baseAddress - of the module
 	 * @return list of the symbols
 	 * @throws IOException
 	 */
 	private List<ISymbol> readSymbolsFrom(SectionHeaderEntry entry, long baseAddress) throws IOException {
-		List<ISymbol> symbols = new LinkedList<ISymbol>();
+		List<ISymbol> symbols = new LinkedList<>();
 		SectionHeaderEntry stringTable;
 		try {
-			stringTable = _sectionHeaderEntries.get((int)entry.link);
+			stringTable = _sectionHeaderEntries.get((int) entry.link);
 		} catch (IndexOutOfBoundsException e) {
-			logger.log(Level.FINER, "Invalid link value " + entry.link + " when reading section header table of length " + _sectionHeaderEntries.size());
+			logger.log(Level.FINER, "Invalid link value " + entry.link + " when reading section header table of length "
+					+ _sectionHeaderEntries.size());
 			return symbols;
 		}
 		seek(stringTable.offset);
@@ -612,68 +580,63 @@ public abstract class ELFFileReader
 				if (name != null) {
 					if (sym.value != 0) {
 						// Always take care comparing 64 bit numbers for >, as we are using Java long as if it were unsigned
-						// i.e. numbers in the top half of 64 bit memory (> 2^63 - 1) appear as negative.  
+						// i.e. numbers in the top half of 64 bit memory (> 2^63 - 1) appear as negative.
 						// If they are both positive or both negative, the comparison is the natural one.
 						// If just one is negative, it appears smaller to > but is in fact bigger so the comparison is reversed.
 						// Draw the truth table of the four cases if that is confusing.
-						if ((sym.value > 0 && baseAddress > 0) 
-								|| (sym.value < 0 && baseAddress < 0)) { // comparison is the natural one
+						if ((sym.value > 0 && baseAddress > 0) || (sym.value < 0 && baseAddress < 0)) { // comparison is the natural one
 							if (sym.value >= baseAddress) {
-								symbols.add(new Symbol(name, sym.value));							
+								symbols.add(new Symbol(name, sym.value));
 							} else {
-								symbols.add(new Symbol(name, baseAddress + sym.value));							
+								symbols.add(new Symbol(name, baseAddress + sym.value));
 							}
 						} else {
 							if (sym.value < baseAddress) { // reverse the comparison
-								symbols.add(new Symbol(name, sym.value));							
+								symbols.add(new Symbol(name, sym.value));
 							} else {
-								symbols.add(new Symbol(name, baseAddress + sym.value));							
+								symbols.add(new Symbol(name, baseAddress + sym.value));
 							}
-							
+
 						}
 					}
 				} else {
-					logger.log(Level.FINER, "Error reading section header name. The core file is invalid and the results may unpredictable");
+					logger.log(Level.FINER,
+							"Error reading section header name. The core file is invalid and the results may unpredictable");
 				}
 			}
 		}
 		return symbols;
 	}
 
-	public boolean is64Bit()
-	{
+	public boolean is64Bit() {
 		return 64 == addressSizeBits();
 	}
-	
-	public byte[] readBytes(int len) throws IOException
-	{
+
+	public byte[] readBytes(int len) throws IOException {
 		byte[] buffer = new byte[len];
 		is.readFully(buffer);
 		return buffer;
 	}
-	
-	public short getMachineType()
-	{
+
+	public short getMachineType() {
 		return _machineType;
 	}
 
-	public List<? extends ProgramHeaderEntry> getProgramHeaderEntries()
-	{
+	public List<? extends ProgramHeaderEntry> getProgramHeaderEntries() {
 		return Collections.unmodifiableList(_programHeaderEntries);
 	}
-	
-	public List<SectionHeaderEntry> getSectionHeaderEntries()
-	{
+
+	public List<SectionHeaderEntry> getSectionHeaderEntries() {
 		return Collections.unmodifiableList(_sectionHeaderEntries);
 	}
-	
+
 	/**
 	 * Gets the data stream for this reader
 	 * @return an ImageInputStream for this reader
 	 * @throws IOException
 	 */
 	public ImageInputStream getStream() throws IOException {
-		if(is != null) {
+		if (is != null) {
 			return is;
 		} else {
 			FileImageInputStream fis = new FileImageInputStream(_file);
@@ -685,29 +648,27 @@ public abstract class ELFFileReader
 	 * Returns the file from which this reader is reading.
 	 * @return File or null if this reader is reading from a stream
 	 */
-	public File getFile()
-	{
+	public File getFile() {
 		return _file;
 	}
 
-	public Properties getProperties()
-	{
+	public Properties getProperties() {
 		Properties props = new Properties();
 		props.setProperty("Object file type", _nameForFileType(_objectType));
 		props.setProperty("Object file version", Integer.toHexString(_version));
 		props.setProperty("Processor-specific flags", Integer.toHexString(_e_flags));
-		
+
 		return props;
 	}
-	
+
 	public int readInt() throws IOException {
 		return is.readInt();
 	}
-	
+
 	public byte readByte() throws IOException {
 		return is.readByte();
 	}
-	
+
 	public void seek(long pos) throws IOException {
 		try {
 			is.seek(baseOffset + pos);
@@ -715,7 +676,7 @@ public abstract class ELFFileReader
 			throw new IOException("Seek index out of bounds in " + getSourceName());
 		}
 	}
-	
+
 	public ByteOrder getByteOrder() {
 		return is.getByteOrder();
 	}
@@ -731,47 +692,46 @@ public abstract class ELFFileReader
 	public void readFully(byte[] b, int off, int len) throws IOException {
 		is.readFully(b, off, len);
 	}
-	
+
 	/**
 	 * Reads a string from the readers current position until
 	 * it is terminated by a null (0) byte.
 	 * Bytes are read and converted to an ASCII string.
 	 * string.
-	 * 
+	 *
 	 * If readByte throws an exception, null will be returned.
-	 *  
+	 *
 	 * @return the null terminated sting at the readers current position or null
 	 * @throws IOException
 	 */
-	public String readString()
-	{
-		String toReturn = null;
+	public String readString() {
 		try {
-			StringBuffer buf = new StringBuffer();
-			byte b = readByte();
-			for (long i = 1; 0 != b; i++) {
-				buf.append(new String(new byte[] {b}, "ASCII"));
-				b = readByte();
+			for (ByteArrayOutputStream buffer = new ByteArrayOutputStream();;) {
+				byte ascii = readByte();
+
+				if (ascii != 0) {
+					buffer.write(ascii);
+				} else {
+					return new String(buffer.toByteArray(), StandardCharsets.US_ASCII);
+				}
 			}
-			toReturn = buf.toString();
 		} catch (Exception e) {
+			return null;
 		}
-		return toReturn;
 	}
-	
+
 	/**
-	 * Get the base address of an executable or library, given the ELF file. 
+	 * Get the base address of an executable or library, given the ELF file.
 	 * This is the lowest virtual address of the Program Header Table entries of type PT_LOAD, which
-	 * is probably the first but we search them all just in case. 
+	 * is probably the first but we search them all just in case.
 	 * The following is summarised from the System V Application Binary Interface,
 	 * gabi41.pdf, section Base Address
-	 * 
-	 *    "... to compute the base address, one determines the memory address associated with 
+	 *
+	 *    "... to compute the base address, one determines the memory address associated with
 	 *    the lowest p_vaddr value for a PT_LOAD segment. This address is truncated ..."
-	 *    
-	 * The truncation is to do with page sizes and in practice not found to be needed. 
-	 * 
-	 * 
+	 *
+	 * The truncation is to do with page sizes and in practice not found to be needed.
+	 *
 	 * @return base address for the executable or library
 	 */
 	public long getBaseAddress() {
@@ -785,11 +745,11 @@ public abstract class ELFFileReader
 		}
 		return lowestVirtualAddressSoFar;
 	}
-	
+
 	/**
 	 * Search the program header table for the dynamic entry. There should be only one of these
 	 * Typically it is within the first few entries, often the third, so this is not expensive
-	 * 
+	 *
 	 * @return the program header table entry for the dynamic table
 	 */
 	public ProgramHeaderEntry getDynamicTableEntry() {
@@ -805,27 +765,26 @@ public abstract class ELFFileReader
 	/**
 	 * Examine the ELF header to determine if this file is an executable or not.
 	 * Often it will instead be a shared library.
-	 * 
+	 *
 	 * @return true if the file is an executable
 	 */
 	public boolean isExecutable() {
 		return (_objectType == ET_EXEC);
 	}
-	
-	
+
 	/**
 	 * Assume the entry given refers to a loaded library or program and
 	 * find and return its name or null if it couldn't be determined.
-	 * 
+	 *
 	 * This method does not throw exceptions as we are seeking around the
 	 * core file which could be damaged or may come from a version of linux
 	 * which doesn't leave this information available, just do our best.
-	 * 
+	 *
 	 * @param ELFFileReader for the core file as a whole
 	 * @return the SONAME (library name) or null
 	 */
 	public String readSONAME(ELFFileReader coreFileReader) {
-		ProgramHeaderEntry dynamicTableEntry = getDynamicTableEntry();		
+		ProgramHeaderEntry dynamicTableEntry = getDynamicTableEntry();
 		try {
 			long imageStart = dynamicTableEntry.virtualAddress;
 
@@ -837,7 +796,7 @@ public abstract class ELFFileReader
 			long tag;
 			long sonameOffset = -1;
 			long strtabAddress = -1;
-			
+
 			do {
 				// Read the tag and the value/pointer (only used after the loop has terminated)
 				tag = readElfWord();
@@ -849,54 +808,51 @@ public abstract class ELFFileReader
 				 * CMVC 161449 - SVT:70:jextract invalid tag error
 				 * The range of valid values in the header has been expanded, so increasing the valid range
 				 * http://refspecs.freestandards.org/elf/gabi4+/ch5.dynamic.html
-				 * DT_RUNPATH 			29 	d_val 	optional 	optional
-				 * DT_FLAGS 			30 	d_val 	optional 	optional
-				 * DT_ENCODING 			32 	unspecified 	unspecified 	unspecified
-				 * DT_PREINIT_ARRAY 	32 	d_ptr 	optional 	ignored
-				 * DT_PREINIT_ARRAYSZ 	33 	d_val 	optional 	ignored
+				 * DT_RUNPATH          29  d_val        optional     optional
+				 * DT_FLAGS            30  d_val        optional     optional
+				 * DT_ENCODING         32  unspecified  unspecified  unspecified
+				 * DT_PREINIT_ARRAY    32  d_ptr        optional     ignored
+				 * DT_PREINIT_ARRAYSZ  33  d_val        optional     ignored
 				 */
-				if ( !((tag >= 0         ) && (tag <= 33        )) &&
-						!((tag >= 0x60000000) && (tag <= 0x6FFFFFFF)) &&
-						!((tag >= 0x70000000) && (tag <= 0x7FFFFFFF))    ) {
-					logger.log(Level.FINER,
-						"Error reading SONAME. Invalid tag value '0x" + 
-						Long.toHexString(tag) +
-						"'. The core file is invalid and the results may unpredictable"
-					);
+				if (   !((tag >=          0) && (tag <=         33))
+					&& !((tag >= 0x60000000) && (tag <= 0x6FFFFFFF))
+					&& !((tag >= 0x70000000) && (tag <= 0x7FFFFFFF))
+				) {
+					logger.log(Level.FINER, "Error reading SONAME. Invalid tag value '0x" + Long.toHexString(tag)
+							+ "'. The core file is invalid and the results may unpredictable");
 				}
-				if( tag == DT_SONAME ) {
+				if (tag == DT_SONAME) {
 					sonameOffset = address;
-				} else if( tag == DT_STRTAB ) {
+				} else if (tag == DT_STRTAB) {
 					strtabAddress = address;
 				}
-
-			} while ((tag != DT_NULL));
+			} while (tag != DT_NULL);
 
 			// If we have the soname pointer and the string table pointer
 			// look up the soname in the string table.
 			// According to the elf spec, the address of the string table (strtabAddress) is always a virtual address.
-			// So, take care to use ELFFileReader's seekToAddress(virtual address) here and not seek(offset), even though 
-			// for some of the J9 modules, e.g. libjvm.so, the address in the dynamic table looks like an offset. 
-			// That is an artifact of the way that the addresses need to be interpreted through the program header table 
-			// for the module. For example, in the dynamic table in a given dump, the address of the string table was 
-			// 0x2630. This looks like an offset and in fact could be treated as such but is really an address because 
+			// So, take care to use ELFFileReader's seekToAddress(virtual address) here and not seek(offset), even though
+			// for some of the J9 modules, e.g. libjvm.so, the address in the dynamic table looks like an offset.
+			// That is an artifact of the way that the addresses need to be interpreted through the program header table
+			// for the module. For example, in the dynamic table in a given dump, the address of the string table was
+			// 0x2630. This looks like an offset and in fact could be treated as such but is really an address because
 			// in that dump the program header table for libjvm.so contains the following entry:
 			//   Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
 			//   LOAD           0x000000 0x0000000000000000 0x0000000000000000 0x025e94 0x025e94 R E 0x100000
-			// This indicates that addresses in the range 0 to 0x025e94 should be understood to be resolved against offset 0 
-			// within the file, so address 0x2630 also means offset 0x2630.  
-			// By contrast, for a different module in the same dump the address of the string table was 0x494754 which is 
+			// This indicates that addresses in the range 0 to 0x025e94 should be understood to be resolved against offset 0
+			// within the file, so address 0x2630 also means offset 0x2630.
+			// By contrast, for a different module in the same dump the address of the string table was 0x494754 which is
 			// definitely not an offset. In this case the program header table contains the following row:
-			//   Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
+			//   Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
 			//   LOAD           0x000000 0x00493000 0x00493000 0x147a8 0x147a8 R E 0x1000
-			// so that the address 0x494754 was at offset (0x494754 - 0x493000) = 0x1754 in the file.  
+			// so that the address 0x494754 was at offset (0x494754 - 0x493000) = 0x1754 in the file.
 			// Always treat the address as an address and use seekToAddress which hunts through the program header table entries
 			// to resolve, and all will be well, regardless of whether the address looks like an offset or not.
-			// As a further complication, though, sometimes the address can only be resolved using the 
+			// As a further complication, though, sometimes the address can only be resolved using the
 			// program header table of the core file, not the module. Hence we try to resolve and seek to the address
 			// first using the module's program header table (elfFile) then the core file's (_reader).
 			// For further details see CMVC 181593
-			if( sonameOffset != -1 && strtabAddress != -1 ) {
+			if (sonameOffset != -1 && strtabAddress != -1) {
 				String name;
 				if (canResolveAddress(strtabAddress + sonameOffset)) {
 					seekToAddress(strtabAddress + sonameOffset);
@@ -905,57 +861,54 @@ public abstract class ELFFileReader
 					coreFileReader.seekToAddress(strtabAddress + sonameOffset);
 					name = coreFileReader.readString();
 				}
-				if((name == null) || (name.length() == 0)) {
+				if ((name == null) || name.isEmpty()) {
 					// If we don't read a string back, or if the string we do get is empty then return null
 					// as the SONAME is unknown
 					return null;
 				}
 				return name;
 			} else {
-				// Even if we do everything right, sometimes we do not find a name. For example, for  
+				// Even if we do everything right, sometimes we do not find a name. For example, for
 				// the library libj9dmp26.so, for some reason, the dynamic table pointer we are passed usually
-				// points at something that is clearly not a valid dynamic table - just some different bit of 
-				// storage. Hence the loop above iterates through until it hits a DT_NULL - zero - or throws a 
-				// IOException - and we come to here with both sonameAddress and strtabAddress == -1.  
-				return null;				
+				// points at something that is clearly not a valid dynamic table - just some different bit of
+				// storage. Hence the loop above iterates through until it hits a DT_NULL - zero - or throws a
+				// IOException - and we come to here with both sonameAddress and strtabAddress == -1.
+				return null;
 			}
 		} catch (IOException e) {
-			logger
-					.info("ProgramHeaderEntry @ "
-							+ Long.toHexString(dynamicTableEntry.virtualAddress)
-							+ " does not appear point to a module with a valid SONAME tag.");
+			logger.info("ProgramHeaderEntry @ " + Long.toHexString(dynamicTableEntry.virtualAddress)
+					+ " does not appear point to a module with a valid SONAME tag.");
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Perform a quick check on two ELF readers to see if they represent the same library.
 	 * otherReader is the one we hope is better that this reader.
-	 * 
+	 *
 	 * This is not the same as checking they are equal as we hope the other reader actually
 	 * has more information in.
-	 * 
+	 *
 	 * @param otherReader another ELFFileReader to compare against this one.
 	 */
-	public boolean isCompatibleWith (ELFFileReader otherReader) {
-		
-		if( null == otherReader ) {
+	public boolean isCompatibleWith(ELFFileReader otherReader) {
+		if (null == otherReader) {
 			return false;
 		}
-		
+
 		/*
 		 * First sanity check the libraries came from the same type of machine.
 		 * (We aren't opening a z/Linux dump on Linux AMD64 and picking up the
 		 * wrong libpthread.so for example.)
 		 */
-		if( this.getMachineType() != otherReader.getMachineType() ) {
+		if (this.getMachineType() != otherReader.getMachineType()) {
 			return false;
 		}
-		
-		if( this._programHeaderCount != otherReader._programHeaderCount) {
+
+		if (this._programHeaderCount != otherReader._programHeaderCount) {
 			return false;
 		}
-		
+
 		/*
 		 * The prelink process means it's common for libc.so.6 (and probably
 		 * other system libraries) to be exactly the same size but to load
@@ -966,24 +919,23 @@ public abstract class ELFFileReader
 		 */
 		Iterator<? extends ProgramHeaderEntry> primaryHeaders = this.getProgramHeaderEntries().iterator();
 		Iterator<? extends ProgramHeaderEntry> secondaryHeaders = otherReader.getProgramHeaderEntries().iterator();
-		while( primaryHeaders.hasNext() && secondaryHeaders.hasNext() ) {
+		while (primaryHeaders.hasNext() && secondaryHeaders.hasNext()) {
 			ProgramHeaderEntry primaryEntry = primaryHeaders.next();
 			ProgramHeaderEntry secondaryEntry = secondaryHeaders.next();
-			if( primaryEntry.virtualAddress != secondaryEntry.virtualAddress ) {
+			if (primaryEntry.virtualAddress != secondaryEntry.virtualAddress) {
 				return false;
 			}
 		}
-		
-		if( this._sectionHeaderCount != otherReader._sectionHeaderCount) {
+
+		if (this._sectionHeaderCount != otherReader._sectionHeaderCount) {
 			return false;
 		}
-		
-		if( this._version != otherReader._version) {
+
+		if (this._version != otherReader._version) {
 			return false;
 		}
-		
+
 		return true;
 	}
-
 
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ProgramHeaderEntry.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ProgramHeaderEntry.java
@@ -27,8 +27,7 @@ import com.ibm.j9ddr.corereaders.memory.IDetailedMemoryRange;
 import com.ibm.j9ddr.corereaders.memory.IMemorySource;
 import com.ibm.j9ddr.corereaders.memory.UnbackedMemorySource;
 
-public class ProgramHeaderEntry
-{
+public class ProgramHeaderEntry {
 	// Program Headers defined in /usr/include/linux/elf.h
 	// type constants
 	// private static final int PT_NULL = 0;
@@ -47,8 +46,7 @@ public class ProgramHeaderEntry
 	// PHE structure definitions:
 	private int _type;
 	public final long fileOffset;
-	public final long fileSize; // if fileSize == 0 then we have to map memory from
-							// external lib file.
+	public final long fileSize; // if fileSize == 0 then we have to map memory from external lib file.
 	public final long virtualAddress;
 	public final long physicalAddress;
 	public final long memorySize;
@@ -57,10 +55,8 @@ public class ProgramHeaderEntry
 
 	// private long _alignment;
 
-	ProgramHeaderEntry(int type, long fileOffset, long fileSize,
-			long virtualAddress, long physicalAddress, long memorySize,
-			int flags, long alignment, ELFFileReader reader)
-	{
+	ProgramHeaderEntry(int type, long fileOffset, long fileSize, long virtualAddress, long physicalAddress,
+			long memorySize, int flags, long alignment, ELFFileReader reader) {
 		_type = type;
 		this.fileOffset = fileOffset;
 		this.fileSize = fileSize;
@@ -72,8 +68,7 @@ public class ProgramHeaderEntry
 		// _alignment = alignment;
 	}
 
-	boolean isEmpty()
-	{
+	boolean isEmpty() {
 		// if the core is not a complete dump of the address space, there will
 		// be missing pieces. These are manifested as program header entries
 		// with a real memory size but a zero file size
@@ -82,57 +77,50 @@ public class ProgramHeaderEntry
 		return 0 == fileSize;
 	}
 
-	boolean isDynamic()
-	{
+	boolean isDynamic() {
 		return PT_DYNAMIC == _type;
 	}
-	
-	boolean isLoadable()
-	{
+
+	boolean isLoadable() {
 		return PT_LOAD == _type;
 	}
 
-	boolean isNote()
-	{
+	boolean isNote() {
 		return PT_NOTE == _type;
 	}
 
 	public boolean isEhFrame() {
 		return PT_GNU_EH_FRAME == _type;
 	}
-	
-	IMemorySource asMemorySource()
-	{
+
+	IMemorySource asMemorySource() {
 		IMemorySource source = null;
 		if (!isEmpty()) {
-			boolean isExecutable = (_flags & PF_X) != 0;
 			source = new ELFMemorySource(virtualAddress, memorySize, fileOffset, reader);
 		} else {
 			source = new UnbackedMemorySource(virtualAddress, memorySize,
 					"ELF ProgramHeaderEntry storage declared but data not included");
 		}
-		Properties memoryProps = ((IDetailedMemoryRange)source).getProperties();
-		memoryProps.setProperty("IN_CORE", ""+(!isEmpty()));
-		if( (_flags & PF_W) != 0 ) {
+		Properties memoryProps = ((IDetailedMemoryRange) source).getProperties();
+		memoryProps.setProperty("IN_CORE", "" + (!isEmpty()));
+		if ((_flags & PF_W) != 0) {
 			memoryProps.setProperty(IDetailedMemoryRange.WRITABLE, Boolean.TRUE.toString());
 		}
-		if( (_flags & PF_X) != 0 ) {
+		if ((_flags & PF_X) != 0) {
 			memoryProps.setProperty(IDetailedMemoryRange.EXECUTABLE, Boolean.TRUE.toString());
 		}
-		if( (_flags & PF_R) != 0 ) {
+		if ((_flags & PF_R) != 0) {
 			memoryProps.setProperty(IDetailedMemoryRange.READABLE, Boolean.TRUE.toString());
 		}
 		return source;
 	}
 
-	boolean validInProcess(long address)
-	{
-		return virtualAddress <= address
-				&& address < virtualAddress + memorySize;
+	boolean validInProcess(long address) {
+		return virtualAddress <= address && address < virtualAddress + memorySize;
 	}
 
-	boolean contains(long address)
-	{
+	boolean contains(long address) {
 		return false == isEmpty() && validInProcess(address);
 	}
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/SectionHeaderEntry.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/SectionHeaderEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2014 IBM Corp. and others
+ * Copyright (c) 2004, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,67 +22,66 @@
 package com.ibm.j9ddr.corereaders.elf;
 
 /**
- * Here, for reference, is the section header table for one of our libraries, libj9jit24.so
+ * Here, for reference, is the section header table for one of our libraries, libj9jit24.so.
  * Note a couple of things about it:
- * There is a null entry at the start
- * The addr is not always the same as the off: that is the sections will be 
- * more spaced out in memory 
+ * There is a null entry at the start.
+ * The addr is not always the same as the off: that is the sections will be
+ * more spaced out in memory.
  * The readelf commands shows how the sections are mapped to segments:
-    Section to Segment mapping:
-    Segment Sections...
-     00     .hash .dynsym .dynstr .gnu.version .gnu.version_r .rel.dyn .rel.plt .init .plt .text .fini .rodata .eh_frame_hdr .eh_frame
-     01     .ctors .dtors .jcr .data.rel.ro .dynamic .got .got.plt .data .bss
-     02     .dynamic
-     03     .eh_frame_hdr
- * Note that some of the later entries are not mapped to segments - although they are on 
- * disk it is not safe to assume that they are in memory
+ *  Section to Segment mapping:
+ *  Segment Sections...
+ *   00  .hash .dynsym .dynstr .gnu.version .gnu.version_r .rel.dyn .rel.plt .init .plt .text .fini .rodata .eh_frame_hdr .eh_frame
+ *   01  .ctors .dtors .jcr .data.rel.ro .dynamic .got .got.plt .data .bss
+ *   02  .dynamic
+ *   03  .eh_frame_hdr
+ * Note that some of the later entries are not mapped to segments - although they are on
+ * disk it is not safe to assume that they are in memory.
  * Some of the later entries have an addr of 0 - these are the ones that may not
- * be mapped. 
-  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
-  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
-  [ 1] .hash             HASH            000000d4 0000d4 000424 04   A  2   0  4
-  [ 2] .dynsym           DYNSYM          000004f8 0004f8 000840 10   A  3  13  4
-  [ 3] .dynstr           STRTAB          00000d38 000d38 000772 00   A  0   0  1
-  [ 4] .gnu.version      VERSYM          000014aa 0014aa 000108 02   A  2   0  2
-  [ 5] .gnu.version_r    VERNEED         000015b4 0015b4 000060 00   A  3   2  4
-  [ 6] .rel.dyn          REL             00001614 001614 02e4e0 08   A  2   0  4
-  [ 7] .rel.plt          REL             0002faf4 02faf4 000328 08   A  2   9  4
-  [ 8] .init             PROGBITS        0002fe1c 02fe1c 000017 00  AX  0   0  4
-  [ 9] .plt              PROGBITS        0002fe34 02fe34 000660 04  AX  0   0  4
-  [10] .text             PROGBITS        000304a0 0304a0 56df04 00  AX  0   0 16
-  [11] .fini             PROGBITS        0059e3a4 59e3a4 00001c 00  AX  0   0  4
-  [12] .rodata           PROGBITS        0059e3c0 59e3c0 061244 00   A  0   0 32
-  [13] .eh_frame_hdr     PROGBITS        005ff604 5ff604 00002c 00   A  0   0  4
-  [14] .eh_frame         PROGBITS        005ff630 5ff630 00009c 00   A  0   0  4
-  [15] .ctors            PROGBITS        006006cc 5ff6cc 00001c 00  WA  0   0  4
-  [16] .dtors            PROGBITS        006006e8 5ff6e8 000008 00  WA  0   0  4
-  [17] .jcr              PROGBITS        006006f0 5ff6f0 000004 00  WA  0   0  4
-  [18] .data.rel.ro      PROGBITS        00600700 5ff700 0141a0 00  WA  0   0 32
-  [19] .dynamic          DYNAMIC         006148a0 6138a0 000100 08  WA  3   0  4
-  [20] .got              PROGBITS        006149a0 6139a0 00128c 04  WA  0   0  4
-  [21] .got.plt          PROGBITS        00615c2c 614c2c 0001a0 04  WA  0   0  4
-  [22] .data             PROGBITS        00615de0 614de0 014d74 00  WA  0   0 32
-  [23] .bss              NOBITS          0062ab60 629b54 002e24 00  WA  0   0 32
-  [24] .comment          PROGBITS        00000000 629b54 002f58 00      0   0  1
-  [25] .note             NOTE            00000000 62caac 0000b8 00      0   0  1
-  [26] .gnu_debuglink    PROGBITS        00000000 62cb64 000018 00      0   0  1
-  [27] .shstrtab         STRTAB          00000000 62cb7c 0000f1 00      0   0  1
-  [28] .symtab           SYMTAB          00000000 62d120 04b800 10     29 19209  4
-  [29] .strtab           STRTAB          00000000 678920 0d7504 00      0   0  1
+ * be mapped.
+ *  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
+ *  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
+ *  [ 1] .hash             HASH            000000d4 0000d4 000424 04   A  2   0  4
+ *  [ 2] .dynsym           DYNSYM          000004f8 0004f8 000840 10   A  3  13  4
+ *  [ 3] .dynstr           STRTAB          00000d38 000d38 000772 00   A  0   0  1
+ *  [ 4] .gnu.version      VERSYM          000014aa 0014aa 000108 02   A  2   0  2
+ *  [ 5] .gnu.version_r    VERNEED         000015b4 0015b4 000060 00   A  3   2  4
+ *  [ 6] .rel.dyn          REL             00001614 001614 02e4e0 08   A  2   0  4
+ *  [ 7] .rel.plt          REL             0002faf4 02faf4 000328 08   A  2   9  4
+ *  [ 8] .init             PROGBITS        0002fe1c 02fe1c 000017 00  AX  0   0  4
+ *  [ 9] .plt              PROGBITS        0002fe34 02fe34 000660 04  AX  0   0  4
+ *  [10] .text             PROGBITS        000304a0 0304a0 56df04 00  AX  0   0 16
+ *  [11] .fini             PROGBITS        0059e3a4 59e3a4 00001c 00  AX  0   0  4
+ *  [12] .rodata           PROGBITS        0059e3c0 59e3c0 061244 00   A  0   0 32
+ *  [13] .eh_frame_hdr     PROGBITS        005ff604 5ff604 00002c 00   A  0   0  4
+ *  [14] .eh_frame         PROGBITS        005ff630 5ff630 00009c 00   A  0   0  4
+ *  [15] .ctors            PROGBITS        006006cc 5ff6cc 00001c 00  WA  0   0  4
+ *  [16] .dtors            PROGBITS        006006e8 5ff6e8 000008 00  WA  0   0  4
+ *  [17] .jcr              PROGBITS        006006f0 5ff6f0 000004 00  WA  0   0  4
+ *  [18] .data.rel.ro      PROGBITS        00600700 5ff700 0141a0 00  WA  0   0 32
+ *  [19] .dynamic          DYNAMIC         006148a0 6138a0 000100 08  WA  3   0  4
+ *  [20] .got              PROGBITS        006149a0 6139a0 00128c 04  WA  0   0  4
+ *  [21] .got.plt          PROGBITS        00615c2c 614c2c 0001a0 04  WA  0   0  4
+ *  [22] .data             PROGBITS        00615de0 614de0 014d74 00  WA  0   0 32
+ *  [23] .bss              NOBITS          0062ab60 629b54 002e24 00  WA  0   0 32
+ *  [24] .comment          PROGBITS        00000000 629b54 002f58 00      0   0  1
+ *  [25] .note             NOTE            00000000 62caac 0000b8 00      0   0  1
+ *  [26] .gnu_debuglink    PROGBITS        00000000 62cb64 000018 00      0   0  1
+ *  [27] .shstrtab         STRTAB          00000000 62cb7c 0000f1 00      0   0  1
+ *  [28] .symtab           SYMTAB          00000000 62d120 04b800 10     29 19209  4
+ *  [29] .strtab           STRTAB          00000000 678920 0d7504 00      0   0  1
  */
 
-class SectionHeaderEntry
-{
+final class SectionHeaderEntry {
 	static final int SHT_SYMTAB = 2; // Symbol table in this section
 	static final int SHT_STRTAB = 3; // String table in this section
-	static final int SHT_NOBITS	= 8; 
+	static final int SHT_NOBITS = 8;
 	static final int SHT_DYNSYM = 11; // Symbol table in this section
 	// private static final int SHT_DYNSTR = 99; // String table in this section
 
 	static final int SHF_ALLOC = 0x2; // Section occupies memory during process execution.
 
-	long _name; // index into section header string table
-	long _type;
+	final long _name; // index into section header string table
+	final long _type;
 	final long _flags;
 	final long address;
 	final long offset;
@@ -91,9 +90,7 @@ class SectionHeaderEntry
 
 	// private long _info;
 
-	SectionHeaderEntry(long name, long type, long flags, long address,
-			long offset, long size, long link, long info)
-	{
+	SectionHeaderEntry(long name, long type, long flags, long address, long offset, long size, long link, long info) {
 		this._name = name;
 		this._type = type;
 		this._flags = flags;
@@ -104,16 +101,14 @@ class SectionHeaderEntry
 		// _info = info;
 	}
 
-	boolean isSymbolTable()
-	{
+	boolean isSymbolTable() {
 		return SHT_SYMTAB == _type || SHT_DYNSYM == _type;
 	}
 
-	public boolean isStringTable()
-	{
+	public boolean isStringTable() {
 		return SHT_STRTAB == _type;
 	}
-	
+
 	public boolean isNoBits() {
 		return SHT_NOBITS == _type;
 	}
@@ -121,8 +116,10 @@ class SectionHeaderEntry
 	public boolean isAllocated() {
 		return (_flags & SHF_ALLOC) == SHF_ALLOC;
 	}
-	
+
 	public String toString() {
-		return String.format("Name %d, Type %d, Flags 0x%x, Address 0x%x, Offset 0x%x, Size 0x%x", _name, _type, _flags, address, offset, size);
+		return String.format("Name %d, Type %d, Flags 0x%x, Address 0x%x, Offset 0x%x, Size 0x%x",
+				_name, _type, _flags, address, offset, size);
 	}
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/memory/BaseMemoryRange.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/memory/BaseMemoryRange.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 IBM Corp. and others
+ * Copyright (c) 2009, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,52 +23,50 @@ package com.ibm.j9ddr.corereaders.memory;
 
 /**
  * Abstract base class containing common logic for IMemoryRange
- * 
+ *
  * @author andhall
- * 
  */
-public abstract class BaseMemoryRange implements IMemoryRange
-{	
+public abstract class BaseMemoryRange implements IMemoryRange {
 	private final boolean fastPathContains;
 	private int alignment;
 	private long baseAddressTestValue;
-	
+
 	protected final long baseAddress;
 	protected final long size;
-	
-	protected BaseMemoryRange(long baseAddress,long size)
-	{
-		//For ranges that are as wide as they are aligned, we can fast-path the contains() operation with an and().
+
+	protected BaseMemoryRange(long baseAddress, long size) {
+		// For ranges that are as wide as they are aligned, we can fast-path the contains() operation with an and().
 		this.baseAddress = baseAddress;
 		this.size = size;
-		
+
 		alignment = 0;
-		
+
 		long workingAddress = baseAddress;
-		for (int i=0; i < 64; i++) {
+		for (int i = 0; i < 64; i++) {
 			if ((workingAddress & 1) == 0) {
 				alignment++;
 			} else {
 				break;
 			}
-			
+
 			workingAddress >>>= 1;
 		}
-		
+
 		baseAddressTestValue = baseAddress >>> alignment;
-		
+
 		long topAddress = getTopAddress();
-		
-		fastPathContains = (baseAddressTestValue == (topAddress >>> alignment) && baseAddressTestValue != ((topAddress + 1) >>> alignment));
+
+		fastPathContains = (baseAddressTestValue == (topAddress >>> alignment)
+				&& baseAddressTestValue != ((topAddress + 1) >>> alignment));
 	}
-	
+
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see com.ibm.dtfj.j9ddr.corereaders.memory.IMemoryRange#contains(long)
 	 */
-	public boolean contains(long address)
-	{
+	@Override
+	public boolean contains(long address) {
 		if (fastPathContains) {
 			return baseAddressTestValue == address >>> alignment;
 		} else {
@@ -77,17 +75,15 @@ public abstract class BaseMemoryRange implements IMemoryRange
 		}
 	}
 
-	public int compareTo(IMemoryRange o)
-	{
-
+	@Override
+	public int compareTo(IMemoryRange o) {
 		if (o.getAddressSpaceId() != this.getAddressSpaceId()) {
 			return this.getAddressSpaceId() - o.getAddressSpaceId();
 		}
 
 		if (Addresses.greaterThan(this.getBaseAddress(), o.getBaseAddress())) {
 			return 1;
-		} else if (Addresses
-				.lessThan(this.getBaseAddress(), o.getBaseAddress())) {
+		} else if (Addresses.lessThan(this.getBaseAddress(), o.getBaseAddress())) {
 			return -1;
 		} else {
 			if (Addresses.greaterThan(this.getTopAddress(), o.getTopAddress())) {
@@ -99,12 +95,11 @@ public abstract class BaseMemoryRange implements IMemoryRange
 			}
 		}
 	}
-	
+
 	@Override
-	public String toString()
-	{
+	public String toString() {
 		StringBuffer buffer = new StringBuffer();
-		
+
 		buffer.append("MemoryRange ");
 		buffer.append(this.getClass().getName());
 		buffer.append(" from ");
@@ -114,43 +109,43 @@ public abstract class BaseMemoryRange implements IMemoryRange
 
 		return buffer.toString();
 	}
-	
-	public boolean isSubRange(IMemoryRange other)
-	{
+
+	@Override
+	public boolean isSubRange(IMemoryRange other) {
 		boolean baseAddressInRange = Addresses.greaterThanOrEqual(other.getBaseAddress(), this.getBaseAddress());
 		boolean topAddressInRange = Addresses.greaterThanOrEqual(this.getTopAddress(), other.getTopAddress());
 		return baseAddressInRange && topAddressInRange;
 	}
 
-	public boolean overlaps(IMemoryRange other)
-	{
+	@Override
+	public boolean overlaps(IMemoryRange other) {
 		return this.contains(other.getBaseAddress())
-		|| this.contains(other.getTopAddress())
-		|| other.contains(this.getBaseAddress())
-		|| other.contains(this.getTopAddress());
+			|| this.contains(other.getTopAddress())
+			|| other.contains(this.getBaseAddress())
+			|| other.contains(this.getTopAddress());
 	}
 
-	public final long getBaseAddress()
-	{
+	@Override
+	public final long getBaseAddress() {
 		return baseAddress;
 	}
 
-	public final long getSize()
-	{
+	@Override
+	public final long getSize() {
 		return size;
 	}
 
-	public final long getTopAddress()
-	{
-		if( size == 0 ) {
+	@Override
+	public final long getTopAddress() {
+		if (size == 0) {
 			return baseAddress;
 		}
 		return baseAddress + size - 1;
 	}
 
-	public boolean isBacked()
-	{
+	@Override
+	public boolean isBacked() {
 		return true;
 	}
-	
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/memory/MemorySourceTable.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/memory/MemorySourceTable.java
@@ -33,177 +33,178 @@ import java.util.ListIterator;
 import java.util.logging.Logger;
 
 /**
- * Class encapsulating the logic for taking a list of memory 
+ * Class encapsulating the logic for taking a list of memory
  * sources and efficiently finding ranges for addresses
- * 
- * @author andhall
  *
+ * @author andhall
  */
-public class MemorySourceTable
-{
-	private static final Logger logger = Logger.getLogger(com.ibm.j9ddr.corereaders.ICoreFileReader.J9DDR_CORE_READERS_LOGGER_NAME);
-	
+public class MemorySourceTable {
+
+	private static final Logger logger = Logger
+			.getLogger(com.ibm.j9ddr.corereaders.ICoreFileReader.J9DDR_CORE_READERS_LOGGER_NAME);
+
 	private static final String FORCE_BINARY_CHOP_RESOLVER_SYSTEM_PROPERTY = "ddr.force.binary.address.resolver";
-	
+
 	private static final boolean FORCE_BINARY_CHOP_RESOLVER;
-	
+
 	private static final String ALLOW_THREE_TIER_TABLE_RESOLVER_PROPERTY = "ddr.allow.three.tier.address.resolver";
-	
+
 	private static final boolean ALLOW_THREE_TIER_TABLE_RESOLVER;
-	
+
 	static long tlbCacheHits = 0;
 	static long tlbCacheMisses = 0;
-	
+
 	static {
 		String forceBinaryResolverString = AccessController.doPrivileged(new PrivilegedAction<String>() {
-
-			public String run()
-			{
+			@Override
+			public String run() {
 				return System.getProperty(FORCE_BINARY_CHOP_RESOLVER_SYSTEM_PROPERTY);
 			}
-			
 		});
-		
-		logger.logp(FINE,"MemoryRangeTable","<clinit>","System property {0} set to {1}",new Object[]{FORCE_BINARY_CHOP_RESOLVER_SYSTEM_PROPERTY,forceBinaryResolverString});
-		
-		if ( forceBinaryResolverString != null && forceBinaryResolverString.toLowerCase().equals("true") ) {
-			FORCE_BINARY_CHOP_RESOLVER = true;
-			logger.logp(FINE,"MemoryRangeTable","<clinit>","BinaryChopResolver forced on.");
-		} else {
-			logger.logp(FINE,"MemoryRangeTable","<clinit>","BinaryChopResolver NOT forced on.");
-			FORCE_BINARY_CHOP_RESOLVER = false;
-		}
-		
-		String allowThreeTierResolverString = AccessController.doPrivileged(new PrivilegedAction<String>() {
 
-			public String run()
-			{
+		logger.logp(FINE, "MemoryRangeTable", "<clinit>", "System property {0} set to {1}",
+				new Object[] { FORCE_BINARY_CHOP_RESOLVER_SYSTEM_PROPERTY, forceBinaryResolverString });
+
+		if (forceBinaryResolverString != null && forceBinaryResolverString.equalsIgnoreCase("true")) {
+			FORCE_BINARY_CHOP_RESOLVER = true;
+			logger.logp(FINE, "MemoryRangeTable", "<clinit>", "BinaryChopResolver forced on.");
+		} else {
+			FORCE_BINARY_CHOP_RESOLVER = false;
+			logger.logp(FINE, "MemoryRangeTable", "<clinit>", "BinaryChopResolver NOT forced on.");
+		}
+
+		String allowThreeTierResolverString = AccessController.doPrivileged(new PrivilegedAction<String>() {
+			@Override
+			public String run() {
 				return System.getProperty(ALLOW_THREE_TIER_TABLE_RESOLVER_PROPERTY);
 			}
-			
 		});
-		
-		logger.logp(FINE,"MemoryRangeTable","<clinit>","System property {0} set to {1}",new Object[]{ALLOW_THREE_TIER_TABLE_RESOLVER_PROPERTY,allowThreeTierResolverString});
-		
-		if ( allowThreeTierResolverString != null && allowThreeTierResolverString.toLowerCase().equals("true") ) {
+
+		logger.logp(FINE, "MemoryRangeTable", "<clinit>", "System property {0} set to {1}",
+				new Object[] { ALLOW_THREE_TIER_TABLE_RESOLVER_PROPERTY, allowThreeTierResolverString });
+
+		if (allowThreeTierResolverString != null && allowThreeTierResolverString.equalsIgnoreCase("true")) {
 			ALLOW_THREE_TIER_TABLE_RESOLVER = true;
-			logger.logp(FINE,"MemoryRangeTable","<clinit>","ThreeTierResolver selection allowed.");
+			logger.logp(FINE, "MemoryRangeTable", "<clinit>", "ThreeTierResolver selection allowed.");
 		} else {
-			logger.logp(FINE,"MemoryRangeTable","<clinit>","ThreeTierResolver selection NOT allowed.");
 			ALLOW_THREE_TIER_TABLE_RESOLVER = false;
+			logger.logp(FINE, "MemoryRangeTable", "<clinit>", "ThreeTierResolver selection NOT allowed.");
 		}
 	}
-	
-	private IAddressResolverStrategy addressResolver = null;
-	
-	private final List<IMemorySource> rawMemorySources = new ArrayList<IMemorySource>();
+
+	private IAddressResolverStrategy addressResolver;
+
+	private final List<IMemorySource> rawMemorySources = new ArrayList<>();
 	private List<IMemorySource> memorySources;
 
-	public final void addMemorySource(IMemorySource source)
-	{
+	public final void addMemorySource(IMemorySource source) {
 		rawMemorySources.add(source);
 		addressResolver = null;
 	}
 
-	public void removeMemorySource(IMemorySource source)
-	{
+	public void removeMemorySource(IMemorySource source) {
 		rawMemorySources.remove(source);
 		addressResolver = null;
 	}
-	
-	public final List<IMemoryRange> getMemorySources() 
-	{
+
+	public final List<IMemoryRange> getMemorySources() {
 		mergeOverlappingRanges();
 		return new ArrayList<IMemoryRange>(memorySources);
 	}
-	
-	public final IMemorySource getRangeForAddress(long address)
-	{
+
+	public final IMemorySource getRangeForAddress(long address) {
 		if (addressResolver == null) {
 			pickAddressResolver();
 		}
-		
+
 		return addressResolver.getRangeForAddress(address);
 	}
-	
-	private void pickAddressResolver()
-	{
+
+	private void pickAddressResolver() {
 		mergeOverlappingRanges();
-		
-		//Need to figure out highest address and worst alignment
+
+		// Need to figure out highest address and worst alignment
 		long highestAddress = 0;
 		int worstAlignment = Integer.MAX_VALUE;
 		long smallestRange = Integer.MAX_VALUE;
-		
+
 		for (IMemoryRange range : memorySources) {
-			if ( Addresses.greaterThan(range.getTopAddress(), highestAddress) ) {
+			if (Addresses.greaterThan(range.getTopAddress(), highestAddress)) {
 				highestAddress = range.getTopAddress();
 			}
-			
+
 			int alignment = getAlignment(range.getBaseAddress());
-			
+
 			if (alignment < worstAlignment) {
 				worstAlignment = alignment;
 			}
-			
+
 			if (range.getSize() < smallestRange) {
 				smallestRange = range.getSize();
 			}
 		}
-		
-		logger.logp(FINE,"MemoryRangeTable", "pickAddressResolver", "Picking address resolver. Highest Address = 0x{0}, worst alignment = {1} bit.",new Object[]{Long.toHexString(highestAddress),worstAlignment});
-		
+
+		logger.logp(FINE, "MemoryRangeTable", "pickAddressResolver",
+				"Picking address resolver. Highest Address = 0x{0}, worst alignment = {1} bit.",
+				new Object[] { Long.toHexString(highestAddress), worstAlignment });
+
 		if (FORCE_BINARY_CHOP_RESOLVER) {
-			logger.logp(FINE,"MemoryRangeTable", "pickAddressResolver", "Selection overridden with {0}",FORCE_BINARY_CHOP_RESOLVER_SYSTEM_PROPERTY);
+			logger.logp(FINE, "MemoryRangeTable", "pickAddressResolver", "Selection overridden with {0}",
+					FORCE_BINARY_CHOP_RESOLVER_SYSTEM_PROPERTY);
 			addressResolver = new BinaryChopAddressResolver(memorySources);
 		} else {
 			if (worstAlignment >= 12 && smallestRange >= 4096) {
-				if (Addresses.lessThan(highestAddress,0x100000000L)) {
-					addressResolver = new FlatPageTableAddressResolver(memorySources,highestAddress,worstAlignment);
-				} else if( ALLOW_THREE_TIER_TABLE_RESOLVER ){
-					logger.logp(FINE,"MemoryRangeTable", "pickAddressResolver", "Three tier table resolver selected, allowed by {0} setting",ALLOW_THREE_TIER_TABLE_RESOLVER_PROPERTY);
-					addressResolver = new ThreeTierPageTableAddressResolver(memorySources, highestAddress, worstAlignment);
+				if (Addresses.lessThan(highestAddress, 0x100000000L)) {
+					addressResolver = new FlatPageTableAddressResolver(memorySources, highestAddress, worstAlignment);
+				} else if (ALLOW_THREE_TIER_TABLE_RESOLVER) {
+					logger.logp(FINE, "MemoryRangeTable", "pickAddressResolver",
+							"Three tier table resolver selected, allowed by {0} setting",
+							ALLOW_THREE_TIER_TABLE_RESOLVER_PROPERTY);
+					addressResolver = new ThreeTierPageTableAddressResolver(memorySources, highestAddress,
+							worstAlignment);
 				}
 			}
 
 		}
 		/* Can't use one of the clever resolvers. We will fall back to binary-chop. */
-		if( addressResolver == null ) {
+		if (addressResolver == null) {
 			addressResolver = new BinaryChopAddressResolver(memorySources);
 		}
-		
-		logger.logp(FINE,"MemoryRangeTable", "pickAddressResolver", "Picked {0} as address resolver.",addressResolver.getClass().getSimpleName());
+
+		logger.logp(FINE, "MemoryRangeTable", "pickAddressResolver",
+				"Picked {0} as address resolver.",
+				addressResolver.getClass().getSimpleName());
 	}
-	
-	private void mergeOverlappingRanges()
-	{
-		memorySources = new ArrayList<IMemorySource>(rawMemorySources);
+
+	private void mergeOverlappingRanges() {
+		memorySources = new ArrayList<>(rawMemorySources);
 		Collections.sort(memorySources);
-		//Resolve any overlapping ranges (seems to happen on AIX occasionally)
+		// Resolve any overlapping ranges (seems to happen on AIX occasionally)
 		if (memorySources.size() > 0) {
-			
 			ListIterator<IMemorySource> rangeIt = memorySources.listIterator();
-			
 			IMemorySource previous = rangeIt.next();
-			
+
 			while (rangeIt.hasNext()) {
 				IMemorySource thisRange = rangeIt.next();
-				
+
 				if (thisRange.overlaps(previous)) {
-					logger.logp(FINE,"MemoryRangeTable","mergeOverlappingRanges","Address range {0} overlaps with {1}",new Object[]{thisRange,previous});
-					//Either thisRange is a subrange of previous or we overlap partially
+					logger.logp(FINE, "MemoryRangeTable", "mergeOverlappingRanges",
+							"Address range {0} overlaps with {1}",
+							new Object[] { thisRange, previous });
+					// Either thisRange is a subrange of previous or we overlap partially
 					if (previous.isSubRange(thisRange)) {
-						//Remove thisRange
-						logger.logp(FINER,"MemoryRangeTable","mergeOverlappingRanges","Removing {0}",thisRange);
+						// Remove thisRange
+						logger.logp(FINER, "MemoryRangeTable", "mergeOverlappingRanges", "Removing {0}", thisRange);
 						rangeIt.remove();
-						//Leave previous as-is
+						// Leave previous as-is
 					} else if (previous.isBacked() == thisRange.isBacked()) {
-						logger.logp(FINER,"MemoryRangeTable","mergeOverlappingRanges","Merging {0} and {1}", new Object[]{thisRange,previous});
-						//Merge
+						logger.logp(FINER, "MemoryRangeTable", "mergeOverlappingRanges", "Merging {0} and {1}",
+								new Object[] { thisRange, previous });
+						// Merge
 						rangeIt.remove();
 						rangeIt.previous();
 						rangeIt.remove();
-						IMemorySource toAdd = new MergedMemoryRange(previous,thisRange);
+						IMemorySource toAdd = new MergedMemoryRange(previous, thisRange);
 						rangeIt.add(toAdd);
 						previous = toAdd;
 					} else {
@@ -215,96 +216,91 @@ public class MemorySourceTable
 			}
 		}
 	}
-	
-	static int getAlignment(long address)
-	{
+
+	static int getAlignment(long address) {
 		int alignment = 0;
-		for (int i=0; i < 64; i++) {
-			
+		for (int i = 0; i < 64; i++) {
 			if ((address & 0x1) == 0) {
 				alignment++;
 			} else {
 				break;
 			}
-			
+
 			address >>= 1;
 		}
-		
+
 		return alignment;
 	}
 
 	/**
 	 * Memory range used for merging overlapping memory ranges.
-	 * 
 	 */
-	private static class MergedMemoryRange extends BaseMemoryRange implements IMemorySource
-	{
+	private static class MergedMemoryRange extends BaseMemoryRange implements IMemorySource {
 
 		private final IMemorySource lower;
-		
+
 		private final IMemorySource upper;
-		
-		public MergedMemoryRange(IMemorySource lower, IMemorySource upper)
-		{
-			super(lower.getBaseAddress(),upper.getTopAddress() - lower.getBaseAddress() + 1);
+
+		public MergedMemoryRange(IMemorySource lower, IMemorySource upper) {
+			super(lower.getBaseAddress(), upper.getTopAddress() - lower.getBaseAddress() + 1);
 			this.lower = lower;
 			this.upper = upper;
 			if (lower.isBacked() != upper.isBacked()) {
-				throw new RuntimeException("Error: creating an instance of MergedMemoryRange where backed and unbacked memory sources are merged");
+				throw new RuntimeException(
+						"Error: creating an instance of MergedMemoryRange where backed and unbacked memory sources are merged");
 			}
 		}
-		
-		public int getAddressSpaceId()
-		{
+
+		@Override
+		public int getAddressSpaceId() {
 			return lower.getAddressSpaceId();
 		}
-		
+
 		@Override
 		public boolean isBacked() {
 			return upper.isBacked();
 		}
 
-		public int getBytes(long address, byte[] buffer, int offset, int length)
-				throws MemoryFault
-		{
+		@Override
+		public int getBytes(long address, byte[] buffer, int offset, int length) throws MemoryFault {
 			if (lower.contains(address) && lower.contains(address + length)) {
 				return lower.getBytes(address, buffer, offset, length);
 			} else if (Addresses.greaterThan(address, lower.getTopAddress())) {
 				return upper.getBytes(address, buffer, offset, length);
 			} else {
-				//Span
-				int sizeInLower = (int)(lower.getTopAddress() - address + 1);
-				
+				// Span
+				int sizeInLower = (int) (lower.getTopAddress() - address + 1);
+
 				int read = lower.getBytes(address, buffer, offset, sizeInLower);
-				
+
 				if (read == sizeInLower) {
 					read += upper.getBytes(address + sizeInLower, buffer, offset + sizeInLower, length - sizeInLower);
 				}
-				
+
 				return read;
 			}
 		}
 
-		public boolean isExecutable()
-		{
+		@Override
+		public boolean isExecutable() {
 			return lower.isExecutable() && upper.isExecutable();
 		}
 
-		public boolean isReadOnly()
-		{
+		@Override
+		public boolean isReadOnly() {
 			return lower.isReadOnly() && upper.isReadOnly();
 		}
 
-		public boolean isShared()
-		{
+		@Override
+		public boolean isShared() {
 			return lower.isShared() && upper.isShared();
 		}
 
-		public String getName()
-		{
+		@Override
+		public String getName() {
 			String lowerResult = lower.getName();
 			String upperResult = upper.getName();
-			
+
 			if (lowerResult != null) {
 				if (upperResult != null) {
 					return lowerResult + " merged with " + upperResult;
@@ -321,92 +317,87 @@ public class MemorySourceTable
 		}
 	}
 
-	
 	/* Abstract strategy for matching addresses to address ranges */
-	private static interface IAddressResolverStrategy
-	{
+	private static interface IAddressResolverStrategy {
 		public IMemorySource getRangeForAddress(long address);
 	}
-	
+
 	/* Class used for debugging misbehaving addres resolver strategies */
 	@SuppressWarnings("unused")
-	private static class DebugAddressResolverStrategy implements IAddressResolverStrategy
-	{
+	private static class DebugAddressResolverStrategy implements IAddressResolverStrategy {
 		private final IAddressResolverStrategy trusted;
 		private final IAddressResolverStrategy untrusted;
-		
-		public DebugAddressResolverStrategy(IAddressResolverStrategy trusted, IAddressResolverStrategy untrusted)
-		{
+
+		public DebugAddressResolverStrategy(IAddressResolverStrategy trusted, IAddressResolverStrategy untrusted) {
 			this.trusted = trusted;
 			this.untrusted = untrusted;
 		}
-		
-		public IMemorySource getRangeForAddress(long address)
-		{
+
+		@Override
+		public IMemorySource getRangeForAddress(long address) {
 			IMemorySource trustedResult = trusted.getRangeForAddress(address);
 			IMemorySource untrustedResult = untrusted.getRangeForAddress(address);
-			
+
 			if (trustedResult.equals(untrustedResult)) {
 				return trustedResult;
 			} else {
-				throw new RuntimeException("Mismatch for address 0x" + Long.toHexString(address) + ". Trusted gave " + trustedResult + ", untrusted gave " + untrustedResult);
+				throw new RuntimeException("Mismatch for address 0x" + Long.toHexString(address)
+						+ ". Trusted gave " + trustedResult + ", untrusted gave " + untrustedResult);
 			}
 		}
 	}
-	
-	private static class BinaryChopAddressResolver implements IAddressResolverStrategy
-	{
+
+	private static class BinaryChopAddressResolver implements IAddressResolverStrategy {
 		private List<IMemorySource> memoryRanges;
-		
+
 		private IMemorySource tlbEntry1 = null;
 		private long entry1HitCount = 0;
-		
+
 		private IMemorySource tlbEntry2 = null;
 		private long entry2HitCount = 0;
-		
-		public BinaryChopAddressResolver(List<IMemorySource> memoryRanges)
-		{
+
+		public BinaryChopAddressResolver(List<IMemorySource> memoryRanges) {
 			this.memoryRanges = memoryRanges;
 			Collections.sort(memoryRanges);
 		}
-		
-		public IMemorySource getRangeForAddress(long address)
-		{
+
+		@Override
+		public IMemorySource getRangeForAddress(long address) {
 			int bottom = 0;
 			int top = memoryRanges.size() - 1;
-			
+
 			IMemorySource tlbEntry = tlbCheck(address);
-			
+
 			if (tlbEntry != null) {
 				if (AbstractMemory.RECORDING_CACHE_STATS) {
 					tlbCacheHits++;
 				}
-				
+
 				return tlbEntry;
 			}
-			
+
 			if (AbstractMemory.RECORDING_CACHE_STATS) {
 				tlbCacheMisses++;
 			}
-			
+
 			while (true) {
 				int middle = (bottom + top) / 2;
-				
+
 				IMemorySource midPoint = memoryRanges.get(middle);
-				
-				if (Addresses.greaterThan(midPoint.getBaseAddress(),address)) {
+
+				if (Addresses.greaterThan(midPoint.getBaseAddress(), address)) {
 					if (bottom == top) {
-						//Memory fault
+						// Memory fault
 						return null;
 					} else {
 						top = middle;
 					}
-				} else if (Addresses.lessThan(midPoint.getTopAddress(),address)) {
+				} else if (Addresses.lessThan(midPoint.getTopAddress(), address)) {
 					if (top == bottom) {
-						//Memory fault
+						// Memory fault
 						return null;
 					} else if (middle == bottom) {
-						//If middle == bottom then top must be bottom + 1
+						// If middle == bottom then top must be bottom + 1
 						bottom = top;
 					} else {
 						bottom = middle;
@@ -418,104 +409,98 @@ public class MemorySourceTable
 				}
 			}
 		}
-		
-		private IMemorySource tlbCheck(long address)
-		{
+
+		private IMemorySource tlbCheck(long address) {
 			if (tlbEntry1 != null && tlbEntry1.contains(address)) {
 				entry1HitCount++;
 				return tlbEntry1;
 			}
-			
+
 			if (tlbEntry2 != null && tlbEntry2.contains(address)) {
 				entry2HitCount++;
 				return tlbEntry2;
 			}
-			
+
 			return null;
 		}
 
-		private void tlbInsert(IMemorySource newEntry)
-		{
+		private void tlbInsert(IMemorySource newEntry) {
 			if (tlbEntry1 == null) {
 				tlbEntry1 = newEntry;
-			} else  if (tlbEntry2 == null) {
+			} else if (tlbEntry2 == null) {
 				tlbEntry2 = newEntry;
 			} else if (entry1HitCount >= entry2HitCount) {
 				tlbEntry2 = newEntry;
 			} else {
 				tlbEntry1 = newEntry;
 			}
-			
+
 			entry1HitCount = 0;
 			entry2HitCount = 0;
 		}
-		
+
 	}
-	
-	private static class FlatPageTableAddressResolver implements IAddressResolverStrategy
-	{
+
+	private static class FlatPageTableAddressResolver implements IAddressResolverStrategy {
 		private final IMemorySource[] pageTable;
-		
+
 		private final long alignment;
 
-		public FlatPageTableAddressResolver(List<IMemorySource> memorySource,
-				long highestAddress, int alignment)
-		{
+		public FlatPageTableAddressResolver(List<IMemorySource> memorySource, long highestAddress, int alignment) {
 			this.alignment = alignment;
 			long slots = (highestAddress >>> alignment) + 1;
-			
-			pageTable = new IMemorySource[(int)slots];
-			
+
+			pageTable = new IMemorySource[(int) slots];
+
 			for (IMemorySource range : memorySource) {
-				int baseSlot = (int)(range.getBaseAddress() >>> alignment);
-				int topSlot = (int)(range.getTopAddress() >>> alignment);
-				
+				int baseSlot = (int) (range.getBaseAddress() >>> alignment);
+				int topSlot = (int) (range.getTopAddress() >>> alignment);
+
 				for (int i = baseSlot; i <= topSlot; i++) {
 					pageTable[i] = range;
 				}
 			}
 		}
 
-		public IMemorySource getRangeForAddress(long address)
-		{
-			int slot = (int)(address >>> alignment);
-			
+		@Override
+		public IMemorySource getRangeForAddress(long address) {
+			int slot = (int) (address >>> alignment);
+
 			if (slot >= pageTable.length) {
 				return null;
 			}
-			
+
 			return pageTable[slot];
 		}
-		
+
 	}
-	
+
 	/**
 	 * Uses a three-tier page table to break up the look-up table into smaller chunks. Uses much less space
 	 * when the address space is sparse.
-	 * @author andhall
 	 *
+	 * @author andhall
 	 */
-	private static class ThreeTierPageTableAddressResolver implements IAddressResolverStrategy
-	{
+	private static class ThreeTierPageTableAddressResolver implements IAddressResolverStrategy {
 
 		private final Object[] pageTable;
 		private final int pageTableSize;
-		
+
 		private final long alignment;
-		
-		//Sizes of each tier
+
+		// Sizes of each tier
 		private final int topLevelBits;
 		private final int midTierBits;
 		private final int bottomTierBits;
-		
-		public ThreeTierPageTableAddressResolver(List<IMemorySource> memorySources, long highestAddress, int alignment)
-		{
+
+		public ThreeTierPageTableAddressResolver(List<IMemorySource> memorySources, long highestAddress,
+				int alignment) {
 			this.alignment = alignment;
 			long slots = (highestAddress >>> alignment);
-			
-			//Work out bits
-			int bits = (int)Math.ceil((Math.log(slots) / Math.log(2)));
-			
+
+			// Work out bits
+			int bits = (int) Math.ceil((Math.log(slots) / Math.log(2)));
+
 			if (bits > 40) {
 				midTierBits = 20;
 				bottomTierBits = 20;
@@ -529,74 +514,71 @@ public class MemorySourceTable
 				midTierBits = 0;
 				bottomTierBits = bits;
 			}
-			
+
 			pageTableSize = 1 << topLevelBits;
 			pageTable = new Object[pageTableSize];
-			
+
 			for (IMemorySource range : memorySources) {
-				
 				long baseSlot = range.getBaseAddress() >>> alignment;
 				long topSlot = range.getTopAddress() >>> alignment;
-				
+
 				for (long i = baseSlot; i <= topSlot; i++) {
-					insert(i,range);
+					insert(i, range);
 				}
 			}
 		}
-		
-		private void insert(long slotIndex, IMemorySource range)
-		{
-			int bottomTierIndex = (int)(slotIndex & ((1 << bottomTierBits) - 1));
+
+		private void insert(long slotIndex, IMemorySource range) {
+			int bottomTierIndex = (int) (slotIndex & ((1 << bottomTierBits) - 1));
 			long workingSlotIndex = slotIndex >>> bottomTierBits;
-			int midTierIndex = (int)(workingSlotIndex & ((1 << midTierBits) - 1));
+			int midTierIndex = (int) (workingSlotIndex & ((1 << midTierBits) - 1));
 			workingSlotIndex >>>= midTierBits;
-			int topTierIndex = (int)workingSlotIndex;
-			
+			int topTierIndex = (int) workingSlotIndex;
+
 			Object[] midTier = (Object[]) pageTable[topTierIndex];
-			
+
 			if (midTier == null) {
 				midTier = new Object[1 << midTierBits];
 				pageTable[topTierIndex] = midTier;
 			}
-			
+
 			IMemorySource[] bottomTier = (IMemorySource[]) midTier[midTierIndex];
-			
+
 			if (null == bottomTier) {
 				bottomTier = new IMemorySource[1 << bottomTierBits];
 				midTier[midTierIndex] = bottomTier;
 			}
-			
+
 			bottomTier[bottomTierIndex] = range;
 		}
 
-		public IMemorySource getRangeForAddress(long address)
-		{
+		@Override
+		public IMemorySource getRangeForAddress(long address) {
 			long slotIndex = address >>> alignment;
 
-			int bottomTierIndex = (int)(slotIndex & ((1 << bottomTierBits) - 1));
+			int bottomTierIndex = (int) (slotIndex & ((1 << bottomTierBits) - 1));
 			long workingSlotIndex = slotIndex >>> bottomTierBits;
-			int midTierIndex = (int)(workingSlotIndex & ((1 << midTierBits) - 1));
+			int midTierIndex = (int) (workingSlotIndex & ((1 << midTierBits) - 1));
 			workingSlotIndex >>>= midTierBits;
-			int topTierIndex = (int)workingSlotIndex;
-			
-			
-			if((topTierIndex < 0) || (topTierIndex >= pageTableSize)) {
-				return null;			//if the requested address is out of range then return null
+			int topTierIndex = (int) workingSlotIndex;
+
+			if ((topTierIndex < 0) || (topTierIndex >= pageTableSize)) {
+				return null; // if the requested address is out of range then return null
 			}
 			Object[] midTier = (Object[]) pageTable[topTierIndex];
 			if (midTier == null) {
 				return null;
 			}
-			
+
 			IMemorySource[] bottomTier = (IMemorySource[]) midTier[midTierIndex];
-			
+
 			if (null == bottomTier) {
 				return null;
 			}
-			
+
 			return bottomTier[bottomTierIndex];
 		}
-		
+
 	}
 
 }


### PR DESCRIPTION
* validate segments are within the bounds of a core file

First commit includes significant cleanup:
* format
* remove trailing whitespace
* use only leading tabs
* add missing `@Override` annotations
* remove redundant initializations
* remove redundant type parameters
* remove unused local variables
* make fields and classes `final` where appropriate
* remove redundant throws clauses
* use `StandardCharsets`