### PR TITLE
Remove references to Weak/SoftCleanable from CleanerShutdown

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/ref/CleanerShutdown.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/ref/CleanerShutdown.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,24 +49,12 @@ public class CleanerShutdown {
 		
 		try {
 			Method phantomRemove = PhantomCleanable.class.getDeclaredMethod("remove", (Class<?>[]) null); //$NON-NLS-1$
-			Method weakRemove = WeakCleanable.class.getDeclaredMethod("remove", (Class<?>[]) null); //$NON-NLS-1$
-			Method softRemove = SoftCleanable.class.getDeclaredMethod("remove", (Class<?>[]) null); //$NON-NLS-1$
 			AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
 				phantomRemove.setAccessible(true);
-				weakRemove.setAccessible(true);
-				softRemove.setAccessible(true);
 				return null;
 			});
 			while(!commonCleanerImpl.phantomCleanableList.isListEmpty()) {
 				phantomRemove.invoke(commonCleanerImpl.phantomCleanableList, (Object[]) null);
-			}
-
-			while(!commonCleanerImpl.weakCleanableList.isListEmpty()) {
-				phantomRemove.invoke(commonCleanerImpl.weakCleanableList, (Object[]) null);
-			}
-
-			while(!commonCleanerImpl.softCleanableList.isListEmpty()) {
-				phantomRemove.invoke(commonCleanerImpl.softCleanableList, (Object[]) null);
 			}
 		} catch (NoSuchMethodException
 				| SecurityException


### PR DESCRIPTION
WeakCleanable and SoftCleanable are removed in JDK16. The cleanup code
for these never worked properly in older versions, obviously it's not
needed.

Fixes https://github.com/eclipse/openj9/issues/10881

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>