### PR TITLE
Add security check at System.loadLibrary(libName)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -1913,9 +1913,6 @@ static ClassLoader callerClassLoader() {
  *							if the library was not allowed to be loaded
  */
 static void loadLibraryWithClassLoader(String libName, ClassLoader loader) {
-	SecurityManager smngr = System.getSecurityManager();
-	if (smngr != null)
-		smngr.checkLink(libName);
 	if (loader != null) {
 		String realLibName = loader.findLibrary(libName);
 		

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -750,6 +750,10 @@ public static void load(String pathName) {
  */
 @CallerSensitive
 public static void loadLibrary(String libName) {
+	SecurityManager smngr = System.getSecurityManager();
+	if (smngr != null) {
+		smngr.checkLink(libName);
+	}
 /*[IF Java15]*/
 	ClassLoader.loadLibrary(getCallerClass(), libName);
 /*[ELSE]*/


### PR DESCRIPTION
Added `SecurityManager.checkLink(libName)` within `System.loadLibrary(libName)`;
Removed the security check within `loadLibraryWithClassLoader()`;
Assume the caller of `ClassLoader.loadLibrary(caller, name, fullPath)` perform the security check.

Note: this fixes an internal test.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>