### PR TITLE
Only read J9Method.extra once

### DIFF
--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -259,10 +259,11 @@ jitResetAllMethods(J9VMThread *currentThread)
 		U_32 methodCount = clazz->romClass->romMethodCount;
 
 		while (methodCount != 0) {
-			if (0 == ((UDATA)method->extra & J9_STARTPC_NOT_TRANSLATED)) {
+			UDATA extra = (UDATA)method->extra;
+			if (0 == (extra & J9_STARTPC_NOT_TRANSLATED)) {
 				/* Do not reset JIT INLs (currently in FSD there are no compiled JNI natives) */
 				if (0 == (J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers & J9AccNative)) {
-					J9JITExceptionTable *metaData = vm->jitConfig->jitGetExceptionTableFromPC(currentThread, (UDATA) method->extra);
+					J9JITExceptionTable *metaData = vm->jitConfig->jitGetExceptionTableFromPC(currentThread, extra);
 					if (NULL != metaData) {
 						/* 0xCC is the "int3" instruction on x86.
 						 * This will cause a crash if this instruction is executed.
@@ -1575,11 +1576,12 @@ static void
 markMethodBreakpointed(J9VMThread * currentThread, J9JITBreakpointedMethod * breakpointedMethod)
 {
 	J9Method * method = breakpointedMethod->method;
+	void * extra = method->extra;
 
 	breakpointedMethod->hasBeenTranslated = FALSE;
-	if ((((UDATA) method->extra) & J9_STARTPC_NOT_TRANSLATED) == 0) {
+	if ((((UDATA) extra) & J9_STARTPC_NOT_TRANSLATED) == 0) {
 		breakpointedMethod->hasBeenTranslated = TRUE;
-		_fsdSwitchToInterpPatchEntry(method->extra);
+		_fsdSwitchToInterpPatchEntry(extra);
 	}
 
 	method->constantPool = (J9ConstantPool *) ((UDATA) method->constantPool | (UDATA)J9_STARTPC_METHOD_BREAKPOINTED);

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -561,8 +561,10 @@ public:
       else
 #endif /* defined(J9VM_OPT_JITSERVER) */
          {
-         TR_ASSERT(!((intptr_t)method->extra & J9_STARTPC_NOT_TRANSLATED), "Method NOT Jitted!");
-         return (void *)method->extra;
+         /* Read extra field only once */
+         void *extra = method->extra;
+         TR_ASSERT(!((intptr_t)extra & J9_STARTPC_NOT_TRANSLATED), "Method NOT Jitted!");
+         return extra;
          }
       }
    static void setJ9MethodExtra(J9Method *method, intptr_t newValue)

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -1126,9 +1126,8 @@ void
 fillJITVTableSlot(J9VMThread *vmStruct, UDATA *currentSlot, J9Method *currentMethod)
 {
 	J9JITConfig *jitConfig = vmStruct->javaVM->jitConfig;
-	UDATA frameBuilder;
-	if (((UDATA)currentMethod->extra & J9_STARTPC_NOT_TRANSLATED) != J9_STARTPC_NOT_TRANSLATED) {
-		frameBuilder = (UDATA)currentMethod->extra;
+	UDATA frameBuilder = (UDATA)currentMethod->extra;
+	if ((frameBuilder & J9_STARTPC_NOT_TRANSLATED) != J9_STARTPC_NOT_TRANSLATED) {
 #if defined(J9SW_PARAMETERS_IN_REGISTERS)
 		/* Add the interpreter preprologue size to get to the JIT->JIT address */
 		frameBuilder += (((U_32 *)frameBuilder)[-1] >> 16);


### PR DESCRIPTION
Since `J9Method.extra` was changed to a volatile in https://github.com/eclipse/openj9/pull/10672, update code that reads the extra field more than once, as suggested in https://github.com/eclipse/openj9/pull/10672#issuecomment-699062420.