### PR TITLE
AArch64: Correct compare instruction used in instanceof

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -780,7 +780,7 @@ void genInstanceOfOrCheckCastSuperClassTest(TR::Node *node, TR::Register *instan
       generateLogicalShiftLeftImmInstruction(cg, node, castClassDepthReg, castClassDepthReg, 3, false);
       generateTrg1MemInstruction(cg, TR::InstOpCode::ldroffx, node, instanceClassSuperClassReg, new (cg->trHeapMemory()) TR::MemoryReference(instanceClassSuperClassesArrayReg, castClassDepthReg, cg));
       }
-   generateCompareInstruction(cg, node, instanceClassSuperClassReg, castClassReg);
+   generateCompareInstruction(cg, node, instanceClassSuperClassReg, castClassReg, true);
 
    if (castClassDepthReg)
       srm->reclaimScratchRegister(castClassDepthReg);


### PR DESCRIPTION
Change compare instruction used in super class test to 64bit instruction
as the values tested are 64bit pointer.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>