### PR TITLE
Fix undefined declarations of currentThread

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -895,7 +895,7 @@ old_slow_jitLoadFlattenableArrayElement(J9VMThread *currentThread)
 		addr = setCurrentExceptionFromJIT(currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, NULL);
 	} else {
 		j9object_t value = NULL;
-		U_32 arrayLength = J9INDEXABLEOBJECT_SIZE(_currentThread, arrayObject);
+		U_32 arrayLength = J9INDEXABLEOBJECT_SIZE(currentThread, arrayObject);
 		if (index >= arrayLength) {
 			buildJITResolveFrameForRuntimeHelper(currentThread, parmCount);
 			addr = setCurrentExceptionFromJIT(currentThread, J9VMCONSTANTPOOL_JAVALANGARRAYINDEXOUTOFBOUNDSEXCEPTION, NULL);
@@ -932,7 +932,7 @@ old_fast_jitLoadFlattenableArrayElement(J9VMThread *currentThread)
 	if (NULL == arrayObject) {
 		goto slow;
 	}
-	arrayLength = J9INDEXABLEOBJECT_SIZE(_currentThread, arrayObject);
+	arrayLength = J9INDEXABLEOBJECT_SIZE(currentThread, arrayObject);
 	if (index >= arrayLength) {
 		goto slow;
 	}
@@ -968,7 +968,7 @@ old_slow_jitStoreFlattenableArrayElement(J9VMThread *currentThread)
 		if (index >= arrayLength) {
 			addr = setCurrentExceptionFromJIT(currentThread, J9VMCONSTANTPOOL_JAVALANGARRAYINDEXOUTOFBOUNDSEXCEPTION, NULL);
 		} else {
-			if (false == VM_VMHelpers::objectArrayStoreAllowed(arrayref, value)) {
+			if (false == VM_VMHelpers::objectArrayStoreAllowed(currentThread, arrayref, value)) {
 				addr = setCurrentExceptionFromJIT(currentThread, J9VMCONSTANTPOOL_JAVALANGARRAYSTOREEXCEPTION, NULL);
 			} else {
 				J9ArrayClass *arrayrefClass = (J9ArrayClass *) J9OBJECT_CLAZZ(currentThread, arrayref);
@@ -998,7 +998,7 @@ old_fast_jitStoreFlattenableArrayElement(J9VMThread *currentThread)
 	if (index >= arrayLength) {
 		goto slow;
 	}
-	if (false == VM_VMHelpers::objectArrayStoreAllowed(arrayref, value)) {
+	if (false == VM_VMHelpers::objectArrayStoreAllowed(currentThread, arrayref, value)) {
 		goto slow;
 	}
 	arrayrefClass = (J9ArrayClass *) J9OBJECT_CLAZZ(currentThread, arrayref);

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1711,12 +1711,12 @@ exit:
 		return method;
 	}
 	static VMINLINE bool
-	objectArrayStoreAllowed(j9object_t array, j9object_t storeValue)
+	objectArrayStoreAllowed(J9VMThread const *currentThread, j9object_t array, j9object_t storeValue)
 	{
 		bool rc = true;
 		if (NULL != storeValue) {
-			J9Class *valueClass = J9OBJECT_CLAZZ(_currentThread, storeValue);
-			J9Class *componentType = ((J9ArrayClass*)J9OBJECT_CLAZZ(_currentThread, array))->componentType;
+			J9Class *valueClass = J9OBJECT_CLAZZ(currentThread, storeValue);
+			J9Class *componentType = ((J9ArrayClass*)J9OBJECT_CLAZZ(currentThread, array))->componentType;
 			/* quick check -- is this a store of a C into a C[]? */
 			if (valueClass != componentType) {
 				/* quick check -- is this a store of a C into a java.lang.Object[]? */

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -5901,7 +5901,7 @@ done:
 			} else {
 				j9object_t value = *(j9object_t*)_sp;
 				/* Runtime check class compatibility */
-				if (false == VM_VMHelpers::objectArrayStoreAllowed(arrayref, value)) {
+				if (false == VM_VMHelpers::objectArrayStoreAllowed(_currentThread, arrayref, value)) {
 					rc = THROW_ARRAY_STORE;
 				} else {
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)


### PR DESCRIPTION
Experienced `error: use of undeclared identifier '_currentThread'` while building with in progress mixed references mode.

`_currentThread` is not accessible in VMHelpers, so it must be passed into the `objectArrayStoreAllowed` function. Some references to `_currentThread` have been updated to `currentThread` instead in the changed files.

Related to: https://github.com/eclipse/openj9/pull/9938