### PR TITLE
Use default parameters for findOrCreateRuntimeHelper

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64JNILinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64JNILinkage.cpp
@@ -282,7 +282,7 @@ void J9::ARM64::JNILinkage::restoreJNICallOutFrame(TR::Node *callNode, bool tear
       // leave a bunch of pinned garbage behind that screws up the gc quality forever
       TR::LabelSymbol      *refPoolRestartLabel = generateLabelSymbol(cg());
       TR::LabelSymbol      *refPoolSnippetLabel = generateLabelSymbol(cg());
-      TR::SymbolReference *collapseSymRef = cg()->getSymRefTab()->findOrCreateRuntimeHelper(TR_ARM64jitCollapseJNIReferenceFrame, false, false, false);
+      TR::SymbolReference *collapseSymRef = cg()->getSymRefTab()->findOrCreateRuntimeHelper(TR_ARM64jitCollapseJNIReferenceFrame);
       TR::Snippet *snippet = new (trHeapMemory()) TR::ARM64HelperCallSnippet(cg(), callNode, refPoolSnippetLabel, collapseSymRef, refPoolRestartLabel);
       cg()->addSnippet(snippet);
       generateTrg1MemInstruction(cg(), TR::InstOpCode::ldrimmx, callNode, scratchReg, new (trHeapMemory()) TR::MemoryReference(javaStackReg, fej9->constJNICallOutFrameFlagsOffset(), cg()));

--- a/runtime/compiler/aarch64/codegen/ARM64Recompilation.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64Recompilation.cpp
@@ -66,7 +66,7 @@ TR::Instruction *TR_ARM64Recompilation::generatePrePrologue()
    TR::Register *lr = machine->getRealRegister(TR::RealRegister::lr); // Link Register
    TR::Register *xzr = machine->getRealRegister(TR::RealRegister::xzr); // zero register
    TR::Node *firstNode = comp()->getStartTree()->getNode();
-   TR::SymbolReference *recompileMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARM64samplingRecompileMethod, false, false, false);
+   TR::SymbolReference *recompileMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARM64samplingRecompileMethod);
    TR_PersistentJittedBodyInfo *info = getJittedBodyInfo();
 
    // Force creation of switch to interpreter preprologue if in Full Speed Debug

--- a/runtime/compiler/aarch64/codegen/ARM64RecompilationSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64RecompilationSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,7 @@
 uint8_t *TR::ARM64RecompilationSnippet::emitSnippetBody()
    {
    uint8_t *buffer = cg()->getBinaryBufferCursor();
-   TR::SymbolReference  *countingRecompMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARM64countingRecompileMethod, false, false, false);
+   TR::SymbolReference  *countingRecompMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARM64countingRecompileMethod);
 
    getSnippetLabel()->setCodeLocation(buffer);
 

--- a/runtime/compiler/aarch64/codegen/CallSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/CallSnippet.cpp
@@ -248,7 +248,7 @@ uint8_t *TR::ARM64CallSnippet::emitSnippetBody()
    // Flush in-register arguments back to the stack for interpreter
    cursor = flushArgumentsToStack(cursor, callNode, getSizeOfArguments(), cg());
 
-   glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(getHelper(), false, false, false);
+   glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(getHelper());
 
    // 'b glueRef' for jitInduceOSRAtCurrentPC, 'bl glueRef' otherwise
    // we use "b" for induceOSR because we want the helper to think that it's been called from the mainline code and not from the snippet.
@@ -407,7 +407,7 @@ uint8_t *TR::ARM64VirtualUnresolvedSnippet::emitSnippetBody()
    uint8_t *cursor = cg()->getBinaryBufferCursor();
    TR::Node *callNode = getNode();
    TR::SymbolReference *methodSymRef = callNode->getSymbolReference();
-   TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARM64virtualUnresolvedHelper, false, false, false);
+   TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARM64virtualUnresolvedHelper);
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
    void *thunk = fej9->getJ2IThunk(callNode->getSymbolReference()->getSymbol()->castToMethodSymbol()->getMethod(), comp);
 
@@ -549,7 +549,7 @@ uint8_t *TR::ARM64InterfaceCallSnippet::emitSnippetBody()
    uint8_t *cursor = cg()->getBinaryBufferCursor();
    TR::Node *callNode = getNode();
    TR::SymbolReference *methodSymRef = getNode()->getSymbolReference();
-   TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARM64interfaceCallHelper, false, false, false);
+   TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARM64interfaceCallHelper);
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
    void* thunk = fej9->getJ2IThunk(callNode->getSymbolReference()->getSymbol()->castToMethodSymbol()->getMethod(), comp);
 
@@ -716,7 +716,7 @@ uint8_t *TR::ARM64CallSnippet::generateVIThunk(TR::Node *callNode, int32_t argSi
                          cg->getDebug()->getName(dataType));
       }
 
-   dispatcher = (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(helper, false, false, false)->getMethodAddress();
+   dispatcher = (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(helper)->getMethodAddress();
 
    buffer = flushArgumentsToStack(buffer, callNode, argSize, cg);
 
@@ -788,7 +788,7 @@ TR_J2IThunk *TR::ARM64CallSnippet::generateInvokeExactJ2IThunk(TR::Node *callNod
                   cg->getDebug()->getName(dataType));
       }
 
-   dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(helper, false, false, false)->getMethodAddress();
+   dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(helper)->getMethodAddress();
 
    buffer = flushArgumentsToStack(buffer, callNode, argSize, cg);
 

--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -190,9 +190,9 @@ J9::ARM64::CodeGenerator::generateSwitchToInterpreterPrePrologue(TR::Instruction
    TR::Register *lr = self()->machine()->getRealRegister(TR::RealRegister::x30); // link register
    TR::Register *xzr = self()->machine()->getRealRegister(TR::RealRegister::xzr); // zero register
    TR::ResolvedMethodSymbol *methodSymbol = comp->getJittedMethodSymbol();
-   TR::SymbolReference *revertToInterpreterSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_ARM64revertToInterpreterGlue, false, false, false);
+   TR::SymbolReference *revertToInterpreterSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_ARM64revertToInterpreterGlue);
    uintptr_t ramMethod = (uintptr_t)methodSymbol->getResolvedMethod()->resolvedMethodAddress();
-   TR::SymbolReference *helperSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition, false, false, false);
+   TR::SymbolReference *helperSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition);
    uintptr_t helperAddr = (uintptr_t)helperSymRef->getMethodAddress();
 
    // x8 must contain the saved LR; see Recompilation.s

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -190,7 +190,7 @@ generateSoftwareReadBarrier(TR::Node *node, TR::CodeGenerator *cg, bool isArdbar
    // TR_softwareReadBarrier helper expects the vmThread in x0.
    generateMovInstruction(cg, node, x0Reg, vmThreadReg);
 
-   TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_softwareReadBarrier, false, false, false);
+   TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_softwareReadBarrier);
    generateImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptr_t)helperSym->getMethodAddress(), deps, helperSym, NULL);
 
    generateTrg1MemInstruction(cg, loadOp, node, tempReg, new (cg->trHeapMemory()) TR::MemoryReference(locationReg, 0, cg));
@@ -1240,7 +1240,7 @@ genHeapAlloc(TR::Node *node, TR::CodeGenerator *cg, bool isVariableLen, uint32_t
        *
        * cmp      lengthReg, #maxObjectSizeInElements
        * b.hi     callLabel
-       * 
+       *
        * uxtw     tempReg, lengthReg
        * ldrimmx  resultReg, [metaReg, offsetToHeapAlloc]
        * lsl      tempReg, lengthReg, #shiftValue
@@ -1251,7 +1251,7 @@ genHeapAlloc(TR::Node *node, TR::CodeGenerator *cg, bool isVariableLen, uint32_t
        * cselx    dataSizeReg, tempReg, tempReg2, ne
        * ldrimmx  heapTopReg, [metaReg, offsetToHeapTop]
        * addimmx  tempReg, resultReg, dataSizeReg
-       * 
+       *
        * # check for overflow
        * cmp      tempReg, heapTopReg
        * b.gt     callLabel
@@ -1260,7 +1260,7 @@ genHeapAlloc(TR::Node *node, TR::CodeGenerator *cg, bool isVariableLen, uint32_t
        *
        */
       // Detect large or negative number of elements in case addr wrap-around
-      // 
+      //
       // The GC will guarantee that at least 'maxObjectSizeGuaranteedNotToOverflow' bytes
       // of slush will exist between the top of the heap and the end of the address space.
       //
@@ -1326,7 +1326,7 @@ genHeapAlloc(TR::Node *node, TR::CodeGenerator *cg, bool isVariableLen, uint32_t
             }
          loadConstant64(cg, node, TR::Compiler->om.discontiguousArrayHeaderSizeInBytes(), heapTopReg);
 
-         generateCondTrg1Src2Instruction(cg, TR::InstOpCode::cselx, node, dataSizeReg, tempReg, heapTopReg, TR::CC_NE); 
+         generateCondTrg1Src2Instruction(cg, TR::InstOpCode::cselx, node, dataSizeReg, tempReg, heapTopReg, TR::CC_NE);
          }
       else
          {
@@ -1789,7 +1789,7 @@ J9::ARM64::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    else
       {
       elementSize = TR::Compiler->om.getSizeOfArrayElement(node);
- 
+
       // If the array cannot be allocated as a contiguous array, then comp->canAllocateInline should have returned -1.
       // The only exception is when the array length is 0.
       headerSize = TR::Compiler->om.contiguousArrayHeaderSizeInBytes();

--- a/runtime/compiler/aarch64/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/J9UnresolvedDataSnippet.cpp
@@ -91,7 +91,7 @@ J9::ARM64::UnresolvedDataSnippet::emitSnippetBody()
    {
    uint8_t *cursor = cg()->getBinaryBufferCursor();
    TR_RuntimeHelper helper = getHelper();
-   TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(helper, false, false, false);
+   TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(helper);
 
    getSnippetLabel()->setCodeLocation(cursor);
 

--- a/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
@@ -1072,7 +1072,7 @@ TR::Register *J9::ARM::JNILinkage::buildDirectDispatch(TR::Node *callNode)
       generateSrc2Instruction(codeGen, ARMOp_tst, callNode, gr4Reg, gr5Reg);
       }
 
-   helperSymRef = codeGen->symRefTab()->findOrCreateRuntimeHelper(TR_ARMjitCollapseJNIReferenceFrame, false, false, false);
+   helperSymRef = codeGen->symRefTab()->findOrCreateRuntimeHelper(TR_ARMjitCollapseJNIReferenceFrame);
    //AOT relocation is handled in TR::ARMImmSymInstruction::generateBinaryEncoding()
    generateImmSymInstruction(codeGen, ARMOp_bl, callNode, (uint32_t)helperSymRef->getMethodAddress(), NULL, helperSymRef, NULL, NULL, ARMConditionCodeEQ);
 

--- a/runtime/compiler/arm/codegen/ARMRecompilation.cpp
+++ b/runtime/compiler/arm/codegen/ARMRecompilation.cpp
@@ -72,7 +72,7 @@ TR::Instruction *TR_ARMRecompilation::generatePrePrologue()
    TR::Register   *gr4 = machine->getRealRegister(TR::RealRegister::gr4);
    TR::Register   *lr = machine->getRealRegister(TR::RealRegister::gr14); // link register
    TR::Node       *firstNode = _compilation->getStartTree()->getNode();
-   TR::SymbolReference *recompileMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARMsamplingRecompileMethod, false, false, false);
+   TR::SymbolReference *recompileMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARMsamplingRecompileMethod);
    TR_PersistentJittedBodyInfo *info = getJittedBodyInfo();
 
 

--- a/runtime/compiler/arm/codegen/ARMRecompilationSnippet.cpp
+++ b/runtime/compiler/arm/codegen/ARMRecompilationSnippet.cpp
@@ -44,7 +44,7 @@ uint8_t *TR::ARMRecompilationSnippet::emitSnippetBody()
    */
 
    uint8_t             *buffer = cg()->getBinaryBufferCursor();
-   TR::SymbolReference  *countingRecompMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARMcountingRecompileMethod, false, false, false);
+   TR::SymbolReference  *countingRecompMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARMcountingRecompileMethod);
 
    getSnippetLabel()->setCodeLocation(buffer);
 

--- a/runtime/compiler/arm/codegen/CallSnippet.cpp
+++ b/runtime/compiler/arm/codegen/CallSnippet.cpp
@@ -262,7 +262,7 @@ uint8_t *TR::ARMCallSnippet::emitSnippetBody()
    // Flush in-register arguments back to the stack for interpreter
    cursor = flushArgumentsToStack(cursor, callNode, getSizeOfArguments(), cg());
 
-   glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(getHelper(), false, false, false);
+   glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(getHelper());
 
    // bl glueRef
    *(int32_t *)cursor = encodeHelperBranchAndLink(glueRef, cursor, callNode, cg());
