### PR TITLE
Move bootjdks to F drive for disk space

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -477,6 +477,8 @@ aarch64_linux_xl_uma:
 x86-64_windows:
   extends: ['boot_jdk_default', 'cuda', 'debuginfo', 'openjdk_reference_repo', 'openssl_bundle']
   boot_jdk:
+    location:
+      all: '/cygdrive/f/Users/jenkins/bootjdks'
     arch: 'x64'
     os: 'windows'
   release:
@@ -529,6 +531,8 @@ x86-64_windows_xl_uma:
 x86-32_windows:
   extends: ['boot_jdk_default', 'debuginfo', 'openjdk_reference_repo', 'openssl_bundle']
   boot_jdk:
+    location:
+      all: '/cygdrive/f/Users/jenkins/bootjdks'
     arch: 'x64'
     os: 'windows'
   release:


### PR DESCRIPTION
The C drive is running low. Moving the bootjdks
to the F drive where we have plenty of free space

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>