### PR TITLE
Add new test case to verify the java.vm.name property of a core file

### DIFF
--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
@@ -610,6 +610,9 @@ public class Constants {
 	public static final String COREINFO_CMD = "coreinfo";
 	public static final String COREINFO_SUCCESS_KEYS = "COMMANDLINE,JAVA VERSION INFO,PLATFORM INFO,Platform Name,OS Level,Processors,Architecture,How Many";
 	public static final String COREINFO_FAILURE_KEYS = "Problem running command";
+	public static final String COREINFO_VERSION_IBM_SUCCESS_KEYS = "JAVA VM NAME,IBM J9 VM";
+	public static final String COREINFO_VERSION_OPENJ9_SUCCESS_KEYS = "JAVA VM NAME,Eclipse OpenJ9 VM";
+	public static final String COREINFO_VERSION_FAILURE_KEYS = "Problem running command";
 	
 	public static final String NATIVEMEMINFO_CMD = "nativememinfo";
 	public static final String NATIVEMEMINFO_SUCCESS_KEYS = "JRE:,VM:,Classes:,Memory Manager,Java Heap:,Other:,Threads:,Java Stack:, bytes, allocations";

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestDDRExtensionGeneral.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestDDRExtensionGeneral.java
@@ -581,4 +581,19 @@ public class TestDDRExtensionGeneral extends DDRExtTesterBase {
 		}
 		assertTrue(validate(nativeMemInfoOutput, Constants.NATIVEMEMINFO_SUCCESS_KEYS, Constants.NATIVEMEMINFO_FAILURE_KEYS));
 	}
+
+	/**
+	 * This junit method tests the !versioninfo output for "IBM J9 VM" or "Eclipse OpenJ9 VM"
+	 */
+	public void testVersionInfo()
+	{
+		String versionInfoOutput = exec(Constants.COREINFO_CMD, new String[] {});
+		String impl = System.getProperty("java.vm.name");
+		if (impl.contains("Eclipse OpenJ9 VM")){
+			assertTrue(validate(versionInfoOutput, Constants.COREINFO_VERSION_OPENJ9_SUCCESS_KEYS, Constants.COREINFO_VERSION_FAILURE_KEYS));
+		}
+		else {
+			assertTrue(validate(versionInfoOutput, Constants.COREINFO_VERSION_IBM_SUCCESS_KEYS, Constants.COREINFO_VERSION_FAILURE_KEYS));
+		}
+	}
 }


### PR DESCRIPTION
Test will run the `!coreinfo` DDR command to verify whether or not the `java.vm.name` property is set to either "IBM J9 VM" or "Eclipse OpenJ9 VM" of a system core file.

Signed-off-by: Dusan-Boskovic <dusan.boskovic@ibm.com>