### PR TITLE
Add jniCheckSubclass2 for two different class types

### DIFF
--- a/runtime/jnichk/jnicheck.c
+++ b/runtime/jnichk/jnicheck.c
@@ -352,19 +352,37 @@ jniCheckParseOptions(J9JavaVM* vm, char* options)
 	return J9VMDLLMAIN_OK;
 }
 
-void jniCheckSubclass(JNIEnv* env, const char* function, IDATA argNum, jobject aJobject, const char* type) {
-	J9JavaVM* j9vm = ((J9VMThread*)env)->javaVM;
-
+void jniCheckSubclass(JNIEnv* env, const char* function, IDATA argNum, jobject aJobject, const char* type)
+{
+	J9JavaVM *j9vm = ((J9VMThread*)env)->javaVM;
 	jclass superclazz = j9vm->EsJNIFunctions->FindClass(env, type);
-	if (superclazz == NULL) {
+
+	if (NULL == superclazz) {
 		jniCheckFatalErrorNLS(env, J9NLS_JNICHK_ARGUMENT_CLASS_NOT_FOUND, function, argNum, type);
 	}
-
 	if (!j9vm->EsJNIFunctions->IsInstanceOf(env, aJobject, superclazz)) {
 		jniCheckFatalErrorNLS(env, J9NLS_JNICHK_ARGUMENT_IS_NOT_SUBCLASS, function, argNum, type);
 	}
 }
 
+void jniCheckSubclass2(JNIEnv* env, const char* function, IDATA argNum, jobject aJobject, const char* type1, const char* type2)
+{
+	J9JavaVM *j9vm = ((J9VMThread*)env)->javaVM;
+	jclass superclazz1 = j9vm->EsJNIFunctions->FindClass(env, type1);
+	jclass superclazz2 = j9vm->EsJNIFunctions->FindClass(env, type2);
+
+	if (NULL == superclazz1) {
+		jniCheckFatalErrorNLS(env, J9NLS_JNICHK_ARGUMENT_CLASS_NOT_FOUND, function, argNum, type1);
+	}
+	if (NULL == superclazz2) {
+		jniCheckFatalErrorNLS(env, J9NLS_JNICHK_ARGUMENT_CLASS_NOT_FOUND, function, argNum, type2);
+	}
+	if (!(j9vm->EsJNIFunctions->IsInstanceOf(env, aJobject, superclazz1)
+		|| j9vm->EsJNIFunctions->IsInstanceOf(env, aJobject, superclazz2))
+	) {
+		jniCheckFatalErrorNLS(env, J9NLS_JNICHK_ARGUMENT_IS_NOT_SUBCLASS2, function, argNum, type1, type2);
+	}
+}
 
 void
 jniCheckRange(JNIEnv* env,  const char* function, const char* type, IDATA arg, IDATA argNum, IDATA min, IDATA max)
@@ -858,7 +876,7 @@ jniCheckArgs(const char *function, int exceptionSafe, int criticalSafe, J9JniChe
 			aJobject = va_arg(va, jobject);
 			jniCheckNull(env, function, argNum, aJobject);
 			jniCheckRef(env, function, argNum, aJobject);
-			/* jniCheckSubclass(env, function, argNum, aJobject, "java/lang/reflect/Constructor" or "java/lang/reflect/Method"); */
+			jniCheckSubclass2(env, function, argNum, aJobject, "java/lang/reflect/Constructor", "java/lang/reflect/Method");
 			if (trace) jniTraceObject(env, aJobject);
 			break;
 

--- a/runtime/jnichk/jnichk_internal.h
+++ b/runtime/jnichk/jnichk_internal.h
@@ -505,6 +505,19 @@ void jniCheckSubclass(JNIEnv* env, const char* function, IDATA argNum, jobject a
 /**
 * @brief
 * @param env
+* @param function
+* @param argNum
+* @param aJobject
+* @param type1
+* @param type2
+* @return void
+*/
+void jniCheckSubclass2(JNIEnv* env, const char* function, IDATA argNum, jobject aJobject, const char* type1, const char* type2);
+
+
+/**
+* @brief
+* @param env
 * @param nlsModule
 * @param nlsIndex
 * @param ...

--- a/runtime/nls/jnck/jnichk.nls
+++ b/runtime/nls/jnck/jnichk.nls
@@ -1020,3 +1020,15 @@ J9NLS_JNICHK_STATIC_FIELDID_PASSED.explanation=Validation of the field ID passed
 J9NLS_JNICHK_STATIC_FIELDID_PASSED.system_action=If -Xcheck:jni:nonfatal has been specified, the JVM continues, otherwise it terminates.
 J9NLS_JNICHK_STATIC_FIELDID_PASSED.user_response=Check that the field ID passed in the function is correct.
 # END NON-TRANSLATABLE
+
+# JNI is not translatable
+J9NLS_JNICHK_ARGUMENT_IS_NOT_SUBCLASS2=JNI error in %1$s: Argument #%2$d is not a subclass of %3$s or %4$s
+# START NON-TRANSLATABLE
+J9NLS_JNICHK_ARGUMENT_IS_NOT_SUBCLASS2.sample_input_1=methodName
+J9NLS_JNICHK_ARGUMENT_IS_NOT_SUBCLASS2.sample_input_2=3
+J9NLS_JNICHK_ARGUMENT_IS_NOT_SUBCLASS2.sample_input_3=package1/Class1
+J9NLS_JNICHK_ARGUMENT_IS_NOT_SUBCLASS2.sample_input_4=package2/Class2
+J9NLS_JNICHK_ARGUMENT_IS_NOT_SUBCLASS2.explanation=The named JNI function has been called with an incorrect parameter type.
+J9NLS_JNICHK_ARGUMENT_IS_NOT_SUBCLASS2.system_action=If -Xcheck:jni:nonfatal has been specified, the JVM continues, otherwise it terminates.
+J9NLS_JNICHK_ARGUMENT_IS_NOT_SUBCLASS2.user_response=Correct the JNI function call.
+# END NON-TRANSLATABLE


### PR DESCRIPTION
Added `jniCheckSubclass2(env, function, argNum, aJobject, type1, type2)`;
Added `J9NLS_JNICHK_ARGUMENT_IS_NOT_SUBCLASS2` for error message `JNI error in %1$s: Argument #%2$d is not a subclass of %3$s or %4$s`.

closes #10479

Signed-off-by: Jason Feng <fengj@ca.ibm.com>