### PR TITLE
Fixes and changes to resolution sequence for unresolved field and virtual calls on Z

### DIFF
--- a/runtime/compiler/z/codegen/J9MemoryReference.cpp
+++ b/runtime/compiler/z/codegen/J9MemoryReference.cpp
@@ -24,6 +24,8 @@
 #pragma csect(STATIC,"TRJ9MRBase#S")
 #pragma csect(TEST,"TRJ9MRBase#T")
 
+#include "codegen/CCData.hpp"
+#include "codegen/CCData_inlines.hpp"
 #include "codegen/MemoryReference.hpp"
 #include "codegen/InstOpCode.hpp"
 #include "codegen/Machine.hpp"
@@ -86,6 +88,8 @@
 #include "infra/Flags.hpp"
 #include "infra/List.hpp"
 #include "ras/Debug.hpp"
+#include "runtime/CodeCache.hpp"
+#include "runtime/CodeCacheManager.hpp"
 #include "z/codegen/EndianConversion.hpp"
 #include "z/codegen/S390Evaluator.hpp"
 #include "z/codegen/S390GenerateInstructions.hpp"
@@ -393,14 +397,15 @@ J9::Z::MemoryReference::create(TR::CodeGenerator* cg, TR::Node* node)
 
       typedef J9::Z::UnresolvedDataReadOnlySnippet::CCUnresolvedData CCUnresolvedData;
 
-      CCUnresolvedData* ccUnresolvedDataAddress =
-         reinterpret_cast<J9::Z::UnresolvedDataReadOnlySnippet::CCUnresolvedData*>(cg->allocateCodeMemory(sizeof(CCUnresolvedData), false));
-
-      if (ccUnresolvedDataAddress == NULL)
+      OMR::CCData *codeCacheData = cg->getCodeCache()->manager()->getCodeCacheData();
+      OMR::CCData::index_t index;
+      if (!(codeCacheData->put(NULL, sizeof(CCUnresolvedData), alignof(CCUnresolvedData), NULL, index)))
          {
          comp->failCompilation<TR::CompilationException>("Could not allocate unresolved data metadata");
          }
       
+      CCUnresolvedData* ccUnresolvedDataAddress = codeCacheData->get<CCUnresolvedData>(index);
+
       TR::SymbolReference *symRef = node->getSymbolReference();
 
       ccUnresolvedDataAddress->indexOrAddress = 0;

--- a/runtime/compiler/z/codegen/J9UnresolvedDataReadOnlySnippet.cpp
+++ b/runtime/compiler/z/codegen/J9UnresolvedDataReadOnlySnippet.cpp
@@ -105,8 +105,9 @@ J9::Z::UnresolvedDataReadOnlySnippet::emitSnippetBody()
 
    // Relative address to the start of the mainline resolution
    intptr_t startResolutionSeqLabelAddr = reinterpret_cast<intptr_t>(startResolveSequenceLabel->getCodeLocation());
-   TR_ASSERT_FATAL(cg()->canUseRelativeLongInstructions(startResolutionSeqLabelAddr), "startResolveSequenceLabel [%p] is outside relative immediate range", startResolutionSeqLabelAddr);*reinterpret_cast<int32_t*>(cursor) = static_cast<int32_t>(startOfResolutionSeqLabelAddr - (intptr_t)helperCallRA);
+   TR_ASSERT_FATAL(cg()->canUseRelativeLongInstructions(startResolutionSeqLabelAddr), "startResolveSequenceLabel [%p] is outside relative immediate range", startResolutionSeqLabelAddr);
    *reinterpret_cast<int32_t*>(cursor) = static_cast<int32_t>(startResolutionSeqLabelAddr - (intptr_t)helperCallRA);
+   cursor += 4;
 
    // Relative address to the next instruction after the snippet call.
    intptr_t snippetCallNextInstrLabelAddress = reinterpret_cast<intptr_t>(snippetCallNextInstrLabel->getCodeLocation());

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -1583,12 +1583,14 @@ J9::Z::PrivateLinkage::buildNoPatchingVirtualDispatchWithResolve(TR::Node *callN
       int32_t vtableOffset;
       };
    
-   ccResolveVirtualData *ccResolveVirtualDataAddress = reinterpret_cast<ccResolveVirtualData *>(cg()->allocateCodeMemory(sizeof(ccResolveVirtualData), false));
-
-   if (!ccResolveVirtualDataAddress)
+   OMR::CCData *codeCacheData = cg()->getCodeCache()->manager()->getCodeCacheData();
+   OMR::CCData::index_t index;
+   if (!(codeCacheData->put(NULL, sizeof(ccResolveVirtualData), 8, NULL, index)))
       {
       comp()->failCompilation<TR::CompilationException>("Could not allocate resovle virtual dispatch metadata");
       }
+ 
+   ccResolveVirtualData *ccResolveVirtualDataAddress = codeCacheData->get<ccResolveVirtualData>(index);
 
    ccResolveVirtualDataAddress->cpAddress = reinterpret_cast<intptr_t> (callNode->getSymbolReference()->getOwningMethod(comp())->constantPool());
    ccResolveVirtualDataAddress->cpIndex = (intptr_t) (callNode->getSymbolReference()->getCPIndexForVM());

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -1585,9 +1585,9 @@ J9::Z::PrivateLinkage::buildNoPatchingVirtualDispatchWithResolve(TR::Node *callN
    
    OMR::CCData *codeCacheData = cg()->getCodeCache()->manager()->getCodeCacheData();
    OMR::CCData::index_t index;
-   if (!(codeCacheData->put(NULL, sizeof(ccResolveVirtualData), 8, NULL, index)))
+   if (!(codeCacheData->put(NULL, sizeof(ccResolveVirtualData), alignof(ccResolveVirtualData), NULL, index)))
       {
-      comp()->failCompilation<TR::CompilationException>("Could not allocate resovle virtual dispatch metadata");
+      comp()->failCompilation<TR::CompilationException>("Could not allocate resolve virtual dispatch metadata");
       }
  
    ccResolveVirtualData *ccResolveVirtualDataAddress = codeCacheData->get<ccResolveVirtualData>(index);


### PR DESCRIPTION
While addressing the suggestions on fixing the GC map issue on Z in https://github.com/eclipse/openj9/pull/10599, compilation failure while building JDK on Z was introduced. Changes in this PR fixes that in addition switching to OMR::CCData API to allocate the codecache data for this resolution sequence.

Signed-off-by: Rahil Shah rahil@ca.ibm.com