### PR TITLE
Add GSKIT installation to pipeline build

### DIFF
--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -615,6 +615,9 @@ def set_build_variables() {
         BUILD_ENV_CMD = ''
     }
 
+    GSKIT_SDK_DOWNLOAD_LINK = buildspec.getScalarField("gskit.sdk", SDK_VERSION)
+    GSKIT_LIB_DOWNLOAD_LINK = buildspec.getScalarField("gskit.lib", SDK_VERSION)
+
     echo "Using BUILD_ENV_CMD = ${BUILD_ENV_CMD}, BUILD_ENV_VARS_LIST = ${BUILD_ENV_VARS_LIST.toString()}"
 }
 


### PR DESCRIPTION
Install on demand GSKIT before building the JDK and add
configure option.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>