### PR TITLE
Remove PUBLIC_BUILD macro

### DIFF
--- a/runtime/compiler/build/toolcfg/common.mk
+++ b/runtime/compiler/build/toolcfg/common.mk
@@ -51,10 +51,6 @@ ifdef ASSUMES
     PRODUCT_DEFINES+=PROD_WITH_ASSUMES
 endif
 
-ifdef PUBLIC_BUILD
-    PRODUCT_DEFINES+=PUBLIC_BUILD
-endif
-
 ifdef ENABLE_GPU
     ifeq (,$(CUDA_HOME))
         $(error You must set CUDA_HOME if ENABLE_GPU is set)

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2601,7 +2601,7 @@ J9::CodeGenerator::doInstructionSelection()
 
    self()->freeAllVariableSizeSymRefs();
 
-#if defined(TR_TARGET_S390) && !defined(PUBLIC_BUILD)
+#if defined(TR_TARGET_S390)
    // Virtual function insertInstructionPrefetches is implemented only for s390 platform,
    // for all other platforms the function is empty
    //

--- a/runtime/compiler/control/CompilationController.cpp
+++ b/runtime/compiler/control/CompilationController.cpp
@@ -1045,11 +1045,9 @@ TR::DefaultCompilationStrategy::processJittedSample(TR_MethodEvent *event)
                         // Exception: bootstrap class methods that are cheap should be upgraded directly at warm
                         if (cmdLineOptions->getOption(TR_UpgradeBootstrapAtWarm) && fe->isClassLibraryMethod((TR_OpaqueMethodBlock *)j9method))
                            {
-#ifndef PUBLIC_BUILD
                            TR_J9SharedCache *sc = TR_J9VMBase::get(jitConfig, event->_vmThread, TR_J9VMBase::AOT_VM)->sharedCache();
                            bool expensiveComp = sc->isHint(j9method, TR_HintLargeMemoryMethodW);
                            if (!expensiveComp)
-#endif //!PUBLIC_BUILD
                               nextOptLevel = warm;
                            }
                         }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -6691,7 +6691,6 @@ TR::CompilationInfoPerThreadBase::installAotCachedMethod(
 //-----------------------------------------
 void TR::CompilationInfo::queueForcedAOTUpgrade(TR_MethodToBeCompiled *originalEntry, uint16_t hints, TR_FrontEnd *fe)
    {
-#ifndef PUBLIC_BUILD
 #if defined(J9VM_INTERP_AOT_RUNTIME_SUPPORT) && defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390))
 
    TR_ASSERT(!originalEntry->isDLTCompile(), "No DLTs allowed in queueForcedAOTUpgrade"); // no DLT here
@@ -6818,7 +6817,6 @@ void TR::CompilationInfo::queueForcedAOTUpgrade(TR_MethodToBeCompiled *originalE
    queueEntry(cur);
    //fprintf(stderr, "Forcefully upgraded j9method %p (entry=%p)\n", cur->_method, cur);
 #endif // #if defined(J9VM_INTERP_AOT_RUNTIME_SUPPORT) && defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390))
-#endif //!PUBLIC_BUILD
    }
 
 
@@ -8736,7 +8734,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
       metaData = that->compile(vmThread, compiler, compilee, *vm, p->_optimizationPlan, scratchSegmentProvider);
 
       }
-#ifndef PUBLIC_BUILD
+
    // Store hints in the SCC
    TR_J9SharedCache *sc = (TR_J9SharedCache *) (vm->sharedCache());
    if (metaData  && !that->_methodBeingCompiled->isDLTCompile() &&
@@ -8811,7 +8809,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
             }
          }
       }
