### PR TITLE
Separate out basic Artifactory config

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/artifactory_cleanup.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/artifactory_cleanup.groovy
@@ -41,7 +41,8 @@ timestamps {
         checkout scm
         def variableFile = load 'buildenv/jenkins/common/variables-functions.groovy'
         variableFile.parse_variables_file()
-        variableFile.set_artifactory_config()
+        variableFile.set_basic_artifactory_config()
+        println ARTIFACTORY_CONFIG
 
         def artifactory_server = params.ARTIFACTORY_SERVER ? params.ARTIFACTORY_SERVER : env.ARTIFACTORY_SERVER
         def server = Artifactory.server artifactory_server


### PR DESCRIPTION
Some jobs only needs certain bits of Artifactory config.
Move those out into a basic function and call it from the
main Art config function

This fixes the Art cleanup script breakage caused by #10458

[skip ci]
Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>