### PR TITLE
Print `initialized` stanza to each file

### DIFF
--- a/runtime/gc_verbose_handler_realtime/VerboseHandlerOutputRealtime.hpp
+++ b/runtime/gc_verbose_handler_realtime/VerboseHandlerOutputRealtime.hpp
@@ -193,7 +193,7 @@ protected:
 	 * @return string representing the human readable "type" of the cycle.
 	 */	
 	virtual const char *getCycleType(UDATA type);
-	virtual void handleInitializedInnerStanzas(J9HookInterface** hook, UDATA eventNum, void* eventData);
+	virtual void outputInitializedInnerStanza(MM_EnvironmentBase *env, MM_VerboseBuffer *buffer);
 
 	MM_VerboseHandlerOutputRealtime(MM_GCExtensions *extensions) :
 		MM_VerboseHandlerOutput(extensions),
@@ -246,7 +246,7 @@ protected:
 	virtual void tearDown(MM_EnvironmentBase *env);
 
 	virtual bool getThreadName(char *buf, UDATA bufLen, OMR_VMThread *vmThread);
-	virtual void writeVmArgs(MM_EnvironmentBase* env);
+	virtual void writeVmArgs(MM_EnvironmentBase* env, MM_VerboseBuffer* buffer);
 
 public:
 	static MM_VerboseHandlerOutput *newInstance(MM_EnvironmentBase *env, MM_VerboseManager *manager);

--- a/runtime/gc_verbose_handler_standard_java/VerboseHandlerOutputStandardJava.cpp
+++ b/runtime/gc_verbose_handler_standard_java/VerboseHandlerOutputStandardJava.cpp
@@ -112,9 +112,9 @@ MM_VerboseHandlerOutputStandardJava::getThreadName(char *buf, UDATA bufLen, OMR_
 }
 
 void
-MM_VerboseHandlerOutputStandardJava::writeVmArgs(MM_EnvironmentBase* env)
+MM_VerboseHandlerOutputStandardJava::writeVmArgs(MM_EnvironmentBase* env, MM_VerboseBuffer* buffer)
 {
-	MM_VerboseHandlerJava::writeVmArgs(_manager, env, static_cast<J9JavaVM*>(_omrVM->_language_vm));
+	MM_VerboseHandlerJava::writeVmArgs(env, buffer, static_cast<J9JavaVM*>(_omrVM->_language_vm));
 }
 
 void

--- a/runtime/gc_verbose_handler_standard_java/VerboseHandlerOutputStandardJava.hpp
+++ b/runtime/gc_verbose_handler_standard_java/VerboseHandlerOutputStandardJava.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,7 +74,7 @@ protected:
 	virtual void outputMemoryInfoInnerStanzaInternal(MM_EnvironmentBase *env, UDATA indent, MM_CollectionStatistics *stats);
 
 	virtual bool getThreadName(char *buf, UDATA bufLen, OMR_VMThread *vmThread);
-	virtual void writeVmArgs(MM_EnvironmentBase* env);
+	virtual void writeVmArgs(MM_EnvironmentBase* env, MM_VerboseBuffer* buffer);
 
 	MM_VerboseHandlerOutputStandardJava(MM_GCExtensions *extensions) :
 		MM_VerboseHandlerOutputStandard(extensions)

--- a/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.cpp
+++ b/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.cpp
@@ -224,9 +224,9 @@ MM_VerboseHandlerOutputVLHGC::getThreadName(char *buf, UDATA bufLen, OMR_VMThrea
 }
 
 void
-MM_VerboseHandlerOutputVLHGC::writeVmArgs(MM_EnvironmentBase* env)
+MM_VerboseHandlerOutputVLHGC::writeVmArgs(MM_EnvironmentBase* env, MM_VerboseBuffer* buffer)
 {
-	MM_VerboseHandlerJava::writeVmArgs(_manager, env, static_cast<J9JavaVM*>(_omrVM->_language_vm));
+	MM_VerboseHandlerJava::writeVmArgs(env, buffer, static_cast<J9JavaVM*>(_omrVM->_language_vm));
 }
 
 void
@@ -288,9 +288,8 @@ MM_VerboseHandlerOutputVLHGC::outputReferenceInfo(MM_EnvironmentBase *env, UDATA
 }
 
 void
