### PR TITLE
Rename workflow to be generic, not snapshot-specific

### DIFF
--- a/.github/workflows/assign-to-snapshot-project.yml
+++ b/.github/workflows/assign-to-snapshot-project.yml
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################/
 
-name: Assign to snapshot project
+name: Assign labels to project
 
 on:
   issues:


### PR DESCRIPTION
Signed-off-by: Dan Heidinga <heidinga@redhat.com>