### PR TITLE
Use client address of prepareForOSR helper

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -503,6 +503,11 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             while (curCache != head);
             }
 
+#if defined(TR_HOST_POWER)
+         for (int32_t i = 0; i < TR_numRuntimeHelpers; ++i)
+            vmInfo._helperAddresses[i] = runtimeHelperValue((TR_RuntimeHelper) i);
+#endif
+
          client->write(response, vmInfo, listOfCacheDescriptors);
          }
          break;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -102,7 +102,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 11;
+   static const uint16_t MINOR_NUMBER = 12;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -336,6 +336,9 @@ class ClientSessionData
       TR_OpaqueClassBlock *_srConstructorAccessorClass;
 #endif // J9VM_OPT_SIDECAR
       U_32 _extendedRuntimeFlags2;
+#if defined(TR_HOST_POWER)
+      void *_helperAddresses[TR_numRuntimeHelpers];
+#endif
       }; // struct VMInfo
 
    /**


### PR DESCRIPTION
On Power, the entry point of the method needs to be stored
in `gr12` register. Current relocation infrastructure cannot
relocate the helper address that's stored in a non-call instruction,
so JITServer just fetches the helper address from the client and sets
it in the helpers table.