@@ -395,7 +395,7 @@ uint8_t *TR::ARMVirtualUnresolvedSnippet::emitSnippetBody()
    {
    uint8_t            *cursor = cg()->getBinaryBufferCursor();
    TR::SymbolReference *methodSymRef = getNode()->getSymbolReference();
-   TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARMvirtualUnresolvedHelper, false, false, false);
+   TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARMvirtualUnresolvedHelper);
 
    TR::Compilation* comp = cg()->comp();
 
@@ -439,7 +439,7 @@ uint8_t *TR::ARMInterfaceCallSnippet::emitSnippetBody()
    {
    uint8_t            *cursor = cg()->getBinaryBufferCursor();
    TR::SymbolReference *methodSymRef = getNode()->getSymbolReference();
-   TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARMinterfaceCallHelper, false, false, false);
+   TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARMinterfaceCallHelper);
 
    getSnippetLabel()->setCodeLocation(cursor);
 
@@ -543,7 +543,7 @@ uint8_t *TR::ARMCallSnippet::generateVIThunk(TR::Node *callNode, int32_t argSize
                   cg->getDebug()->getName(dataType));
       }
 
-   dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(helper, false, false, false)->getMethodAddress();
+   dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(helper)->getMethodAddress();
 
    buffer = flushArgumentsToStack(buffer, callNode, argSize, cg);
 
@@ -606,7 +606,7 @@ TR_J2IThunk *TR::ARMCallSnippet::generateInvokeExactJ2IThunk(TR::Node *callNode,
                   cg->getDebug()->getName(dataType));
       }
 
-   dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(helper, false, false, false)->getMethodAddress();
+   dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(helper)->getMethodAddress();
 
    buffer = flushArgumentsToStack(buffer, callNode, argSize, cg);
 

--- a/runtime/compiler/arm/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/arm/codegen/J9UnresolvedDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,7 +76,7 @@ J9::ARM::UnresolvedDataSnippet::emitSnippetBody()
 
    getSnippetLabel()->setCodeLocation(cursor);
 
-   *(int32_t *)cursor = encodeHelperBranchAndLink(cg()->symRefTab()->findOrCreateRuntimeHelper(getHelper(), false, false, false), cursor, getNode(), cg());  // BL resolve
+   *(int32_t *)cursor = encodeHelperBranchAndLink(cg()->symRefTab()->findOrCreateRuntimeHelper(getHelper()), cursor, getNode(), cg());  // BL resolve
    cursor += 4;
 
    *(int32_t *)cursor = (intptr_t)getAddressOfDataReference();   // Code Cache RA

--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -2610,7 +2610,7 @@ J9::CodeGenerator::printNVVMIR(
                    isLongMul ? "i64" : "i32");
       }
    else if (node->getOpCodeValue() == TR::bneg || node->getOpCodeValue() == TR::sneg ||
-            node->getOpCodeValue() == TR::ineg || node->getOpCodeValue() == TR::lneg || 
+            node->getOpCodeValue() == TR::ineg || node->getOpCodeValue() == TR::lneg ||
             node->getOpCodeValue() == TR::fneg || node->getOpCodeValue() == TR::dneg)
       {
       getNodeName(node->getChild(0), name0, self()->comp());
@@ -3596,7 +3596,7 @@ J9::CodeGenerator::generateGPU()
       parm->setSymbolReference(parmSymRef);
       callNode->setAndIncChild(12, parm);
 
-      TR::SymbolReference *helper = self()->comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_callGPU, false, false, false);
+      TR::SymbolReference *helper = self()->comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_callGPU);
       helper->getSymbol()->castToMethodSymbol()->setLinkage(TR_System);
       callNode->setSymbolReference(helper);
       TR::Node *treetop = TR::Node::create(callNode, TR::treetop, 1);

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -216,8 +216,8 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          std::string encoded = FlatPersistentClassInfo::serializeHierarchy(table);
 
          client->write(response, ranges, unloadedClasses->getMaxRanges(), encoded);
-            { 
-            OMR::CriticalSection romClassCache(compInfo->getclassesCachedAtServerMonitor());  
+            {
+            OMR::CriticalSection romClassCache(compInfo->getclassesCachedAtServerMonitor());
             compInfo->getclassesCachedAtServer().clear();
             }
          break;
@@ -455,12 +455,12 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          vmInfo._writeBarrierType = TR::Compiler->om.writeBarrierType();
          vmInfo._compressObjectReferences = TR::Compiler->om.compressObjectReferences();
          vmInfo._processorDescription = TR::Compiler->target.cpu.getProcessorDescription();
-         vmInfo._noTypeInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact0, false, false, false)->getMethodAddress();
-         vmInfo._int64InvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactJ, false, false, false)->getMethodAddress();
-         vmInfo._int32InvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact1, false, false, false)->getMethodAddress();
-         vmInfo._addressInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactL, false, false, false)->getMethodAddress();
-         vmInfo._floatInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactF, false, false, false)->getMethodAddress();
-         vmInfo._doubleInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactD, false, false, false)->getMethodAddress();
+         vmInfo._noTypeInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact0)->getMethodAddress();
+         vmInfo._int64InvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactJ)->getMethodAddress();
+         vmInfo._int32InvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact1)->getMethodAddress();
+         vmInfo._addressInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactL)->getMethodAddress();
+         vmInfo._floatInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactF)->getMethodAddress();
+         vmInfo._doubleInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactD)->getMethodAddress();
          vmInfo._interpreterVTableOffset = TR::Compiler->vm.getInterpreterVTableOffset();
          vmInfo._maxHeapSizeInBytes = TR::Compiler->vm.maxHeapSizeInBytes();
          vmInfo._enableGlobalLockReservation = vmThread->javaVM->enableGlobalLockReservation;
