### PR TITLE
Make new hotFieldMarking code compatible with JITServer

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -507,6 +507,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          for (int32_t i = 0; i < TR_numRuntimeHelpers; ++i)
             vmInfo._helperAddresses[i] = runtimeHelperValue((TR_RuntimeHelper) i);
 #endif
+         vmInfo._isHotReferenceFieldRequired = TR::Compiler->om.isHotReferenceFieldRequired();
 
          client->write(response, vmInfo, listOfCacheDescriptors);
          }
@@ -908,6 +909,13 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          TR_OpaqueClassBlock *clazz = std::get<0>(recv);
          uint32_t alignFromStart = std::get<1>(recv);
          fe->markClassForTenuredAlignment(comp, clazz, alignFromStart);
+         client->write(response, JITServer::Void());
+         }
+         break;
+      case MessageType::VM_reportHotField:
+         {
+         auto recv = client->getRecvData<int32_t, J9Class *, uint8_t, uint32_t>();
+         fe->reportHotField(std::get<0>(recv), std::get<1>(recv), std::get<2>(recv), std::get<3>(recv));
          client->write(response, JITServer::Void());
          }
          break;

--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -128,6 +128,13 @@ J9::ObjectModel::sizeofReferenceField()
 bool
 J9::ObjectModel::isHotReferenceFieldRequired()
    {
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_isHotReferenceFieldRequired;
+      }
+#endif /* defined(J9VM_OPT_JITSERVER) */
    return TR::Compiler->javaVM->memoryManagerFunctions->j9gc_hot_reference_field_required(TR::Compiler->javaVM);
    }
 

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1362,8 +1362,19 @@ TR_J9ServerVM::setJ2IThunk(char *signatureChars, uint32_t signatureLength, void 
 void
 TR_J9ServerVM::markClassForTenuredAlignment(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, uint32_t alignFromStart)
    {
+   if (!TR::Compiler->om.isHotReferenceFieldRequired() && !comp->compileRelocatableCode())
+      {
+      JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+      stream->write(JITServer::MessageType::VM_markClassForTenuredAlignment, clazz, alignFromStart);
+      stream->read<JITServer::Void>();
+      }
+   }
+
+void
+TR_J9ServerVM::reportHotField(int32_t reducedCpuUtil, J9Class* clazz, uint8_t fieldOffset,  uint32_t reducedFrequency)
+   {
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_markClassForTenuredAlignment, clazz, alignFromStart);
+   stream->write(JITServer::MessageType::VM_reportHotField, reducedCpuUtil, clazz, fieldOffset, reducedFrequency);
    stream->read<JITServer::Void>();
    }
 

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -147,6 +147,7 @@ public:
    virtual TR_OpaqueMethodBlock *getMethodFromClass(TR_OpaqueClassBlock *methodClass, char *methodName, char *signature, TR_OpaqueClassBlock *callingClass) override;
    virtual bool isClassVisible(TR_OpaqueClassBlock *sourceClass, TR_OpaqueClassBlock *destClass) override;
    virtual void markClassForTenuredAlignment(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, uint32_t alignFromStart) override;
+   virtual void reportHotField(int32_t reducedCpuUtil, J9Class* clazz, uint8_t fieldOffset,  uint32_t reducedFrequency) override;
    virtual int32_t * getReferenceSlotsInClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazz) override;
    virtual uint32_t getMethodSize(TR_OpaqueMethodBlock *method) override;
    virtual void * addressOfFirstClassStatic(TR_OpaqueClassBlock *clazz) override;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -102,7 +102,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 12;
+   static const uint16_t MINOR_NUMBER = 13;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -171,6 +171,7 @@ enum MessageType : uint16_t
    VM_getMethodFromClass,
    VM_isClassVisible,
    VM_markClassForTenuredAlignment,
+   VM_reportHotField,
    VM_getReferenceSlotsInClass,
    VM_getMethodSize,
    VM_addressOfFirstClassStatic,
