### PR TITLE
Compile twice for DDR on z/OS so optimization is not hindered

### DIFF
--- a/runtime/makelib/targets.mk.zos.inc.ftl
+++ b/runtime/makelib/targets.mk.zos.inc.ftl
@@ -52,11 +52,6 @@ $(UMA_EXETARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 
 </#assign>
 
-<#if uma.spec.flags.opt_useOmrDdr.enabled>
-  CFLAGS   += -Wc,debug
-  CXXFLAGS += -Wc,debug
-</#if>
-
 ifndef UMA_DO_NOT_OPTIMIZE_CCODE
   ifeq ($(VERSION_MAJOR),8)
     UMA_OPTIMIZATION_FLAGS = -O3 -Wc,"ARCH(7)" -Wc,"TUNE(10)"

--- a/runtime/thread/threadshared.mk.ftl
+++ b/runtime/thread/threadshared.mk.ftl
@@ -1,6 +1,5 @@
 # This makefile is generated using an UMA template.
 
-#
 # Copyright (c) 2015, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
@@ -20,7 +19,6 @@
 # [2] http://openjdk.java.net/legal/assembly-exception.html
 #
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
-#
 
 # UMA_PATH_TO_ROOT can be overridden by a command-line argument to 'make'.
 UMA_PATH_TO_ROOT ?= ../
@@ -37,11 +35,6 @@ THREAD_SRCDIR := $(top_srcdir)/thread/
 MODULE_NAME_NOSTREAM := j9thr
 MODULE_NAME := $(MODULE_NAME_NOSTREAM)${uma.buildinfo.version.major}${uma.buildinfo.version.minor}
 ARTIFACT_TYPE := c_shared
-
-<#if uma.spec.flags.opt_useOmrDdr.enabled && uma.spec.type.zos>
-CFLAGS   += -Wc,debug
-CXXFLAGS += -Wc,debug
-</#if>
 
 include $(THREAD_SRCDIR)thread_include.mk
 


### PR DESCRIPTION
Performance is seriously degraded on z/OS when files are compiled with `-Wc,debug` (for example, GC times are increased by a factor of over 2.5). On the other hand, `-Wc,debug` is required to produce the debug information required by DDR.

The solution is to compile files twice on z/OS when DDR is enabled. The first compile uses `-Wc,debug` to produce the `*.dbg` file required for DDR, a second compile omits `-Wc,debug` to avoid limiting the optimizer.

See also: eclipse/omr#5626.