@@ -546,9 +546,9 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
       case MessageType::VM_stackWalkerMaySkipFrames:
          {
          client->getRecvData<JITServer::Void>();
-         client->write(response, 
-            vmThread->javaVM->jlrMethodInvoke, 
-            vmThread->javaVM->srMethodAccessor ? (TR_OpaqueClassBlock *) J9VM_J9CLASS_FROM_JCLASS(vmThread, vmThread->javaVM->srMethodAccessor) : NULL, 
+         client->write(response,
+            vmThread->javaVM->jlrMethodInvoke,
+            vmThread->javaVM->srMethodAccessor ? (TR_OpaqueClassBlock *) J9VM_J9CLASS_FROM_JCLASS(vmThread, vmThread->javaVM->srMethodAccessor) : NULL,
             vmThread->javaVM->srConstructorAccessor ? (TR_OpaqueClassBlock *) J9VM_J9CLASS_FROM_JCLASS(vmThread, vmThread->javaVM->srConstructorAccessor) : NULL);
          }
          break;
@@ -1787,7 +1787,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
                case TR_ResolvedMethodType::Static:
                   {
                   TR::VMAccessCriticalSection resolveStaticMethodRef(fe);
-                  ramMethod = jitResolveStaticMethodRef(fe->vmThread(), owningMethod->cp(), cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME); 
+                  ramMethod = jitResolveStaticMethodRef(fe->vmThread(), owningMethod->cp(), cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
                   if (ramMethod) createMethod = true;
                   break;
                   }
@@ -3211,7 +3211,7 @@ remoteCompile(
       compiler->setOption(TR_Server);
 
       // Check the _classesCachedAtServer set to determine whether JITServer is likely to have this class already cached.
-      // If so, do not send the ROMClass content to save network traffic. 
+      // If so, do not send the ROMClass content to save network traffic.
       bool serializeClass = false;
       {
       OMR::CriticalSection romClassCache(compInfo->getclassesCachedAtServerMonitor());
@@ -3223,7 +3223,7 @@ remoteCompile(
          }
       }
 
-   auto classInfoTuple = JITServerHelpers::packRemoteROMClassInfo(clazz, compiler->fej9vm()->vmThread(), compiler->trMemory(), serializeClass);   
+   auto classInfoTuple = JITServerHelpers::packRemoteROMClassInfo(clazz, compiler->fej9vm()->vmThread(), compiler->trMemory(), serializeClass);
    std::string optionsStr = TR::Options::packOptions(compiler->getOptions());
    std::string recompMethodInfoStr = compiler->isRecompilationEnabled() ? std::string((char *) compiler->getRecompilationInfo()->getMethodInfo(), sizeof(TR_PersistentMethodInfo)) : std::string();
 
@@ -3282,7 +3282,7 @@ remoteCompile(
       if (JITServer::MessageType::compilationCode == response)
          {
          auto recv = client->getRecvData<std::string, std::string, CHTableCommitData, std::vector<TR_OpaqueClassBlock*>,
-                                         std::string, std::string, std::vector<TR_ResolvedJ9Method*>, 
+                                         std::string, std::string, std::vector<TR_ResolvedJ9Method*>,
                                          TR_OptimizationPlan, std::vector<SerializedRuntimeAssumption>>();
          statusCode = compilationOK;
          codeCacheStr = std::get<0>(recv);
@@ -3364,7 +3364,7 @@ remoteCompile(
       }
    catch (...)
       {
-      // For any other type of exception disconnect the socket 
+      // For any other type of exception disconnect the socket
       client->~ClientStream();
       TR_Memory::jitPersistentFree(client);
       compInfoPT->setClientStream(NULL);
@@ -3405,7 +3405,7 @@ remoteCompile(
                {
                uint8_t *basePtr = it.isOffsetFromMetaDataBase() ? (uint8_t*)metaData : (uint8_t*)(metaData->codeCacheAlloc);
                uint8_t *addrToPatch = (uint8_t*)(basePtr + it.getOffset());
-               switch (it.getKind()) 
+               switch (it.getKind())
                   {
                   case RuntimeAssumptionOnRegisterNative:
                      {
@@ -3432,7 +3432,7 @@ remoteCompile(
                      }
                   default:
                      TR_ASSERT_FATAL(false, "Runtime assumption of kind %d is not handled by JITClient\n", it.getKind());
-                  } // end switch (it->getKind()) 
+                  } // end switch (it->getKind())
                }
             metaData->runtimeAssumptionList = *(compiler->getMetadataAssumptionList());
             }

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -59,7 +59,7 @@ void J9::RecognizedCallTransformer::process_java_lang_Class_IsAssignableFrom(TR:
    treetop->insertBefore(TR::TreeTop::create(comp(), TR::Node::createWithSymRef(TR::NULLCHK, 1, 1, TR::Node::create(node, TR::PassThrough, 1, fromClass), nullchk)));
 
    TR::Node::recreate(treetop->getNode(), TR::treetop);
-   node->setSymbolReference(comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_checkAssignable, false, false, false));
+   node->setSymbolReference(comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_checkAssignable));
    node->setAndIncChild(0, TR::Node::createWithSymRef(TR::aloadi, 1, 1, toClass, comp()->getSymRefTab()->findOrCreateClassFromJavaLangClassSymbolRef()));
    node->setAndIncChild(1, TR::Node::createWithSymRef(TR::aloadi, 1, 1, fromClass, comp()->getSymRefTab()->findOrCreateClassFromJavaLangClassSymbolRef()));
    node->swapChildren();
@@ -261,7 +261,7 @@ void J9::RecognizedCallTransformer::processUnsafeAtomicCall(TR::TreeTop* treetop
       auto isObjectNullTreeTop = TR::TreeTop::create(comp(), isObjectNullNode);
       treetop->insertBefore(isObjectNullTreeTop);
       treetop->getEnclosingBlock()->split(treetop, cfg, fixupCommoning);
- 
+
       if (enableTrace)
          traceMsg(comp(), "Created isObjectNull test node n%dn, non-null object will fall through to Block_%d\n", isObjectNullNode->getGlobalIndex(), treetop->getEnclosingBlock()->getNumber());
 

--- a/runtime/compiler/optimizer/JProfilingValue.cpp
+++ b/runtime/compiler/optimizer/JProfilingValue.cpp
@@ -162,7 +162,7 @@ loadConst(TR::DataType dt)
  * has been configured to use JProfiling.
  */
 int32_t
-TR_JProfilingValue::perform() 
+TR_JProfilingValue::perform()
    {
    if (comp()->getProfilingMode() == JProfiling)
       {
@@ -174,16 +174,16 @@ TR_JProfilingValue::perform()
       if (trace())
          traceMsg(comp(), "JProfiling has been enabled, run JProfilingValue\n");
       }
-   else 
+   else
       {
       if (trace())
          traceMsg(comp(), "JProfiling has been disabled, skip JProfilingValue\n");
       return 0;
       }
-   
+
    cleanUpAndAddProfilingCandidates();
    if (trace())
-      comp()->dumpMethodTrees("After Cleaning up Trees"); 
+      comp()->dumpMethodTrees("After Cleaning up Trees");
    lowerCalls();
 
    if (comp()->isProfilingCompilation())
@@ -205,23 +205,23 @@ void TR_JProfilingValue::cleanUpAndAddProfilingCandidates()
       {
       TR::Node *node = cursor->getNode();
       /*
-       * If we find a profiling candidate while walking the treetop, we add a place holder call to profile the value. 
+       * If we find a profiling candidate while walking the treetop, we add a place holder call to profile the value.
        * In this scenario a placeholder call will be places after the treetop in which we encounter a candidate and decided to
-       * profile it. To make sure we do not examine unnecessary trees, record next tree top before examining the tree and inserting a profiling placeholder. 
+       * profile it. To make sure we do not examine unnecessary trees, record next tree top before examining the tree and inserting a profiling placeholder.
        */
       TR::TreeTop *nextTT = cursor->getNextTreeTop();
-      if (node->isProfilingCode() 
-         && node->getOpCodeValue() == TR::treetop 
-         && node->getFirstChild()->getOpCode().isCall() 
-         && (comp()->getSymRefTab()->isNonHelper(node->getFirstChild()->getSymbolReference(), TR::SymbolReferenceTable::jProfileValueSymbol) 
+      if (node->isProfilingCode()
+         && node->getOpCodeValue() == TR::treetop
+         && node->getFirstChild()->getOpCode().isCall()
+         && (comp()->getSymRefTab()->isNonHelper(node->getFirstChild()->getSymbolReference(), TR::SymbolReferenceTable::jProfileValueSymbol)
             || comp()->getSymRefTab()->isNonHelper(node->getFirstChild()->getSymbolReference(), TR::SymbolReferenceTable::jProfileValueWithNullCHKSymbol)))
          {
          TR::Node *value = node->getFirstChild()->getFirstChild();
-         
+
          if ((alreadyProfiledValues->isSet(value->getGlobalIndex()) || value->getOpCode().isLoadConst()) &&
                performTransformation(comp(), "%s Removing profiling treetop, node n%dn is already profiled\n",
                   optDetailString(), value->getGlobalIndex()))
-            /* Found that second and third child were having more than one ref counts. 
+            /* Found that second and third child were having more than one ref counts.
             TR_ASSERT_FATAL(node->getFirstChild()->getSecondChild()->getReferenceCount() == 1 &&
                node->getFirstChild()->getThirdChild()->getReferenceCount() == 1,
                "Second and Third Child of the value calls should be referenced only once");
@@ -233,7 +233,7 @@ void TR_JProfilingValue::cleanUpAndAddProfilingCandidates()
             {
             alreadyProfiledValues->set(value->getGlobalIndex());
             }
-         
+
          }
       // Emptying a bit vector after scanning whole extended basic blocks will keep number of bits set in bit vector low.
       else if (node->getOpCodeValue() == TR::BBStart && !node->getBlock()->isExtensionOfPreviousBlock())
@@ -259,22 +259,22 @@ TR_JProfilingValue::performOnNode(TR::Node *node, TR::TreeTop *cursor, TR_BitVec
    TR::Node *profiledNode = NULL;
    TR::Node *constNode = NULL;
    TR::SymbolReference *profiler = NULL;
-   if (node->getOpCode().isCallIndirect() && !node->getByteCodeInfo().doNotProfile() 
-      && (node->getSymbol()->getMethodSymbol()->isVirtual() 
+   if (node->getOpCode().isCallIndirect() && !node->getByteCodeInfo().doNotProfile()
+      && (node->getSymbol()->getMethodSymbol()->isVirtual()
          || node->getSymbol()->getMethodSymbol()->isInterface()))
       {
       profiledNode = node->getFirstChild();
       TR::Node *nextTTNode = cursor->getNextTreeTop() ? cursor->getNextTreeTop()->getNode() : NULL;
       /*
-       * RecompilationModifier adds the profiling placeholder call for Virtual calls. 
+       * RecompilationModifier adds the profiling placeholder call for Virtual calls.
        * Quickly check the next treetop, if it is profiling same virtual call target. In that case we do not need to add
        * Profiling Call as it is already there.
        */
-      if (!(alreadyProfiledValues->isSet(profiledNode->getGlobalIndex()) 
-         || (nextTTNode && nextTTNode->isProfilingCode() 
-               && nextTTNode->getOpCodeValue() == TR::treetop 
-               && nextTTNode->getFirstChild()->getOpCode().isCall() 
-               && comp()->getSymRefTab()->isNonHelper(nextTTNode->getFirstChild()->getSymbolReference(), TR::SymbolReferenceTable::jProfileValueSymbol) 
+      if (!(alreadyProfiledValues->isSet(profiledNode->getGlobalIndex())
+         || (nextTTNode && nextTTNode->isProfilingCode()
+               && nextTTNode->getOpCodeValue() == TR::treetop
+               && nextTTNode->getFirstChild()->getOpCode().isCall()
+               && comp()->getSymRefTab()->isNonHelper(nextTTNode->getFirstChild()->getSymbolReference(), TR::SymbolReferenceTable::jProfileValueSymbol)
                && nextTTNode->getFirstChild()->getFirstChild() == profiledNode)))
          {
          preceedingTT = cursor;
@@ -283,9 +283,9 @@ TR_JProfilingValue::performOnNode(TR::Node *node, TR::TreeTop *cursor, TR_BitVec
             optDetailString(), node->getGlobalIndex(), profiledNode);
          }
       }
-   else if (!node->getByteCodeInfo().doNotProfile() 
-            && (node->getOpCodeValue() == TR::instanceof 
-               || node->getOpCodeValue() == TR::checkcast 
+   else if (!node->getByteCodeInfo().doNotProfile()
+            && (node->getOpCodeValue() == TR::instanceof
+               || node->getOpCodeValue() == TR::checkcast
                || node->getOpCodeValue() == TR::checkcastAndNULLCHK)
             && !alreadyProfiledValues->isSet(node->getFirstChild()->getGlobalIndex()))
       {
@@ -308,7 +308,7 @@ TR_JProfilingValue::performOnNode(TR::Node *node, TR::TreeTop *cursor, TR_BitVec
       TR::TreeTop *callTree = TR::TreeTop::create(comp(), preceedingTT, TR::Node::create(TR::treetop, 1, call));
       callTree->getNode()->setIsProfilingCode();
       }
-   
+
    for (int i = 0; i < node->getNumChildren(); ++i)
       performOnNode(node->getChild(i), cursor, alreadyProfiledValues, checklist);
    }
@@ -328,7 +328,7 @@ TR_JProfilingValue::lowerCalls()
          (comp()->getSymRefTab()->isNonHelper(node->getFirstChild()->getSymbolReference(), TR::SymbolReferenceTable::jProfileValueSymbol) ||
             comp()->getSymRefTab()->isNonHelper(node->getFirstChild()->getSymbolReference(), TR::SymbolReferenceTable::jProfileValueWithNullCHKSymbol)))
          {
-         // Backward Analysis in the extended basic block to get list of address nodes 
+         // Backward Analysis in the extended basic block to get list of address nodes
          for (TR::TreeTop *iter = cursor->getPrevTreeTop();
             iter && (iter->getNode()->getOpCodeValue() != TR::BBStart || iter->getNode()->getBlock()->isExtensionOfPreviousBlock());
             iter = iter->getPrevTreeTop())
@@ -389,7 +389,7 @@ TR_JProfilingValue::lowerCalls()
  * |     aconst <table address>                                                |
  * | ...                                                                       |
  * |---------------------------------------------------------------------------|
- * 
+ *
  * Becomes:
  *
  * |--------------------------------------|
@@ -443,7 +443,7 @@ TR_JProfilingValue::lowerCalls()
  *                         |                                                           |
  *                         |--------------------------------|                          |
  *                         |                                |                          |
- *                         v                                |                          | 
+ *                         v                                |                          |
  *          |------------------------------|                |                          |
  *          | quickInc                     |                |                          |
  *          |------------------------------|                |                          |
@@ -466,7 +466,7 @@ TR_JProfilingValue::lowerCalls()
  *          |------------------------------|
  *          |  ...                         |
  *          |------------------------------|
- *          
+ *
  *
  * \param insertionPoint Treetop to insert profiling code after.
  * \param value Value to profile.
@@ -514,7 +514,7 @@ TR_JProfilingValue::addProfilingTrees(
 
    /********************* mainline Return Block *********************/
    TR::Block *mainlineReturn = originalBlock->splitPostGRA(insertionPoint->getNextTreeTop(), cfg, true, NULL);
-   
+
    TR::Node *origBlockGlRegDeps = originalBlock->getExit()->getNode()->getNumChildren() == 1 ? originalBlock->getExit()->getNode()->getFirstChild() : NULL;
    if (trace)
       traceMsg(comp, "\t\t\tUsing split mainline return block = %d\n", mainlineReturn->getNumber());
@@ -554,7 +554,7 @@ TR_JProfilingValue::addProfilingTrees(
       if (origBlockGlRegDeps != NULL)
          {
          TR::Node *exitGlRegDeps = copyGlRegDeps(comp, origBlockGlRegDeps);
-         checkIfQueueForRecompilation->addChildren(&exitGlRegDeps, 1); 
+         checkIfQueueForRecompilation->addChildren(&exitGlRegDeps, 1);
          }
       lastBranchToMainlineReturnTT = checkIfNeedToProfileValue;
       if (trace)
@@ -566,7 +566,7 @@ TR_JProfilingValue::addProfilingTrees(
       {
       /*
        * Objects under instanceOf and checkCast needs NULL Check and we look for this candidate while we walk trees in JProfilingValue.
-       * TODO: As we look for VFT Candidates for type test in this pass only, we have an object available to do the null test. 
+       * TODO: As we look for VFT Candidates for type test in this pass only, we have an object available to do the null test.
        * In case some one else decides to add VFT profiling around type test in other pass, it should also add the null test to guard
        * the profiling, as due to other optimizations it might be possible that VFT load is uncommoned and converted to load from the temp slot or register.
        */
@@ -584,13 +584,13 @@ TR_JProfilingValue::addProfilingTrees(
       if (origBlockGlRegDeps != NULL)
          {
          TR::Node *exitGlRegDeps = copyGlRegDeps(comp,origBlockGlRegDeps);
-         nullTest->addChildren(&exitGlRegDeps, 1); 
+         nullTest->addChildren(&exitGlRegDeps, 1);
          }
       lastBranchToMainlineReturnTT = nullTestTree;
       if (trace)
          traceMsg(comp, "\t\t\tNull test performed in in block_%d\n", iter->getNumber());
       }
-   
+
    /********************* quickTest Block *********************/
    TR::Node *quickTestValue = convertType(value, roundedType);
    TR::Node *address = TR::Node::aconst(value, table->getBaseAddress());
@@ -603,7 +603,7 @@ TR_JProfilingValue::addProfilingTrees(
    TR::Node *addressOfKeys = TR::Node::aconst(value, table->getBaseAddress() + table->getKeysOffset());
    TR::Node *conditionNode = TR::Node::create(value, comp->il.opCodeForCompareEquals(roundedType), 2, quickTestValue,
       loadValue(comp, roundedType, addressOfKeys, convertedHashIndex));
-   
+
    TR::Node *selectNode = TR::Node::create(comp->il.opCodeForSelect(roundedType), 3, conditionNode, hashIndex, otherIndex);
    TR::TreeTop *incIndexTreeTop = TR::TreeTop::create(comp, TR::Node::create(TR::treetop, 1, selectNode));
    iter->append(incIndexTreeTop);
@@ -616,7 +616,7 @@ TR_JProfilingValue::addProfilingTrees(
       }
    if (trace)
       traceMsg(comp, "\t\t\tQuick Test to check if value is already being profiled is in block_%d\n", quickTestBlock->getNumber());
-   
+
    TR::Node *checkIfTableIsLockedNode = TR::Node::create(value, comp->il.opCodeForCompareGreaterOrEquals(lockType), 2, lock, TR::Node::sconst(value, 0));
    TR::Node *checkNode = TR::Node::createif(TR::ificmpeq,
       TR::Node::create(value, TR::ior, 2, conditionNode, checkIfTableIsLockedNode),
@@ -624,8 +624,8 @@ TR_JProfilingValue::addProfilingTrees(
    if (origBlockGlRegDeps != NULL)
       {
       TR::Node *exitGlRegDeps = copyGlRegDeps(comp, origBlockGlRegDeps);
-      checkNode->addChildren(&exitGlRegDeps, 1); 
-      } 
+      checkNode->addChildren(&exitGlRegDeps, 1);
+      }
    TR::TreeTop *checkNodeTreeTop = TR::TreeTop::create(comp, incIndexTreeTop, checkNode);
 
    /********************* quickInc index Block *********************/
@@ -636,7 +636,7 @@ TR_JProfilingValue::addProfilingTrees(
    TR::Block *quickInc = quickTestBlock->split(incTree, cfg, false, true);
    quickInc->setIsExtensionOfPreviousBlock();
    if (trace)
-      traceMsg(comp, "\t\t\tQuick increment performed in block_%d\n", quickInc->getNumber());   
+      traceMsg(comp, "\t\t\tQuick increment performed in block_%d\n", quickInc->getNumber());
 
 
    /********************* helper call block *********************/
@@ -649,12 +649,12 @@ TR_JProfilingValue::addProfilingTrees(
    cfg->addEdge(quickTestBlock, helper);
    cfg->addEdge(helper, mainlineReturn);
    checkNode->setBranchDestination(helper->getEntry());
-   
+
    TR::Node *glRegDepsOfMainlineEntry = mainlineReturn->getEntry()->getNode()->getNumChildren() == 1 ? mainlineReturn->getEntry()->getNode()->getFirstChild() : NULL;
    TR::Node *valueChildOfHelperCall = NULL;
    TR::Node *goToMainlineNode = TR::Node::create(value, TR::Goto, 0, mainlineReturn->getEntry());
    TR::TreeTop::create(comp, helper->getEntry(), goToMainlineNode);
-   
+
    if (glRegDepsOfMainlineEntry != NULL)
       {
       // Copying GlRegDeps of the Mainline Entry block to the helper block.
@@ -663,7 +663,7 @@ TR_JProfilingValue::addProfilingTrees(
       helper->getEntry()->getNode()->setAndIncChild(0, duplicateGlRegDeps);
       TR::Node *origDuplicateGlRegDeps = duplicateGlRegDeps;
       duplicateGlRegDeps = TR::Node::copy(duplicateGlRegDeps);
-      
+
       for (int32_t i = origDuplicateGlRegDeps->getNumChildren() - 1; i >= 0; --i)
          {
          TR::Node * dep = origDuplicateGlRegDeps->getChild(i);
@@ -671,11 +671,11 @@ TR_JProfilingValue::addProfilingTrees(
          }
       duplicateGlRegDeps->setReferenceCount(0);
       goToMainlineNode->addChildren(&duplicateGlRegDeps, 1);
-      
+
       if (profilingValue->getOpCode().isStoreReg() || profilingValue->getOpCode().isLoadReg())
          {
          // Looking for the regLoad in the entry
-         TR::Node *helperCallGlRegDeps = helper->getEntry()->getNode()->getFirstChild(); 
+         TR::Node *helperCallGlRegDeps = helper->getEntry()->getNode()->getFirstChild();
          if (profilingValue->requiresRegisterPair(comp))
             {
             for (int i=0; i < helperCallGlRegDeps->getNumChildren(); i++)
@@ -710,10 +710,10 @@ TR_JProfilingValue::addProfilingTrees(
             }
          }
       }
-   // In case we can not find value in register or temp slot, store the value to temp slot before going to helper block. 
+   // In case we can not find value in register or temp slot, store the value to temp slot before going to helper block.
    if (valueChildOfHelperCall == NULL)
       {
-      TR::SymbolReference *storedValueSymRef = NULL; 
+      TR::SymbolReference *storedValueSymRef = NULL;
       if (profilingValue->getOpCode().isStoreDirect() || (profilingValue->getOpCode().isLoadDirect() && !profilingValue->getOpCode().isLoadConst()))
          {
          storedValueSymRef = profilingValue->getSymbolReference();
@@ -722,7 +722,7 @@ TR_JProfilingValue::addProfilingTrees(
          {
          traceMsg(comp, "\t\t\tNode n%dn needs to be stored on temp slot\n", profilingValue->getGlobalIndex());
          // profiledValue is normal Node which is not referenced further. Store value to temp slot at the beginning of quick test
-         TR::TreeTop *storeValue = TR::TreeTop::create(comp, quickTestBlock->getEntry(), storeNode(comp,  profilingValue, storedValueSymRef)); 
+         TR::TreeTop *storeValue = TR::TreeTop::create(comp, quickTestBlock->getEntry(), storeNode(comp,  profilingValue, storedValueSymRef));
          }
       valueChildOfHelperCall = TR::Node::createLoad(value, storedValueSymRef);
       }
@@ -730,12 +730,12 @@ TR_JProfilingValue::addProfilingTrees(
    // Add the call to the helper and return to the mainline
    TR::TreeTop *helperCallTreeTop = TR::TreeTop::create(comp, helper->getEntry(), createHelperCall(comp,
       valueChildOfHelperCall,
-      TR::Node::aconst(value, table->getBaseAddress()))); 
+      TR::Node::aconst(value, table->getBaseAddress())));
    if (trace)
-      traceMsg(comp, "\t\t\tHelper call in block_%d\n", helper->getNumber()); 
+      traceMsg(comp, "\t\t\tHelper call in block_%d\n", helper->getNumber());
    TR::NodeChecklist checklist(comp);
    checklist.add(value);
-   TR::TreeTop *tt = quickTestBlock->getEntry(), *end = mainlineReturn->getEntry(); 
+   TR::TreeTop *tt = quickTestBlock->getEntry(), *end = mainlineReturn->getEntry();
    while (tt && tt != end)
       {
       TR::Node *node = tt->getNode();
@@ -755,8 +755,8 @@ TR_JProfilingValue::addProfilingTrees(
    }
 
 /**
- * Utility function to Copy the GlRegDeps 
- * 
+ * Utility function to Copy the GlRegDeps
+ *
  * @param comp Compilation Object
  * @param origGlRegDeps Original GlRegDeps to bbe copied
  * @return TR::Node* New GlRegDeps copied from origGlRegDeps
@@ -889,11 +889,11 @@ TR_JProfilingValue::createHelperCall(TR::Compilation *comp, TR::Node *value, TR:
       {
       if (value->getDataType() != TR::Address)
          value = convertType(value, TR::Int32);
-      profiler = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_jProfile32BitValue, false, false, false);
+      profiler = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_jProfile32BitValue);
       }
    else
       {
-      profiler = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_jProfile64BitValue, false, false, false);
+      profiler = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_jProfile64BitValue);
       }
 
 #if defined(TR_HOST_POWER) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64) || defined(TR_HOST_S390)
@@ -1004,7 +1004,7 @@ TR_JProfilingValue::computeHash(TR::Compilation *comp, TR_AbstractHashTableProfi
          orOp    = TR::ior;
          constOp = TR::iconst;
          }
-   
+
       TR::SymbolReference *symRef = comp->getSymRefTab()->findOrCreateArrayShadowSymbolRef(TR::Int8, NULL);
 
       // Extract each bit and merge into final result

--- a/runtime/compiler/optimizer/SPMDParallelizer.cpp
+++ b/runtime/compiler/optimizer/SPMDParallelizer.cpp
@@ -2173,7 +2173,7 @@ void TR_SPMDKernelParallelizer::insertGPUEstimate(TR::Node *firstNode, TR::Block
    TR::ILOpCodes addressLoadOpCode = TR::lload;
 
    TR::Node *estimateGPUNode = TR::Node::create(firstNode, TR::icall, 7);
-   helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_estimateGPU, false, false, false);
+   helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_estimateGPU);
    helper->getSymbol()->castToMethodSymbol()->setLinkage(_helperLinkage);
    estimateGPUNode->setSymbolReference(helper);
 
@@ -2219,7 +2219,7 @@ void TR_SPMDKernelParallelizer::insertGPUParmsAllocate(TR::Node *firstNode, TR::
    TR::ILOpCodes addressLoadOpCode = TR::lload;
 
    TR::Node *allocateParmsNode = TR::Node::create(firstNode, addressCallOpCode, 2);
-   helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_allocateGPUKernelParms, false, false, false);
+   helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_allocateGPUKernelParms);
    helper->getSymbol()->castToMethodSymbol()->setLinkage(_helperLinkage);
    allocateParmsNode->setSymbolReference(helper);
 
@@ -2266,7 +2266,7 @@ void TR_SPMDKernelParallelizer::insertGPUInvalidateSequence(TR::Node *firstNode,
       if (hoistAccess) continue;
 
       invalidateGPUNode = TR::Node::create(firstNode, addressCallOpCode, 2);
-      helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_invalidateGPU, false, false, false);
+      helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_invalidateGPU);
       helper->getSymbol()->castToMethodSymbol()->setLinkage(_helperLinkage/*@*/);
       invalidateGPUNode->setSymbolReference(helper);
 
@@ -2289,7 +2289,7 @@ void TR_SPMDKernelParallelizer::insertGPUErrorHandler(TR::Node *firstNode, TR::B
    TR::CFG *cfg = comp()->getFlowGraph();
 
    TR::Node *getStateGPUNode = TR::Node::create(firstNode, TR::icall, 2);
-   helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_getStateGPU, false, false, false);
+   helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_getStateGPU);
    helper->getSymbol()->castToMethodSymbol()->setLinkage(_helperLinkage);
    getStateGPUNode->setSymbolReference(helper);
 
@@ -2361,7 +2361,7 @@ void TR_SPMDKernelParallelizer::insertGPUCopyFromSequence(TR::Node *firstNode, T
          }
 
       TR::Node *copyFromGPUNode = TR::Node::create(firstNode, TR::icall, 7);
-      helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_copyFromGPU, false, false, false);
+      helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_copyFromGPU);
       helper->getSymbol()->castToMethodSymbol()->setLinkage(_helperLinkage);
       copyFromGPUNode->setSymbolReference(helper);
 
@@ -2474,7 +2474,7 @@ void TR_SPMDKernelParallelizer::insertGPUCopyToSequence(TR::Node *firstNode, TR:
 
       TR::Node *copyToGPUNode = TR::Node::create(firstNode, addressCallOpCode, 10);
 
-      helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_copyToGPU, false, false, false);
+      helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_copyToGPU);
       helper->getSymbol()->castToMethodSymbol()->setLinkage(_helperLinkage);
       copyToGPUNode->setSymbolReference(helper);
 
@@ -2542,7 +2542,7 @@ void TR_SPMDKernelParallelizer::insertGPUKernelLaunch(TR::SymbolReference *alloc
    TR::SymbolReference *helper;
    TR::Node *launchGPUKernelNode = TR::Node::create(firstNode, TR::icall, 8);
 
-   helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_launchGPUKernel, false, false, false);
+   helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_launchGPUKernel);
    helper->getSymbol()->castToMethodSymbol()->setLinkage(_helperLinkage);
    launchGPUKernelNode->setSymbolReference(helper);
 
@@ -2589,7 +2589,7 @@ void TR_SPMDKernelParallelizer::insertGPURegionEntry(TR::Block * loopInvariantBl
 
    TR::Node* regionEntryGPUNode = TR::Node::create(insertionPoint->getNode(), addressCallOpCode, 5);
 
-   helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_regionEntryGPU, false, false, false);
+   helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_regionEntryGPU);
    helper->getSymbol()->castToMethodSymbol()->setLinkage(_helperLinkage/*@*/);
    regionEntryGPUNode->setSymbolReference(helper);
 
@@ -2642,7 +2642,7 @@ TR::Node* TR_SPMDKernelParallelizer::insertFlushGPU(TR::Block* flushGPUBlock, TR
    TR::TreeTop *insertionPoint = flushGPUBlock->getEntry();
 
    TR::Node* flushGPUNode = TR::Node::create(insertionPoint->getNode(), TR::icall, 2);
-   helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_flushGPU, false, false, false);
+   helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_flushGPU);
    helper->getSymbol()->castToMethodSymbol()->setLinkage(_helperLinkage/*@*/);
    flushGPUNode->setSymbolReference(helper);
 
@@ -2725,7 +2725,7 @@ void TR_SPMDKernelParallelizer::insertGPURegionExits(List<TR::Block>* exitBlocks
       TR::TreeTop *insertionPoint = exitBlock->getEntry();
 
       TR::Node* regionExitGPUNode = TR::Node::create(insertionPoint->getNode(), TR::icall, 4);
-      helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_regionExitGPU, false, false, false);
+      helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_regionExitGPU);
       helper->getSymbol()->castToMethodSymbol()->setLinkage(_helperLinkage/*@*/);
       regionExitGPUNode->setSymbolReference(helper);
 
@@ -2795,7 +2795,7 @@ void TR_SPMDKernelParallelizer::insertGPURegionExitInRegionExits(List<TR::Block>
       TR::TreeTop *insertionPoint = regionExitGPUBlock->getEntry();
 
       TR::Node* regionExitGPUNode = TR::Node::create(insertionPoint->getNode(), TR::icall, 4);
-      helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_regionExitGPU, false, false, false);
+      helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_regionExitGPU);
       helper->getSymbol()->castToMethodSymbol()->setLinkage(_helperLinkage/*@*/);
       regionExitGPUNode->setSymbolReference(helper);
 
@@ -3521,7 +3521,7 @@ bool TR_SPMDKernelParallelizer::visitCPUNode(TR::Node *node, int32_t visitCount,
 
       if (method)
          {
-         if (trace()) 
+         if (trace())
             traceMsg(comp(), "inside IntPipeline%s.forEach\n",
                method->getRecognizedMethod() == TR::java_util_stream_IntPipelineHead_forEach ? "$Head" : "");
 
@@ -3542,7 +3542,7 @@ bool TR_SPMDKernelParallelizer::visitCPUNode(TR::Node *node, int32_t visitCount,
 
          TR::Method * method = node->getSymbolReference()->getSymbol()->castToMethodSymbol()->getMethod();
          const char * signature = method->signature(comp()->trMemory(), stackAlloc);
-         
+
          if (trace())
             traceMsg(comp(), "signature: %s\n", signature ? signature : "NULL");
 
@@ -4142,7 +4142,7 @@ bool TR_SPMDKernelParallelizer::checkIndependence(TR_RegionStructure *loop, TR_U
             {
             if (trace())
                traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: Testing (def %p, def %p) for dependence\n", defs[dc], defs[dc2]);
-            
+
             if (!loop->isExprInvariant(defs[dc]->getFirstChild()) &&
                 !loop->isExprInvariant(defs[dc2]->getFirstChild()) &&
                 areNodesEquivalent(comp,defs[dc]->getFirstChild(), defs[dc2]->getFirstChild()))
@@ -4160,7 +4160,7 @@ bool TR_SPMDKernelParallelizer::checkIndependence(TR_RegionStructure *loop, TR_U
                traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: def %p and def %p are dependent\n", defs[dc], defs[dc2]);
                traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: will not vectorize\n");
                }
-            
+
             return false;
             }
          }

--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -350,7 +350,7 @@ uint8_t *TR::PPCCallSnippet::emitSnippetBody()
 
    TR_RuntimeHelper runtimeHelper = getInterpretedDispatchHelper(methodSymRef, callNode->getDataType(),
                                                                  methodSymbol->isSynchronised(), isNativeStatic, cg());
-   glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(runtimeHelper, false, false, false);
+   glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(runtimeHelper);
 
    intptr_t helperAddress = (intptr_t)glueRef->getMethodAddress();
    if (cg()->directCallRequiresTrampoline(helperAddress, (intptr_t)cursor))
@@ -531,7 +531,7 @@ uint8_t *TR::PPCVirtualUnresolvedSnippet::emitSnippetBody()
    TR::Compilation *comp = cg()->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
    TR::Node       *callNode = getNode();
-   TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCvirtualUnresolvedHelper, false, false, false);
+   TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCvirtualUnresolvedHelper);
    void *thunk = fej9->getJ2IThunk(callNode->getSymbolReference()->getSymbol()->castToMethodSymbol()->getMethod(), comp);
    uint8_t *j2iThunkRelocationPoint;
 
@@ -648,7 +648,7 @@ uint8_t *TR::PPCInterfaceCallSnippet::emitSnippetBody()
    TR::Node       *callNode = getNode();
    TR::Compilation *comp = cg()->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
-   TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCinterfaceCallHelper, false, false, false);
+   TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCinterfaceCallHelper);
    void *thunk = fej9->getJ2IThunk(callNode->getSymbolReference()->getSymbol()->castToMethodSymbol()->getMethod(), comp);
    uint8_t *j2iThunkRelocationPoint;
 
@@ -860,25 +860,25 @@ uint8_t *TR::PPCCallSnippet::generateVIThunk(TR::Node *callNode, int32_t argSize
    switch (callNode->getDataType())
           {
           case TR::NoType:
-                 dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtual0, false, false, false)->getMethodAddress();
+                 dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtual0)->getMethodAddress();
                  break;
           case TR::Int32:
-                 dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtual1, false, false, false)->getMethodAddress();
+                 dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtual1)->getMethodAddress();
                  break;
           case TR::Address:
                  if (comp->target().is64Bit())
-                    dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtualJ, false, false, false)->getMethodAddress();
+                    dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtualJ)->getMethodAddress();
                  else
-                    dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtual1, false, false, false)->getMethodAddress();
+                    dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtual1)->getMethodAddress();
                  break;
           case TR::Int64:
-                 dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtualJ, false, false, false)->getMethodAddress();
+                 dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtualJ)->getMethodAddress();
                  break;
           case TR::Float:
-                 dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtualF, false, false, false)->getMethodAddress();
+                 dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtualF)->getMethodAddress();
                  break;
           case TR::Double:
-                 dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtualD, false, false, false)->getMethodAddress();
+                 dispatcher = (intptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtualD)->getMethodAddress();
                  break;
           default:
                  TR_ASSERT(0, "Bad return data type for a call node.  DataType was %s\n",
@@ -991,25 +991,25 @@ TR_J2IThunk *TR::PPCCallSnippet::generateInvokeExactJ2IThunk(TR::Node *callNode,
    switch (callNode->getDataType())
           {
           case TR::NoType:
-                 dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact0, false, false, false);
+                 dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact0);
                  break;
           case TR::Int32:
-                 dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact1, false, false, false);
+                 dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact1);
                  break;
           case TR::Address:
                  if (comp->target().is64Bit())
-                    dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactJ, false, false, false);
+                    dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactJ);
                  else
-                    dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact1, false, false, false);
+                    dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact1);
                  break;
           case TR::Int64:
-                 dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactJ, false, false, false);
+                 dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactJ);
                  break;
           case TR::Float:
