### PR TITLE
Remove TR_CROSS_COMPILE_ONLY macros

### DIFF
--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -93,7 +93,6 @@ int32_t J9::Recompilation::limitMethodsCompiled = 0;
 int32_t J9::Recompilation::hotThresholdMethodsCompiled = 0;
 int32_t J9::Recompilation::scorchingThresholdMethodsCompiled = 0;
 
-#if !defined(TR_CROSS_COMPILE_ONLY)
 bool
 J9::Recompilation::isAlreadyBeingCompiled(
       TR_OpaqueMethodBlock *methodInfo,
@@ -105,7 +104,6 @@ J9::Recompilation::isAlreadyBeingCompiled(
       return fej9->isBeingCompiled(methodInfo, startPC);
    return TR::Recompilation::isAlreadyPreparedForRecompile(startPC);
    }
-#endif
 
 void setDllSlip(char*CodeStart,char*CodeEnd,char*dllName, TR::Compilation * comp)
 {
@@ -180,7 +178,6 @@ J9::Recompilation::sampleMethod(
 
    int32_t totalSampleCount = globalSampleCount;
 
-#if !defined(TR_CROSS_COMPILE_ONLY)
    J9Method * j9method = (J9Method *) methodInfo;
 
    /* Reject samples to native methods */
@@ -234,7 +231,6 @@ J9::Recompilation::sampleMethod(
             TR::Recompilation::jitRecompilationsInduced++;
          }
       }
-#endif
    }
 
 
@@ -1202,8 +1198,6 @@ void initializeJitRuntimeHelperTable(char isSMP)
    #define SET runtimeHelpers.setAddress
    #define SET_CONST runtimeHelpers.setConstant
 
-#if !defined(TR_CROSS_COMPILE_ONLY)
-
 #if defined(TR_HOST_POWER)
    PPCinitializeValueProfiler();
 #elif defined(TR_HOST_S390)
@@ -1304,8 +1298,6 @@ void initializeJitRuntimeHelperTable(char isSMP)
    SET(TR_S390induceRecompilation,              (void *)_induceRecompilation,       TR_Helper);
    SET_CONST(TR_S390induceRecompilation_unwrapper, (void *) induceRecompilation_unwrapper);
    SET_CONST(TR_S390CEnvironmentAddress,(void *)TOC_UNWRAP_ENV((void *)_jitProfileValue));
-
-#endif
 
 #endif
 

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -1156,7 +1156,6 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_jitRetranslateCaller,         (void *)jitRetranslateCaller,                TR_Helper);
    SET(TR_jitRetranslateCallerWithPrep, (void *)jitRetranslateCallerWithPreparation, TR_Helper);
 
-#if !defined(TR_CROSS_COMPILE_ONLY)
 #ifdef TR_HOST_X86
 
    // --------------------------------- X86 ------------------------------------
@@ -1685,8 +1684,6 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
       a  = runtimeHelpers.getFunctionEntryPointOrConst(h);
       fprintf(stderr,"TR_S390interfaceCallHelperSingleDynamicSlot= _helpers[%d]=0x%p \n",h,a);
       }
-#endif
-
 #endif
 
    #undef SET


### PR DESCRIPTION
This patch removes TR_CROSS_COMPILE_ONLY macros according to the issue #10086.