-#endif // !PUBLIC_BUILD
+
    return metaData;
    }
 

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -1210,11 +1210,10 @@ TR_J9ByteCodeIlGenerator::prependGuardedCountForRecompilation(TR::Block * origin
    else
       {
       TR::Node *loadFlagNode = TR::Node::createWithSymRef(node, TR::iload, 0, comp()->getSymRefTab()->findOrCreateCountForRecompileSymbolRef());
-#ifndef PUBLIC_BUILD
+
       if (comp()->getOption(TR_EnableGCRPatching))
          cmpFlagNode = TR::Node::createif(TR::ificmpne, loadFlagNode, TR::Node::create(node, TR::iconst, 0, 1), originalFirstBlock->getEntry());
       else
-#endif
          cmpFlagNode = TR::Node::createif(TR::ificmpeq, loadFlagNode, TR::Node::create(node, TR::iconst, 0, 0), originalFirstBlock->getEntry());
       }
    TR::TreeTop *cmpFlag = TR::TreeTop::create(comp(), cmpFlagNode);
@@ -1240,7 +1239,7 @@ TR_J9ByteCodeIlGenerator::prependGuardedCountForRecompilation(TR::Block * origin
    TR::Block *callRecompileBlock = TR::Block::createEmptyBlock(comp());
    callRecompileBlock->append(TR::TreeTop::createResetTree(comp(), node, comp()->getRecompilationInfo()->getCounterSymRef(),
                                                           comp()->getOptions()->getGCRResetCount(), NULL, true));
-#ifndef PUBLIC_BUILD
+
    // Create the instruction that will patch my cmp
    if (comp()->getOption(TR_EnableGCRPatching))
       {
@@ -1250,7 +1249,6 @@ TR_J9ByteCodeIlGenerator::prependGuardedCountForRecompilation(TR::Block * origin
                              comp()->getSymRefTab()->findOrCreateGCRPatchPointSymbolRef())));
       }
 
-#endif
    TR::TreeTop *callTree = TR::TransformUtil::generateRetranslateCallerWithPrepTrees(node, TR_PersistentMethodInfo::RecompDueToGCR, comp());
    callRecompileBlock->append(callTree);
    callRecompileBlock->setIsCold(true);

--- a/runtime/compiler/optimizer/MonitorElimination.cpp
+++ b/runtime/compiler/optimizer/MonitorElimination.cpp
@@ -430,7 +430,6 @@ int32_t TR::MonitorElimination::perform()
          traceMsg(comp(),"findRedundantMonitors returned true.  About to remove Redundant Monitors\n");
       removeRedundantMonitors();
 
-#ifndef PUBLIC_BUILD
       /* enable TLE by default on supported HW for now */
       if(!comp()->getOption(TR_DisableTLE) && comp()->cg()->getSupportsTLE())
          {
@@ -446,8 +445,6 @@ int32_t TR::MonitorElimination::perform()
                   transformMonitorsIntoTMRegions();
             }
          }
-#endif
-
       }
    else
       {
@@ -1059,8 +1056,6 @@ void TR::MonitorElimination::addOSRGuard(TR::TreeTop *guard)
       monitor->getOSRGuards().add(guard);
       }
    }
-
-#ifndef PUBLIC_BUILD
 
 // returns true if  we find at least one monitor who is a candidate for TM
 bool TR::MonitorElimination::evaluateMonitorsForTMCandidates()
@@ -1704,7 +1699,6 @@ void TR::MonitorElimination::transformMonitorsIntoTMRegions()
 
    }
 