-                 dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactF, false, false, false);
+                 dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactF);
                  break;
           case TR::Double:
-                 dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactD, false, false, false);
+                 dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactD);
                  break;
           default:
                  TR_ASSERT(0, "Bad return data type '%s' for call node [" POINTER_PRINTF_FORMAT "]\n",

--- a/runtime/compiler/p/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/p/codegen/ForceRecompilationSnippet.cpp
@@ -45,7 +45,7 @@
 uint8_t *TR::PPCForceRecompilationSnippet::emitSnippetBody()
    {
    uint8_t             *buffer = cg()->getBinaryBufferCursor();
-   TR::SymbolReference  *induceRecompilationSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCinduceRecompilation, false, false, false);
+   TR::SymbolReference  *induceRecompilationSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCinduceRecompilation);
    intptr_t startPC = (intptr_t)((uint8_t*)cg()->getCodeStart());
 
    getSnippetLabel()->setCodeLocation(buffer);

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -1041,7 +1041,7 @@ J9::Power::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(TR::
    deps->addPostCondition(jumpReg, TR::RealRegister::gr11);
 
    // Generate helper address and branch
-   TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(helperIndex, false, false, false);
+   TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(helperIndex);
    TR::Instruction *call = generateDepImmSymInstruction(cg, TR::InstOpCode::bl, node, reinterpret_cast<uintptr_t>(helperSym->getMethodAddress()), deps, helperSym);
    call->PPCNeedsGCMap(linkageProperties.getPreservedRegisterMapForGC());
 
@@ -1181,7 +1181,7 @@ void generateReportFieldAccessOutlinedInstructions(TR::Node *node, TR::LabelSymb
    deps->addPostCondition(jumpReg, TR::RealRegister::gr11);
 
    // Generate branch instruction to jump into helper
-   TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(helperIndex, false, false, false);
+   TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(helperIndex);
    TR::Instruction *call = generateDepImmSymInstruction(cg, TR::InstOpCode::bl, node, reinterpret_cast<uintptr_t>(helperSym->getMethodAddress()), deps, helperSym);
    call->PPCNeedsGCMap(linkageProperties.getPreservedRegisterMapForGC());
 
@@ -1697,7 +1697,7 @@ TR::Register *iGenerateSoftwareReadBarrier(TR::Node *node, TR::CodeGenerator *cg
    // TR_softwareReadBarrier helper expects the vmThread in r3.
    generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, r3Reg, metaReg);
 
-   TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_softwareReadBarrier, false, false, false);
+   TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_softwareReadBarrier);
    generateDepImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptr_t)helperSym->getMethodAddress(), deps, helperSym);
 
    generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, objReg, TR::MemoryReference::createWithDisplacement(cg, locationReg, 0, 4));
