### PR TITLE
Print JITServer version info in vlog

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2118,6 +2118,7 @@ J9::Options::setupJITServerOptions()
 
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))
       {
+      JITServer::CommunicationStream::printJITServerVersion();
       TR::PersistentInfo *persistentInfo = compInfo->getPersistentInfo();
       if (persistentInfo->getRemoteCompilationMode() == JITServer::SERVER)
          {

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -29,6 +29,7 @@
 #include "net/LoadSSLLibs.hpp"
 #include "net/Message.hpp"
 #include "infra/Statistics.hpp"
+#include "env/VerboseLog.hpp"
 
 
 namespace JITServer
@@ -59,6 +60,12 @@ public:
    static uint64_t getJITServerFullVersion()
       {
       return Message::buildFullVersion(getJITServerVersion(), CONFIGURATION_FLAGS);
+      }
+
+   static void printJITServerVersion()
+      {
+      // print the human-readable version string
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "JITServer version: %u.%u.%u", MAJOR_NUMBER, MINOR_NUMBER, PATCH_NUMBER);
       }
 
 protected:


### PR DESCRIPTION
The version is printed at the beginning of vlog
in the `MAJOR_NUMBER.MINOR_NUMBER.PATCH_NUMBER` format.

Closes: #10837