-#endif
 
 bool TR::MonitorElimination::killsReadMonitorProperty(TR::Node *node)
    {

--- a/runtime/compiler/optimizer/MonitorElimination.hpp
+++ b/runtime/compiler/optimizer/MonitorElimination.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -168,7 +168,6 @@ class MonitorElimination : public TR::Optimization
    void removeRedundantMonitors();
 
    //TransactionalMemory
-#ifndef PUBLIC_BUILD
    bool evaluateMonitorsForTMCandidates();
    void transformMonitorsIntoTMRegions();
    void searchAndLabelNearbyMonitors(TR_ActiveMonitor *currentMonitor);
@@ -179,7 +178,7 @@ class MonitorElimination : public TR::Optimization
 
    TR_Array<TR::Block *>* createFailHandlerBlocks(TR_ActiveMonitor *monitor, TR::SymbolReference *tempSymRef, TR::Block *monitorBlock, TR::Block *tstartblock);
    TR::SymbolReference *createAndInsertTMRetryCounter(TR_ActiveMonitor *monitor);
-#endif
+
    void resetReadMonitors(int32_t);
    bool tagReadMonitors();
    bool transformIntoReadMonitor();

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -12647,7 +12647,6 @@ TR::Register *J9::Power::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::
 
 TR::Register *J9::Power::TreeEvaluator::tstartEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-#ifndef PUBLIC_BUILD
    // tstart
    //  - persistentFailNode
    //  - transientFailNode
@@ -12818,16 +12817,13 @@ TR::Register *J9::Power::TreeEvaluator::tstartEvaluator(TR::Node *node, TR::Code
    cg->decReferenceCount(persistentFailureNode);
    cg->decReferenceCount(transientFailureNode);
    cg->decReferenceCount(fallThrough);
-#endif //PUBLIC_BUILD
 
    return NULL;
    }
 
 TR::Register *J9::Power::TreeEvaluator::tfinishEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-#ifndef PUBLIC_BUILD
    generateInstruction(cg, TR::InstOpCode::tend_r, node);
-#endif //PUBLIC_BUILD
    return NULL;
    }
 

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -2808,13 +2808,10 @@ TR_RelocationRecordProfiledInlinedMethod::preparePrivateData(TR_RelocationRuntim
       J9UTF8 *inlinedCodeClassName = J9ROMCLASS_CLASSNAME(inlinedCodeRomClass);
       RELO_LOG(reloRuntime->reloLogger(), 6,"\tpreparePrivateData: inlinedCodeRomClass %p %.*s\n", inlinedCodeRomClass, J9UTF8_LENGTH(inlinedCodeClassName), J9UTF8_DATA(inlinedCodeClassName));
 
-#if defined(PUBLIC_BUILD)
-      J9ClassLoader *classLoader = NULL;
-#else
       void *classChainIdentifyingLoader = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainIdentifyingLoaderOffsetInSharedCache(reloTarget));
       RELO_LOG(reloRuntime->reloLogger(), 6,"\tpreparePrivateData: classChainIdentifyingLoader %p\n", classChainIdentifyingLoader);
       J9ClassLoader *classLoader = (J9ClassLoader *) reloRuntime->fej9()->sharedCache()->persistentClassLoaderTable()->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
-#endif
+
       RELO_LOG(reloRuntime->reloLogger(), 6,"\tpreparePrivateData: classLoader %p\n", classLoader);
 
       if (classLoader)
@@ -4755,21 +4752,16 @@ TR_RelocationRecordPointer::preparePrivateData(TR_RelocationRuntime *reloRuntime
    if (getInlinedSiteMethod(reloRuntime, inlinedSiteIndex(reloTarget)) != (TR_OpaqueMethodBlock *)-1)
       {
       J9ClassLoader *classLoader = NULL;
-#if !defined(PUBLIC_BUILD)
       void *classChainIdentifyingLoader = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainIdentifyingLoaderOffsetInSharedCache(reloTarget));
       RELO_LOG(reloRuntime->reloLogger(), 6,"\tpreparePrivateData: classChainIdentifyingLoader %p\n", classChainIdentifyingLoader);
       classLoader = (J9ClassLoader *) reloRuntime->fej9()->sharedCache()->persistentClassLoaderTable()->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
-#endif
       RELO_LOG(reloRuntime->reloLogger(), 6,"\tpreparePrivateData: classLoader %p\n", classLoader);
 
       if (classLoader != NULL)
          {
          uintptr_t *classChain = (uintptr_t *) reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainForInlinedMethod(reloTarget));
          RELO_LOG(reloRuntime->reloLogger(), 6,"\tpreparePrivateData: classChain %p\n", classChain);
-
-#if !defined(PUBLIC_BUILD)
          classPointer = (J9Class *) reloRuntime->fej9()->sharedCache()->lookupClassFromChainAndLoader(classChain, (void *) classLoader);
-#endif
          RELO_LOG(reloRuntime->reloLogger(), 6,"\tpreparePrivateData: classPointer %p\n", classPointer);
          }
       }

