### PR TITLE
Insert arg count in VMThread's tempSlot for invokeBasic calls

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -1013,6 +1013,17 @@ J9::CodeGenerator::lowerTreeIfNeeded(
       self()->lowerNonhelperCallIfNeeded(node, tt);
       }
 
+   if (node->getOpCode().isCall() &&
+       !node->getSymbol()->castToMethodSymbol()->isHelper() &&
+       (node->getSymbol()->castToMethodSymbol()->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeBasic))
+      {
+      TR::SymbolReference *vmThreadTempSlotSymRef = self()->comp()->getSymRefTab()->findOrCreateVMThreadTempSlotFieldSymbolRef();
+      TR::Node *numArgsNode = TR::Node::iconst(node, node->getNumArguments() - 1);
+      TR::Node *storeNode = TR::Node::createStore(vmThreadTempSlotSymRef, numArgsNode, TR::istore);
+      storeNode->setByteCodeIndex(node->getByteCodeIndex());
+      TR::TreeTop::create(self()->comp(), tt->getPrevTreeTop(), storeNode);
+      }
+
    // J9
    //
    // if we found this iterator method inlined in a scorching method

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -2322,6 +2322,20 @@ J9::SymbolReferenceTable::findOrCreateProfilingBufferEndSymbolRef()
    return element(profilingBufferEndSymbol);
    }
 
+TR::SymbolReference *
+J9::SymbolReferenceTable::findOrCreateVMThreadTempSlotFieldSymbolRef()
+   {
+   if (!element(j9VMThreadTempSlotFieldSymbol))
+      {
+      TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
+      TR::Symbol * sym = TR::RegisterMappedSymbol::createMethodMetaDataSymbol(trHeapMemory(), "j9VMThreadTempSlotField");
+      sym->setDataType(TR::Address);
+      element(j9VMThreadTempSlotFieldSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), j9VMThreadTempSlotFieldSymbol, sym);
+      element(j9VMThreadTempSlotFieldSymbol)->setOffset(fej9->thisThreadGetTempSlotOffset());
+      aliasBuilder.addressStaticSymRefs().set(getNonhelperIndex(j9VMThreadTempSlotFieldSymbol));
+      }
+   return element(j9VMThreadTempSlotFieldSymbol);
+   }
 
 TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateProfilingBufferSymbolRef(intptr_t offset)

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -76,6 +76,15 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    TR::SymbolReference * findOrCreateOSRScratchBufferSymbolRef();
    TR::SymbolReference * findOrCreateOSRFrameIndexSymbolRef();
 
+   /** \brief
+    * Find or create VMThread tempSlot symbol reference. J9VMThread.tempSlot provides a mechanism for the
+    * compiler to provide information that the VM can use for various reasons - such as locating items on
+    * the stack during a call to internal native methods that are signature-polymorphic.
+    *
+    * \return TR::SymbolReference* the VMThreadTempSlotField symbol reference
+    */
+   TR::SymbolReference * findOrCreateVMThreadTempSlotFieldSymbolRef();
+
    // CG linkage
    TR::SymbolReference * findOrCreateAcquireVMAccessSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol); // minor rework
    TR::SymbolReference * findOrCreateReleaseVMAccessSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol); // minor rework


### PR DESCRIPTION
MethodHandle.invokeBasic is implemented as an internal native
method that is signature polymorphic. When calling invokeBasic
from the JIT body, the VM needs to know the number of arguments
for the invokeBasic call in order to locate the receiver object
on the stack. This implementation inserts a node at the lowering
trees phase to store the number of args into the VMThread.tempSlot
right before the call to MethodHandle.invokeBasic.

Depends: #10617, eclipse/omr#5597

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>