### PR TITLE
Use TR_UNIMPLEMENTED macro in JIT

### DIFF
--- a/runtime/compiler/runtime/JITServerIProfiler.cpp
+++ b/runtime/compiler/runtime/JITServerIProfiler.cpp
@@ -163,7 +163,7 @@ JITServerIProfiler::profilingSample(uintptr_t pc, uintptr_t data, bool addIt, bo
    if (addIt)
       return NULL; // Server should not create any samples
 
-   TR_ASSERT(false, "not implemented for JITServer");
+   TR_ASSERT_FATAL(false, "profilingSample(pc...) should not be called on JITServer");
    return NULL;
    }
 

--- a/runtime/compiler/z/codegen/S390CHelperLinkage.hpp
+++ b/runtime/compiler/z/codegen/S390CHelperLinkage.hpp
@@ -50,8 +50,8 @@ public:
 
    CHelperLinkage(TR::CodeGenerator * cg, TR_S390LinkageConventions elc=TR_JavaHelper, TR_LinkageConventions lc=TR_CHelper);
 
-   virtual void createPrologue(TR::Instruction * cursor) { TR_ASSERT(false, "Not Implemented"); }
-   virtual void createEpilogue(TR::Instruction * cursor) { TR_ASSERT(false, "Not Implemented"); }
+   virtual void createPrologue(TR::Instruction * cursor) { TR_UNIMPLEMENTED(); }
+   virtual void createEpilogue(TR::Instruction * cursor) { TR_UNIMPLEMENTED(); }
 
    virtual void setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol * method)
       {
@@ -63,10 +63,10 @@ public:
       TR_ASSERT_FATAL(false, "CHelperLinkage should only be used for call-outs");
       }
 
-   virtual void mapStack(TR::ResolvedMethodSymbol *symbol) { TR_ASSERT(false, "Not Implemented"); }
-   virtual void mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex) { TR_ASSERT(false, "Not Implemented"); }
-   virtual bool hasToBeOnStack(TR::ParameterSymbol * parm) { TR_ASSERT(false, "Not Implemented"); return false; }
-   virtual void initS390RealRegisterLinkage() { TR_ASSERT(false, "Not Implemented"); }
+   virtual void mapStack(TR::ResolvedMethodSymbol *symbol) { TR_UNIMPLEMENTED(); }
+   virtual void mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex) { TR_UNIMPLEMENTED(); }
+   virtual bool hasToBeOnStack(TR::ParameterSymbol * parm) { TR_UNIMPLEMENTED(); return false; }
+   virtual void initS390RealRegisterLinkage() { TR_UNIMPLEMENTED(); }
    virtual TR::RealRegister::RegNum setMethodMetaDataRegister(TR::RealRegister::RegNum r) { return _methodMetaDataRegister = r; }
    virtual TR::RealRegister::RegNum getMethodMetaDataRegister() { return _methodMetaDataRegister; }
    virtual TR::RealRegister::RegNum setReturnAddressRegister(TR::RealRegister::RegNum r) { return _returnAddressRegister = r; }


### PR DESCRIPTION
This patch replaces TR_ASSERT(false, "Not implemented yet") with TR_UNIMPLEMENTED()

Fixes #4888

Signed-off-by: Alexey Anufriev <contact@alexey-anufriev.com>