@@ -1814,7 +1814,7 @@ TR::Register *aGenerateSoftwareReadBarrier(TR::Node *node, TR::CodeGenerator *cg
    // TR_softwareReadBarrier helper expects the vmThread in r3.
    generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, r3Reg, metaReg);
 
-   TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_softwareReadBarrier, false, false, false);
+   TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_softwareReadBarrier);
    generateDepImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptr_t)helperSym->getMethodAddress(), deps, helperSym);
 
    generateTrg1MemInstruction(cg, TR::InstOpCode::Op_load, node, tempReg, TR::MemoryReference::createWithDisplacement(cg, locationReg, 0, TR::Compiler->om.sizeofReferenceAddress()));
@@ -5312,8 +5312,8 @@ TR::Register *J9::Power::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::C
    int32_t lwOffset = fej9->getByteOffsetToLockword((TR_OpaqueClassBlock *) cg->getMonClass(node));
    TR::Compilation *comp = cg->comp();
 
-   if (comp->getOption(TR_OptimizeForSpace) || 
-         comp->getOption(TR_FullSpeedDebug) || 
+   if (comp->getOption(TR_OptimizeForSpace) ||
+         comp->getOption(TR_FullSpeedDebug) ||
          (TR::Compiler->om.areValueTypesEnabled() && cg->isMonitorValueType(node) == TR_yes) ||
          comp->getOption(TR_DisableInlineMonExit))
       {
@@ -7721,7 +7721,7 @@ static bool simpleReadMonitor(TR::Node *node, TR::CodeGenerator *cg, TR::Node *o
 void J9::Power::TreeEvaluator::generateCheckForValueTypeMonitorEnterOrExit(TR::Node *node, TR::LabelSymbol *helperCallLabel, TR::Register *objReg, TR::Register *objectClassReg, TR::Register *tempReg, TR::Register *condReg, TR::CodeGenerator *cg)
 {
    //get class of object
-   generateLoadJ9Class(node, objectClassReg, objReg, cg); 
+   generateLoadJ9Class(node, objectClassReg, objReg, cg);
 
    //get memory reference to class flags
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
@@ -7730,7 +7730,7 @@ void J9::Power::TreeEvaluator::generateCheckForValueTypeMonitorEnterOrExit(TR::N
    //check J9ClassIsValueType flag
    generateTrg1MemInstruction(cg,TR::InstOpCode::lwz, node, tempReg, classFlagsMemRef);
    generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::andi_r, node, tempReg, tempReg, condReg, J9ClassIsValueType);
-   
+
    //If obj is value type, call VM helper and throw IllegalMonitorState exception, else continue as usual
    generateConditionalBranchInstruction(cg, TR::InstOpCode::bne, node, helperCallLabel, condReg);
 }
@@ -7799,7 +7799,7 @@ TR::Register *J9::Power::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Co
    TR::addDependency(conditions, objectClassReg, TR::RealRegister::NoReg, TR_GPR, cg);
    conditions->getPreConditions()->getRegisterDependency(conditions->getAddCursorForPre() - 1)->setExcludeGPR0();
    conditions->getPostConditions()->getRegisterDependency(conditions->getAddCursorForPost() - 1)->setExcludeGPR0();
-   
+
    if (lookupOffsetReg)
       {
       TR::addDependency(conditions, lookupOffsetReg, TR::RealRegister::NoReg, TR_GPR, cg);
@@ -8747,7 +8747,7 @@ static TR::Register *VMinlineCompareAndSwapObject(TR::Node *node, TR::CodeGenera
       // TR_softwareReadBarrier helper expects the vmThread in r3.
       generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, r3Reg, metaReg);
 
-      TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_softwareReadBarrier, false, false, false);
+      TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_softwareReadBarrier);
       generateDepImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptr_t)helperSym->getMethodAddress(), deps, helperSym);
 
       generateDepLabelInstruction(cg, TR::InstOpCode::label, node, endReadBarrierLabel, deps);
@@ -11268,7 +11268,7 @@ static TR::Register *inlineEncodeUTF16(TR::Node *node, TR::CodeGenerator *cg)
    // Generate helper call
    TR_RuntimeHelper helper;
    helper = bigEndian ? TR_PPCencodeUTF16Big : TR_PPCencodeUTF16Little;
-   TR::SymbolReference *helperSym = cg->comp()->getSymRefTab()->findOrCreateRuntimeHelper(helper, false, false, false);
+   TR::SymbolReference *helperSym = cg->comp()->getSymRefTab()->findOrCreateRuntimeHelper(helper);
    generateDepImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptr_t)helperSym->getMethodAddress(), deps, helperSym);
 
    for (uint32_t i = 0; i < node->getNumChildren(); ++i) cg->decReferenceCount(node->getChild(i));
@@ -11743,10 +11743,10 @@ static void inlineArrayCopy_ICF(TR::Node *node, int64_t byteLen, TR::Register *s
       TR::Register *regs[4] = {tmp1Reg, tmp2Reg, tmp3Reg, tmp4Reg};
       TR::Register *fpRegs[4] = {fp1Reg, fp2Reg, fp3Reg, fp4Reg};
       int32_t groups, residual;
-   
+
       static bool disableLEArrayCopyInline = (feGetEnv("TR_disableLEArrayCopyInline") != NULL);
       bool supportsLEArrayCopyInline = cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) && !disableLEArrayCopyInline && cg->comp()->target().cpu.isLittleEndian() && cg->comp()->target().cpu.hasFPU() && cg->comp()->target().is64Bit();
