### PR TITLE
JDK16 requires JVM_IsCDSDumpingEnabled

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -357,6 +357,7 @@ if(NOT JAVA_SPEC_VERSION LESS 15)
 		# Additions for Java 15 (General)
 		JVM_RegisterLambdaProxyClassForArchiving
 		JVM_LookupLambdaProxyClassFromArchive
+		JVM_IsCDSDumpingEnabled
 	)
 endif()
 
@@ -364,7 +365,6 @@ if(JAVA_SPEC_VERSION EQUAL 15)
 	jvm_add_exports(jvm
 		# Java 15 only
 		JVM_GetRandomSeedForCDSDump
-		JVM_IsCDSDumpingEnabled
 		JVM_IsCDSSharingEnabled
 	)
 elseif(NOT JAVA_SPEC_VERSION LESS 16)

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -349,12 +349,12 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<!-- Additions for Java 15 (General) -->
 		<export name="JVM_RegisterLambdaProxyClassForArchiving"/>
 		<export name="JVM_LookupLambdaProxyClassFromArchive"/>
+		<export name="JVM_IsCDSDumpingEnabled"/>
 	</exports>
 
 	<exports group="jdk15only">
 		<!-- Additions for Java 15 only -->
 		<export name="JVM_GetRandomSeedForCDSDump"/>
-		<export name="JVM_IsCDSDumpingEnabled"/>
 		<export name="JVM_IsCDSSharingEnabled"/>
 	</exports>
 

--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -1758,6 +1758,13 @@ JVM_LookupLambdaProxyClassFromArchive(JNIEnv *env, jclass arg1, jstring arg2, jo
 	assert(!"JVM_LookupLambdaProxyClassFromArchive unimplemented");
 	return NULL;
 }
+
+JNIEXPORT jboolean JNICALL
+JVM_IsCDSDumpingEnabled(JNIEnv *env)
+{
+	/* OpenJ9 does not support -Xshare:dump, so we return false unconditionally. */
+	return JNI_FALSE;
+}
 #endif /* JAVA_SPEC_VERSION >= 15 */
 
 #if JAVA_SPEC_VERSION == 15
@@ -1766,13 +1773,6 @@ JVM_GetRandomSeedForCDSDump()
 {
 	/* OpenJ9 does not support -Xshare:dump, so we return zero unconditionally. */
 	return 0;
-}
-
-JNIEXPORT jboolean JNICALL
-JVM_IsCDSDumpingEnabled(JNIEnv *env)
-{
-	/* OpenJ9 does not support -Xshare:dump, so we return false unconditionally. */
-	return JNI_FALSE;
 }
 
 JNIEXPORT jboolean JNICALL

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -333,7 +333,7 @@ _IF([JAVA_SPEC_VERSION >= 15],
 	[_X(JVM_RegisterLambdaProxyClassForArchiving, JNICALL, false, void, JNIEnv *env, jclass arg1, jstring arg2, jobject arg3, jobject arg4, jobject arg5, jobject arg6, jclass arg7)])
 _IF([JAVA_SPEC_VERSION >= 15],
 	[_X(JVM_LookupLambdaProxyClassFromArchive, JNICALL, false, jclass, JNIEnv *env, jclass arg1, jstring arg2, jobject arg3, jobject arg4, jobject arg5, jobject arg6, jboolean arg7)])
-_IF([JAVA_SPEC_VERSION == 15],
+_IF([JAVA_SPEC_VERSION >= 15],
 	[_X(JVM_IsCDSDumpingEnabled, JNICALL, false, jboolean, JNIEnv *env)])
 _IF([JAVA_SPEC_VERSION >= 16],
 	[_X(JVM_IsDynamicDumpingEnabled, JNICALL, false, jboolean, JNIEnv *env)])


### PR DESCRIPTION
Enabled `JVM_IsCDSDumpingEnabled` for `JDK15+` from previously `JDK15` only.

Note: this fixes following error:
```
01:08:38  /home/jenkins/workspace/Build_JDKnext_x86-64_linux_Personal/build/linux-x86_64-server-release/support/native/java.base/libjava/CDS.o: In function `Java_jdk_internal_misc_CDS_isDumpingArchive0':
01:08:38  /home/jenkins/workspace/Build_JDKnext_x86-64_linux_Personal/./src/java.base/share/native/libjava/CDS.c:49: undefined reference to `JVM_IsCDSDumpingEnabled'
01:08:38  collect2: error: ld returned 1 exit status
```
`JDK16` with this PR builds and `java -version` output:
```
openjdk version "16-internal" 2021-03-16
OpenJDK Runtime Environment (build 16-internal+0-adhoc.fengjcaibmcom.openj9-openjdk-jdk)
Eclipse OpenJ9 VM (build jdk16jvmiscdsde-e9d73ae0f6, JRE 16 Mac OS X amd64-64-Bit Compressed References 20201020_000000 (JIT enabled, AOT enabled)
OpenJ9   - e9d73ae0f6
OMR      - b7e8a5d78
JCL      - bf162e351b0 based on jdk-16+20)
```

Issue https://github.com/eclipse/openj9/issues/10935

Signed-off-by: Jason Feng <fengj@ca.ibm.com>