### PR TITLE
Remove references to 'com.ibm.oti.vm.library.version'

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -67,7 +67,6 @@
 		<source path="src/openj9.jvm/share/classes"/>
 		<source path="src/openj9.sharedclasses/share/classes"/>
 		<source path="src/openj9.zosconditionhandling/share/classes"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
 		<parameter name="msg:outputdir" value="com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>
@@ -92,7 +91,6 @@
 		<source path="src/openj9.jvm/share/classes"/>
 		<source path="src/openj9.sharedclasses/share/classes"/>
 		<source path="src/openj9.zosconditionhandling/share/classes"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
 		<parameter name="msg:outputdir" value="com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>
@@ -120,7 +118,6 @@
 		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
 		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava11.jar"/>
 		<source path="src"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>
@@ -148,7 +145,6 @@
 		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
 		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava15.jar"/>
 		<source path="src"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>
@@ -176,7 +172,6 @@
 		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
 		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava15.jar"/>
 		<source path="src"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>
@@ -204,7 +199,6 @@
 		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
 		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava11.jar"/>
 		<source path="src"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>
@@ -232,7 +226,6 @@
 		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava14.jar"/>
 		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sun190Panama.jar"/>
 		<source path="src"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>
@@ -247,7 +240,6 @@
 		<source path="src/java.base/share/classes"/>
 		<source path="src/openj9.dataaccess/share/classes"/>
 		<source path="src/openj9.zosconditionhandling/share/classes"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
 		<parameter name="msg:outputdir" value="com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>
@@ -262,7 +254,6 @@
 		<source path="src/java.base/share/classes"/>
 		<source path="src/openj9.dtfj/share/classes"/>
 		<source path="src/openj9.zosconditionhandling/share/classes"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
 		<parameter name="msg:outputdir" value="com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>
@@ -278,7 +269,6 @@
 		<source path="src/openj9.dtfj/share/classes"/>
 		<source path="src/openj9.dtfjview/share/classes"/>
 		<source path="src/openj9.zosconditionhandling/share/classes"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
 		<parameter name="msg:outputdir" value="com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>
@@ -293,7 +283,6 @@
 		<source path="src/java.base/share/classes"/>
 		<source path="src/openj9.traceformat/share/classes"/>
 		<source path="src/openj9.zosconditionhandling/share/classes"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
 		<parameter name="msg:outputdir" value="com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>
@@ -309,7 +298,6 @@
 		<source path="src/openj9.dtfj/share/classes"/>
 		<source path="src/openj9.dtfjview/share/classes"/>
 		<source path="src/openj9.traceformat/share/classes"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
 		<parameter name="msg:outputdir" value=""/>
 	</configuration>
 

--- a/jcl/src/openj9.cuda/share/classes/com/ibm/cuda/Cuda.java
+++ b/jcl/src/openj9.cuda/share/classes/com/ibm/cuda/Cuda.java
@@ -98,10 +98,7 @@ public final class Cuda {
 
 	static {
 		AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-			/*[USEMACROS]*/
-			String version = System.getProperty("com.ibm.oti.vm.library.version", "%%MACRO@com.ibm.oti.vm.library.version%%"); //$NON-NLS-1$ //$NON-NLS-2$
-
-			System.loadLibrary("cuda4j".concat(version)); //$NON-NLS-1$
+			System.loadLibrary("cuda4j29"); //$NON-NLS-1$
 			return null;
 		});
 


### PR DESCRIPTION
* don't use preprocessor macro or system property in `Cuda.java`
  - upcoming changes to the extension repos will remove unnecessary read permission for the system property
* stop defining preprocessor macro `com.ibm.oti.vm.library.version` - it's no longer used in any JCL code