### PR TITLE
AArch64: Fix constJNIReferenceFrameAllocatedFlags test in JNILinkage

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64JNILinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64JNILinkage.cpp
@@ -286,7 +286,9 @@ void J9::ARM64::JNILinkage::restoreJNICallOutFrame(TR::Node *callNode, bool tear
       TR::Snippet *snippet = new (trHeapMemory()) TR::ARM64HelperCallSnippet(cg(), callNode, refPoolSnippetLabel, collapseSymRef, refPoolRestartLabel);
       cg()->addSnippet(snippet);
       generateTrg1MemInstruction(cg(), TR::InstOpCode::ldrimmx, callNode, scratchReg, new (trHeapMemory()) TR::MemoryReference(javaStackReg, fej9->constJNICallOutFrameFlagsOffset(), cg()));
-      generateTestImmInstruction(cg(), callNode, scratchReg, fej9->constJNIReferenceFrameAllocatedFlags(), true);
+
+      TR_ASSERT_FATAL(fej9->constJNIReferenceFrameAllocatedFlags() == 0x30000, "constJNIReferenceFrameAllocatedFlags must be 0x30000");
+      generateTestImmInstruction(cg(), callNode, scratchReg, 0x401, false); // 0x401 is immr:imms for 0x30000
       generateConditionalBranchInstruction(cg(), TR::InstOpCode::b_cond, callNode, refPoolSnippetLabel, TR::CC_NE);
       generateLabelInstruction(cg(), TR::InstOpCode::label, callNode, refPoolRestartLabel);
       }


### PR DESCRIPTION
This commit fixed immediate value of `tst` instruction used in JNILinkage.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>