### PR TITLE
Modify !coreinfo command to output the "java.vm.name" property of a core file

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/CoreInfoCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/CoreInfoCommand.java
@@ -105,7 +105,9 @@ public class CoreInfoCommand extends Command
 			/* Print Java Version Info */
 			out.println("JAVA VERSION INFO\n" + properties.get("java.fullversion"));
 			/* Print Java VM Version Info */
-			out.println("JAVA VM VERSION\t- " + properties.get("java.vm.version") + "\n");
+			out.println("JAVA VM VERSION\t- " + properties.get("java.vm.version"));
+			/* Print Java VM Name */
+			out.println("JAVA VM NAME\t- " + properties.get("java.vm.name"));
 			
 			/* Print Platform Info */
 			boolean is64BitPlatform = (process.bytesPerPointer() == 8) ? true : false;


### PR DESCRIPTION


Signed-off-by: Dusan-Boskovic <dusan.boskovic@ibm.com>