### PR TITLE
Remove MethodHandle.invokeWithArgumentsHelper

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -608,9 +608,6 @@ public abstract class MethodHandle
 		final static MethodHandle spreader_7 = MethodHandles.spreadInvoker(MethodType.genericMethodType(7), 0);
 		
 	}
-
-	
-	private static native Object invokeWithArgumentsHelper(MethodHandle mh, Object[] args);
 	
 	/**
 	 * Helper method to call {@link #invokeWithArguments(Object[])}.

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -455,7 +455,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          vmInfo._writeBarrierType = TR::Compiler->om.writeBarrierType();
          vmInfo._compressObjectReferences = TR::Compiler->om.compressObjectReferences();
          vmInfo._processorDescription = TR::Compiler->target.cpu.getProcessorDescription();
-         vmInfo._invokeWithArgumentsHelperMethod = J9VMJAVALANGINVOKEMETHODHANDLE_INVOKEWITHARGUMENTSHELPER_METHOD(fe->getJ9JITConfig()->javaVM);
          vmInfo._noTypeInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact0, false, false, false)->getMethodAddress();
          vmInfo._int64InvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactJ, false, false, false)->getMethodAddress();
          vmInfo._int32InvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact1, false, false, false)->getMethodAddress();

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2120,16 +2120,6 @@ static bool doResolveAtRuntime(J9Method *method, I_32 cpIndex, TR::Compilation *
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
    if (!method)
       return true;
-   else if (method == J9VMJAVALANGINVOKEMETHODHANDLE_INVOKEWITHARGUMENTSHELPER_METHOD(fej9->getJ9JITConfig()->javaVM))
-      {
-      // invokeWithArgumentsHelper is a weirdo
-      if (fej9->isAOT_DEPRECATED_DO_NOT_USE())
-         {
-         comp->failCompilation<TR::CompilationException>("invokeWithArgumentsHelper");
-         }
-      else
-         return false; // It is incorrect to try to resolve this
-      }
    else if (comp->ilGenRequest().details().isMethodHandleThunk()) // cmvc 195373
       return false;
    else if (fej9->getJ9JITConfig()->runtimeFlags & J9JIT_RUNTIME_RESOLVE)

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -633,19 +633,7 @@ static bool doResolveAtRuntime(J9Method *method, I_32 cpIndex, TR::Compilation *
       return true;
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
    auto stream = fej9->_compInfoPT->getMethodBeingCompiled()->_stream;
-   if (method == fej9->_compInfoPT->getClientData()->getOrCacheVMInfo(stream)->_invokeWithArgumentsHelperMethod)
-      {
-      // invokeWithArgumentsHelper is a weirdo
-      if (fej9->isAOT_DEPRECATED_DO_NOT_USE())
-         {
-         comp->failCompilation<TR::CompilationException>("invokeWithArgumentsHelper");
-         }
-      else
-         {
-         return false; // It is incorrect to try to resolve this
-         }
-      }
-   else if (comp->ilGenRequest().details().isMethodHandleThunk()) // cmvc 195373
+   if (comp->ilGenRequest().details().isMethodHandleThunk()) // cmvc 195373
       {
       return false;
       }

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -389,7 +389,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<staticmethodref class="java/lang/J9VMInternals" name="threadCleanup" signature="(Ljava/lang/Thread;)V"/>
 	<staticmethodref class="java/lang/J9VMInternals" name="newInstanceImpl" signature="(Ljava/lang/Class;)Ljava/lang/Object;" flags="jit_newInstancePrototype"/>
 	<staticmethodref class="java/lang/J9VMInternals" name="formatNoSuchMethod" signature="(Ljava/lang/String;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/String;"/>
-	<staticmethodref class="java/lang/invoke/MethodHandle" name="invokeWithArgumentsHelper" signature="(Ljava/lang/invoke/MethodHandle;[Ljava/lang/Object;)Ljava/lang/Object;" flags="opt_methodHandle"/>
 	<specialmethodref class="java/lang/invoke/MethodHandle" name="forGenericInvoke" signature="(Ljava/lang/invoke/MethodType;Z)Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/>
 	<specialmethodref class="java/lang/invoke/MethodHandle" name="returnFilterPlaceHolder" signature="()Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/>
 	<specialmethodref class="java/lang/invoke/MethodHandle" name="foldHandlePlaceHolder" signature="()Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/>


### PR DESCRIPTION
This PR does the minimum to remove the unused helper by deleting
the method and removing the vmconstantpool reference.  Only
uses of the vmconstantpool macros are removed.

Further cleanup required to completely remove references but
this avoids any startup issues for OJ9 & OJDK MH implementations

Signed-off-by: Dan Heidinga <heidinga@redhat.com>