--- a/runtime/compiler/z/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/z/codegen/ForceRecompilationSnippet.cpp
@@ -58,10 +58,8 @@ TR::S390ForceRecompilationSnippet::emitSnippetBody()
    *(int32_t *) cursor = 0xDEADBEEF;
    cursor += sizeof(int32_t);
 
-#if !defined(PUBLIC_BUILD)
    // Generate RIOFF if RI is supported.
    cursor = generateRuntimeInstrumentationOnOffInstruction(cg(), cursor, TR::InstOpCode::RIOFF);
-#endif
 
    // BRCL
    *(int16_t *) cursor = 0xC0F4;
@@ -107,11 +105,7 @@ uint32_t
 TR::S390ForceRecompilationSnippet::getLength(int32_t  estimatedSnippetStart)
    {
    uint32_t length = 12;  // LARL + BRCL
-
-#if !defined(PUBLIC_BUILD)
    length += getRuntimeInstrumentationOnOffInstructionLength(cg());
-#endif
-
    return length;
    }
 

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -11523,7 +11523,6 @@ J9::Z::TreeEvaluator::countDigitsHelper(TR::Node * node, TR::CodeGenerator * cg,
 TR::Register *
 J9::Z::TreeEvaluator::tstartEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-#ifndef PUBLIC_BUILD
    //   [0x00000000803797c8] (  0)  tstart
    //   [0x0000000080379738] (  1)    branch --> block 28 BBStart at [0x0000000080378bc8]
    //   [0x00000000803f15f8] (  1)      GlRegDeps
@@ -11674,7 +11673,6 @@ J9::Z::TreeEvaluator::tstartEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    cg->decReferenceCount(brPersistentNode);
    cg->decReferenceCount(brTransientNode);
    cg->decReferenceCount(fallThrough);
-#endif
 
    return NULL;
    }
@@ -11685,10 +11683,8 @@ J9::Z::TreeEvaluator::tstartEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 J9::Z::TreeEvaluator::tfinishEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-#ifndef PUBLIC_BUILD
    TR::MemoryReference * tempMR1 = generateS390MemoryReference(cg->machine()->getRealRegister(TR::RealRegister::GPR0),0,cg);
    TR::Instruction * cursor = generateSInstruction(cg, TR::InstOpCode::TEND, node, tempMR1);
-#endif
 
    return NULL;
    }
@@ -11699,7 +11695,6 @@ J9::Z::TreeEvaluator::tfinishEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 J9::Z::TreeEvaluator::tabortEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-#ifndef PUBLIC_BUILD
    TR::Instruction *cursor;
    TR::LabelSymbol * labelDone = generateLabelSymbol(cg);
    TR::Register *codeReg = cg->allocateRegister();
@@ -11715,7 +11710,6 @@ J9::Z::TreeEvaluator::tabortEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    cursor = generateSInstruction(cg, TR::InstOpCode::TABORT, node, codeMR);
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, labelDone);
    cg->stopUsingRegister(codeReg);
-#endif
    return NULL;
    }
 

--- a/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
@@ -233,10 +233,8 @@ J9::Z::UnresolvedDataSnippet::emitSnippetBody()
          }
       }
 
-#if !defined(PUBLIC_BUILD)
    // Generate RIOFF if RI is supported.
    cursor = generateRuntimeInstrumentationOnOffInstruction(cg(), cursor, TR::InstOpCode::RIOFF);
