### PR TITLE
Enable tests of JEP 360 & 384 for Java 16+

### DIFF
--- a/test/functional/Java15andUp/playlist.xml
+++ b/test/functional/Java15andUp/playlist.xml
@@ -43,8 +43,7 @@
             <group>functional</group>
         </groups>
         <subsets>
-            <!-- run for Java 15 only since this is a preview feature. -->
-            <subset>15</subset>
+            <subset>15+</subset>
         </subsets>
     </test>
     <test>
@@ -67,8 +66,7 @@
             <group>functional</group>
         </groups>
         <subsets>
-            <!-- run for Java 15 only since this is a preview feature. -->
-            <subset>15</subset>
+            <subset>15+</subset>
         </subsets>
     </test>
 </playlist>


### PR DESCRIPTION
Re-enable back tests of JEP 360 & 384 for Java 16+ that were disabled in #10243