### PR TITLE
Add missing WINDOWS define

### DIFF
--- a/runtime/cmake/platform/os/win.cmake
+++ b/runtime/cmake/platform/os/win.cmake
@@ -32,6 +32,7 @@ if(OMR_ENV_DATA64)
         -D_WIN64
     )
 endif()
+list(APPEND OMR_PLATFORM_DEFINITIONS -DWINDOWS)
 
 # Set flags we use to build the interpreter
 omr_stringify(CMAKE_J9VM_CXX_FLAGS


### PR DESCRIPTION
MSVC adds this for us, but this is required for some of the
NASM code in the jit

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>