-#endif
 
    // TODO: We could use LRL / LGRL here but the JIT does not guarantee that the Data Constant be 4 / 8 byte aligned,
    // so we cannot make use of these instructions in general. We should explore the idea of aligning 4 / 8 byte data
@@ -422,10 +420,7 @@ J9::Z::UnresolvedDataSnippet::getLength(int32_t  estimatedSnippetStart)
    if (isInstanceData())
       length += (comp->target().is64Bit()) ? 36 : 28;
 
-#if !defined(PUBLIC_BUILD)
    length += getRuntimeInstrumentationOnOffInstructionLength(cg());
-#endif
-
    return length;
    }
 

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -273,10 +273,8 @@ TR::S390J9CallSnippet::emitSnippetBody()
    TR_RuntimeHelper runtimeHelper = getInterpretedDispatchHelper(methodSymRef, callNode->getDataType());
    TR::SymbolReference * glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(runtimeHelper, false, false, false);
 
-#if !defined(PUBLIC_BUILD)
    // Generate RIOFF if RI is supported.
    cursor = generateRuntimeInstrumentationOnOffInstruction(cg(), cursor, TR::InstOpCode::RIOFF);
-#endif
 
    // data area start address
    uintptr_t dataStartAddr = (uintptr_t) (getPICBinaryLength(cg()) + cursor);
@@ -511,9 +509,7 @@ TR::S390VirtualUnresolvedSnippet::emitSnippetBody()
    getSnippetLabel()->setCodeLocation(cursor);
 
    // Generate RIOFF if RI is supported.
-#if !defined(PUBLIC_BUILD)
    cursor = generateRuntimeInstrumentationOnOffInstruction(cg(), cursor, TR::InstOpCode::RIOFF);
-#endif
 
    cursor = generatePICBinary(cg(), cursor, glueRef);
 
@@ -591,9 +587,7 @@ TR::S390VirtualUnresolvedSnippet::getLength(int32_t  estimatedSnippetStart)
    {
    TR::Compilation* comp = cg()->comp();
    uint32_t length = getPICBinaryLength(cg()) + 7 * sizeof(uintptr_t) + TR::Compiler->om.sizeofReferenceAddress();
-#if !defined(PUBLIC_BUILD)
    length += getRuntimeInstrumentationOnOffInstructionLength(cg());
-#endif
    return length;
    }
 

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -1274,7 +1274,6 @@ J9::Z::PrivateLinkage::createPrologue(TR::Instruction * cursor)
       }
 
       // End of stack overflow checking code ////////////////////////
-#if !defined(PUBLIC_BUILD)
    static bool bppoutline = (feGetEnv("TR_BPRP_Outline")!=NULL);
 
    if (bppoutline && cg()->_outlineCall._frequency != -1)
@@ -1291,7 +1290,6 @@ J9::Z::PrivateLinkage::createPrologue(TR::Instruction * cursor)
       TR::MemoryReference * tempMR = generateS390MemoryReference(epReg, 0, cg());
       cursor = generateS390BranchPredictionPreloadInstruction(cg(), TR::InstOpCode::BPP, firstNode, cg()->_outlineArrayCall._callLabel, (int8_t) 0xD, tempMR, cursor);
       }
-#endif
 
       if (cg()->getSupportsRuntimeInstrumentation())
          cursor = TR::TreeEvaluator::generateRuntimeInstrumentationOnOffSequence(cg(), TR::InstOpCode::RION, firstNode, cursor, true);
@@ -1460,9 +1458,7 @@ J9::Z::PrivateLinkage::createEpilogue(TR::Instruction * cursor)
    TR::RealRegister * epReg = getRealRegister(getEntryPointRegister());
    int32_t blockNumber = -1;
 
-#if !defined(PUBLIC_BUILD)
    bool enableBranchPreload = cg()->supportsBranchPreload();
