### PR TITLE
Cull stack depth in dumpAllThreads later on

### DIFF
--- a/runtime/jcl/common/mgmtthread.c
+++ b/runtime/jcl/common/mgmtthread.c
@@ -703,7 +703,7 @@ Java_openj9_internal_tools_attach_target_DiagnosticUtils_dumpAllThreadsImpl(JNIE
 				{
 					++numThreads;
 					exc = getThreadInfo(currentThread, vmThread, info,
-							maxDepth, getLockedMonitors);
+							(jsize)J9_THREADINFO_MAX_STACK_DEPTH, getLockedMonitors);
 					if (exc > 0) {
 						freeThreadInfos(currentThread, allinfo, numThreads);
 						goto dumpAll_failWithExclusive;
@@ -748,7 +748,7 @@ Java_openj9_internal_tools_attach_target_DiagnosticUtils_dumpAllThreadsImpl(JNIE
 	}
 	vmfns->internalExitVMToJNI(currentThread);
 
-	result = createThreadInfoArray(env, allinfo, numThreads, (jsize)J9_THREADINFO_MAX_STACK_DEPTH);
+	result = createThreadInfoArray(env, allinfo, numThreads, maxDepth);
 	j9mem_free_memory(allinfo);
 	
 	Trc_JCL_threadmxbean_dumpAllThreads_Exit(env, result);

--- a/test/functional/Java10andUp/src/org/openj9/test/java/lang/management/ThreadMXBean/APITestJava10.java
+++ b/test/functional/Java10andUp/src/org/openj9/test/java/lang/management/ThreadMXBean/APITestJava10.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -205,6 +205,22 @@ public class APITestJava10 extends ThreadMXBeanTestCase {
 		final int REQUESTED_DEPTH = 5;
 		Thread t = new LambdaTestThread(REQUESTED_DEPTH - 2); // Subtract 1 for the run() method and 1 for the lambda.
 		checkThreadInfo(REQUESTED_DEPTH, t);
+	}
+
+	/* ThreadInfo objects contain MonitorInfo objects which carry stack depth info that can be higher than
+	 * max depth passed to dumpAllThreads. dumpAllThreads should still produce the ThreadInfo objects.
+	 * See https://github.com/eclipse/openj9/issues/10796
+	 */
+	@Test(groups = { "level.extended" })
+	public void testDumpWithMonitorDepthHigherThanLimit() {
+		try {
+			ThreadInfo[] threads = myBean.dumpAllThreads(true, true, 1);
+			for (ThreadInfo thInfo : threads) {
+				Assert.assertTrue(thInfo.getStackTrace().length <= 1, "Stack depth should be truncated to 1");
+			}
+		} catch (ArrayIndexOutOfBoundsException e) {
+			Assert.fail("Failed to dump threads", e);
+		}
 	}
 
 	private void checkThreadInfo(int requestedDepth, Thread t) {


### PR DESCRIPTION
We need the full stacktrace from getThreadInfo function since later in the
createThreadInfoArray, we copy over MonitorInfo objects which may refer to
stack frames beyond the max depth argument passed into dumpAllThreads.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Fixes https://github.com/eclipse/openj9/issues/10796