### PR TITLE
Also handle types I8 & U8 in CStringFieldFormatter

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/structureformat/extensions/CStringFieldFormatter.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/structureformat/extensions/CStringFieldFormatter.java
@@ -34,43 +34,49 @@ import com.ibm.j9ddr.vm29.pointer.PointerPointer;
 import com.ibm.j9ddr.vm29.pointer.U8Pointer;
 
 /**
- * Field formatter that adds the value of any char * string fields
- *
+ * Field formatter that adds the value of any char * string fields.
  */
-public class CStringFieldFormatter extends BaseFieldFormatter 
+public class CStringFieldFormatter extends BaseFieldFormatter
 {
-
 	public static final int MAXIMUM_LENGTH = 120;
-	
+
 	@Override
 	public FormatWalkResult postFormat(String name, String type,
 			String declaredType, int typeCode, long address, PrintStream out,
 			Context context, IStructureFormatter structureFormatter)
-			throws CorruptDataException 
 	{
 		if (typeCode == StructureTypeManager.TYPE_POINTER) {
 			CTypeParser parser = new CTypeParser(declaredType);
-			
-			if (parser.getCoreType().equals("char") && parser.getSuffix().equals("*")) {
-				U8Pointer ptr = U8Pointer.cast(PointerPointer.cast(address).at(0));
-				
-				if (ptr.isNull()) {
-					return FormatWalkResult.KEEP_WALKING;
-				}
-				
-				String str = ptr.getCStringAtOffset(0, MAXIMUM_LENGTH);
-				
-				if (str.length() > 0) {
-					out.print(" // \"");
-					out.print(str);
-					if (str.length() >= MAXIMUM_LENGTH) {
-						out.print("...");
+			String coreType = parser.getCoreType();
+
+			switch (coreType) {
+			case "char":
+			case "I8":
+			case "U8":
+				if (parser.getSuffix().equals("*")) {
+					try {
+						U8Pointer ptr = U8Pointer.cast(PointerPointer.cast(address).at(0));
+
+						if (ptr.notNull()) {
+							String str = ptr.getCStringAtOffset(0, MAXIMUM_LENGTH);
+
+							out.print(" // \"");
+							out.print(str);
+							if (str.length() >= MAXIMUM_LENGTH) {
+								out.print("...");
+							}
+							out.print("\"");
+						}
+					} catch (CorruptDataException e) {
+						/* ignore */
 					}
-					out.print("\"");
 				}
+				break;
+			default:
+				break;
 			}
 		}
-		
+
 		return FormatWalkResult.KEEP_WALKING;
 	}
 }


### PR DESCRIPTION
The aliases defined by StructureAliases29.dat:
```
  char=U8
  signed char=I8
  unsigned char=U8
```
mean that getCoreType() will not normally be "char" and so `CStringFieldFormatter` will usually do nothing.

I noticed this while reviewing #10853.