### PR TITLE
Enable OpenJDKCompileStub.OpenJDKCompileStubThrowError() in IBM builds

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/OpenJDKCompileStub.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/OpenJDKCompileStub.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
+/*[INCLUDE-IF Sidecar18-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this


### PR DESCRIPTION
`OpenJDKCompileStubThrowError()` can be used universally, in both IBM and
OpenJ9 builds, to pin point a stub method, which should not be used due
to lack of an implementation.

`MethodHandleResolver.linkCallerMethod()` invokes
`OpenJDKCompileStubThrowError()` in IBM builds. So, its implementation is
being exposed to IBM builds for resolving a compile-time error.

Related: https://github.com/eclipse/openj9/issues/7352

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>