### PR TITLE
WIP: Enable cfg simplifier

### DIFF
--- a/runtime/compiler/optimizer/J9CFGSimplifier.cpp
+++ b/runtime/compiler/optimizer/J9CFGSimplifier.cpp
@@ -34,10 +34,6 @@
 
 bool J9::CFGSimplifier::simplifyIfPatterns(bool needToDuplicateTree)
    {
-   static char *enableCFGSimplification = feGetEnv("TR_enableCFGSimplificaiton");
-   if (enableCFGSimplification == NULL)
-      return false;
-
    return OMR::CFGSimplifier::simplifyIfPatterns(needToDuplicateTree)
           || simplifyResolvedRequireNonNull(needToDuplicateTree)
           || simplifyUnresolvedRequireNonNull(needToDuplicateTree)


### PR DESCRIPTION
Work has been done to fix bugs in the CFG simplification optimization and
disable parts of this simplification which are believed to have remaining bugs.

See: #8397, #9754, https://github.com/eclipse/omr/pull/5605

Signed-off-by: Ryan Shukla <ryans@ibm.com>