### PR TITLE
GetObjectField Xcheck:jni uses JNIC_NONNULLOBJECT

### DIFF
--- a/runtime/jnichk/jnicwrappers.c
+++ b/runtime/jnichk/jnicwrappers.c
@@ -1940,7 +1940,7 @@ checkGetObjectField(JNIEnv *env, jobject obj, jfieldID fieldID)
 	J9JavaVM* j9vm = ((J9VMThread*)env)->javaVM;
 	jobject actualResult;
 	J9JniCheckLocalRefState refTracking;
-	static const U_32 argDescriptor[] = { JNIC_JOBJECT, JNIC_JFIELDINSTANCEID, 0 };
+	static const U_32 argDescriptor[] = { JNIC_NONNULLOBJECT, JNIC_JFIELDINSTANCEID, 0 };
 	static const char function[] = "GetObjectField";
 
 	jniCheckArgs(function, 0, CRITICAL_WARN, &refTracking, argDescriptor, env, obj, fieldID);


### PR DESCRIPTION
The object field passed to `GetObjectField` can't be `NULL`.

Note: regarding https://github.com/eclipse/openj9/issues/10476#issuecomment-703804345, `JNIC_NONNULLOBJECT` is already defined and used in other places. I am going to address https://github.com/eclipse/openj9/issues/10479 in a separated PR instead.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>