### PR TITLE
Add JDK16 JVM_LogLambdaFormInvoker & JVM_IsDumpingClassList

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -374,6 +374,8 @@ elseif(NOT JAVA_SPEC_VERSION LESS 16)
 		JVM_GetRandomSeedForDumping
 		JVM_IsDynamicDumpingEnabled
 		JVM_IsSharingEnabled
+		JVM_LogLambdaFormInvoker
+		JVM_IsDumpingClassList
 	)
 endif()
 

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -364,6 +364,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="JVM_GetRandomSeedForDumping"/>
 		<export name="JVM_IsDynamicDumpingEnabled"/>
 		<export name="JVM_IsSharingEnabled"/>
+		<export name="JVM_LogLambdaFormInvoker"/>
+		<export name="JVM_IsDumpingClassList"/>
 	</exports>
 
 </exportlists>

--- a/runtime/j9vm/javanextvmi.c
+++ b/runtime/j9vm/javanextvmi.c
@@ -38,6 +38,18 @@ JVM_DefineArchivedModules(JNIEnv *env, jobject obj1, jobject obj2)
 {
 	assert(!"JVM_DefineArchivedModules unimplemented");
 }
+
+JNIEXPORT void JNICALL
+JVM_LogLambdaFormInvoker(JNIEnv *env, jstring str)
+{
+	assert(!"JVM_LogLambdaFormInvoker unimplemented");
+}
+
+JNIEXPORT jboolean JNICALL
+JVM_IsDumpingClassList(JNIEnv *env)
+{
+	return JNI_FALSE;
+}
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
 #if JAVA_SPEC_VERSION >= 11

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -343,4 +343,8 @@ _IF([JAVA_SPEC_VERSION >= 16],
 	[_X(JVM_IsSharingEnabled, JNICALL, false, jboolean, JNIEnv *env)])
 _IF([JAVA_SPEC_VERSION >= 16],
 	[_X(JVM_DefineArchivedModules, JNICALL, false, void, JNIEnv *env, jobject obj1, jobject obj2)])
+_IF([JAVA_SPEC_VERSION >= 16],
+	[_X(JVM_LogLambdaFormInvoker, JNICALL, false, void, JNIEnv *env, jstring str)])
+_IF([JAVA_SPEC_VERSION >= 16],
+	[_X(JVM_IsDumpingClassList, JNICALL, false, jboolean, JNIEnv *env)])
 _X(JVM_IsUseContainerSupport, JNICALL, false, jboolean, JNIEnv *env)


### PR DESCRIPTION
Stubbed `JVM_LogLambdaFormInvoker`;
Return `JNI_FALSE` for `JVM_IsDumpingClassList` Since OpenJ9 doesn't support `CDS`.

Note: this fixes `JDK16` build with `openj9-staging` branch.
```
08:56:48  /home/jenkins/workspace/Build_JDKnext_x86-64_linux_Personal/build/linux-x86_64-server-release/support/native/java.base/libjava/CDS.o: In function `Java_jdk_internal_misc_CDS_isDumpingClassList0':
08:56:48  /home/jenkins/workspace/Build_JDKnext_x86-64_linux_Personal/./src/java.base/share/native/libjava/CDS.c:59: undefined reference to `JVM_IsDumpingClassList'
08:56:48  /home/jenkins/workspace/Build_JDKnext_x86-64_linux_Personal/build/linux-x86_64-server-release/support/native/java.base/libjava/CDS.o: In function `Java_jdk_internal_misc_CDS_logLambdaFormInvoker':
08:56:48  /home/jenkins/workspace/Build_JDKnext_x86-64_linux_Personal/./src/java.base/share/native/libjava/CDS.c:64: undefined reference to `JVM_LogLambdaFormInvoker'
08:56:48  collect2: error: ld returned 1 exit status
```
With this PR, `JDK16` builds and the `java -version` output:
```
openjdk version "16-internal" 2021-03-16
OpenJDK Runtime Environment (build 16-internal+0-adhoc.fengjcaibmcom.openj9-openjdk-jdk)
Eclipse OpenJ9 VM (build master-1e0f329b62, JRE 16 Mac OS X amd64-64-Bit Compressed References 20201012_000000 (JIT enabled, AOT enabled)
OpenJ9   - 1e0f329b62
OMR      - cfd55882d
JCL      - c058dc41ecf based on jdk-16+19)
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>