### PR TITLE
(0.23.0) AArch64: Add missing memory barriers

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -423,6 +423,10 @@ J9::ARM64::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg
       generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, 0xE);
 
    generateMemSrc1Instruction(cg, TR::InstOpCode::strimmx, node, tempMR, sourceRegister, NULL);
+
+   if (needSync)
+      generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, 0xF);
+
    wrtbarEvaluator(node, sourceRegister, destinationRegister, firstChild->isNonNull(), true, cg);
 
    if (killSource)
@@ -521,6 +525,9 @@ J9::ARM64::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::CodeGenerator *c
       generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, 0xE);
 
    generateMemSrc1Instruction(cg, storeOp, node, tempMR, translatedSrcReg);
+
+   if (needSync)
+      generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, 0xF);
 
    wrtbarEvaluator(node, sourceRegister, destinationRegister, secondChild->isNonNull(), true, cg);
 


### PR DESCRIPTION
A read-write barrier is required after volatile store.
This commit adds a read-writer barrier to `J9::ARM64::TreeEvaluator::awrtbarEvaluator`
and `J9::ARM64::TreeEvaluator::awrtbariEvaluator`.

master PR: https://github.com/eclipse/openj9/pull/10897

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>