@@ -206,7 +207,7 @@ enum MessageType : uint16_t
    VM_getFields,
 
    // For static TR::CompilationInfo methods
-   CompInfo_isCompiled, // 171
+   CompInfo_isCompiled, // 172
    CompInfo_getPCIfCompiled,
    CompInfo_getInvocationCount,
    CompInfo_setInvocationCount,
@@ -220,7 +221,7 @@ enum MessageType : uint16_t
    CompInfo_getJ9MethodStartPC,
 
    // For J9::ClassEnv Methods
-   ClassEnv_classFlagsValue, // 183
+   ClassEnv_classFlagsValue, // 184
    ClassEnv_classDepthOf,
    ClassEnv_classInstanceSize,
    ClassEnv_superClassesOf,
@@ -233,13 +234,13 @@ enum MessageType : uint16_t
    ClassEnv_getROMClassRefName,
 
    // For TR_J9SharedCache
-   SharedCache_getClassChainOffsetInSharedCache, // 194
+   SharedCache_getClassChainOffsetInSharedCache, // 195
    SharedCache_rememberClass,
    SharedCache_addHint,
    SharedCache_storeSharedData,
 
    // For runFEMacro
-   runFEMacro_invokeCollectHandleNumArgsToCollect, // 198
+   runFEMacro_invokeCollectHandleNumArgsToCollect, // 199
    runFEMacro_invokeExplicitCastHandleConvertArgs,
    runFEMacro_targetTypeL,
    runFEMacro_invokeILGenMacrosInvokeExactAndFixup,
@@ -265,24 +266,24 @@ enum MessageType : uint16_t
    runFEMacro_invokeCollectHandleAllocateArray,
 
    // for JITServerPersistentCHTable
-   CHTable_getAllClassInfo, // 222
+   CHTable_getAllClassInfo, // 223
    CHTable_getClassInfoUpdates,
    CHTable_commit,
    CHTable_clearReservable,
 
    // for JITServerIProfiler
-   IProfiler_profilingSample, // 226
+   IProfiler_profilingSample, // 227
    IProfiler_searchForMethodSample,
    IProfiler_getMaxCallCount,
    IProfiler_setCallCount,
 
-   Recompilation_getExistingMethodInfo, // 230
+   Recompilation_getExistingMethodInfo, // 231
    Recompilation_getJittedBodyInfoFromPC,
 
    ClassInfo_getRemoteROMString,
 
    // for KnownObjectTable
-   KnownObjectTable_getOrCreateIndex, // 233
+   KnownObjectTable_getOrCreateIndex, // 234
    KnownObjectTable_getOrCreateIndexAt,
    KnownObjectTable_getPointer,
    KnownObjectTable_getExistingIndexAt,
@@ -296,7 +297,7 @@ enum MessageType : uint16_t
    KnownObjectTable_invokeDirectHandleDirectCall,
    KnownObjectTable_getKnownObjectTableDumpInfo,
 
-   ClassEnv_isClassRefValueType, // 245
+   ClassEnv_isClassRefValueType, // 246
    MessageType_MAXTYPE
    };
 
@@ -442,6 +443,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "VM_getMethodFromClass",
    "VM_isClassVisible",
    "VM_markClassForTenuredAlignment",
+   "VM_reportHotField",
    "VM_getReferenceSlotsInClass",
    "VM_getMethodSize",
    "VM_addressOfFirstClassStatic",
@@ -475,7 +477,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "VM_getObjectSizeClass",
    "VM_stackWalkerMaySkipFramesSVM",
    "VM_getFields",
-   "CompInfo_isCompiled", // 171
+   "CompInfo_isCompiled", // 172
    "CompInfo_getPCIfCompiled",
    "CompInfo_getInvocationCount",
    "CompInfo_setInvocationCount",
@@ -487,7 +489,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "CompInfo_setInvocationCountAtomic",
    "CompInfo_isClassSpecial",
    "CompInfo_getJ9MethodStartPC",