-   
+
       if (cg->comp()->target().is64Bit())
          {
          groups = byteLen >> 5;
@@ -11757,21 +11757,21 @@ static void inlineArrayCopy_ICF(TR::Node *node, int64_t byteLen, TR::Register *s
          groups = byteLen >> 4;
          residual = byteLen & 0x0000000F;
          }
-   
+
       int32_t regIx = 0, ix = 0, fpRegIx = 0;
       int32_t memRefSize;
       TR::InstOpCode::Mnemonic load, store;
       TR::Compilation* comp = cg->comp();
-   
+
       /* Some machines have issues with 64bit loads/stores in 32bit mode, ie. sicily, do not check for is64BitProcessor() */
       memRefSize = TR::Compiler->om.sizeofReferenceAddress();
       load = TR::InstOpCode::Op_load;
       store = TR::InstOpCode::Op_st;
-   
+
       if (groups != 0)
          {
          TR::LabelSymbol *loopStart;
-   
+
          if (groups != 1)
             {
             if (groups <= UPPER_IMMED)
@@ -11779,11 +11779,11 @@ static void inlineArrayCopy_ICF(TR::Node *node, int64_t byteLen, TR::Register *s
             else
                loadConstant(cg, node, groups, regs[0]);
             generateSrc1Instruction(cg, TR::InstOpCode::mtctr, node, regs[0]);
-   
+
             loopStart = generateLabelSymbol(cg);
             generateLabelInstruction(cg, TR::InstOpCode::label, node, loopStart);
             }
-   
+
          if (supportsLEArrayCopyInline)
             {
             generateTrg1MemInstruction(cg, TR::InstOpCode::lfd, node, fpRegs[3], TR::MemoryReference::createWithDisplacement(cg, src,            0, memRefSize));
@@ -11798,10 +11798,10 @@ static void inlineArrayCopy_ICF(TR::Node *node, int64_t byteLen, TR::Register *s
             generateTrg1MemInstruction(cg, load, node, regs[1], TR::MemoryReference::createWithDisplacement(cg, src, 2*memRefSize, memRefSize));
             generateTrg1MemInstruction(cg, load, node, regs[0], TR::MemoryReference::createWithDisplacement(cg, src, 3*memRefSize, memRefSize));
             }
-   
+
          if (groups != 1)
             generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, src, src, 4*memRefSize);
-   
+
          if (supportsLEArrayCopyInline)
             {
             generateMemSrc1Instruction(cg, TR::InstOpCode::stfd, node, TR::MemoryReference::createWithDisplacement(cg, dst,            0, memRefSize), fpRegs[3]);
@@ -11816,7 +11816,7 @@ static void inlineArrayCopy_ICF(TR::Node *node, int64_t byteLen, TR::Register *s
             generateMemSrc1Instruction(cg, store, node, TR::MemoryReference::createWithDisplacement(cg, dst, 2*memRefSize, memRefSize), regs[1]);
             generateMemSrc1Instruction(cg, store, node, TR::MemoryReference::createWithDisplacement(cg, dst, 3*memRefSize, memRefSize), regs[0]);
             }
-   
+
          if (groups != 1)
             {
             generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, dst, dst, 4*memRefSize);
@@ -11827,7 +11827,7 @@ static void inlineArrayCopy_ICF(TR::Node *node, int64_t byteLen, TR::Register *s
             ix = 4*memRefSize;
             }
          }
-   
+
       for (; residual>=memRefSize; residual-=memRefSize, ix+=memRefSize)
          {
          if (supportsLEArrayCopyInline)
@@ -11847,7 +11847,7 @@ static void inlineArrayCopy_ICF(TR::Node *node, int64_t byteLen, TR::Register *s
             generateMemSrc1Instruction(cg, store, node, TR::MemoryReference::createWithDisplacement(cg, dst, ix, memRefSize), oneReg);
             }
          }
-   
+
       if (residual != 0)
          {
          if (residual & 4)
@@ -11944,7 +11944,7 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
          }
       case TR::jdk_internal_misc_Unsafe_copyMemory0:
       case TR::sun_misc_Unsafe_copyMemory:
-         if (comp->canTransformUnsafeCopyToArrayCopy() 
+         if (comp->canTransformUnsafeCopyToArrayCopy()
             && methodSymbol->isNative()
             && performTransformation(comp,
                   "O^O Call arraycopy instead of Unsafe.copyMemory: %s\n", cg->getDebug()->getName(node)))
@@ -12951,7 +12951,7 @@ TR::Register *J9::Power::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::C
                tmp3Reg = cg->allocateRegister(TR_GPR);
                tmp4Reg = cg->allocateRegister(TR_GPR);
                }
-   
+
             if (supportsLEArrayCopyInline)
                {
                numDeps += 4;
@@ -12991,7 +12991,7 @@ TR::Register *J9::Power::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::C
                deps->addPostCondition(tmp3Reg, TR::RealRegister::NoReg);
                deps->addPostCondition(tmp4Reg, TR::RealRegister::NoReg);
                }
-   
+
             if (supportsLEArrayCopyInline)
                {
                deps->addPostCondition(fp1Reg, TR::RealRegister::NoReg);
@@ -13046,7 +13046,7 @@ TR::Register *J9::Power::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::C
          generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, r3Reg, metaReg);
 
          TR::RegisterDependencyConditions *helperDeps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 0, cg->trMemory());
-         TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_referenceArrayCopy, false, false, false);
+         TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_referenceArrayCopy);
 
          gcPoint = generateDepImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptr_t)helperSym->getMethodAddress(), helperDeps, helperSym);
          gcPoint->PPCNeedsGCMap(pp.getPreservedRegisterMapForGC());
@@ -13380,7 +13380,7 @@ TR::Register *J9::Power::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::C
    generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, lengthReg, dstAddrReg); //lengthReg is tied to r7.  Need to copy lengthReg first.
 
    TR::RegisterDependencyConditions *helperDeps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 0, cg->trMemory());
-   TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_referenceArrayCopy, false, false, false);
+   TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_referenceArrayCopy);
 
    gcPoint = generateDepImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptr_t)helperSym->getMethodAddress(), helperDeps, helperSym);
    gcPoint->PPCNeedsGCMap(pp.getPreservedRegisterMapForGC());

--- a/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
@@ -129,7 +129,7 @@ uint8_t *J9::Power::UnresolvedDataSnippet::emitSnippetBody()
          refNum = TR_PPCinterpreterUnresolvedStaticDataGlue;
       }
 
-   glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(refNum, false, false, false);
+   glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(refNum);
    getSnippetLabel()->setCodeLocation(cursor);
 
    intptr_t helperAddress = (intptr_t)glueRef->getMethodAddress();

--- a/runtime/compiler/p/codegen/PPCJNILinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCJNILinkage.cpp
@@ -595,7 +595,7 @@ TR::Register *J9::Power::JNILinkage::buildDirectDispatch(TR::Node *callNode)
          //        Pending GAC's verification. ***
          uint32_t            flagValue = fej9->constJNIReferenceFrameAllocatedFlags();
          TR::LabelSymbol      *refPoolRestartLabel = generateLabelSymbol(cg());
-         TR::SymbolReference *collapseSymRef = cg()->getSymRefTab()->findOrCreateRuntimeHelper(TR_PPCcollapseJNIReferenceFrame, false, false, false);
+         TR::SymbolReference *collapseSymRef = cg()->getSymRefTab()->findOrCreateRuntimeHelper(TR_PPCcollapseJNIReferenceFrame);
 
          generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, callNode, gr30Reg, TR::MemoryReference::createWithDisplacement(cg(), stackPtr, fej9->constJNICallOutFrameFlagsOffset(), TR::Compiler->om.sizeofReferenceAddress()));
          simplifyANDRegImm(callNode, gr31Reg, gr30Reg, flagValue, cg());

--- a/runtime/compiler/p/codegen/PPCRecompilation.cpp
+++ b/runtime/compiler/p/codegen/PPCRecompilation.cpp
@@ -84,7 +84,7 @@ TR::Instruction *TR_PPCRecompilation::generatePrePrologue()
    TR::Machine *machine = cg()->machine();
    TR::Register   *gr0 = machine->getRealRegister(TR::RealRegister::gr0);
    TR::Node       *firstNode = comp->getStartTree()->getNode();
-   TR::SymbolReference *recompileMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCsamplingRecompileMethod, false, false, false);
+   TR::SymbolReference *recompileMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCsamplingRecompileMethod);
    TR_PersistentJittedBodyInfo *info = getJittedBodyInfo();
    // force creation of switch to interpreter pre prologue if in Full Speed Debug
    if (cg()->mustGenerateSwitchToInterpreterPrePrologue())

--- a/runtime/compiler/p/codegen/PPCRecompilationSnippet.cpp
+++ b/runtime/compiler/p/codegen/PPCRecompilationSnippet.cpp
@@ -46,7 +46,7 @@ uint8_t *TR::PPCRecompilationSnippet::emitSnippetBody()
    {
    uint8_t             *buffer = cg()->getBinaryBufferCursor();
    TR::Compilation *comp = cg()->comp();
-   TR::SymbolReference  *countingRecompMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCcountingRecompileMethod, false, false, false);
+   TR::SymbolReference  *countingRecompMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCcountingRecompileMethod);
    bool                 longPrologue = getBranchToSnippet()->getFarRelocation();
 
    getSnippetLabel()->setCodeLocation(buffer);

--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -1147,7 +1147,7 @@ void J9::X86::AMD64::JNILinkage::checkForJNIExceptions(TR::Node *callNode)
 
    TR::Snippet *snippet =
       new (trHeapMemory()) TR::X86CheckFailureSnippet(cg(),
-                                     cg()->symRefTab()->findOrCreateRuntimeHelper(TR_throwCurrentException, false, false, false),
+                                     cg()->symRefTab()->findOrCreateRuntimeHelper(TR_throwCurrentException),
                                      snippetLabel,
                                      instr,
                                      _JNIDispatchInfo.requiresFPstackPop);

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -558,22 +558,22 @@ uint8_t *J9::X86::AMD64::PrivateLinkage::generateVirtualIndirectThunk(TR::Node *
    switch (callNode->getDataType())
       {
       case TR::NoType:
-         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_AMD64icallVMprJavaSendVirtual0, false, false, false);
+         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_AMD64icallVMprJavaSendVirtual0);
          break;
       case TR::Int64:
-         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_AMD64icallVMprJavaSendVirtualJ, false, false, false);
+         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_AMD64icallVMprJavaSendVirtualJ);
          break;
       case TR::Address:
-         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_AMD64icallVMprJavaSendVirtualL, false, false, false);
+         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_AMD64icallVMprJavaSendVirtualL);
          break;
       case TR::Int32:
-         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_AMD64icallVMprJavaSendVirtual1, false, false, false);
+         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_AMD64icallVMprJavaSendVirtual1);
          break;
       case TR::Float:
-         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_AMD64icallVMprJavaSendVirtualF, false, false, false);
+         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_AMD64icallVMprJavaSendVirtualF);
          break;
       case TR::Double:
-         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_AMD64icallVMprJavaSendVirtualD, false, false, false);
+         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_AMD64icallVMprJavaSendVirtualD);
          break;
       default:
          TR_ASSERT(0, "Bad return data type '%s' for call node [" POINTER_PRINTF_FORMAT "]\n",
@@ -632,22 +632,22 @@ TR_J2IThunk *J9::X86::AMD64::PrivateLinkage::generateInvokeExactJ2IThunk(TR::Nod
    switch (callNode->getDataType())
       {
       case TR::NoType:
-         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact0, false, false, false);
+         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact0);
          break;
       case TR::Int64:
-         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactJ, false, false, false);
+         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactJ);
          break;
       case TR::Address:
-         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactL, false, false, false);
+         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactL);
          break;
       case TR::Int32:
-         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact1, false, false, false);
+         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact1);
          break;
       case TR::Float:
-         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactF, false, false, false);
+         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactF);
          break;
       case TR::Double:
-         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactD, false, false, false);
+         glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactD);
          break;
       default:
          TR_ASSERT(0, "Bad return data type '%s' for call node [" POINTER_PRINTF_FORMAT "]\n",
@@ -674,7 +674,7 @@ TR_J2IThunk *J9::X86::AMD64::PrivateLinkage::generateInvokeExactJ2IThunk(TR::Nod
       // JMPImm4 helper
       //
       *(uint8_t *)cursor++ = 0xe9;
-      TR::SymbolReference *helper = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_methodHandleJ2IGlue, false, false, false);
+      TR::SymbolReference *helper = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_methodHandleJ2IGlue);
       int32_t disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor+4, helper);
       *(int32_t *)cursor = disp32;
       cursor += 4;

--- a/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
+++ b/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
@@ -86,7 +86,7 @@ uint8_t *TR::X86AllocPrefetchSnippet::emitSnippetBody()
    else
       {
       TR_RuntimeHelper helper = (comp->getOption(TR_EnableNewX86PrefetchTLH)) ? TR_X86newPrefetchTLH : TR_X86prefetchTLH;
-      helperSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(helper, false, false, false);
+      helperSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(helper);
       disp32 = cg()->branchDisplacementToHelperOrTrampoline(buffer+4, helperSymRef);
       if (fej9->needRelocationsForHelpers())
          {

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -180,7 +180,7 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
 
       // Slow path lookup dispatch
       //
-      _dispatchSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86IPicLookupDispatch, false, false, false);
+      _dispatchSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86IPicLookupDispatch);
 
       *cursor++ = 0xe8;  // CALL
       disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor+4, _dispatchSymRef);
