### PR TITLE
(0.23.0) Change TR_ASSERT_FATAL into failCompilation call

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -865,11 +865,11 @@ J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * ow
       containingClass =
          owningMethod->definingClassFromCPFieldRef(comp(), cpIndex, isStatic);
 
-      TR_ASSERT_FATAL(
-         containingClass != NULL,
-         "failed to get defining class of field ref cpIndex=%d in owning method J9Method=%p",
-         cpIndex,
-         owningMethod->getNonPersistentIdentifier());
+      if (containingClass == NULL)
+         comp()->failCompilation<TR::CompilationException>(
+            "failed to get defining class of resolved field ref cpIndex=%d in owning method J9Method=%p",
+            cpIndex,
+            owningMethod->getNonPersistentIdentifier());
 
       ResolvedFieldShadowKey key(containingClass, offset, type);
       TR::SymbolReference *symRef =


### PR DESCRIPTION
`findOrCreateShadowSymbol()` tries to reuse symrefs produced by
`findOrFabricateShadowSymbol()` when the shadow corresponds to the same
field. Detecting that the fields are in fact the same requires checking
that the defining class is the same. Normally, the expectation is that
if a cp field ref is resolved, then the cp ref pointing to the defining
class must also be resolved. However, in #9416, it appears as though
this may not always be the case, which triggers an assert. As a
temporary work around, the assert is changed to an abort compilation to
avoid taking the JVM. Because the assert is useful for detecting such
cases, this patch is only submitted for the release branch so that
further investigation can continue on the main development branch.

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>