### PR TITLE
Disable initializeMethodRunAddressVarHandle for OpenJDK MethodHandles

### DIFF
--- a/runtime/vm/initsendtarget.cpp
+++ b/runtime/vm/initsendtarget.cpp
@@ -83,6 +83,7 @@ initializeMethodRunAddressMethodHandle(J9Method *method)
 }
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 static VMINLINE bool
 initializeMethodRunAddressVarHandle(J9Method *method)
 {
@@ -202,6 +203,7 @@ initializeMethodRunAddressVarHandle(J9Method *method)
 
 	return NULL != encodedAccessMode;
 }
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 void
 initializeMethodRunAddress(J9VMThread *vmThread, J9Method *method)
@@ -216,9 +218,11 @@ initializeMethodRunAddress(J9VMThread *vmThread, J9Method *method)
 	}
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 	if (initializeMethodRunAddressVarHandle(method)) {
 		return;
 	}
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 	if (J9_EVENT_IS_HOOKED(vm->hookInterface, J9HOOK_VM_INITIALIZE_SEND_TARGET)) {
 		method->methodRunAddress = NULL;


### PR DESCRIPTION
For OpenJDK `VarHandles`, the `invokevirtual` calls to the `VarHandle`
polymorphic methods are rewritten to the `invokehandle` bytecode in
`ClassFileOracle` (https://github.com/eclipse/openj9/pull/10557). The `invokevarhandle` INL is not used with
OpenJDK `VarHandles`. For OpenJDK `VarHandles`, the `VarHandleInternal`
class is unused, and its methods do not have to be translated to the
`invokevarhandle` INL. So, `initializeMethodRunAddressVarHandle` is
disabled for OpenJDK `VarHandles`.

Related: https://github.com/eclipse/openj9/issues/7352

Co-authored-by: Jack Lu <Jack.S.Lu@ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>