-#endif
 
    dep = cursor->getNext()->getDependencyConditions();
    offset = getOffsetToRegSaveArea();
@@ -1493,7 +1489,7 @@ J9::Z::PrivateLinkage::createEpilogue(TR::Instruction * cursor)
       if (comp()->getOption(TR_TraceCG))
          traceMsg(comp(), "No RAREG context restore needed in Epilog\n");
       }
-#if !defined(PUBLIC_BUILD)
+
    if (enableBranchPreload && (cursor->getNext() == cg()->_hottestReturn._returnInstr))
       {
       if (cg()->_hottestReturn._frequency > 6 && cg()->_hottestReturn._insertBPPInEpilogue)
@@ -1504,7 +1500,6 @@ J9::Z::PrivateLinkage::createEpilogue(TR::Instruction * cursor)
          cg()->_hottestReturn._insertBPPInEpilogue = false;
          }
       }
-#endif
 
    // Restore GPRs
    firstUsedReg = getFirstRestoredRegister(TR::RealRegister::GPR6, TR::RealRegister::GPR12);
@@ -1558,7 +1553,6 @@ J9::Z::PrivateLinkage::createEpilogue(TR::Instruction * cursor)
       cursor = TR::TreeEvaluator::generateRuntimeInstrumentationOnOffSequence(cg(), TR::InstOpCode::RIOFF, currentNode, cursor, true);
 
 
-#if !defined(PUBLIC_BUILD)
    if (enableBranchPreload)
       {
       if (cursor->getNext() == cg()->_hottestReturn._returnInstr)
@@ -1569,7 +1563,6 @@ J9::Z::PrivateLinkage::createEpilogue(TR::Instruction * cursor)
             }
          }
       }
-#endif
 
    cursor = generateS390RegInstruction(cg(), TR::InstOpCode::BCR, currentNode, getRealRegister(getReturnAddressRegister()), cursor);
    ((TR::S390RegInstruction *)cursor)->setBranchCondition(TR::InstOpCode::COND_BCR);

--- a/runtime/compiler/z/codegen/S390StackCheckFailureSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390StackCheckFailureSnippet.cpp
@@ -222,10 +222,8 @@ TR::S390StackCheckFailureSnippet::emitSnippetBody()
          }
       }
 
-#if !defined(PUBLIC_BUILD)
    // Generate RIOFF if RI is supported.
    cursor = generateRuntimeInstrumentationOnOffInstruction(cg(), cursor, TR::InstOpCode::RIOFF);
-#endif
 
    // Now we generate a BRASL to target
    *(int16_t *) cursor = 0xC0E5;                                                      // BRASL     r14, <Helper Addr>
@@ -263,11 +261,9 @@ TR::S390StackCheckFailureSnippet::emitSnippetBody()
    cursor += sizeof(int32_t);
    returnLocationInSnippet = cursor;
 
-#if !defined(PUBLIC_BUILD)
    // Generate RION if RI is supported.
    //temporary disable to allow RI on zlinux
    //cursor = generateRuntimeInstrumentationOnOffInstruction(cg(), cursor, TR::InstOpCode::RION);
-#endif
 
    // If non-Trex, we need to reload the RA from the stack.
    if (requireRALoad)                                                                 // -->non-Trex<--  L/LG     r14, 0(r5)
@@ -403,12 +399,10 @@ TR::S390StackCheckFailureSnippet::getLength(int32_t)
       size += (is64BitTarget)?34:28;
       }
 
-#if !defined(PUBLIC_BUILD)
    // RI Hooks
    //temporary only RIOFF to allow RI on zlinux
    size += getRuntimeInstrumentationOnOffInstructionLength(cg());
    //size += 2 * getRuntimeInstrumentationOnOffInstructionLength(cg());
-#endif
 
    return size;
    }


### PR DESCRIPTION
This patch removes PUBLIC_BUILD macros according to the issue #9729.