### PR TITLE
Reduce the number of TargetVM in test_startupShutdownRobustness()

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/AttachHandler.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/AttachHandler.java
@@ -363,7 +363,7 @@ public class AttachHandler extends Thread {
 	protected boolean terminate(boolean wakeHandler) {
 		
 		if (LOGGING_DISABLED != loggingStatus) {
-		IPC.logMessage("AttachHandler terminate: Attach API is being shut down"); //$NON-NLS-1$
+			IPC.logMessage("AttachHandler terminate: Attach API is being shut down, currentAttachThread = " + currentAttachThread); //$NON-NLS-1$
 		}
 		
 		synchronized (stateSync) {
@@ -516,7 +516,7 @@ public class AttachHandler extends Thread {
 				/* Set  the current thread as a System Thread */
 				com.ibm.oti.vm.VM.markCurrentThreadAsSystem();
 				if (LOGGING_DISABLED != loggingStatus) {
-					IPC.logMessage("shutting down attach API"); //$NON-NLS-1$
+					IPC.logMessage("shutting down attach API : " + mainHandler); //$NON-NLS-1$
 				}
 				if (null == mainHandler) {
 					return; /* the constructor failed */
@@ -540,7 +540,7 @@ public class AttachHandler extends Thread {
 					while (System.nanoTime() < shutdownDeadlineNs) {
 						currentAttachThread.join(timeout); /* timeout in milliseconds */
 						if (currentAttachThread.getState() != Thread.State.TERMINATED) {
-							IPC.logMessage("Timeout waiting for wait loop termination.  Retry #"+retryNumber); //$NON-NLS-1$
+							IPC.logMessage(currentAttachThread + "Timeout waiting for wait loop termination.  Retry #" + retryNumber); //$NON-NLS-1$
 							timeout *= 2;
 							AttachHandler.terminateWaitLoop(true, retryNumber);
 							++retryNumber;

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/CommonDirectory.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/CommonDirectory.java
@@ -278,6 +278,7 @@ public abstract class CommonDirectory {
 	public static int notifyVm(int numberOfTargets, boolean global) {
 		if (LOGGING_DISABLED != loggingStatus) {
 			IPC.logMessage("notifyVm ", numberOfTargets, " targets"); //$NON-NLS-1$ //$NON-NLS-2$
+			IPC.logMessage(getCommonDirFileObject().getAbsolutePath() + ", global = " + global); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return IPC.notifyVm(getCommonDirFileObject().getAbsolutePath(), CONTROLLER_NOTIFIER, numberOfTargets, global);
 	}

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/IPC.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/IPC.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2019 IBM Corp. and others
+ * Copyright (c) 2009, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -493,6 +493,9 @@ public class IPC {
 	private static void printLogMessageHeader(PrintStream log) {
 		long currentTime = System.currentTimeMillis();
 		log.print(currentTime);
+		log.print("("); //$NON-NLS-1$
+		log.print(new java.util.Date());
+		log.print(")"); //$NON-NLS-1$
 		log.print(" "); //$NON-NLS-1$
 		String id = AttachHandler.getVmId();
 		if (0 == id.length()) {

--- a/runtime/jcl/common/attach.c
+++ b/runtime/jcl/common/attach.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2019 IBM Corp. and others
+ * Copyright (c) 2009, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -493,13 +493,11 @@ Java_openj9_internal_tools_attach_target_IPC_cancelNotify(JNIEnv *env, jclass cl
 jint JNICALL
 Java_openj9_internal_tools_attach_target_IPC_waitSemaphore(JNIEnv *env, jclass clazz)
 {
+	J9JavaVM *javaVM = ((J9VMThread*) env)->javaVM;
+	jint status = 0;
 
-	PORT_ACCESS_FROM_VMC( ((J9VMThread *) env) );
-
-	J9JavaVM* javaVM = ((J9VMThread*) env)->javaVM;
-	jint status;
-
-	Trc_JCL_attach_waitSemaphoreEntry(env);
+	PORT_ACCESS_FROM_JAVAVM(javaVM);
+	Trc_JCL_attach_waitSemaphoreEntry2(env, javaVM->attachContext.semaphore);
 	status = (jint) j9shsem_wait(javaVM->attachContext.semaphore, 0, 0);
 	Trc_JCL_attach_waitSemaphoreExit(env, status);
 	return status;
@@ -511,11 +509,10 @@ Java_openj9_internal_tools_attach_target_IPC_waitSemaphore(JNIEnv *env, jclass c
 void JNICALL
 Java_openj9_internal_tools_attach_target_IPC_closeSemaphore(JNIEnv *env, jclass clazz)
 {
+	J9JavaVM *javaVM = ((J9VMThread*) env)->javaVM;
 
-	PORT_ACCESS_FROM_VMC( ((J9VMThread *) env) );
-
-	J9JavaVM* javaVM = ((J9VMThread*) env)->javaVM;
-
+	PORT_ACCESS_FROM_JAVAVM(javaVM);
+	Trc_JCL_attach_closeSemaphoreEntry(env, javaVM->attachContext.semaphore);
 	j9shsem_close(&javaVM->attachContext.semaphore);
 	Trc_JCL_attach_closeSemaphore(env);
 	return;
@@ -527,14 +524,12 @@ Java_openj9_internal_tools_attach_target_IPC_closeSemaphore(JNIEnv *env, jclass 
 jint JNICALL
 Java_openj9_internal_tools_attach_target_IPC_destroySemaphore(JNIEnv *env, jclass clazz)
 {
-
-	PORT_ACCESS_FROM_VMC( ((J9VMThread *) env) );
-
 	jint status = 0; /* return success if the semaphore is already closed or destroyed */
-	struct j9shsem_handle **handle;
+	struct j9shsem_handle **handle = NULL;
+	J9JavaVM *javaVM = ((J9VMThread*) env)->javaVM;
 
-	J9JavaVM* javaVM = ((J9VMThread*) env)->javaVM;
-
+	PORT_ACCESS_FROM_JAVAVM(javaVM);
+	Trc_JCL_attach_destroySemaphoreEntry(env, javaVM->attachContext.semaphore);
 	handle = &javaVM->attachContext.semaphore;
 	if (NULL != handle) {
 		status = (jint) j9shsem_destroy(handle);

--- a/runtime/jcl/j9jcl.tdf
+++ b/runtime/jcl/j9jcl.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2006, 2019 IBM Corp. and others
+// Copyright (c) 2006, 2020 IBM Corp. and others
 //	
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -348,7 +348,7 @@ TraceEvent=Trc_JCL_attach_chmod Overhead=1 Level=1 Template="Java_com_ibm_tools_
 TraceEvent=Trc_JCL_attach_createSharedResourcesDir Overhead=1 Level=1 Template="createSharedResourcesDir %s, status=%d"
 TraceEvent=Trc_JCL_attach_openSemaphore Overhead=1 Level=1 Template="openSemaphore name=%s, control director = %s, status=%d"
 TraceEvent=Trc_JCL_attach_notifyVm obsolete Overhead=1 Noenv Level=1 Template="notifyVm on semphore %s, control director = %s, status=%d"
-TraceEntry=Trc_JCL_attach_waitSemaphoreEntry Overhead=1 Level=1 Template="Java_com_ibm_tools_attach_javaSE_IPC_waitSemaphoreImpl waiting on semaphore"
+TraceEntry=Trc_JCL_attach_waitSemaphoreEntry Obsolete Overhead=1 Level=1 Template="Java_com_ibm_tools_attach_javaSE_IPC_waitSemaphoreImpl waiting on semaphore"
 TraceExit=Trc_JCL_attach_waitSemaphoreExit Overhead=1 Level=1 Template="Java_com_ibm_tools_attach_javaSE_IPC_waitSemaphoreImpl received post on semaphore, status = %d"
 TraceEvent=Trc_JCL_attach_closeSemaphore Overhead=1 Level=1 Template="Java_com_ibm_tools_attach_javaSE_IPC_closeSemaphoreImpl"
 TraceEvent=Trc_JCL_attach_destroySemaphore Overhead=1 Level=1 Template="Java_com_ibm_tools_attach_javaSE_IPC_destroySemaphoreImpl status = %d"
@@ -638,3 +638,7 @@ TraceExit=Trc_JCL_com_ibm_oti_shared_SharedClassURLClasspathHelperImpl_notifyCla
 TraceEvent=Trc_JCL_com_ibm_oti_shared_SharedClassURLClasspathHelperImpl_notifyClasspathChange3_ExitError_Event Overhead=1 Level=1 Template="JCL: SharedClassURLClasspathHelperImpl notifyClasspathChange3: Creating new classpath entries failed. Exiting with -1."
 TraceExit=Trc_JCL_com_ibm_oti_shared_SharedClassURLClasspathHelperImpl_notifyClasspathChange3_Exit Overhead=1 Level=1 Template="JCL: SharedClassURLClasspathHelperImpl notifyClasspathChange3: Exiting"
 TraceExit=Trc_JCL_com_ibm_oti_shared_SharedClassURLClasspathHelperImpl_notifyClasspathChange3_ExitUrlCountZero Overhead=1 Level=1 Template="JCL: SharedClassURLClasspathHelperImpl notifyClasspathChange3: Exiting because URL count is 0"
+
+TraceEntry=Trc_JCL_attach_waitSemaphoreEntry2 Overhead=1 Level=1 Template="Java_com_ibm_tools_attach_javaSE_IPC_waitSemaphoreImpl waiting on semaphore (%p)"
+TraceEntry=Trc_JCL_attach_closeSemaphoreEntry Overhead=1 Level=1 Template="Java_com_ibm_tools_attach_javaSE_IPC_closeSemaphoreImpl closing semaphore (%p)"
+TraceEntry=Trc_JCL_attach_destroySemaphoreEntry Overhead=1 Level=1 Template="Java_com_ibm_tools_attach_javaSE_IPC_destroySemaphoreImpl destroying semaphore (%p)"

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestAttachErrorHandling.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestAttachErrorHandling.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -96,15 +96,17 @@ public class TestAttachErrorHandling extends AttachApiTest implements TestConsta
 	public void test_startupShutdownRobustness() throws IOException {
 		File ipcDir=new File(System.getProperty("java.io.tmpdir"), testName);
 		ipcDir.mkdir();
+		logger.debug("test_startupShutdownRobustness ipcDir = " + ipcDir.getAbsolutePath());
 		File logDir=new File(System.getProperty("java.io.tmpdir"), testName+"_logs");
 		logDir.mkdir();
+		logger.debug("test_startupShutdownRobustness logDir = " + logDir.getAbsolutePath());
 		
 		ArrayList<TargetManager> targets = new ArrayList<TargetManager>();
 		ArrayList<String> vmArgs = new ArrayList<String>();
 		vmArgs.add("-Dcom.ibm.tools.attach.directory="+ ipcDir.getAbsolutePath());
 		vmArgs.add("-Dcom.ibm.tools.attach.logging=yes");
 		vmArgs.add("-Dcom.ibm.tools.attach.log.name="+logDir.getAbsolutePath()+File.separatorChar);
-		for (int i = 0; i < 10; ++i)  {
+		for (int i = 0; i < 5; ++i)  {
 			TargetManager tgt = new TargetManager(TARGET_VM_CLASS, null, vmArgs, null);
 			targets.add(tgt);
 			tgt.syncWithTarget();
@@ -134,21 +136,31 @@ public class TestAttachErrorHandling extends AttachApiTest implements TestConsta
 			}
 			File targetDir = new File(ipcDir, targetId);
 			if (targetDir.exists()) {
-				logger.debug("delete "+victim.getTargetPid());
+				logger.debug("delete " + victim.getTargetPid() + ", " + targetDir.getAbsolutePath());
 				/* note that the error recovery mechanisms may recreate files */
 				deleteRecursive(targetDir, false);
+			} else {
+				logger.debug("targetDir NOT exists for targetID (" + victim.getTargetPid() + ") at " + targetDir.getAbsolutePath());
 			}
 		}
 	}
 
 	private void terminateAndCheckLogs(File logDir, TargetManager tgt) {
 		String targetPid = tgt.getTargetPid();
-		logger.debug("terminate "+targetPid);
+		logger.debug("terminateAndCheckLogs: terminate " + tgt + " with targetPid = " + targetPid);
 		tgt.terminateTarget(true);
-		File logfile = new File(logDir, "_"+targetPid+".log");
+		File logfile = new File(logDir, "_" + targetPid + ".log");
 		String logfilePath = logfile.getAbsolutePath();
 
-		AssertJUnit.assertTrue("cannot find "+logfilePath, logfile.exists());
+		logger.debug("logfilePath = " + logfilePath);
+		AssertJUnit.assertTrue("cannot find " + logfilePath, logfile.exists());
+		logger.debug("******* tgt.getOutOutput() starts *******");
+		logger.debug(tgt.getOutOutput());
+		logger.debug("******* tgt.getOutOutput() ends   *******");
+		logger.debug("******* tgt.getErrOutput() starts *******");
+		logger.debug(tgt.getErrOutput());
+		logger.debug("******* tgt.getErrOutput() ends   *******");
+		
 		try {
 			BufferedReader logReader = new BufferedReader(new FileReader(logfile));
 			String line;

--- a/test/functional/TestUtilities/src/org/openj9/test/attachAPI/TargetManager.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/attachAPI/TargetManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -325,6 +325,7 @@ class TargetManager {
 	boolean syncWithTarget() {
 		targetVmStatus = readTargetPidAndStatus();
 		if (!TargetStatus.INIT_SUCCESS.equals(targetVmStatus)) {
+			logger.debug("TargetManager.syncWithTarget() failed!");
 			return false;
 		}
 		if (null == targetId) {

--- a/test/functional/TestUtilities/src/org/openj9/test/attachAPI/TargetVM.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/attachAPI/TargetVM.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,7 +47,7 @@ public class TargetVM {
 		}
 		BufferedReader inRdr = new BufferedReader(new InputStreamReader(
 				System.in));
-		System.err.println("starting");
+		System.err.println(new java.util.Date() + " : TargetVM starting");
 		long pid = 0;
 		try {
 			pid = TargetManager.getProcessId();
@@ -74,7 +74,7 @@ public class TargetVM {
 			if (null == cmd) {
 				System.out.println(pid + " stdin closed unexpectedly");
 			} else {
-				System.out.println(pid + " terminated by \"" + cmd + "\"");
+				System.out.println(new java.util.Date() + " : " + pid + " terminated by \"" + cmd + "\"");
 			}
 			/* force a reference to keep the Properties object alive */
 			if (!propertyValue.equals(p.getProperty(propertyKey))) {
@@ -88,8 +88,11 @@ public class TargetVM {
 		} finally {
 			System.out.flush();
 			System.err.flush();
-			System.out.println("terminated");
+			System.out.println(new java.util.Date() + " : terminated from System.out");
+			System.out.flush();
 			System.out.close();
+			System.err.println(new java.util.Date() + " : terminated from System.err");
+			System.err.flush();
 			System.err.close();
 		}
 	}
@@ -97,7 +100,7 @@ public class TargetVM {
 	private static String waitForTermination(BufferedReader inRdr, long pid,
 			String cmd) throws IOException {
 		while ((null != cmd) && !cmd.contains(TargetManager.TARGETVM_STOP)) {
-			System.out.println(pid + " received \"" + cmd + "\"");
+			System.out.println(new java.util.Date() + " : waitForTermination: " + pid + " received \"" + cmd + "\"");
 			System.out.flush();
 			cmd = inRdr.readLine();
 		}


### PR DESCRIPTION
Changed the number of `TargetVM` from `10` to `5` to ensure all target VM can be notified when the target folders are deleted;
Added more log messages and trace points.

Note: In normal scenarios, the number of `TargetVM` can be determined via https://github.com/eclipse/openj9/blob/b71e0caddf3a6170fe368305fbbd1e2a8187b62a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/WaitLoop.java#L108-L110
When the target folder are deleted, the number of target is determined via https://github.com/eclipse/openj9/blob/b71e0caddf3a6170fe368305fbbd1e2a8187b62a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/AttachHandler.java#L459-L464
which is around `7` in usual case, and eventually causes some targetVM not notified.
Deleting the target folders are not normal usages, this is a test issue, changing the target VM number to `5` fixed the issue (verified in grinders). 

closes https://github.com/eclipse/openj9/issues/7010

Signed-off-by: Jason Feng <fengj@ca.ibm.com>