### PR TITLE
(0.23) Increase maximum length of formatted output string in DDR

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/structureformat/extensions/CStringFieldFormatter.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/structureformat/extensions/CStringFieldFormatter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2014 IBM Corp. and others
+ * Copyright (c) 2010, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,7 +40,7 @@ import com.ibm.j9ddr.vm29.pointer.U8Pointer;
 public class CStringFieldFormatter extends BaseFieldFormatter 
 {
 
-	public static final int MAXIMUM_LENGTH = 50;
+	public static final int MAXIMUM_LENGTH = 120;
 	
 	@Override
 	public FormatWalkResult postFormat(String name, String type,


### PR DESCRIPTION
There are cases of truncation of output in cases where full file path is
a part of output. Call site is an example, it includes __FILE__
Increasing maximum output from 50 to 120

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>