### PR TITLE
Enable testJITServer tests for Power

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -631,7 +631,7 @@
 		echo $(Q)$(TEST_JDK_BIN)$(D)jitserver doesn't exist; assuming this JDK does not support JITServer and trivially passing the test.$(Q); \
 	fi; \
 	$(TEST_STATUS)</command>
-		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<platformRequirements>os.linux,^arch.arm,^arch.aarch64,^arch.s390x,bits.64</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
This commit enables `testJITServer_0(1)` tests for
`ppc64le` and `ppc64le_jit`. This means that test behavior
is the same between x86 and Power. On the `*_jit` platforms,
all tests are run with JITServer, while on regular platforms,
only `testJITServer` tests use it.