-MM_VerboseHandlerOutputVLHGC::handleInitializedInnerStanzas(J9HookInterface** hook, UDATA eventNum, void* eventData)
-{
-	handleInitializedRegion(hook, eventNum, eventData);
+MM_VerboseHandlerOutputVLHGC::outputInitializedInnerStanza(MM_EnvironmentBase *env, MM_VerboseBuffer *buffer){
+	outputInitializedRegion(env, buffer);
 }
 
 void

--- a/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.hpp
+++ b/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -93,7 +93,7 @@ private:
 
 
 protected:
-	virtual void handleInitializedInnerStanzas(J9HookInterface** hook, UDATA eventNum, void* eventData);
+	virtual void outputInitializedInnerStanza(MM_EnvironmentBase *env, MM_VerboseBuffer *buffer);
 
 	/**
 	 * @returns true if memory-info staza is multiline. Caller than format first and last line accordingly.
@@ -120,7 +120,7 @@ protected:
 	virtual void tearDown(MM_EnvironmentBase *env);
 
 	virtual bool getThreadName(char *buf, UDATA bufLen, OMR_VMThread *vmThread);
-	virtual void writeVmArgs(MM_EnvironmentBase* env);
+	virtual void writeVmArgs(MM_EnvironmentBase* env, MM_VerboseBuffer* buffer);
 
 	MM_VerboseHandlerOutputVLHGC(MM_GCExtensions *extensions)
 		: MM_VerboseHandlerOutput(extensions)

--- a/runtime/gc_verbose_java/VerboseHandlerJava.cpp
+++ b/runtime/gc_verbose_java/VerboseHandlerJava.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,7 @@
 #include "VerboseWriterChain.hpp"
 #include "GCExtensions.hpp"
 #include "FinalizeListManager.hpp"
+#include "VerboseBuffer.hpp"
 
 void
 MM_VerboseHandlerJava::outputFinalizableInfo(MM_VerboseManager *manager, MM_EnvironmentBase *env, UDATA indent)
@@ -63,22 +64,21 @@ MM_VerboseHandlerJava::getThreadName(char *buf, UDATA bufLen, OMR_VMThread *omrT
 }
 
 void
-MM_VerboseHandlerJava::writeVmArgs(MM_VerboseManager *manager, MM_EnvironmentBase* env, J9JavaVM *vm)
+MM_VerboseHandlerJava::writeVmArgs(MM_EnvironmentBase* env, MM_VerboseBuffer* buffer, J9JavaVM *vm)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	JavaVMInitArgs* vmArgs = vm->vmArgsArray->actualVMArgs;
-	MM_VerboseWriterChain* writer = manager->getWriterChain();
-	writer->formatAndOutput(env, 1, "<vmargs>");
+	buffer->formatAndOutput(env,  1, "<vmargs>");
 	for (jint i = 0; i < vmArgs->nOptions; ++i) {
 		char escapedXMLString[128];
 		UDATA optLen = strlen(vmArgs->options[i].optionString);
 		UDATA escapeConsumed = escapeXMLString(OMRPORT_FROM_J9PORT(PORTLIB), escapedXMLString, sizeof(escapedXMLString), vmArgs->options[i].optionString, optLen);
 		const char* dots = (escapeConsumed < optLen) ? "..." : "";
 		if (NULL == vmArgs->options[i].extraInfo) {
-			writer->formatAndOutput(env, 2, "<vmarg name=\"%s%s\" />", escapedXMLString, dots);
+			buffer->formatAndOutput(env, 2, "<vmarg name=\"%s%s\" />", escapedXMLString, dots);
 		} else {
-			writer->formatAndOutput(env, 2, "<vmarg name=\"%s%s\" value=\"%p\" />", escapedXMLString, dots, vmArgs->options[i].extraInfo);
+			buffer->formatAndOutput(env, 2, "<vmarg name=\"%s%s\" value=\"%p\" />", escapedXMLString, dots, vmArgs->options[i].extraInfo);
 		}
 	}
-	writer->formatAndOutput(env, 1, "</vmargs>");
+	buffer->formatAndOutput(env, 1, "</vmargs>");
 }

--- a/runtime/gc_verbose_java/VerboseHandlerJava.hpp
+++ b/runtime/gc_verbose_java/VerboseHandlerJava.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,7 @@
 #include "mmhook.h"
 #include "Base.hpp"
 
+class MM_VerboseBuffer;
 class MM_VerboseManager;
 class MM_EnvironmentBase;
 
@@ -51,7 +52,7 @@ public:
 	/**
 	 * Output Java VM arguments.
 	 */
-	static void writeVmArgs(MM_VerboseManager *manager, MM_EnvironmentBase* env, J9JavaVM *vm);
+	static void writeVmArgs(MM_EnvironmentBase* env, MM_VerboseBuffer* buffer, J9JavaVM *vm);
 };
 
 #endif /* VERBOSEHANDLERJAVA_HPP_ */


### PR DESCRIPTION
OMR: https://github.com/eclipse/omr/pull/5607
When using `-Xverbosegclog`, prints Initialized stanza at the beginning of each file.
In order to achieve this, following changes have been made:

In `MM_VerboseHandlerOutputRealtime`:
- Replace `handleInitializedInnerStanzas` with `outputInitializedInnerStanza` to print `metronome` stanza to one `VerboseBuffer`

In `MM_VerboseHandlerOutputStandardJava`, 'MM_VerboseHandlerOutputRealtime', 'MM_VerboseHandlerJava',modify `writeVmArgs()` to take a `VerboseBuffer`