### PR TITLE
Remove remnants of JVMPI from JIT

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -916,9 +916,6 @@ public:
    enum {SMALL_LAG=1, MEDIUM_LAG, LARGE_LAG};
    bool methodCanBeCompiled(TR_FrontEnd *, TR_ResolvedMethod *compilee, TR_FilterBST *&filter);
 
-   void emitJvmpiExtendedDataBuffer(TR::Compilation *&compiler, J9VMThread *vmThread, J9Method *&_method, TR_MethodMetaData *metaData);
-   void emitJvmpiCallSites(TR::Compilation *&compiler, J9VMThread *vmThread, J9Method *&_method);
-
    void setAllCompilationsShouldBeInterrupted();
 
    int32_t getIprofilerMaxCount() const { return _iprofilerMaxCount; }

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2262,25 +2262,6 @@ J9::Options::fePostProcessAOT(void * base)
    return true;
    }
 
-static inline bool jvmpiInterface(J9JavaVM * javaVM)
-   {
-   #ifdef J9VM_PROF_JVMPI
-      return javaVM->jvmpiInterface != 0;
-   #else
-      return false;
-   #endif
-   }
-
-static inline UDATA jvmpiExtensions(J9JITConfig * jitConfig)
-   {
-   #ifdef J9VM_PROF_JVMPI
-      //return javaVM->jvmpiInterface != 0 ? jitConfig->jvmpiExtensions : 0;
-      return enableCompiledMethodLoadHookOnly ? 0 : jitConfig->jvmpiExtensions;
-   #else
-      return 0;
-   #endif
-   }
-
 bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
    {
    // vmPostProcess is called indirectly from the JIT_INITIALIZED phase
@@ -2372,22 +2353,19 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
 
    // Determine whether or not to generate method enter and exit hooks
    //
-   if (!jvmpiInterface(javaVM) || (jvmpiExtensions(jitConfig) & J9JIT_JVMPI_GEN_COMPILED_ENTRY_EXIT))
+   if ((*vmHooks)->J9HookDisable(vmHooks, J9HOOK_VM_METHOD_ENTER))
       {
-      if ((*vmHooks)->J9HookDisable(vmHooks, J9HOOK_VM_METHOD_ENTER))
-         {
-         self()->setOption(TR_ReportMethodEnter);
+      self()->setOption(TR_ReportMethodEnter);
 #if !defined(TR_HOST_S390) && !defined(TR_HOST_POWER) && !defined(TR_HOST_X86)
-         doAOT = false;
+      doAOT = false;
 #endif
-         }
-      if ((*vmHooks)->J9HookDisable(vmHooks, J9HOOK_VM_METHOD_RETURN))
-         {
-         self()->setOption(TR_ReportMethodExit);
+      }
+   if ((*vmHooks)->J9HookDisable(vmHooks, J9HOOK_VM_METHOD_RETURN))
+      {
+      self()->setOption(TR_ReportMethodExit);
 #if !defined(TR_HOST_S390) && !defined(TR_HOST_POWER) && !defined(TR_HOST_X86)
-         doAOT = false;
+      doAOT = false;
 #endif
-         }
       }
 
    // Determine whether or not to disable allocation inlining

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -6715,9 +6715,7 @@ TR_J9ByteCodeIlGenerator::genReturn(TR::ILOpCodes nodeop, bool monitorExit)
       TR::SymbolReference * methodExitSymRef = symRefTab()->findOrCreateReportMethodExitSymbolRef(_methodSymbol);
 
       TR::Node * methodExitNode;
-      if (comp()->getOption(TR_OldJVMPI))
-         methodExitNode = TR::Node::createWithSymRef(TR::MethodExitHook, 0, methodExitSymRef);
-      else if (nodeop == TR::Return)
+      if (nodeop == TR::Return)
          {
          loadConstant(TR::aconst, (void *)0);
          methodExitNode = TR::Node::createWithSymRef(TR::MethodExitHook, 1, 1, pop(), methodExitSymRef);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -781,10 +781,6 @@ TR::Register *J9::X86::I386::TreeEvaluator::conditionalHelperEvaluator(TR::Node 
 #endif
 
 #ifdef TR_TARGET_64BIT
-// Hack markers
-#define JVMPI_HOOKS_WITHOUT_SNIPPETS (!debug("enableSnippetsForJVMPI")) // Snippets can't yet do the necessary linkage logic
-
-
 TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    // TODO:AMD64: Try to common this with the IA32 version
@@ -823,19 +819,6 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
    //          aconst (RAM method)
    //
 
-   // Decrement the reference count on the constant placeholder parameter to
-   // the MethodEnterHook call.  An evaluation isn't necessary because the
-   // constant value isn't used here.
-   //
-   if (node->getOpCodeValue() == TR::MethodEnterHook && !JVMPI_HOOKS_WITHOUT_SNIPPETS)
-      {
-      if (node->getSecondChild()->getOpCode().isCall() &&
-          node->getSecondChild()->getNumChildren() > 1)
-         {
-         cg->decReferenceCount(node->getSecondChild()->getFirstChild());
-         }
-      }
-
    // The child contains an inline test.
    //
    TR::Node *testNode    = node->getFirstChild();
@@ -851,8 +834,7 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
    //
    // The reference counts will be decremented when the call node is evaluated.
    //
-   if (JVMPI_HOOKS_WITHOUT_SNIPPETS &&
-       (node->getOpCodeValue() == TR::MethodEnterHook || node->getOpCodeValue() == TR::MethodExitHook))
+   if (node->getOpCodeValue() == TR::MethodEnterHook || node->getOpCodeValue() == TR::MethodExitHook)
       {
       TR::Node *callNode = node->getSecondChild();
 
@@ -910,8 +892,7 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
 
    TR::Instruction *startInstruction = generateLabelInstruction(LABEL, node, startLabel, cg);
 
-   if (JVMPI_HOOKS_WITHOUT_SNIPPETS &&
-       (node->getOpCodeValue() == TR::MethodEnterHook || node->getOpCodeValue() == TR::MethodExitHook))
+   if (node->getOpCodeValue() == TR::MethodEnterHook || node->getOpCodeValue() == TR::MethodExitHook)
       {
       TR::Node *callNode = node->getSecondChild();
 


### PR DESCRIPTION
This patch removes remnants of JVMPI from JIT according to issue #10022.