### PR TITLE
port defaultLazySymbolResolution, forceLazySymbolResolution into openj9

### DIFF
--- a/test/functional/cmdLineTests/defaultLazySymbolResolution/build.xml
+++ b/test/functional/cmdLineTests/defaultLazySymbolResolution/build.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="cmdLineTests" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests defaultLazySymbolResolution
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/defaultLazySymbolResolution" />
+	<property name="src" location="." />
+
+	<target name="buildvm" description="build VM_Test.jar">
+		<subant target="build">
+			<property name="DEST" value="${DEST}"/>
+			<fileset dir="../../VM_Test/" includes="build.xml" />
+		</subant>
+		<delete>
+			<fileset dir="${DEST}">
+				<exclude name="VM_Test.jar"/>
+			</fileset>
+		</delete>
+	</target>
+
+	<target name="dist" depends="buildvm" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml,*.mk"/>
+		</copy>
+	</target>
+
+	<target name="build" >
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/defaultLazySymbolResolution/defaultLazySymbolResolution.xml
+++ b/test/functional/cmdLineTests/defaultLazySymbolResolution/defaultLazySymbolResolution.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 VMARGS Lazy Link Option Tests" timeout="60">
+	<!-- This test passes when a user library loads in spite of an unresolved symbol. 
+	     Used to test the default behaviour of native user library symbol resolution on linux except realtime version. -->
+	<test id="defaultLazySymbolResolution">
+		<command>$EXE$ -Xtrace:print=j9vm.229-232 -Xtrace:print=j9prt.241-245 -Xtrace:print=j9prt.926 -classpath $Q$$J9JAR$$Q$ j9vm.test.jni.LazyLinkTest</command>
+		<output regex="yes" type="success">.*Result: loaded.*</output>
+		<output regex="yes" type="failure">.*Not found in java\.library\.path.*</output>
+ 	</test>
+</suite>

--- a/test/functional/cmdLineTests/defaultLazySymbolResolution/playlist.xml
+++ b/test/functional/cmdLineTests/defaultLazySymbolResolution/playlist.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+  	<test>
+		<testCaseName>cmdLineTester_defaultLazySymbolResolution</testCaseName>
+		<variations>
+			<variation>Mode101</variation>
+			<variation>Mode601</variation>
+		</variations>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DJ9JAR=$(Q)$(TEST_RESROOT)$(D)VM_Test.jar$(Q) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)defaultLazySymbolResolution.xml$(Q) \
+	-xids all,$(PLATFORM) -explainExcludes -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<platformRequirements>os.linux</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<types>
+			<type>native</type>
+		</types>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+</playlist>

--- a/test/functional/cmdLineTests/forceLazySymbolResolution/build.xml
+++ b/test/functional/cmdLineTests/forceLazySymbolResolution/build.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="cmdLineTests" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests forceLazySymbolResolution
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/forceLazySymbolResolution" />
+	<property name="src" location="." />
+
+	<target name="buildvm" description="build VM_Test.jar">
+		<subant target="build">
+			<property name="DEST" value="${DEST}"/>
+			<fileset dir="../../VM_Test/" includes="build.xml" />
+		</subant>
+		<delete>
+			<fileset dir="${DEST}">
+				<exclude name="VM_Test.jar"/>
+			</fileset>
+		</delete>
+	</target>
+
+	<target name="dist" depends="buildvm" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml,*.mk"/>
+		</copy>
+	</target>
+
+	<target name="build" >
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/forceLazySymbolResolution/forceLazySymbolResolution.xml
+++ b/test/functional/cmdLineTests/forceLazySymbolResolution/forceLazySymbolResolution.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 VMARGS Lazy Link Option Tests" timeout="60">
+	<test id="forceLazySymbolResolution_loaded">
+		<!-- This test passes when a user library loads in spite of an unresolved symbol. 
+			 Used to test the -XX:+LazySymbolResolution on linux. -->
+		<command>$EXE$ -Xtrace:print=j9vm.229-232 -Xtrace:print=j9prt.241-245 -Xtrace:print=j9prt.926 -XX:+LazySymbolResolution -classpath $Q$$J9JAR$$Q$ j9vm.test.jni.LazyLinkTest</command>
+		<output regex="yes" type="success">.*Result: loaded.*</output>
+		<output regex="yes" type="failure">.*Not found in java\.library\.path.*</output>
+ 	</test>
+	<test id="forceLazySymbolResolution_unresolved">
+		<!-- This test passes when a user library fails to load due to an unresolved symbol. 
+			 Used to test the -XX:-LazySymbolResolution on linux. -->
+		<command>$EXE$ -Xtrace:print=j9vm.229-232 -Xtrace:print=j9prt.241-245 -Xtrace:print=j9prt.926 -XX:-LazySymbolResolution -classpath $Q$$J9JAR$$Q$ j9vm.test.jni.LazyLinkTest</command>
+		<output regex="yes" type="success">.*Result: unresolved.*</output>
+		<output regex="yes" type="failure">.*Not found in java\.library\.path.*</output>
+ 	</test>
+</suite>

--- a/test/functional/cmdLineTests/forceLazySymbolResolution/playlist.xml
+++ b/test/functional/cmdLineTests/forceLazySymbolResolution/playlist.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+	<test>
+		<testCaseName>cmdLineTester_forceLazySymbolResolution</testCaseName>
+		<variations>
+			<variation>Mode101</variation>
+			<variation>Mode601</variation>
+		</variations>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DJ9JAR=$(Q)$(TEST_RESROOT)$(D)VM_Test.jar$(Q) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)forceLazySymbolResolution.xml$(Q) \
+	-xids all,$(PLATFORM) -explainExcludes -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<platformRequirements>os.linux</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<types>
+			<type>native</type>
+		</types>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>			
+		</impls>
+	</test>
+</playlist>


### PR DESCRIPTION
related: backlog/issue 391


Signed-off-by: OscarQQ <Yixin.Qian@ibm.com>