### PR TITLE
Add null check to J9::CPU::detect

### DIFF
--- a/runtime/compiler/env/J9CPU.cpp
+++ b/runtime/compiler/env/J9CPU.cpp
@@ -70,6 +70,9 @@ J9::CPU::customize(OMRProcessorDesc processorDescription)
 TR::CPU
 J9::CPU::detect(OMRPortLibrary * const omrPortLib)
    {   
+   if (omrPortLib == NULL)
+      return TR::CPU();
+
    OMRPORT_ACCESS_FROM_OMRPORT(omrPortLib);
    OMRProcessorDesc processorDescription;
    omrsysinfo_get_processor_description(&processorDescription);


### PR DESCRIPTION
Change `J9::CPU::detect` to return generic CPU object
when `omrPortLib` is NULL.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>