### PR TITLE
Add jextract option to disable buildID check

### DIFF
--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/NewElfDump.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/NewElfDump.java
@@ -1547,8 +1547,7 @@ public class NewElfDump extends CoreReaderSupport {
 		}
 
 		return buildProcess(builder, addressSpace, pid, commandLine,
-					getEnvironmentVariables(builder), failingThread,
-					threads.iterator(), executable);
+				environment, failingThread, threads.iterator(), executable);
 	}
 
 	private Object buildProcess(Builder builder, Object addressSpace, String pid, String commandLine,

--- a/runtime/cmake/build_tags.cmake
+++ b/runtime/cmake/build_tags.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,9 @@
 
 string(TIMESTAMP J9VM_CURRENT_YEAR "%Y")
 string(TIMESTAMP J9VM_BUILD_DATE "%Y%m%d")
-string(TIMESTAMP J9VM_UNIQUE_BUILD_ID "%Y%m%d%H%M%S")
+string(TIMESTAMP J9VM_BUILD_TIME "%Y%m%d%H%M%S")
+string(RANDOM ALPHABET "0123456789abcdef" LENGTH 16 RANDOM_SEED ${J9VM_BUILD_TIME} J9VM_UNIQUE_BUILD_ID)
+set(J9VM_UNIQUE_BUILD_ID "0x${J9VM_UNIQUE_BUILD_ID}")
 
 # information intended to be overridden at build time
 set(BUILD_ID 000000 CACHE STRING "")

--- a/runtime/jextractnatives/jextractnatives_internal.h
+++ b/runtime/jextractnatives/jextractnatives_internal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,6 @@
 *
 * This file contains implementation-private function prototypes and
 * type definitions for the JEXTRACTNATIVES module.
-*
 */
 
 #include "j9.h"
@@ -40,11 +39,10 @@
 extern "C" {
 #endif
 
-void run_command( const char *cmd );
+void run_command(const char *cmd);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* jextractnatives_internal_h */
-

--- a/runtime/oti/jextractnatives_api.h
+++ b/runtime/oti/jextractnatives_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,6 @@
 *
 * This file contains public function prototypes and
 * type definitions for the JEXTRACTNATIVES module.
-*
 */
 
 #include "j9.h"
@@ -56,19 +55,19 @@ extern "C" {
 void JNICALL
 Java_com_ibm_jvm_j9_dump_extract_Main_doCommand(JNIEnv *env, jobject obj, jobject dumpObj, jstring commandObject);
 
-
 /**
 * @brief
 * @param *env
 * @param obj
 * @param dumpObj
+* @param disableBuildIdCheck
 * @return jlong environment pointer
 */
 jlong JNICALL
-Java_com_ibm_jvm_j9_dump_extract_Main_getEnvironmentPointer(JNIEnv * env, jobject obj, jobject dumpObj);
+Java_com_ibm_jvm_j9_dump_extract_Main_getEnvironmentPointer(JNIEnv * env, jobject obj, jobject dumpObj, jboolean disableBuildIdCheck);
 
 #ifdef __cplusplus
-}
+} /* extern "C" */
 #endif
 
 #endif /* jextractnatives_api_h */

--- a/sourcetools/com.ibm.uma/com/ibm/j9/uma/configuration/freemarker/BuildInfo.java
+++ b/sourcetools/com.ibm.uma/com/ibm/j9/uma/configuration/freemarker/BuildInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,9 +30,9 @@ import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 
 public class BuildInfo implements TemplateHashModel {
-	
+
 	ConfigurationImpl config;
-	
+
 	public BuildInfo(ConfigurationImpl config) {
 		this.config = config;
 	}
@@ -49,14 +49,20 @@ public class BuildInfo implements TemplateHashModel {
 			int buildidint = Integer.valueOf(buildidstr);
 			return new SimpleScalar(Integer.toString(buildidint));
 		} else if (arg0.equals("unique_build_id")) {
-			long uniqueBuildId = config.getBuildSpec().getId().hashCode();
-			uniqueBuildId <<= 32; 
+			String buildId = config.getBuildSpec().getId();
+			/*
+			 * Remove "_cmprssptrs" from linux_x86-64_cmprssptrs, for example,
+			 * to generate the same uniqueBuildId as for linux_x86-64.
+			 */
+			buildId = buildId.replace("_cmprssptrs", "");
+			long uniqueBuildId = buildId.hashCode();
+			uniqueBuildId <<= 32;
 			String buildidstr = config.replaceMacro("buildid");
 			int buildidint = Integer.valueOf(buildidstr);
 			uniqueBuildId |= buildidint;
-			return new SimpleScalar("0x"+Long.toHexString(uniqueBuildId).toUpperCase());
+			return new SimpleScalar("0x" + Long.toHexString(uniqueBuildId).toUpperCase());
 		} else if (arg0.equalsIgnoreCase("sourceControl")) {
-			 return new SourceControl(config);
+			return new SourceControl(config);
 		} else if (arg0.equalsIgnoreCase("runtime")) {
 			return new SimpleScalar(config.getBuildInfo().getRuntime());
 		} else if (arg0.equalsIgnoreCase("defaultSizes")) {


### PR DESCRIPTION
Disable check if `jextract.disable.J9RAS.buildID.check` is set (to any value).

* always query environment pointer before analyzing dump
* clean up `jextract` support code
* generate `J9VM_UNIQUE_BUILD_ID` randomly for cmake builds

Fixes #10676.