### PR TITLE
Disable invokevarhandle bytecode for OpenJDK VarHandles

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -8449,6 +8449,7 @@ foundITable:
 	VMINLINE VM_BytecodeAction
 	invokevarhandle(REGISTER_ARGS_LIST)
 	{
+#if defined(J9VM_OPT_METHOD_HANDLE)
 		VM_BytecodeAction rc = GOTO_RUN_METHODHANDLE;
 
 		/* Determine stack shape */
@@ -8524,6 +8525,11 @@ foundITable:
 		}
 done:
 		return rc;
+#else /* defined(J9VM_OPT_METHOD_HANDLE) */
+	/* invokevarhandle is not used for OpenJDK VarHandles (J9VM_OPT_OPENJDK_METHODHANDLE). */
+	Assert_VM_unreachable();
+	return EXECUTE_BYTECODE;
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 	}
 
 	VMINLINE VM_BytecodeAction


### PR DESCRIPTION
For OpenJDK VarHandles, the invokevirtual calls to the VarHandle
polymorphic methods are rewritten to the invokehandle bytecode in
ClassFileOracle (https://github.com/eclipse/openj9/pull/10557). The invokevarhandle bytecode is not used
with OpenJDK VarHandles. So, it is disabled for OpenJDK VarHandles
(J9VM_OPT_OPENJDK_METHODHANDLE).

Related: #7352

Co-authored-by: Jack Lu <Jack.S.Lu@ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>