### PR TITLE
Add the missing live locals info to the new blocks in tree lowering

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -171,7 +171,7 @@ static TR::Node *lowerCASValues(
  * @details
  *
  * This transformation adds checks for the cases where the acmp can be performed
- * without calling the VM helper. The trasformed Trees represen the following operation:
+ * without calling the VM helper. The transformed Trees represent the following operation:
  *
  * 1. If the address of lhs and rhs are the same, produce an eq (true) result
  *    and skip the call (note the two objects must be the same regardless of
@@ -215,7 +215,7 @@ static TR::Node *lowerCASValues(
  *        |
  *        v
  *  +-----------------+
- *  |BBStart
+ *  |BBStart          |
  *  |ificmpeq --> ... |
  *  |  iRegLoad x     |
  *  |  iconst 0       |
@@ -251,7 +251,7 @@ J9::CodeGenerator::fastpathAcmpHelper(TR::Node *node, TR::TreeTop *tt, const boo
    // next treetop and then at the current one
    TR::Block* prevBlock = tt->getEnclosingBlock();
    TR::Block* targetBlock = prevBlock->splitPostGRA(tt->getNextTreeTop(), cfg, true, NULL);
-   TR::Block* callBlock = prevBlock->split(tt, cfg);
+   TR::Block* callBlock = prevBlock->splitPostGRAWithoutFixingCommoning(tt, cfg, true, NULL);
    callBlock->setIsExtensionOfPreviousBlock(true);
    if (trace)
       traceMsg(comp, "Isolated call node n%dn in block_%d\n", node->getGlobalIndex(), callBlock->getNumber());
@@ -1660,7 +1660,7 @@ J9::CodeGenerator::lowerArrayStoreCHK(TR::Node *node, TR::TreeTop *tt)
                                self()->symRefTab()->findOrCreateNullCheckSymbolRef(currentMethod));
       TR::TreeTop *nullCheckTT = prevBlock->append(TR::TreeTop::create(self()->comp(), nullCheck));
 
-      TR::Block *nullCheckBlock = prevBlock->split(nullCheckTT, cfg);
+      TR::Block *nullCheckBlock = prevBlock->splitPostGRAWithoutFixingCommoning(nullCheckTT, cfg, true, NULL);
 
       nullCheckBlock->setIsExtensionOfPreviousBlock(true);
 

--- a/runtime/compiler/optimizer/JProfilingValue.cpp
+++ b/runtime/compiler/optimizer/JProfilingValue.cpp
@@ -576,7 +576,7 @@ TR_JProfilingValue::addProfilingTrees(
       iter->append(nullTestTree);
       if (lastBranchToMainlineReturnTT != NULL)
          {
-         TR::Block *temp = iter->split(nullTestTree, cfg, false, true);
+         TR::Block *temp = iter->splitPostGRAWithoutFixingCommoning(nullTestTree, cfg, true, NULL);
          temp->setIsExtensionOfPreviousBlock();
          cfg->addEdge(iter, mainlineReturn);
          iter = temp;
@@ -608,7 +608,7 @@ TR_JProfilingValue::addProfilingTrees(
    TR::TreeTop *incIndexTreeTop = TR::TreeTop::create(comp, TR::Node::create(TR::treetop, 1, selectNode));
    iter->append(incIndexTreeTop);
 
-   TR::Block *quickTestBlock = iter->split(incIndexTreeTop, cfg, false, true);
+   TR::Block *quickTestBlock = iter->splitPostGRAWithoutFixingCommoning(incIndexTreeTop, cfg, true, NULL);
    quickTestBlock->setIsExtensionOfPreviousBlock();
    if (lastBranchToMainlineReturnTT != NULL)
       {
@@ -633,7 +633,7 @@ TR_JProfilingValue::addProfilingTrees(
    TR::Node *counterBaseAddress = TR::Node::aconst(value, table->getBaseAddress() + table->getFreqOffset());
    TR::TreeTop *incTree = TR::TreeTop::create(comp, checkNodeTreeTop,
       incrementMemory(comp, counterType, effectiveAddress(counterType, counterBaseAddress, convertType(selectNode, systemType, true))));
-   TR::Block *quickInc = quickTestBlock->split(incTree, cfg, false, true);
+   TR::Block *quickInc = quickTestBlock->splitPostGRAWithoutFixingCommoning(incTree, cfg, true, NULL);
    quickInc->setIsExtensionOfPreviousBlock();
    if (trace)
       traceMsg(comp, "\t\t\tQuick increment performed in block_%d\n", quickInc->getNumber());


### PR DESCRIPTION
When the tree is transformed into new blocks in `fastpathAcmpHelper` or `lowerArrayStoreCHK`, the live locals info is not passed on from the previous block to the newly created blocks. The missing live locals causes missing GC map for the objects.

Many thanks to @liqunl for finding the cause of the missing GC map. 

Depends on: 
- [ ] eclipse/omr#5639

Fixes #10869

