### PR TITLE
Eliminate verbose log message related to existance of AOT class chains

### DIFF
--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -1368,11 +1368,7 @@ TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, bool create)
       OMR::CriticalSection classChainDataMapMonitor(clientData->getClassChainDataMapMonitor());
       auto it = cache.find(clazz);
       if (it != cache.end())
-         {
-         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Chain exists (%p) so nothing to store \n", it->second);
          return it->second;
-         }
       }
    _stream->write(JITServer::MessageType::SharedCache_rememberClass, clazz, create);
    UDATA * chainData = std::get<0>(_stream->read<UDATA *>());


### PR DESCRIPTION
Eliminated AOT class chains messages under ```TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, bool create)```
issue: #10422

Signed-off-by: Eman Elsabban <eman.elsaban1@gmail.com>