### PR TITLE
Ensure AOT Compilation in JIT Dump

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7274,9 +7274,11 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
          else
             {
             // Heuristic: generate AOT only for downgraded compilations in the second run
-            if (!isSecondAOTRun &&
-                entry->_optimizationPlan->isOptLevelDowngraded())
+            if ((!isSecondAOTRun && entry->_optimizationPlan->isOptLevelDowngraded()) ||
+                entry->getMethodDetails().isJitDumpAOTMethod())
+               {
                canDoRelocatableCompile = true;
+               }
             }
          }
       }

--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -284,9 +284,9 @@ static TR_CompilationErrorCode recompileMethodForLog(
    J9VMThread         *vmThread,
    J9Method           *ramMethod,
    TR::CompilationInfo *compInfo,
-   TR_J9VMBase        *frontendOfThread,
    TR_Hotness          optimizationLevel,
    bool                profilingCompile,
+   bool                aotCompile,
    void               *oldStartPC,
    TR::FILE *logFile
    )
@@ -326,7 +326,7 @@ static TR_CompilationErrorCode recompileMethodForLog(
    // TODO: this is indiscriminately compiling as J9::DumpMethodRequest, which is wrong;
    //       should be fixed by checking if the method is indeed DLT, and compiling DLT if so
       {
-      J9::JitDumpMethodDetails details(ramMethod);
+      J9::JitDumpMethodDetails details(ramMethod, aotCompile);
       compInfo->compileMethod(vmThread, details, oldStartPC, TR_no, &compErrCode, &successfullyQueued, plan);
       }
 
@@ -586,15 +586,29 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
                if (!(jittedMethodsOnStack[i]._method))
                   continue;
 
+               bool isAOTBody = false;
+               J9JITExceptionTable *metadata = NULL;
+               void *startPC = jittedMethodsOnStack[i]._oldStartPC;
+               if (startPC)
+                  {
+                  metadata = jitConfig->jitGetExceptionTableFromPC(crashedThread, (UDATA)startPC);
+                  if (metadata)
+                     {
+                     TR_PersistentJittedBodyInfo *bodyInfo = (TR_PersistentJittedBodyInfo *)metadata->bodyInfo;
+                     if (bodyInfo)
+                        isAOTBody = bodyInfo->getIsAotedBody();
+                     }
+                  }
+
                TR_CompilationErrorCode compErrCode;
                compErrCode = recompileMethodForLog(
                   crashedThread,
                   jittedMethodsOnStack[i]._method,
                   compInfo,
-                  frontendOfThread,
                   jittedMethodsOnStack[i]._optLevel,
                   false,
-                  jittedMethodsOnStack[i]._oldStartPC,
+                  isAOTBody,
+                  startPC,
                   logFile
                );
                } // for
@@ -664,9 +678,9 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
                         crashedThread,
                         (J9Method *)(comp->getCurrentMethod()->getPersistentIdentifier()),
                         compInfo,
-                        frontendOfThread,
                         (TR_Hotness)comp->getOptLevel(),
                         comp->isProfilingCompilation(),
+                        comp->compileRelocatableCode(),
                         oldStartPC,
                         logFile
                      );

--- a/runtime/compiler/ilgen/IlGeneratorMethodDetails.hpp
+++ b/runtime/compiler/ilgen/IlGeneratorMethodDetails.hpp
@@ -65,13 +65,20 @@ class JitDumpMethodDetails : public TR::IlGeneratorMethodDetails
    // Objects cannot hold data of its own: must store in the _data union in TR::IlGeneratorMethodDetails
 
 public:
-   JitDumpMethodDetails(J9Method* method) : TR::IlGeneratorMethodDetails(method) { }
-   JitDumpMethodDetails(const JitDumpMethodDetails& other) : TR::IlGeneratorMethodDetails(other.getMethod()) { }
+   JitDumpMethodDetails(J9Method* method, bool aotCompile) : TR::IlGeneratorMethodDetails(method)
+      {
+      _data._aotCompile = aotCompile;
+      }
+   JitDumpMethodDetails(const JitDumpMethodDetails& other) : TR::IlGeneratorMethodDetails(other.getMethod())
+      {
+      _data._aotCompile = other._data._aotCompile;
+      }
 
    virtual const char * name()     const { return "DumpMethod"; }
 
-   virtual bool isOrdinaryMethod() const { return false; }
-   virtual bool isJitDumpMethod()     const { return true; }
+   virtual bool isOrdinaryMethod()   const { return false; }
+   virtual bool isJitDumpMethod()    const { return true; }
+   virtual bool isJitDumpAOTMethod() const { return _data._aotCompile; }
 
 
    virtual bool sameAs(TR::IlGeneratorMethodDetails & other, TR_FrontEnd *fe)

--- a/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.hpp
+++ b/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.hpp
@@ -105,6 +105,7 @@ public:
 
    virtual bool isOrdinaryMethod()     const { return true; }
    virtual bool isJitDumpMethod()      const { return false; }
+   virtual bool isJitDumpAOTMethod()   const { return false; }
    virtual bool isNewInstanceThunk()   const { return false; }
    virtual bool isMethodInProgress()   const { return false; }
    virtual bool isArchetypeSpecimen()  const { return false; }
@@ -152,6 +153,7 @@ protected:
          uintptr_t *_handleRef;
          uintptr_t *_argRef;
          } _methodHandleData;
+      bool _aotCompile;
       } _data;
 
    };


### PR DESCRIPTION
Ensure that if there is a crash during an AOT compilation, the JIT Dump
performs an AOT compilation as well.

Signed-off-by: Irwin D'Souza <dsouzai.gh@gmail.com>