### PR TITLE
Allow -Xdump options for jcmd Dump.* commands

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticProperties.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticProperties.java
@@ -369,10 +369,10 @@ public class DiagnosticProperties {
 	 * Encode information about an exception into properties.
 	 *
 	 * @param e Exception object
-	 * @return Properties object
+	 * @return DiagnosticProperties object
 	 */
-	public static Properties makeExceptionProperties(Exception e) {
-		Properties props = new Properties();
+	public static DiagnosticProperties makeExceptionProperties(Exception e) {
+		DiagnosticProperties props = new DiagnosticProperties();
 		props.put(IPC.PROPERTY_DIAGNOSTICS_ERROR, Boolean.toString(true));
 		props.put(IPC.PROPERTY_DIAGNOSTICS_ERRORTYPE, e.getClass().getName());
 		String msg = e.getMessage();


### PR DESCRIPTION
Default system and heap dumps to `request=exclusive+prepwalk`

Fix a bug reporting an exception when requesting a dump.

Update the tests.

Fixes #10747

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>