### PR TITLE
Safely identify internal class references

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4626,6 +4626,7 @@ typedef struct J9InternalVMFunctions {
 #endif /* JAVA_SPEC_VERSION >= 15 */
 	void ( *storeFlattenableArrayElement)(struct J9VMThread *currentThread, j9object_t receiverObject, U_32 index, j9object_t paramObject);
 	j9object_t ( *loadFlattenableArrayElement)(struct J9VMThread *currentThread, j9object_t receiverObject, U_32 index, BOOLEAN fast);
+	UDATA ( *jniIsInternalClassRef)(struct J9JavaVM *vm, jobject ref);
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -990,6 +990,15 @@ initializeInitialMethods(J9JavaVM *vm);
 /* ---------------- jnicsup.c ---------------- */
 
 /**
+* @brief Determine if a JNI ref is an internal class ref
+* @param *vm
+* @param ref
+* @return UDATA
+*/
+UDATA
+jniIsInternalClassRef(J9JavaVM *vm, jobject ref);
+
+/**
 * @brief
 * @param *currentThread
 * @param *clazz

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -392,4 +392,5 @@ J9InternalVMFunctions J9InternalFunctions = {
 #endif /* JAVA_SPEC_VERSION >= 15 */
 	storeFlattenableArrayElement,
 	loadFlattenableArrayElement,
+	jniIsInternalClassRef
 };

--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -2158,6 +2158,27 @@ findJNIMethod(J9VMThread* currentThread, J9Class* clazz, char* name, char* signa
 	return result;
 }
 
+UDATA
+jniIsInternalClassRef(J9JavaVM *vm, jobject ref)
+{
+	UDATA rc = FALSE;
+	J9ClassWalkState classWalkState;
+	J9Class *clazz = allLiveClassesStartDo(&classWalkState, vm, NULL);
+	while (clazz != NULL) {
+		do {
+			if (ref == (jobject)&clazz->classObject) {
+				rc = TRUE;
+				goto done;
+			}
+			clazz = clazz->replacedClass;
+		} while (NULL != clazz);
+		clazz = allLiveClassesNextDo(&classWalkState);
+	}
+done:
+	allLiveClassesEndDo(&classWalkState);
+	return rc;
+}
+
 static jobjectRefType JNICALL
 getObjectRefType(JNIEnv *env, jobject obj)
 {
@@ -2166,8 +2187,6 @@ getObjectRefType(JNIEnv *env, jobject obj)
 	jobjectRefType rc = JNIInvalidRefType;
 	J9JNIReferenceFrame* frame;
 	J9JavaStack* stack = vmThread->stackObject;
-	J9ClassWalkState classWalkState;
-	J9Class * clazz;
 
 	VM_VMAccess::inlineEnterVMFromJNI(vmThread);
 
@@ -2229,15 +2248,10 @@ getObjectRefType(JNIEnv *env, jobject obj)
 
 	/* Check for class refs */
 
-	clazz = allLiveClassesStartDo(&classWalkState, vm, NULL);
-	while (clazz != NULL) {
-		if (obj == (jobject) &(clazz->classObject)) {
-			rc = JNILocalRefType;
-			break;
-		}
-		clazz = allLiveClassesNextDo(&classWalkState);
+	if (jniIsInternalClassRef(vm, obj)) {
+		rc = JNILocalRefType;
+		goto done;
 	}
-	allLiveClassesEndDo(&classWalkState);
 
 done:
 	VM_VMAccess::inlineExitVMToJNI(vmThread);


### PR DESCRIPTION
- commonize code between JNI check and JNI GetObjectRefType
- fix detection to handle replaced classes
- JNI check now considers internal class refs to be local rather than
global (this matches GetObjectRefType and the RI)

Fixes: #10481

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>