### PR TITLE
Use TR_UNIMPLEMENTED macro in JIT

### DIFF
--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -6644,8 +6644,7 @@ TR_CISCTransformer::analyzeBoolTable(TR_BitVector **bv, TR::TreeTop **retSameExi
                      ntakenBV -= tmpBV;
                      break;
                   default:
-                     TR_ASSERT(false, "not implemented yet");
-                     // not implemented yet
+                     TR_UNIMPLEMENTED();
                      return false;
                   }
 
@@ -6781,7 +6780,7 @@ TR_CISCTransformer::analyzeByteBoolTable(TR_CISCNode *boolTable, uint8_t *table2
          defBV.setAll(   0+BYTEBVOFFSET, 255+BYTEBVOFFSET);
          break;
       default:
-         TR_ASSERT(false, "not implemented yet");
+         TR_UNIMPLEMENTED();
          // not implemented yet
          return -1;     // error
       }
@@ -6867,7 +6866,7 @@ TR_CISCTransformer::analyzeCharBoolTable(TR_CISCNode *boolTable, uint8_t *table6
          defBV.setAll(0, 65535);
          break;
       default:
-         TR_ASSERT(false, "not implemented yet");
+         TR_UNIMPLEMENTED();
          // not implemented yet
          return -1;     // error
       }

--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -4992,7 +4992,7 @@ CISCTransform2TRTOArray(TR_CISCTransformer *trans)
                }
             else
                {
-               TR_ASSERT(false, "Not implemented yet");
+               TR_UNIMPLEMENTED();
                }
             }
          }

--- a/runtime/compiler/runtime/JITServerIProfiler.cpp
+++ b/runtime/compiler/runtime/JITServerIProfiler.cpp
@@ -163,7 +163,7 @@ JITServerIProfiler::profilingSample(uintptr_t pc, uintptr_t data, bool addIt, bo
    if (addIt)
       return NULL; // Server should not create any samples
 
-   TR_ASSERT(false, "not implemented for JITServer");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 

--- a/runtime/compiler/z/codegen/S390CHelperLinkage.hpp
+++ b/runtime/compiler/z/codegen/S390CHelperLinkage.hpp
@@ -50,8 +50,8 @@ public:
 
    CHelperLinkage(TR::CodeGenerator * cg, TR_S390LinkageConventions elc=TR_JavaHelper, TR_LinkageConventions lc=TR_CHelper);
 
-   virtual void createPrologue(TR::Instruction * cursor) { TR_ASSERT(false, "Not Implemented"); }
-   virtual void createEpilogue(TR::Instruction * cursor) { TR_ASSERT(false, "Not Implemented"); }
+   virtual void createPrologue(TR::Instruction * cursor) { TR_UNIMPLEMENTED(); }
+   virtual void createEpilogue(TR::Instruction * cursor) { TR_UNIMPLEMENTED(); }
 
    virtual void setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol * method)
       {
@@ -63,10 +63,10 @@ public:
       TR_ASSERT_FATAL(false, "CHelperLinkage should only be used for call-outs");
       }
 
-   virtual void mapStack(TR::ResolvedMethodSymbol *symbol) { TR_ASSERT(false, "Not Implemented"); }
-   virtual void mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex) { TR_ASSERT(false, "Not Implemented"); }
-   virtual bool hasToBeOnStack(TR::ParameterSymbol * parm) { TR_ASSERT(false, "Not Implemented"); return false; }
-   virtual void initS390RealRegisterLinkage() { TR_ASSERT(false, "Not Implemented"); }
+   virtual void mapStack(TR::ResolvedMethodSymbol *symbol) { TR_UNIMPLEMENTED(); }
+   virtual void mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex) { TR_UNIMPLEMENTED(); }
+   virtual bool hasToBeOnStack(TR::ParameterSymbol * parm) { TR_UNIMPLEMENTED(); return false; }
+   virtual void initS390RealRegisterLinkage() { TR_UNIMPLEMENTED(); }
    virtual TR::RealRegister::RegNum setMethodMetaDataRegister(TR::RealRegister::RegNum r) { return _methodMetaDataRegister = r; }
    virtual TR::RealRegister::RegNum getMethodMetaDataRegister() { return _methodMetaDataRegister; }
    virtual TR::RealRegister::RegNum setReturnAddressRegister(TR::RealRegister::RegNum r) { return _returnAddressRegister = r; }


### PR DESCRIPTION
This patch replaces `TR_ASSERT(false, "Not implemented yet")` with `TR_UNIMPLEMENTED()`