@@ -348,7 +348,7 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
          TR_ASSERT_FATAL(0, "Can't handle resolved VPICs here yet!");
          }
 
-      _dispatchSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86populateVPicVTableDispatch, false, false, false);
+      _dispatchSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86populateVPicVTableDispatch);
 
       getSnippetLabel()->setCodeLocation(cursor);
 
@@ -416,9 +416,9 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
       uint8_t *picSlotCursor = _startOfPicInstruction->getBinaryEncoding();
 
       TR::SymbolReference *resolveSlotHelperSymRef =
-         cg()->symRefTab()->findOrCreateRuntimeHelper(resolveSlotHelper, false, false, false);
+         cg()->symRefTab()->findOrCreateRuntimeHelper(resolveSlotHelper);
       TR::SymbolReference *populateSlotHelperSymRef =
-         cg()->symRefTab()->findOrCreateRuntimeHelper(populateSlotHelper, false, false, false);
+         cg()->symRefTab()->findOrCreateRuntimeHelper(populateSlotHelper);
 
       // Patch first slot test with call to resolution helper.
       //
@@ -861,7 +861,7 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       TR_RuntimeHelper resolutionHelper = methodSymbol->isStatic() ?
          TR_X86interpreterUnresolvedStaticGlue : TR_X86interpreterUnresolvedSpecialGlue;
 
-      TR::SymbolReference *helperSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(resolutionHelper, false, false, false);
+      TR::SymbolReference *helperSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(resolutionHelper);
 
       *cursor++ = 0xe8;    // CALL
       *(int32_t *)cursor = cg()->branchDisplacementToHelperOrTrampoline(cursor + 4, helperSymRef);
@@ -890,7 +890,7 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
 
       // JMP interpreterStaticAndSpecialGlue
       //
-      helperSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86interpreterStaticAndSpecialGlue, false, false, false);
+      helperSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86interpreterStaticAndSpecialGlue);
 
       *cursor++ = 0xe9;    // JMP
       *(int32_t *)cursor = cg()->branchDisplacementToHelperOrTrampoline(cursor + 4, helperSymRef);
@@ -999,7 +999,7 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
 
       TR::SymbolReference* dispatchSymRef =
           methodSymbol->isHelper() && methodSymRef->isOSRInductionHelper() ? methodSymRef :
-                                                                             cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86interpreterStaticAndSpecialGlue, false, false, false);
+                                                                             cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86interpreterStaticAndSpecialGlue);
 
       *(int32_t *)cursor = cg()->branchDisplacementToHelperOrTrampoline(cursor + 4, dispatchSymRef);
 

--- a/runtime/compiler/x/codegen/CheckFailureSnippet.cpp
+++ b/runtime/compiler/x/codegen/CheckFailureSnippet.cpp
@@ -315,7 +315,7 @@ uint8_t *TR::X86CheckFailureSnippetWithResolve::emitSnippetBody()
    //
    *buffer++ = 0xe8;                      // call  Imm4 glue routine
 
-   TR::SymbolReference * glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(getHelper(), false, false, false);
+   TR::SymbolReference * glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(getHelper());
    intptr_t glueAddress = (intptr_t)glueSymRef->getMethodAddress();
    if (NEEDS_TRAMPOLINE(glueAddress, buffer+4, cg()))
       {

--- a/runtime/compiler/x/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/x/codegen/ForceRecompilationSnippet.cpp
@@ -48,7 +48,7 @@ uint8_t *TR::X86ForceRecompilationSnippet::emitSnippetBody()
    uint8_t *buffer = cg()->getBinaryBufferCursor();
    getSnippetLabel()->setCodeLocation(buffer);
 
-   TR::SymbolReference *helper = cg()->symRefTab()->findOrCreateRuntimeHelper(cg()->comp()->target().is64Bit()? TR_AMD64induceRecompilation : TR_IA32induceRecompilation, false, false, false);
+   TR::SymbolReference *helper = cg()->symRefTab()->findOrCreateRuntimeHelper(cg()->comp()->target().is64Bit()? TR_AMD64induceRecompilation : TR_IA32induceRecompilation);
    intptr_t helperAddress = (intptr_t)helper->getMethodAddress();
    *buffer++ = 0xe8; // CallImm4
    if (NEEDS_TRAMPOLINE(helperAddress, buffer+4, cg()))

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -457,7 +457,7 @@ J9::X86::CodeGenerator::generateSwitchToInterpreterPrePrologue(
    deps->addPreCondition(ediRegister, TR::RealRegister::edi, self());
 
    TR::SymbolReference *helperSymRef =
-      self()->symRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition, false, false, false);
+      self()->symRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition);
 
    if (comp->target().is64Bit())
       {

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1548,7 +1548,7 @@ TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Cod
 
       auto snippetLabel = generateLabelSymbol(cg);
       auto instr = generateLabelInstruction(JNE4, node, snippetLabel, cg); // ReferenceArrayCopy set ZF when succeed.
-      auto snippet = new (cg->trHeapMemory()) TR::X86CheckFailureSnippet(cg, cg->symRefTab()->findOrCreateRuntimeHelper(TR_arrayStoreException, false, false, false),
+      auto snippet = new (cg->trHeapMemory()) TR::X86CheckFailureSnippet(cg, cg->symRefTab()->findOrCreateRuntimeHelper(TR_arrayStoreException),
                                                                          snippetLabel, instr, false);
       cg->addSnippet(snippet);
       }
@@ -6351,7 +6351,7 @@ static void genHeapAlloc(
             else
                {
                generateLabelInstruction(JG4, node, restartLabel, cg);
-               TR::SymbolReference * helperSymRef = cg->getSymRefTab()->findOrCreateRuntimeHelper(TR_X86CodeCachePrefetchHelper, false, false, false);
+               TR::SymbolReference * helperSymRef = cg->getSymRefTab()->findOrCreateRuntimeHelper(TR_X86CodeCachePrefetchHelper);
                TR::MethodSymbol *helperSymbol = helperSymRef->getSymbol()->castToMethodSymbol();
 #ifdef J9VM_GC_NON_ZERO_TLH
                if (!comp->getOption(TR_DisableDualTLH) && node->canSkipZeroInitialization())
@@ -8728,7 +8728,7 @@ inlineNanoTime(
          resultAddress = NULL;
          }
 
-      TR::SymbolReference *gtod = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_AMD64clockGetTime,false,false,false);
+      TR::SymbolReference *gtod = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_AMD64clockGetTime);
       TR::Node *timevalNode = TR::Node::createWithSymRef(node, TR::loadaddr, 0, cg->getNanoTimeTemp());
       TR::Node *clockSourceNode = TR::Node::create(node, TR::iconst, 0, CLOCK_MONOTONIC);
       TR::Node *callNode    = TR::Node::createWithSymRef(TR::call, 2, 2, clockSourceNode, timevalNode, gtod);

--- a/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
@@ -113,7 +113,7 @@ J9::X86::UnresolvedDataSnippet::emitSnippetBody()
       return TR_X86OpCode(BADIA32Op).binary(cursor);
       }
 
-   _glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(getHelper(), false, false, false);
+   _glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(getHelper());
 
    if (cg()->comp()->target().is64Bit())
       {

--- a/runtime/compiler/x/codegen/RecompilationSnippet.cpp
+++ b/runtime/compiler/x/codegen/RecompilationSnippet.cpp
@@ -46,7 +46,7 @@ TR::X86RecompilationSnippet::X86RecompilationSnippet(TR::LabelSymbol    *lab,
                                                          TR::CodeGenerator *cg)
    : TR::Snippet(cg, node, lab, true)
    {
-   setDestination(cg->symRefTab()->findOrCreateRuntimeHelper(cg->comp()->target().is64Bit()? TR_AMD64countingRecompileMethod : TR_IA32countingRecompileMethod, false, false, false));
+   setDestination(cg->symRefTab()->findOrCreateRuntimeHelper(cg->comp()->target().is64Bit()? TR_AMD64countingRecompileMethod : TR_IA32countingRecompileMethod));
    }
 
 uint32_t TR::X86RecompilationSnippet::getLength(int32_t estimatedSnippetStart)

--- a/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
@@ -508,7 +508,7 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
 
       TR::Snippet *snippet = new (trHeapMemory()) TR::X86CheckFailureSnippet(
             cg(),
-            cg()->symRefTab()->findOrCreateRuntimeHelper(TR_throwCurrentException, false, false, false),
+            cg()->symRefTab()->findOrCreateRuntimeHelper(TR_throwCurrentException),
             snippetLabel,
             instr,
             callNode->getDataType() == TR::Float || callNode->getDataType() == TR::Double);

--- a/runtime/compiler/x/runtime/X86RelocationTarget.cpp
+++ b/runtime/compiler/x/runtime/X86RelocationTarget.cpp
@@ -127,7 +127,7 @@ j9ThunkInvokeExactHelperFromTerseSignature(UDATA signatureLength, char *signatur
          helper = TR_icallVMprJavaSendInvokeExact1;
          break;
       }
-   TR::SymbolReference *symRef = reloRuntime->comp()->getSymRefTab()->findOrCreateRuntimeHelper(helper, false, false, false);
+   TR::SymbolReference *symRef = reloRuntime->comp()->getSymRefTab()->findOrCreateRuntimeHelper(helper);
 
    return symRef->getMethodAddress();
    }

--- a/runtime/compiler/z/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/z/codegen/ForceRecompilationSnippet.cpp
@@ -41,7 +41,7 @@ TR::S390ForceRecompilationSnippet::emitSnippetBody()
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
 
    uint32_t rEP = (uint32_t) cg()->getEntryPointRegister() - 1;
-   TR::SymbolReference * glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390induceRecompilation, false, false, false);
+   TR::SymbolReference * glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390induceRecompilation);
 
    // Set up the start of data constants and jump to helper.
    // We generate:

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3757,7 +3757,7 @@ TR::Instruction* J9::Z::CodeGenerator::generateVMCallHelperSnippet(TR::Instructi
 
    TR::ResolvedMethodSymbol* methodSymbol = comp->getJittedMethodSymbol();
 
-   TR::SymbolReference* helperSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition, false, false, false);
+   TR::SymbolReference* helperSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition);
 
    // AOT relocation for the helper address
    TR::S390EncodingRelocation* encodingRelocation = new (self()->trHeapMemory()) TR::S390EncodingRelocation(TR_AbsoluteHelperAddress, helperSymRef);

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -3809,7 +3809,7 @@ J9::Z::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(TR::Code
    deps->addPostCondition(scratchReg2, cg->getReturnAddressRegister());
 
    // Now make the call. Return value of the call is in GPR2 (cpIndexReg).
-   TR::Instruction *call = generateDirectCall(cg, node, false /*myself*/, cg->symRefTab()->findOrCreateRuntimeHelper(helperIndex, false, false, false), deps);
+   TR::Instruction *call = generateDirectCall(cg, node, false /*myself*/, cg->symRefTab()->findOrCreateRuntimeHelper(helperIndex), deps);
    call->setNeedsGCMap(0x0000FFFF);
    call->setDependencyConditions(deps);
 
@@ -3965,7 +3965,7 @@ void generateReportFieldAccessOutlinedInstructions(TR::Node *node, TR::LabelSymb
    dependencies->addPostCondition(scratch2, cg->getReturnAddressRegister());
 
    // Now generate the call to VM Helper to report the fieldwatch.
-   TR::Instruction *call = generateDirectCall(cg, node, false /*myself*/, cg->symRefTab()->findOrCreateRuntimeHelper(helperIndex, false, false, false), dependencies);
+   TR::Instruction *call = generateDirectCall(cg, node, false /*myself*/, cg->symRefTab()->findOrCreateRuntimeHelper(helperIndex), dependencies);
    call->setNeedsGCMap(0x0000FFFF);
    call->setDependencyConditions(dependencies);
 
@@ -9603,7 +9603,7 @@ J9::Z::TreeEvaluator::genArrayCopyWithArrayStoreCHK(TR::Node* node,
    TR::Register *tmpReg    = cg->allocateRegister();
    TR::Register *R2SaveReg = cg->allocateRegister();
 
-   TR::SymbolReference* helperCallSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390referenceArrayCopyHelper, false, false, false);
+   TR::SymbolReference* helperCallSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390referenceArrayCopyHelper);
    TR::Snippet * helperCallSnippet = new (cg->trHeapMemory()) TR::S390HelperCallSnippet(cg, node, callLabel,
                                                                               helperCallSymRef, doneLabel);
    cg->addSnippet(helperCallSnippet);
@@ -11853,7 +11853,7 @@ J9::Z::TreeEvaluator::generateSoftwareReadBarrier(TR::Node* node,
    TR::Instruction *gcPoint = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, callLabel);
    gcPoint->setNeedsGCMap(0);
    auto readBarHelperSnippet = new (cg->trHeapMemory()) TR::S390HelperCallSnippet(cg, node, callLabel,
-                                                                                  cg->symRefTab()->findOrCreateRuntimeHelper(TR_softwareReadBarrier, false, false, false),
+                                                                                  cg->symRefTab()->findOrCreateRuntimeHelper(TR_softwareReadBarrier),
                                                                                   callEndLabel);
    cg->addSnippet(readBarHelperSnippet);
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, callEndLabel);

