### PR TITLE
Add custom hook to pipeline build

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -583,6 +583,7 @@ def build_all() {
                         get_source()
                         variableFile.set_sdk_variables()
                         variableFile.set_artifactory_config(BUILD_IDENTIFIER)
+                        variableFile.set_build_custom_options()
                         build()
                         archive_sdk()
                     } finally {

--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -616,6 +616,12 @@ def set_build_variables() {
     }
 
     echo "Using BUILD_ENV_CMD = ${BUILD_ENV_CMD}, BUILD_ENV_VARS_LIST = ${BUILD_ENV_VARS_LIST.toString()}"
+
+    if (VARIABLES.misc.custom_filename) {
+        customFile = load VARIABLES.misc.custom_filename
+    } else {
+        customFile = null
+    }
 }
 
 def set_sdk_variables() {
@@ -1515,6 +1521,9 @@ def create_job(JOB_NAME, SDK_VERSION, SPEC, downstreamJobType, id) {
     params.put('DISCARDER_NUM_BUILDS', DISCARDER_NUM_BUILDS)
     params.put('SCM_REPO', SCM_REPO)
     params.put('SCM_BRANCH', SCM_BRANCH)
+    if (USER_CREDENTIALS_ID) {
+        params.put('USER_CREDENTIALS_ID', USER_CREDENTIALS_ID)
+    }
 
     def templatePath = 'buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy'
     pipelineFunctions.retry_and_delay(
@@ -1581,4 +1590,11 @@ def download_boot_jdk(bootJDKVersion, bootJDK) {
         """
     }
 }
+
+def set_build_custom_options() {
+    if (customFile) {
+        customFile.set_extra_options()
+    }
+}
+
 return this

--- a/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
@@ -40,6 +40,7 @@ if (!binding.hasVariable('SCM_REPO')) SCM_REPO = 'https://github.com/eclipse/ope
 if (SCM_BRANCH ==~ /origin\/pr\/[0-9]+\/merge/) {
     SCM_BRANCH = 'master'
 }
+if (!binding.hasVariable('USER_CREDENTIALS_ID')) USER_CREDENTIALS_ID = ''
 
 pipelineScript = 'buildenv/jenkins/jobs/pipelines/Pipeline-Initialize.groovy'
 
@@ -50,6 +51,9 @@ pipelineJob("$JOB_NAME") {
             scm {
                 git {
                     remote {
+                        if (USER_CREDENTIALS_ID) {
+                            credentials(USER_CREDENTIALS_ID)
+                        }
                         url(SCM_REPO)
                     }
                     branch(SCM_BRANCH)


### PR DESCRIPTION
Add hook to set extra configuration options before building the JDK.
Add credentials to job DSL scm if provided.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>