-   "ClassEnv_classFlagsValue", // 183
+   "ClassEnv_classFlagsValue", // 184
    "ClassEnv_classDepthOf",
    "ClassEnv_classInstanceSize",
    "ClassEnv_superClassesOf",
@@ -498,11 +500,11 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "ClassEnv_getITable",
    "ClassEnv_classHasIllegalStaticFinalFieldModification",
    "ClassEnv_getROMClassRefName",
-   "SharedCache_getClassChainOffsetInSharedCache", // 194
+   "SharedCache_getClassChainOffsetInSharedCache", // 195
    "SharedCache_rememberClass",
    "SharedCache_addHint",
    "SharedCache_storeSharedData",
-   "runFEMacro_invokeCollectHandleNumArgsToCollect", // 198
+   "runFEMacro_invokeCollectHandleNumArgsToCollect", // 199
    "runFEMacro_invokeExplicitCastHandleConvertArgs",
    "runFEMacro_targetTypeL",
    "runFEMacro_invokeILGenMacrosInvokeExactAndFixup",
@@ -526,18 +528,18 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "runFEMacro_invokeFilterArgumentsWithCombinerHandleFilterPosition",
    "runFEMacro_invokeFilterArgumentsWithCombinerHandleArgumentIndices",
    "runFEMacro_invokeCollectHandleAllocateArray",
-   "CHTable_getAllClassInfo", // 222
+   "CHTable_getAllClassInfo", // 223
    "CHTable_getClassInfoUpdates",
    "CHTable_commit",
    "CHTable_clearReservable",
-   "IProfiler_profilingSample", // 226
+   "IProfiler_profilingSample", // 227
    "IProfiler_searchForMethodSample",
    "IProfiler_getMaxCallCount",
    "IProfiler_setCallCount",
-   "Recompilation_getExistingMethodInfo", // 230
+   "Recompilation_getExistingMethodInfo", // 231
    "Recompilation_getJittedBodyInfoFromPC",
    "ClassInfo_getRemoteROMString",
-   "KnownObjectTable_getOrCreateIndex", // 232
+   "KnownObjectTable_getOrCreateIndex", // 233
    "KnownObjectTable_getOrCreateIndexAt",
    "KnownObjectTable_getPointer",
    "KnownObjectTable_getExistingIndexAt",
@@ -549,7 +551,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "KnownObjectTable_getReferenceField",
    "KnownObjectTable_invokeDirectHandleDirectCall",
    "KnownObjectTable_getKnownObjectTableDumpInfo",
-   "ClassEnv_isClassRefValueType", // 245
+   "ClassEnv_isClassRefValueType", // 246
    };
    }; // namespace JITServer
 #endif // MESSAGE_TYPES_HPP

--- a/runtime/compiler/optimizer/HotFieldMarking.cpp
+++ b/runtime/compiler/optimizer/HotFieldMarking.cpp
@@ -76,7 +76,7 @@ static int32_t getReducedFrequencyMax(int32_t currentValue, int32_t count, int32
 
 int32_t TR_HotFieldMarking::perform()
    {
-   if (!jitConfig->javaVM->memoryManagerFunctions->j9gc_hot_reference_field_required(jitConfig->javaVM))
+   if (!TR::Compiler->om.isHotReferenceFieldRequired())
       {
       if (trace())
          traceMsg(comp(), "Skipping hot field marking since dynamic breadth first scan ordering is disabled\n");

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -339,6 +339,7 @@ class ClientSessionData
 #if defined(TR_HOST_POWER)
       void *_helperAddresses[TR_numRuntimeHelpers];
 #endif
+      bool _isHotReferenceFieldRequired;
       }; // struct VMInfo
 
    /**


### PR DESCRIPTION
New hotFieldMarking code introduced new front-end queries
that communicate with VM. This commit makes them compatible
with JITServer, by making sure that server sends appropriate
information to the client and vice versa.

Also reduced the potential number of messages in `markClassForTenuredAlignment` by adding server-side guards before sending the remote message