### PR TITLE
Fix the Chinese modules path issue in JVM initialization

### DIFF
--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -822,3 +822,5 @@ TraceEvent=Trc_VM_ConvertToJavaFullyQualifiedName_Get_ClassName Overhead=1 Level
 TraceEvent=Trc_VM_ConvertMethodSignature_Malformed_Signature Overhead=1 Level=1 Template="ConvertMethodSignature - malformed signature %.*s at index i = %d"
 TraceEvent=Trc_VM_ConvertMethodSignature_Signature_BufferSize Overhead=1 Level=4 Template="ConvertMethodSignature - signature %.*s has bufferSize %d"
 TraceEvent=Trc_VM_ConvertMethodSignature_Signature_Result Overhead=1 Level=4 Template="ConvertMethodSignature - result (%s) with resultLength %llu"
+
+TraceEvent=Trc_VM_initializeModulesPathEntry_loadJImageFailed NoEnv Overhead=1 Level=1 Template="initializeModulesPathEntry - attempt to load %.*s as jimage file failed with error=%d"


### PR DESCRIPTION
The change is to convert the module path from UTF8 to
the platform encode setting on Windows to ensure it works
correctly to open the jimage file.

Fixes: #10312

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>