### PR TITLE
Fix crash freeing JIT structures at the end of the Snapshot run

### DIFF
--- a/runtime/codert_vm/jitavl.c
+++ b/runtime/codert_vm/jitavl.c
@@ -35,14 +35,7 @@ void avl_jit_artifact_free_all(J9JavaVM *javaVM, J9AVLTree *tree) {
 
 	avl_jit_artifact_free_node(javaVM, (J9JITHashTable *)tree->rootNode);
 
-#if defined(J9VM_OPT_SNAPSHOTS)
-	if (IS_SNAPSHOT_RUN(javaVM)) {
-		vmsnapshot_free_memory(tree);
-	} else
-#endif
-	{
-		j9mem_free_memory(tree);
-	}
+	j9mem_free_memory(tree);
 }
 
 

--- a/runtime/vm/segment.c
+++ b/runtime/vm/segment.c
@@ -133,7 +133,7 @@ void freeMemorySegment(J9JavaVM *javaVM, J9MemorySegment *segment, BOOLEAN freeD
 		 */
 		if (J9_ARE_ANY_BITS_SET(segment->type, MEMORY_TYPE_CODE | MEMORY_TYPE_FIXED_RAM_CLASS | MEMORY_TYPE_VIRTUAL)) {
 #if defined(J9VM_OPT_SNAPSHOTS)
-			if (IS_SNAPSHOT_RUN(javaVM) && J9_ARE_ALL_BITS_SET(segment->type, MEMORY_TYPE_CODE))
+			if (IS_SNAPSHOT_RUN(javaVM) && J9_ARE_ANY_BITS_SET(segment->type, MEMORY_TYPE_CODE | MEMORY_TYPE_CCDATA))
 				vmsnapshot_free_memory(segment->baseAddress);
 			else
 #endif /* defined(J9VM_OPT_SNAPSHOTS) */


### PR DESCRIPTION
This PR ensures the right functions are used to free memory, specifically:

1. Using `j9mem_free_memory` to free `jitConfig->translationArtifacts`
2. Using `vmsnapshot_free_memory` to free the CCData segment in `jitConfig->dataCacheList`