### PR TITLE
Array JIT Helper NULL check fix

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -1002,7 +1002,7 @@ old_fast_jitStoreFlattenableArrayElement(J9VMThread *currentThread)
 		goto slow;
 	}
 	arrayrefClass = (J9ArrayClass *) J9OBJECT_CLAZZ(currentThread, arrayref);
-	if (NULL == value) {
+	if ((J9_IS_J9CLASS_VALUETYPE(arrayrefClass->componentType)) && (NULL == value)) {
 		goto slow;
 	}
 	currentThread->javaVM->internalVMFunctions->storeFlattenableArrayElement(currentThread, arrayref, index, value);


### PR DESCRIPTION
Replaced existing NULL check with one that first checks if the
value is a Valuetype then perform a NULL check. This is because
you can not write NULL to value types.

Signed-off-by: Oussama Saoudi <oussama.saoudi@ibm.com>