### PR TITLE
Fix incorrect helper trampolines when disableTOC is set

### DIFF
--- a/runtime/compiler/runtime/Trampoline.cpp
+++ b/runtime/compiler/runtime/Trampoline.cpp
@@ -87,8 +87,8 @@ void ppcCreateHelperTrampolines(uint8_t *trampPtr, int32_t numHelpers)
             *(int32_t *)buffer = 0x3d600000 | ((helper>>48) & 0x0000ffff);
             buffer += 4;
 
-            // oris gr11, gr11, bits 16--31
-            *(int32_t *)buffer = 0x656b0000 | ((helper>>32) & 0x0000ffff);
+            // ori gr11, gr11, bits 16--31
+            *(int32_t *)buffer = 0x616b0000 | ((helper>>32) & 0x0000ffff);
             buffer += 4;
 
             // rldicr gr11, gr11, 32, 31


### PR DESCRIPTION
During a previous rework of how trampolines are generated, support was
added for helper trampolines to be generated when the pTOC is explicitly
disabled. However, this implementation accidentally used an oris
instruction where it should have used an ori instruction, which results
in the branch going to the wrong address. This bug has been fixed.

Fixes: #10939
Signed-off-by: Ben Thomas <ben@benthomas.ca>