### PR TITLE
Change to different project assigner action

### DIFF
--- a/.github/workflows/assign-to-snapshot-project.yml
+++ b/.github/workflows/assign-to-snapshot-project.yml
@@ -25,14 +25,21 @@ name: Assign to snapshot project
 on:
   issues:
     types: [labeled]
+  pull_request:
+    types: [labeled]
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+
+# Source: https://github.com/marketplace/actions/assign-to-one-project
 jobs:
-  automate-project-columns:
+  assign_one_project:
     runs-on: ubuntu-latest
+    name: Assign to Snapshot Project
     if: github.event.label.name == 'snapshot'
     steps:
-      - uses: alex-page/github-project-automation-plus@v0.3.0
-        with:
-          project: Snapshot+Restore
-          column: To do
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: snapshot label assigner
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      with:
+        project: 'https://github.com/eclipse/openj9/projects/17'


### PR DESCRIPTION
Change to use the action from:
https://github.com/marketplace/actions/assign-to-one-project

to handle assign issues and pull requests with the
`snaphot` label to the `Snapshot+Restore` project.

This has been tested on my https://github.com/DanHeidinga/ToyTest
repo and shown to work there.

Note, Github builds the docker image from the provided Dockerfile
in the action repo so we can trust the image matches the source
in that repo.
See https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-docker-container-action
for details on the docker image build process.

Signed-off-by: Dan Heidinga <heidinga@redhat.com>