--- a/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
@@ -179,57 +179,57 @@ J9::Z::UnresolvedDataSnippet::emitSnippetBody()
       {
       if (resolveForStore())
          {
-         glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interpreterUnresolvedInstanceDataStoreGlue, false, false, false);
+         glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interpreterUnresolvedInstanceDataStoreGlue);
          }
       else
          {
-         glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interpreterUnresolvedInstanceDataGlue, false, false, false);
+         glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interpreterUnresolvedInstanceDataGlue);
          }
       }
    else if (getDataSymbol()->isClassObject())
       {
       if (getDataSymbol()->addressIsCPIndexOfStatic())
          {
-         glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interpreterUnresolvedClassGlue2, false, false, false);
+         glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interpreterUnresolvedClassGlue2);
          }
       else
          {
-         glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interpreterUnresolvedClassGlue, false, false, false);
+         glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interpreterUnresolvedClassGlue);
          }
       }
    else if (getDataSymbol()->isConstString())
       {
-      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interpreterUnresolvedStringGlue, false, false, false);
+      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interpreterUnresolvedStringGlue);
       }
    else if (getDataSymbol()->isConstMethodType())
       {
-      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_interpreterUnresolvedMethodTypeGlue, false, false, false);
+      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_interpreterUnresolvedMethodTypeGlue);
       }
    else if (getDataSymbol()->isConstMethodHandle())
       {
-      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_interpreterUnresolvedMethodHandleGlue, false, false, false);
+      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_interpreterUnresolvedMethodHandleGlue);
       }
    else if (getDataSymbol()->isCallSiteTableEntry())
       {
-      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_interpreterUnresolvedCallSiteTableEntryGlue, false, false, false);
+      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_interpreterUnresolvedCallSiteTableEntryGlue);
       }
    else if (getDataSymbol()->isMethodTypeTableEntry())
       {
-      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_interpreterUnresolvedMethodTypeTableEntryGlue, false, false, false);
+      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_interpreterUnresolvedMethodTypeTableEntryGlue);
       }
    else if (getDataSymbol()->isConstantDynamic())
       {
-      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390jitResolveConstantDynamicGlue, false, false, false);
+      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390jitResolveConstantDynamicGlue);
       }
    else // must be static data
       {
       if (resolveForStore())
          {
-         glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interpreterUnresolvedStaticDataStoreGlue, false, false, false);
+         glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interpreterUnresolvedStaticDataStoreGlue);
          }
       else
          {
-         glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interpreterUnresolvedStaticDataGlue, false, false, false);
+         glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interpreterUnresolvedStaticDataGlue);
          }
       }
 

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -62,30 +62,30 @@ TR::S390J9CallSnippet::generateVIThunk(TR::Node * callNode, int32_t argSize, TR:
    switch (callNode->getDataType())
       {
       case TR::NoType:
-         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390icallVMprJavaSendVirtual0, false, false, false);
+         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390icallVMprJavaSendVirtual0);
          break;
       case TR::Int32:
-         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390icallVMprJavaSendVirtual1, false, false, false);
+         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390icallVMprJavaSendVirtual1);
          break;
       case TR::Address:
          if (comp->target().is64Bit())
             {
-            dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390icallVMprJavaSendVirtualJ, false, false, false);
+            dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390icallVMprJavaSendVirtualJ);
             }
          else
             {
-            dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390icallVMprJavaSendVirtual1, false, false, false);
+            dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390icallVMprJavaSendVirtual1);
             }
 
          break;
       case TR::Int64:
-         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390icallVMprJavaSendVirtualJ, false, false, false);
+         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390icallVMprJavaSendVirtualJ);
          break;
       case TR::Float:
-         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390icallVMprJavaSendVirtualF, false, false, false);
+         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390icallVMprJavaSendVirtualF);
          break;
       case TR::Double:
-         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390icallVMprJavaSendVirtualD, false, false, false);
+         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390icallVMprJavaSendVirtualD);
          break;
       default:
          TR_ASSERT(0, "Bad return data type for a call node.  DataType was %s\n",
@@ -155,25 +155,25 @@ TR::S390J9CallSnippet::generateInvokeExactJ2IThunk(TR::Node * callNode, int32_t 
    switch (callNode->getDataType())
       {
       case TR::NoType:
-         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact0, false, false, false);
+         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact0);
          break;
       case TR::Int32:
-         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact1, false, false, false);
+         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact1);
          break;
       case TR::Address:
          if (comp->target().is64Bit())
-            dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactJ, false, false, false);
+            dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactJ);
          else
-            dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact1, false, false, false);
+            dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact1);
          break;
       case TR::Int64:
-         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactJ, false, false, false);
+         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactJ);
          break;
       case TR::Float:
-         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactF, false, false, false);
+         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactF);
          break;
       case TR::Double:
-         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactD, false, false, false);
+         dispatcherSymbol = cg->symRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactD);
          break;
       default:
          TR_ASSERT(0, "Bad return data type for a call node.  DataType was %s\n",
@@ -215,7 +215,7 @@ TR::S390J9CallSnippet::generateInvokeExactJ2IThunk(TR::Node * callNode, int32_t 
       *(int16_t *) cursor = 0xC0F4;   // BRCL   <Helper Addr>
       cursor += 2;
 
-      TR::SymbolReference *helper = cg->symRefTab()->findOrCreateRuntimeHelper(TR_methodHandleJ2IGlue, false, false, false);
+      TR::SymbolReference *helper = cg->symRefTab()->findOrCreateRuntimeHelper(TR_methodHandleJ2IGlue);
       intptr_t destAddr = (intptr_t)helper->getMethodAddress();
 #if defined(TR_TARGET_64BIT)
 #if defined(J9ZOS390)
@@ -272,7 +272,7 @@ TR::S390J9CallSnippet::emitSnippetBody()
    cursor = S390flushArgumentsToStack(cursor, callNode, getSizeOfArguments(), cg());
 
    TR_RuntimeHelper runtimeHelper = getInterpretedDispatchHelper(methodSymRef, callNode->getDataType());
-   TR::SymbolReference * glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(runtimeHelper, false, false, false);
+   TR::SymbolReference * glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(runtimeHelper);
 
    // Generate RIOFF if RI is supported.
    cursor = generateRuntimeInstrumentationOnOffInstruction(cg(), cursor, TR::InstOpCode::RIOFF);
@@ -505,7 +505,7 @@ TR::S390VirtualUnresolvedSnippet::emitSnippetBody()
    uint8_t * cursor = cg()->getBinaryBufferCursor();
    TR::Node * callNode = getNode();
    TR::Compilation *comp = cg()->comp();
-   TR::SymbolReference * glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390virtualUnresolvedHelper, false, false, false);
+   TR::SymbolReference * glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390virtualUnresolvedHelper);
 
    getSnippetLabel()->setCodeLocation(cursor);
 
@@ -621,15 +621,15 @@ TR::S390InterfaceCallSnippet::emitSnippetBody()
 
    if (getNumInterfaceCallCacheSlots() == 0)
       {
-      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interfaceCallHelper, false, false, false);
+      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interfaceCallHelper);
       }
    else if (comp->getOption(TR_enableInterfaceCallCachingSingleDynamicSlot))
       {
-      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interfaceCallHelperSingleDynamicSlot, false, false, false);
+      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interfaceCallHelperSingleDynamicSlot);
       }
    else
       {
-      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interfaceCallHelperMultiSlots, false, false, false);
+      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390interfaceCallHelperMultiSlots);
       }
 
    // Set up the start of data constants and jump to helper.

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -2431,7 +2431,7 @@ J9::Z::PrivateLinkage::callPreJNICallOffloadCheck(TR::Node * callNode)
    TR::CodeGenerator * codeGen = cg();
    TR::LabelSymbol * offloadOffRestartLabel = generateLabelSymbol(codeGen);
    TR::LabelSymbol * offloadOffSnippetLabel = generateLabelSymbol(codeGen);
-   TR::SymbolReference * offloadOffSymRef = codeGen->symRefTab()->findOrCreateRuntimeHelper(TR_S390jitPreJNICallOffloadCheck, false, false, false);
+   TR::SymbolReference * offloadOffSymRef = codeGen->symRefTab()->findOrCreateRuntimeHelper(TR_S390jitPreJNICallOffloadCheck);
 
    TR::Instruction *gcPoint = generateS390BranchInstruction(
       codeGen, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, callNode, offloadOffSnippetLabel);
@@ -2452,7 +2452,7 @@ J9::Z::PrivateLinkage::callPostJNICallOffloadCheck(TR::Node * callNode)
    TR::Instruction *gcPoint = generateS390BranchInstruction(
       codeGen, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, callNode, offloadOnSnippetLabel);
    gcPoint->setNeedsGCMap(0);
-   TR::SymbolReference * offloadOnSymRef = codeGen->symRefTab()->findOrCreateRuntimeHelper(TR_S390jitPostJNICallOffloadCheck, false, false, false);
+   TR::SymbolReference * offloadOnSymRef = codeGen->symRefTab()->findOrCreateRuntimeHelper(TR_S390jitPostJNICallOffloadCheck);
    codeGen->addSnippet(new (trHeapMemory()) TR::S390HelperCallSnippet(codeGen, callNode,
       offloadOnSnippetLabel, offloadOnSymRef, offloadOnRestartLabel));
    generateS390LabelInstruction(codeGen, TR::InstOpCode::LABEL, callNode, offloadOnRestartLabel);
@@ -2479,7 +2479,7 @@ void J9::Z::PrivateLinkage::collapseJNIReferenceFrame(TR::Node * callNode,
       generateS390BranchInstruction(codeGen, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, callNode, refPoolSnippetLabel);
    gcPoint->setNeedsGCMap(0);
 
-   TR::SymbolReference * collapseSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390collapseJNIReferenceFrame, false, false, false);
+   TR::SymbolReference * collapseSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_S390collapseJNIReferenceFrame);
    codeGen->addSnippet(new (trHeapMemory()) TR::S390HelperCallSnippet(codeGen, callNode,
       refPoolSnippetLabel, collapseSymRef, refPoolRestartLabel));
    generateS390LabelInstruction(cg(), TR::InstOpCode::LABEL, callNode, refPoolRestartLabel);

--- a/runtime/compiler/z/codegen/S390Recompilation.cpp
+++ b/runtime/compiler/z/codegen/S390Recompilation.cpp
@@ -187,7 +187,7 @@ TR_S390Recompilation::generatePrePrologue()
 
       samplingRecompileMethodAddressMemRef->setOffset(offsetFromEPRegisterValueToSamplingRecompileMethod);
 
-      TR::SymbolReference* helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390samplingRecompileMethod, false, false, false);
+      TR::SymbolReference* helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390samplingRecompileMethod);
 
       // AOT relocation for the interpreter glue address
       TR::S390EncodingRelocation* encodingRelocation = new (cg->trHeapMemory()) TR::S390EncodingRelocation(TR_AbsoluteHelperAddress, helperSymRef);
@@ -401,7 +401,7 @@ TR_S390Recompilation::generatePrologue(TR::Instruction* cursor)
 
    TR::Instruction* countingRecompileMethodAddressDataConstant = NULL;
 
-   TR::SymbolReference* helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390countingRecompileMethod, false, false, false);
+   TR::SymbolReference* helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390countingRecompileMethod);
 
    // AOT relocation for the helper address
    TR::S390EncodingRelocation* encodingRelocation = new (cg->trHeapMemory()) TR::S390EncodingRelocation(TR_AbsoluteHelperAddress, NULL);
@@ -486,7 +486,7 @@ TR_S390Recompilation::generatePrologue(TR::Instruction* cursor)
 
    TR::Instruction* countingPatchCallSiteAddressDataConstant = NULL;
 
-   helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390countingPatchCallSite, false, false, false);
+   helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390countingPatchCallSite);
 
    // AOT relocation for the helper address
    encodingRelocation = new (cg->trHeapMemory()) TR::S390EncodingRelocation(TR_AbsoluteHelperAddress, NULL);


### PR DESCRIPTION
* Replace references to findOrCreateRuntimeHelper on Z
* Replace references to findOrCreateRuntimeHelper on Power
* Replace references to findOrCreateRuntimeHelper on X86
* Replace references to findOrCreateRuntimeHelper on AArch64
* Replace references to findOrCreateRuntimeHelper on ARM
* Replace references to findOrCreateRuntimeHelper in common code