### PR TITLE
Use valueOf instead of primitive wrapper constructors

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/MemoryInfoStream.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/MemoryInfoStream.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2014 IBM Corp. and others
+ * Copyright (c) 2014, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -144,7 +144,7 @@ public class MemoryInfoStream extends Stream {
 				props.setProperty(EXECUTABLE, FALSE);
 			}
 			
-			memoryInfo.put(new Long(baseAddress), props);
+			memoryInfo.put(Long.valueOf(baseAddress), props);
 		}
 		
 		/* Merge the extra properties into the memory info. */

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/ThreadInfoStream.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/ThreadInfoStream.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2014 IBM Corp. and others
+ * Copyright (c) 2014, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -124,7 +124,7 @@ public class ThreadInfoStream extends Stream {
 				props.put("ExitTime_Formatted", exitTimeStr);
 			}
 			
-			threadInfo.put(new Long(threadId), props);
+			threadInfo.put(Long.valueOf(threadId), props);
 		}
 		
 		/* Merge the extra properties into the thread info. */

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/dumpreader/SystemTrace.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/dumpreader/SystemTrace.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2013 IBM Corp. and others
+ * Copyright (c) 2006, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -404,11 +404,11 @@ public class SystemTrace {
         Integer getField(int offset, int length) throws IOException {
             if (offset != 0) {
                 if (length == 1) {
-                    return new Integer(space.readUnsignedByte(address + offset));
+                    return Integer.valueOf(space.readUnsignedByte(address + offset));
                 } else if (length == 2) {
-                    return new Integer(space.readUnsignedShort(address + offset));
+                    return Integer.valueOf(space.readUnsignedShort(address + offset));
                 } else {
-                    return new Integer(space.readInt(address + offset));
+                    return Integer.valueOf(space.readInt(address + offset));
                 }
             }
             return null;
@@ -527,7 +527,7 @@ public class SystemTrace {
     }
 
     private Context getContext(long tod, int pid, int ppid) {
-        Integer key = new Integer((pid << 16) | ppid);
+        Integer key = Integer.valueOf((pid << 16) | ppid);
         Context context = (Context)contextMap.get(key);
         if (context == null) {
             context = new Context(tod, pid, ppid);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/le/Caa.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/le/Caa.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2018 IBM Corp. and others
+ * Copyright (c) 2006, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -89,7 +89,7 @@ public class Caa {
          * of registers found */
         String s = System.getProperty("zebedee.where.skip");
         if (s != null) {
-            whereSkip = new Integer(s).intValue();
+            whereSkip = Integer.valueOf(s).intValue();
         }
     }
 
@@ -142,7 +142,7 @@ public class Caa {
             caaTemplate = new Caa32Template();
             String s = space.getDump().getProductRelease();
             if (s != null) {
-                int release = new Integer(s).intValue();
+                int release = Integer.valueOf(s).intValue();
                 if (release >= 11) {
                     caaTemplate = new Caa32_11Template();
                     log.fine("switched to new caa format");
@@ -156,7 +156,7 @@ public class Caa {
             caaTemplate = new Caa64Template();
             String s = space.getDump().getProductRelease();
             if (s != null) {
-                int release = new Integer(s).intValue();
+                int release = Integer.valueOf(s).intValue();
                 if (release >= 11) {
                     caaTemplate = new Caa64_11Template();
                     log.fine("switched to new caa format");
@@ -167,7 +167,7 @@ public class Caa {
             caaTemplate = new Caa32Template();
             String s = space.getDump().getProductRelease();
             if (s != null) {
-                int release = new Integer(s).intValue();
+                int release = Integer.valueOf(s).intValue();
                 if (release >= 11) {
                     caaTemplate = new Caa32_11Template();
                     log.fine("switched to new caa format");
@@ -855,7 +855,7 @@ public class Caa {
     public Edb getEdb() {
         if (edb == null) {
             try {
-                Long edbkey = new Long(ceecaaedb());
+                Long edbkey = Long.valueOf(ceecaaedb());
                 edb = (Edb)space.getUserMap().get(edbkey);
                 if (edb == null) {
                     /* We are the first Caa in this Edb */

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/mvs/Tcb.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/mvs/Tcb.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2019 IBM Corp. and others
+ * Copyright (c) 2006, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -136,7 +136,7 @@ public class Tcb {
 
         String s = space.getDump().getProductRelease();
         if (s != null) {
-            release = new Integer(s).intValue();
+            release = Integer.valueOf(s).intValue();
         }
     }
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/util/AbstractHashMap.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/util/AbstractHashMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2013 IBM Corp. and others
+ * Copyright (c) 2006, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -237,7 +237,7 @@ public abstract class AbstractHashMap implements Serializable {
         }
 
         public Object nextElement() {
-            return new Long(nextInt());
+            return Long.valueOf(nextInt());
         }
 
         public long nextInt() {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/util/IntegerLruCache.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/util/IntegerLruCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2013 IBM Corp. and others
+ * Copyright (c) 2006, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -108,7 +108,7 @@ public final class IntegerLruCache extends AbstractLruCache {
             }
             put(key, value);
             if (doCheck) {
-                check.put(new Long(key), new Integer(value));
+                check.put(Long.valueOf(key), Integer.valueOf(value));
                 if (get(key) != value) {
                     throw new Error("found " + get(key) + " expected " + value);
                 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/util/IntegerMap.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/util/IntegerMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2013 IBM Corp. and others
+ * Copyright (c) 2006, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -104,13 +104,13 @@ public final class IntegerMap extends AbstractHashMap {
             }
             put(key, value);
             if (doCheck) {
-                check.put(new Long(key), new Long(value));
+                check.put(Long.valueOf(key), Long.valueOf(value));
                 if (get(key) != value) {
                     throw new Error("found " + get(key) + " expected " + value);
                 }
                 if (remove) {
                     remove(key);
-                    check.remove(new Long(key));
+                    check.remove(Long.valueOf(key));
                 }
             }
         }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/PointerGenerator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/PointerGenerator.java
@@ -974,7 +974,7 @@ public class PointerGenerator {
 		if (cacheFields) {
 			writer.format("\t\tif (CACHE_FIELDS) {%n");
 			writer.format("\t\t\tif (%s_cache == null) {%n", getter);
-			writer.format("\t\t\t\t%s_cache = new Boolean(getBoolAtOffset(%s._%sOffset_));%n", getter, structure.getName(), offsetConstant);
+			writer.format("\t\t\t\t%s_cache = Boolean.valueOf(getBoolAtOffset(%s._%sOffset_));%n", getter, structure.getName(), offsetConstant);
 			writer.format("\t\t\t}%n");
 			writer.format("\t\t\treturn %s_cache.booleanValue();%n", getter);
 			writer.format("\t\t} else {%n\t");
@@ -999,7 +999,7 @@ public class PointerGenerator {
 		if (cacheFields) {
 			writer.format("\t\tif (CACHE_FIELDS) {%n");
 			writer.format("\t\t\tif (%s_cache == null) {%n", getter);
-			writer.format("\t\t\t\t%s_cache = new Double(getDoubleAtOffset(%s._%sOffset_));%n", getter, structure.getName(), offsetConstant);
+			writer.format("\t\t\t\t%s_cache = Double.valueOf(getDoubleAtOffset(%s._%sOffset_));%n", getter, structure.getName(), offsetConstant);
 			writer.format("\t\t\t}%n");
 			writer.format("\t\t\treturn %s_cache.doubleValue();%n", getter);
 			writer.format("\t\t} else {%n\t");
@@ -1027,13 +1027,13 @@ public class PointerGenerator {
 			writer.format("\t\tif (CACHE_FIELDS) {%n");
 			writer.format("\t\t\tif (%s_cache == null) {%n", getter);
 			writer.format("\t\t\t\tif (%s.SIZEOF == 1) {%n", enumType);
-			writer.format("\t\t\t\t\t%s_cache = new Long(getByteAtOffset(%s._%sOffset_));%n", getter, structure.getName(), offsetConstant);
+			writer.format("\t\t\t\t\t%s_cache = Long.valueOf(getByteAtOffset(%s._%sOffset_));%n", getter, structure.getName(), offsetConstant);
 			writer.format("\t\t\t\t} else if (%s.SIZEOF == 2) {%n", enumType);
-			writer.format("\t\t\t\t\t%s_cache = new Long(getShortAtOffset(%s._%sOffset_));%n", getter, structure.getName(), offsetConstant);
+			writer.format("\t\t\t\t\t%s_cache = Long.valueOf(getShortAtOffset(%s._%sOffset_));%n", getter, structure.getName(), offsetConstant);
 			writer.format("\t\t\t\t} else if (%s.SIZEOF == 4) {%n", enumType);
-			writer.format("\t\t\t\t\t%s_cache = new Long(getIntAtOffset(%s._%sOffset_));%n", getter, structure.getName(), offsetConstant);
+			writer.format("\t\t\t\t\t%s_cache = Long.valueOf(getIntAtOffset(%s._%sOffset_));%n", getter, structure.getName(), offsetConstant);
 			writer.format("\t\t\t\t} else if (%s.SIZEOF == 8) {%n", enumType);
-			writer.format("\t\t\t\t\t%s_cache = new Long(getLongAtOffset(%s._%sOffset_));%n", getter, structure.getName(), offsetConstant);
+			writer.format("\t\t\t\t\t%s_cache = Long.valueOf(getLongAtOffset(%s._%sOffset_));%n", getter, structure.getName(), offsetConstant);
 			writer.format("\t\t\t\t} else {%n");
 			writer.format("\t\t\t\t\tthrow new IllegalArgumentException(\"Unexpected ENUM size in core file\");%n");
 			writer.format("\t\t\t\t}%n");
@@ -1099,7 +1099,7 @@ public class PointerGenerator {
 		if (cacheFields) {
 			writer.format("\t\tif (CACHE_FIELDS) {%n");
 			writer.format("\t\t\tif (%s_cache == null) {%n", getter);
-			writer.format("\t\t\t\t%s_cache = new Float(getFloatAtOffset(%s._%sOffset_));%n", getter, structure.getName(), offsetConstant);
+			writer.format("\t\t\t\t%s_cache = Float.valueOf(getFloatAtOffset(%s._%sOffset_));%n", getter, structure.getName(), offsetConstant);
 			writer.format("\t\t\t}%n");
 			writer.format("\t\t\treturn %s_cache.floatValue();%n", getter);
 			writer.format("\t\t} else {%n\t");

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ClassHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ClassHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -206,7 +206,7 @@ public class J9ClassHelper
 	
 	private static HashMap<String, J9ObjectFieldOffset> getFieldOffsetCache(J9ClassPointer clazz)
 	{
-		Long classAddr = new Long(clazz.getAddress());
+		Long classAddr = Long.valueOf(clazz.getAddress());
 		HashMap<String, J9ObjectFieldOffset> fieldOffsetCache = classToFieldOffsetCacheMap.get(classAddr);
 		
 		if(null != fieldOffsetCache) { 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ObjectHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ObjectHelper.java
@@ -159,11 +159,11 @@ public class J9ObjectHelper
 			try {
 				getObjectField(objPointer, getFieldOffset(objPointer, "value", "[B"));
 
-				isStringBackedByByteArray = new Boolean(true);
+				isStringBackedByByteArray = Boolean.valueOf(true);
 			} catch (NoSuchElementException e) {
 				getObjectField(objPointer, getFieldOffset(objPointer, "value", "[C"));
 
-				isStringBackedByByteArray = new Boolean(false);
+				isStringBackedByByteArray = Boolean.valueOf(false);
 			}
 		}
 		

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/AnalyseRomClassUTF8Command.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/AnalyseRomClassUTF8Command.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -119,9 +119,9 @@ public class AnalyseRomClassUTF8Command extends Command {
 					long sizet = 0;
 					long dup = 1;
 					if (cpsavedSize == null) {
-						sizet = new Long(length);
+						sizet = Long.valueOf(length);
 					} else {
-						sizet = new Long(length) + cpsavedSize[0];
+						sizet = Long.valueOf(length) + cpsavedSize[0];
 						dup += cpsavedSize[1];
 					}
 					utf8global.put(csectionName, new Long[]{sizet, dup});
@@ -133,9 +133,9 @@ public class AnalyseRomClassUTF8Command extends Command {
 						String key = csectionName + "-" + cloader;
 						cpsavedSize = utf8classloader.get(key);
 						if (cpsavedSize == null) {
-							sizet = new Long(length);
+							sizet = Long.valueOf(length);
 						} else {
-							sizet = new Long(length) + cpsavedSize[0];
+							sizet = Long.valueOf(length) + cpsavedSize[0];
 							dup += cpsavedSize[1];
 						}
 						utf8classloader.put(key, new Long[] {sizet, dup});
@@ -143,9 +143,9 @@ public class AnalyseRomClassUTF8Command extends Command {
 						dup = 1;
 						cpsavedSize = utf8bootstraploader.get(csectionName);
 						if (cpsavedSize == null) {
-							sizet = new Long(length);
+							sizet = Long.valueOf(length);
 						} else {
-							sizet = new Long(length) + cpsavedSize[0];
+							sizet = Long.valueOf(length) + cpsavedSize[0];
 							dup += cpsavedSize[1];
 						}
 						utf8bootstraploader.put(csectionName, new Long[] {sizet, dup});
@@ -179,9 +179,9 @@ public class AnalyseRomClassUTF8Command extends Command {
 						long nodesize = 0;
 						long nodecount= 1;
 						if (nodecountsize == null) {
-							nodesize = new Long(entry.getValue()[0]);
+							nodesize = Long.valueOf(entry.getValue()[0]);
 						} else {
-							nodesize = new Long(entry.getValue()[0]) + nodecountsize[1];
+							nodesize = Long.valueOf(entry.getValue()[0]) + nodecountsize[1];
 							nodecount += nodecountsize[0];
 						}
 						distrmap.put(diskey, new Long[] {nodecount, nodesize});
@@ -256,9 +256,9 @@ public class AnalyseRomClassUTF8Command extends Command {
 						long nodesize = 0;
 						long nodecount= 1;
 						if (nodecountsize == null) {
-							nodesize = new Long(entry.getValue()[0]);
+							nodesize = Long.valueOf(entry.getValue()[0]);
 						} else {
-							nodesize = new Long(entry.getValue()[0]) + nodecountsize[1];
+							nodesize = Long.valueOf(entry.getValue()[0]) + nodecountsize[1];
 							nodecount += nodecountsize[0];
 						}
 						distrmap.put(diskey, new Long[] {nodecount, nodesize});
@@ -284,9 +284,9 @@ public class AnalyseRomClassUTF8Command extends Command {
 						long nodesize = 0;
 						long nodecount= 1;
 						if (nodecountsize == null) {
-							nodesize = new Long(entry.getValue()[0]);
+							nodesize = Long.valueOf(entry.getValue()[0]);
 						} else {
-							nodesize = new Long(entry.getValue()[0]) + nodecountsize[1];
+							nodesize = Long.valueOf(entry.getValue()[0]) + nodecountsize[1];
 							nodecount += nodecountsize[0];
 						}
 						distrmap.put(diskey, new Long[] {nodecount, nodesize});

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/RuntimeSettingsCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/RuntimeSettingsCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -97,7 +97,7 @@ public class RuntimeSettingsCommand extends Command
 				initialSoftmx = cmdline.substring(start + length, end);
 				initialSoftmx = initialSoftmx.toUpperCase();
 			}
-			currentSoftmx = new Long(GCExtensions.softMx().longValue());
+			currentSoftmx = Long.valueOf(GCExtensions.softMx().longValue());
 			qualifiedCurrentSoftmx = currentSoftmx.toString();
 			Matcher m = p.matcher(initialSoftmx);
 
@@ -229,7 +229,7 @@ public class RuntimeSettingsCommand extends Command
 	 * a qualified size such as '4K' 
 	 */
 	private String sizeInBytes(String qSize) {
-		Long number = new Long(qSize.substring(0, qSize.length()-1));
+		Long number = Long.valueOf(qSize.substring(0, qSize.length()-1));
 		if (qSize.endsWith("K")) {
 			number = number * 1024;
 		} else if (qSize.endsWith("M")) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaFieldInstance.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaFieldInstance.java
@@ -70,11 +70,11 @@ public class DTFJJavaFieldInstance extends DTFJJavaField {
 				case INTEGER_SIGNATURE :
 					return Integer.valueOf(getInt(object));
 				case FLOAT_SIGNATURE :
-					return new Float(getFloat(object));
+					return Float.valueOf(getFloat(object));
 				case LONG_SIGNATURE :
 					return Long.valueOf(getLong(object));
 				case DOUBLE_SIGNATURE :
-					return new Double(getDouble(object));
+					return Double.valueOf(getDouble(object));
 				case ARRAY_PREFIX_SIGNATURE :
 				case OBJECT_PREFIX_SIGNATURE :
 					J9ROMFieldShapePointer fieldShape = fieldOffset.getField();

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaFieldStatic.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaFieldStatic.java
@@ -65,11 +65,11 @@ public class DTFJJavaFieldStatic extends DTFJJavaField {
 				case INTEGER_SIGNATURE :
 					return Integer.valueOf(getInt(object));
 				case FLOAT_SIGNATURE :
-					return new Float(getFloat(object));
+					return Float.valueOf(getFloat(object));
 				case LONG_SIGNATURE :
 					return Long.valueOf(getLong(object));
 				case DOUBLE_SIGNATURE :
-					return new Double(getDouble(object));
+					return Double.valueOf(getDouble(object));
 				case ARRAY_PREFIX_SIGNATURE :
 				case OBJECT_PREFIX_SIGNATURE :
 					J9ObjectPointer data = getObject();

--- a/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/test/stackwalker/testapp/TestApp1.java
+++ b/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/test/stackwalker/testapp/TestApp1.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 IBM Corp. and others
+ * Copyright (c) 2009, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -432,7 +432,7 @@ INNER:		for (;j < 10;j++) {
 								'a',
 								'b',
 								'c',
-								new Character('Z'),
+								Character.valueOf('Z'),
 								3.141459,
 								43.2,
 								23432.234,

--- a/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/test/JavaClassTest.java
+++ b/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/test/JavaClassTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,7 +65,7 @@ public class JavaClassTest extends DTFJUnitTest {
 	
 	public static final Comparator<Object> CONSTANCT_POOL_REFERENCES_SORT_ORDER = new Comparator<Object>() {
 		public int compare(Object o1, Object o2) {
-			return new Long(((JavaObject) o1).getID().getAddress()).compareTo(new Long(((JavaObject) o2).getID().getAddress()));
+			return Long.valueOf(((JavaObject) o1).getID().getAddress()).compareTo(Long.valueOf(((JavaObject) o2).getID().getAddress()));
 		}
 	};
 	

--- a/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/test/JavaMethodTest.java
+++ b/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/test/JavaMethodTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,7 +42,7 @@ public class JavaMethodTest extends DTFJUnitTest {
 		public int compare(Object o1, Object o2) {
 			ImageSection i1 = (ImageSection) o1;
 			ImageSection i2 = (ImageSection) o2;
-			return new Long(i1.getBaseAddress().getAddress()).compareTo(new Long(i2.getBaseAddress().getAddress()));
+			return Long.valueOf(i1.getBaseAddress().getAddress()).compareTo(Long.valueOf(i2.getBaseAddress().getAddress()));
 		}
 	};
 	

--- a/jcl/src/java.base/share/classes/java/lang/reflect/Array.java
+++ b/jcl/src/java.base/share/classes/java/lang/reflect/Array.java
@@ -2,7 +2,7 @@
 package java.lang.reflect;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2010 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,7 +71,7 @@ public static Object get(Object array, int index) throws IllegalArgumentExceptio
 		return ((short[])array)[index];
 	} else if (arrayClass == byte[].class) {
 		/* Avoiding Byte cache yields 5x performance improvement. */
-		return new Byte(((byte[])array)[index]);
+		return Byte.valueOf(((byte[])array)[index]);
 	} else {
 		try {
 			return ((Object[])array)[index];

--- a/sourcetools/com.ibm.admincache/src/com/ibm/admincache/Config.java
+++ b/sourcetools/com.ibm.admincache/src/com/ibm/admincache/Config.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2017 IBM Corp. and others
+ * Copyright (c) 2008, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -613,7 +613,7 @@ abstract class Config {
         		addedFileName = _unicityOfFileName.get(fileNameCanonical);
         		if (addedFileName == null) {
         			fileNames().add(fileNameCanonical);
-        			_unicityOfFileName.put(fileNameCanonical, new Integer(0));
+        			_unicityOfFileName.put(fileNameCanonical, Integer.valueOf(0));
         		}
         	} else {
         		if (badFileEncountered())

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestExpireDestroyOnCorruptCache.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestExpireDestroyOnCorruptCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2019 IBM Corp. and others
+ * Copyright (c) 2010, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,7 +55,7 @@ public class TestExpireDestroyOnCorruptCache extends TestUtils {
 		}
 
 		/* expire all caches not used for past 1 min */
-		expireAllCachesWithTime(new Integer(1).toString());
+		expireAllCachesWithTime(Integer.valueOf(1).toString());
 		/* expire does not delete caches detected as corrupt during oscache->startup() */
 		checkFileExistsForPersistentCache("Foo");
 		

--- a/test/functional/DDR_Test/src/j9vm/test/corehelper/StackMapCoreGenerator.java
+++ b/test/functional/DDR_Test/src/j9vm/test/corehelper/StackMapCoreGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -108,7 +108,7 @@ public class StackMapCoreGenerator {
 	 */
 	public void stackMapTestMethod_3(int i, String s, long l, char[] charArray) {
 		int[] intArray = new int[10];
-		stackMapTestMethod_4('0', false, new Integer("1"), new Exception(), 1,
+		stackMapTestMethod_4('0', false, Integer.valueOf("1"), new Exception(), 1,
 				intArray);
 
 	}

--- a/test/functional/J9 Exclude File Support/src/com/oti/j9/exclude/XMLParser.java
+++ b/test/functional/J9 Exclude File Support/src/com/oti/j9/exclude/XMLParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -182,7 +182,7 @@ public class XMLParser {
 
 		int base = 10;
 		if (firstDigit == '0') {
-			if (i == length) return new Integer(0);
+			if (i == length) return Integer.valueOf(0);
 			if ((firstDigit = string.charAt(i++)) == 'x' || firstDigit == 'X') {
 				if (i == length) throw new NumberFormatException(string);
 				firstDigit = string.charAt(i++);
@@ -210,7 +210,7 @@ public class XMLParser {
 			result = -result;
 			if (result < 0) throw new NumberFormatException(string);
 		}
-		return new Integer(result);
+		return Integer.valueOf(result);
 	}
 
 	// Primitive: Scan character data

--- a/test/functional/JIT_Test/src/jit/test/jitt/gc/Scavenge.java
+++ b/test/functional/JIT_Test/src/jit/test/jitt/gc/Scavenge.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,7 +43,7 @@ public class Scavenge extends jit.test.jitt.Test {
 
 	private void tst_jit1(int recursionDepth, Object z, boolean triggerGC) {
 
-		Integer i = new Integer(recursionDepth - 1); // make a temp
+		Integer i = Integer.valueOf(recursionDepth - 1); // make a temp
 
 		if (recursionDepth == 0) {
 			if (triggerGC)
@@ -63,7 +63,7 @@ public class Scavenge extends jit.test.jitt.Test {
 	public void testScavenge() {
 		Scavenge x = new Scavenge();
 		for (int j = 0; j < 101; j++) {
-			x.tst_jit1(10, new Integer(j), false);
+			x.tst_jit1(10, Integer.valueOf(j), false);
 		}
 		x.tst_jit1(10, "trigger_gc_now", true);
 	}

--- a/test/functional/JIT_Test/src/jit/test/stringconcat/StringConcatTest.java
+++ b/test/functional/JIT_Test/src/jit/test/stringconcat/StringConcatTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,7 +58,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildDefaultStr(){
-		return new Integer(5).toString() + " of us are going to buy " + new Integer(1).toString() + " orange " + "each";
+		return Integer.valueOf(5).toString() + " of us are going to buy " + Integer.valueOf(1).toString() + " orange " + "each";
 	}
 		
 	public void testDefaultPattern_With_Negative_Integer(){
@@ -68,7 +68,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildDefaultPattern_With_Negative_Integer(){
-		return new Integer(-5).toString() + " is smaller than " + new Integer(-1).toString() + " to " + "a sane person";
+		return Integer.valueOf(-5).toString() + " is smaller than " + Integer.valueOf(-1).toString() + " to " + "a sane person";
 	}
 		
 	public void testNullStr_Middle(){
@@ -78,7 +78,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildNullStr_Middle(){
-		return new Integer(-5).toString() + " is bigger than " + new Integer(1).toString() + null + " to a less than sane person";
+		return Integer.valueOf(-5).toString() + " is bigger than " + Integer.valueOf(1).toString() + null + " to a less than sane person";
 	}
 		
 	public void testNullStr_End(){
@@ -88,7 +88,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildNullStr_End(){
-		return new Integer(-5).toString() + " is bigger than " + new Integer(-1).toString() + " to a less than sane person " + null;
+		return Integer.valueOf(-5).toString() + " is bigger than " + Integer.valueOf(-1).toString() + " to a less than sane person " + null;
 	}
 		
 	public void testAutoboxedInteger(){
@@ -118,7 +118,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildInvalidPattern_SISS(){
-		return "I wrote " + new Integer(2).toString() + " cliches either side of " + new Integer(1).toString() + " good verse";
+		return "I wrote " + Integer.valueOf(2).toString() + " cliches either side of " + Integer.valueOf(1).toString() + " good verse";
 	}
 	
 	public void testInvalidPattern_ISIS(){
@@ -128,7 +128,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildInvalidPattern_ISIS(){
-		return new Integer(1).toString() + " of us is going to sleep at " + new Integer(2).toString() + " am";
+		return Integer.valueOf(1).toString() + " of us is going to sleep at " + Integer.valueOf(2).toString() + " am";
 	}
 	
 	public void testInvalidPattern_ISISISIS(){
@@ -144,7 +144,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildInvalidPattern_ISISSS(){
-		return  new Integer(1).toString() + " side of the moon is good enough for " + new Integer(1).toString() + " earth " + "full of " + "moonstruck ants";
+		return  Integer.valueOf(1).toString() + " side of the moon is good enough for " + Integer.valueOf(1).toString() + " earth " + "full of " + "moonstruck ants";
 	}
 	
 	public void testInvalidPattern_ISISSI(){
@@ -154,7 +154,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildInvalidPattern_ISISSI(){
-		return  new Integer(1).toString() + " side of the moon is good enough for " + new Integer(1).toString() + " earth " + "full of " + "moonstruck ants but " + new Integer(1);
+		return  Integer.valueOf(1).toString() + " side of the moon is good enough for " + Integer.valueOf(1).toString() + " earth " + "full of " + "moonstruck ants but " + Integer.valueOf(1);
 	}
 	
 	public void testInvalidPattern_ISISSISS(){
@@ -164,7 +164,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildInvalidPattern_ISISSISS(){
-		return  new Integer(1).toString() + " side of the moon is good enough for " + new Integer(1).toString() + " earth " + "full of " + "moonstruck ants but " + new Integer(1) + " disagrees with this";
+		return  Integer.valueOf(1).toString() + " side of the moon is good enough for " + Integer.valueOf(1).toString() + " earth " + "full of " + "moonstruck ants but " + Integer.valueOf(1) + " disagrees with this";
 	}
 	
 	public void testInvalidPattern_ISISSISC(){
@@ -174,7 +174,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildInvalidPattern_ISISSISC(){
-		return  new Integer(1).toString() + " side of the moon is good enough for " + new Integer(1).toString() + " earth " + "full of " + "moonstruck ants but " + new Integer(1) + " disagrees with thi" + new Character('s');
+		return  Integer.valueOf(1).toString() + " side of the moon is good enough for " + Integer.valueOf(1).toString() + " earth " + "full of " + "moonstruck ants but " + Integer.valueOf(1) + " disagrees with thi" + Character.valueOf('s');
 	}
 	
 	public void testConstantString(){
@@ -184,7 +184,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildConstantString(){
-		final String s = new Integer(5).toString() + " of us are going to buy " + new Integer(1).toString() + " orange " + "each";
+		final String s = Integer.valueOf(5).toString() + " of us are going to buy " + Integer.valueOf(1).toString() + " orange " + "each";
 		return s;
 	}
 	
@@ -199,7 +199,7 @@ public class StringConcatTest {
 		String s = null;
 		int c = 0 ; 
 		do{
-			s = "I am " + new Integer(1).toString() + " therefore I am many";
+			s = "I am " + Integer.valueOf(1).toString() + " therefore I am many";
 			c++;
 		} while( c < degree );
 		return s;
@@ -216,7 +216,7 @@ public class StringConcatTest {
 		String s = null;
 		int c = 0 ; 
 		do{
-			s = "I think therefore I a" + new Character('m');
+			s = "I think therefore I a" + Character.valueOf('m');
 			c++;
 		} while( c < degree );
 		return s;
@@ -233,7 +233,7 @@ public class StringConcatTest {
 		String s = null;
 		int c = 0 ; 
 		do{
-			s = new Integer(5).toString() + " of us are going to buy " + new Integer(1).toString() + " orange " + "each";
+			s = Integer.valueOf(5).toString() + " of us are going to buy " + Integer.valueOf(1).toString() + " orange " + "each";
 			c++;
 		} while( c < degree );
 		return s;

--- a/test/functional/JIT_Test/src/jit/test/tr/VPTypeTests/cTypeTests.java
+++ b/test/functional/JIT_Test/src/jit/test/tr/VPTypeTests/cTypeTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -344,7 +344,7 @@ public class cTypeTests {
 
    private void subtest012(String s[]) {
       boolean bool = false;
-      Double d = new Double(1.1);
+      Double d = Double.valueOf(1.1);
       Object o = d;
       o = s;
       try {

--- a/test/functional/JIT_Test/src/jit/test/tr/chtable/PreexistenceTest3.java
+++ b/test/functional/JIT_Test/src/jit/test/tr/chtable/PreexistenceTest3.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,7 +51,7 @@ public class PreexistenceTest3 {
 	 }
 		
       public Object next() {
-         return new Long(cursor++);
+         return Long.valueOf(cursor++);
 	 }
 
       public void remove() {
@@ -68,7 +68,7 @@ public class PreexistenceTest3 {
 		}
 
 		public Long getValue() {
-			return new Long(value);
+			return Long.valueOf(value);
 		}
 	}
 

--- a/test/functional/JIT_Test/src/jit/test/tr/liveMonitor/monTests.java
+++ b/test/functional/JIT_Test/src/jit/test/tr/liveMonitor/monTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -406,7 +406,7 @@ public class monTests {
 
 class A {
    public A() {
-      intValue = new Integer(6023);
+      intValue = Integer.valueOf(6023);
       lock = new Object();
    }
 

--- a/test/functional/JIT_Test/src/jit/test/tr/stringPeephole/BigDecimalToStringTest.java
+++ b/test/functional/JIT_Test/src/jit/test/tr/stringPeephole/BigDecimalToStringTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,7 +38,7 @@ public class BigDecimalToStringTest{
       @Test
       public void testBigDecimal0ToString() {
          NumberFormat format = new DecimalFormat("###,###,##0");
-         BigDecimal bigDecimalValue = new BigDecimal(new Double(0.000));
+         BigDecimal bigDecimalValue = new BigDecimal(Double.valueOf(0.000));
          String s = bigDecimalToString(format, bigDecimalValue);
          logger.debug("Converting BigDecimal with value 0 to string ...");
          Assert.assertEquals(s, "0");

--- a/test/functional/JIT_Test/src/jit/test/vich/JNILocalRef.java
+++ b/test/functional/JIT_Test/src/jit/test/vich/JNILocalRef.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2018 IBM Corp. and others
+ * Copyright (c) 2006, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,13 @@ import jit.test.vich.utils.Timer;
  * @author
  */
 public class JNILocalRef {
-	
+
+	private static class LocalRefClass {
+		LocalRefClass() {
+			super();
+		}
+	}
+
 	private static Logger logger = Logger.getLogger(JNILocalRef.class);
 	Timer timer;
 
@@ -53,38 +59,38 @@ public class JNILocalRef {
 	@Test(groups = { "level.sanity","component.jit" })
 	public void testJNILocalRef()
 	{
-		Object o1 = new Integer(0);
-		Object o2 = new Integer(0);
-		Object o3 = new Integer(0);
-		Object o4 = new Integer(0);
-		Object o5 = new Integer(0);
-		Object o6 = new Integer(0);
-		Object o7 = new Integer(0);
-		Object o8 = new Integer(0);
-		Object o9 = new Integer(0);
-		Object o10 = new Integer(0);
-		Object o11 = new Integer(0);
-		Object o12 = new Integer(0);
-		Object o13 = new Integer(0);
-		Object o14 = new Integer(0);
-		Object o15 = new Integer(0);
-		Object o16 = new Integer(0);
-		Object o17 = new Integer(0);
-		Object o18 = new Integer(0);
-		Object o19 = new Integer(0);
-		Object o20 = new Integer(0);
-		Object o21 = new Integer(0);
-		Object o22 = new Integer(0);
-		Object o23 = new Integer(0);
-		Object o24 = new Integer(0);
-		Object o25 = new Integer(0);
-		Object o26 = new Integer(0);
-		Object o27 = new Integer(0);
-		Object o28 = new Integer(0);
-		Object o29 = new Integer(0);
-		Object o30 = new Integer(0);
-		Object o31 = new Integer(0);
-		Object o32 = new Integer(0);
+		Object o1 = new LocalRefClass();
+		Object o2 = new LocalRefClass();
+		Object o3 = new LocalRefClass();
+		Object o4 = new LocalRefClass();
+		Object o5 = new LocalRefClass();
+		Object o6 = new LocalRefClass();
+		Object o7 = new LocalRefClass();
+		Object o8 = new LocalRefClass();
+		Object o9 = new LocalRefClass();
+		Object o10 = new LocalRefClass();
+		Object o11 = new LocalRefClass();
+		Object o12 = new LocalRefClass();
+		Object o13 = new LocalRefClass();
+		Object o14 = new LocalRefClass();
+		Object o15 = new LocalRefClass();
+		Object o16 = new LocalRefClass();
+		Object o17 = new LocalRefClass();
+		Object o18 = new LocalRefClass();
+		Object o19 = new LocalRefClass();
+		Object o20 = new LocalRefClass();
+		Object o21 = new LocalRefClass();
+		Object o22 = new LocalRefClass();
+		Object o23 = new LocalRefClass();
+		Object o24 = new LocalRefClass();
+		Object o25 = new LocalRefClass();
+		Object o26 = new LocalRefClass();
+		Object o27 = new LocalRefClass();
+		Object o28 = new LocalRefClass();
+		Object o29 = new LocalRefClass();
+		Object o30 = new LocalRefClass();
+		Object o31 = new LocalRefClass();
+		Object o32 = new LocalRefClass();
 		
 		try
 		{

--- a/test/functional/JIT_Test/src/jit/test/vich/JNIObjectArray.java
+++ b/test/functional/JIT_Test/src/jit/test/vich/JNIObjectArray.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2018 IBM Corp. and others
+ * Copyright (c) 2006, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,7 +55,7 @@ public class JNIObjectArray {
 	{
 		for (int i = 0; i < array.length; i++)
 		{
-			array[i] = new Integer(0);
+			array[i] = Integer.valueOf(0);
 		}
 	}
 	

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestClassLoadingMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestClassLoadingMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -190,7 +190,7 @@ public class TestClassLoadingMXBean {
 			Boolean before = (Boolean)mbs.getAttribute(objName, "Verbose");
 			// Toggle the boolean state of "isVerbose"
 			boolean newVal = !before;
-			attr = new Attribute("Verbose", new Boolean(newVal));
+			attr = new Attribute("Verbose", Boolean.valueOf(newVal));
 			mbs.setAttribute(objName, attr);
 			Boolean after = (Boolean)mbs.getAttribute(objName, "Verbose");
 			assert (newVal == after);
@@ -212,7 +212,7 @@ public class TestClassLoadingMXBean {
 		}
 
 		// Let's try and set some non-writable attributes.
-		attr = new Attribute("LoadedClassCount", new Integer(25));
+		attr = new Attribute("LoadedClassCount", Integer.valueOf(25));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Unreacheable code: should have thrown an exception.");
@@ -227,7 +227,7 @@ public class TestClassLoadingMXBean {
 			logger.debug("Exception occurred, as expected: " + e1.getMessage());
 		}
 
-		attr = new Attribute("TotalLoadedClassCount", new Long(3300));
+		attr = new Attribute("TotalLoadedClassCount", Long.valueOf(3300));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Unreacheable code: should have thrown an exception.");
@@ -242,7 +242,7 @@ public class TestClassLoadingMXBean {
 			logger.debug("Exception occurred, as expected: " + e1.getMessage());
 		}
 
-		attr = new Attribute("UnloadedClassCount", new Long(38));
+		attr = new Attribute("UnloadedClassCount", Long.valueOf(38));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Unreacheable code: should have thrown an exception.");
@@ -258,7 +258,7 @@ public class TestClassLoadingMXBean {
 		}
 
 		// Try and set the Verbose attribute with an incorrect type.
-		attr = new Attribute("Verbose", new Long(42));
+		attr = new Attribute("Verbose", Long.valueOf(42));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Unreacheable code: should have thrown an exception.");
@@ -337,7 +337,7 @@ public class TestClassLoadingMXBean {
 	public final void testSetAttributes() {
 		// Ideal scenario...
 		AttributeList attList = new AttributeList();
-		Attribute verbose = new Attribute("Verbose", new Boolean(false));
+		Attribute verbose = new Attribute("Verbose", Boolean.valueOf(false));
 		attList.add(verbose);
 		AttributeList setAttrs = null;
 		try {
@@ -355,7 +355,7 @@ public class TestClassLoadingMXBean {
 
 		// A failure scenario - a non-existent attribute...
 		AttributeList badList = new AttributeList();
-		Attribute garbage = new Attribute("Bantry", new Long(2888));
+		Attribute garbage = new Attribute("Bantry", Long.valueOf(2888));
 		badList.add(garbage);
 		try {
 			setAttrs = mbs.setAttributes(objName, badList);
@@ -371,7 +371,7 @@ public class TestClassLoadingMXBean {
 
 		// Another failure scenario - a non-writable attribute...
 		badList = new AttributeList();
-		garbage = new Attribute("TotalLoadedClassCount", new Long(2888));
+		garbage = new Attribute("TotalLoadedClassCount", Long.valueOf(2888));
 		badList.add(garbage);
 		try {
 			setAttrs = mbs.setAttributes(objName, badList);
@@ -387,7 +387,7 @@ public class TestClassLoadingMXBean {
 
 		// Yet another failure scenario - a wrongly-typed attribute...
 		badList = new AttributeList();
-		garbage = new Attribute("Verbose", new Long(2888));
+		garbage = new Attribute("Verbose", Long.valueOf(2888));
 		badList.add(garbage);
 		try {
 			setAttrs = mbs.setAttributes(objName, badList);
@@ -406,7 +406,7 @@ public class TestClassLoadingMXBean {
 	public final void testInvoke() {
 		// ClassLoadingMXBean has no operations to invoke...
 		try {
-			Object retVal = mbs.invoke(objName, "KissTheBlarney", new Object[] { new Long(7446), new Long(54) },
+			Object retVal = mbs.invoke(objName, "KissTheBlarney", new Object[] { Long.valueOf(7446), Long.valueOf(54) },
 					new String[] { "java.lang.Long", "java.lang.Long" });
 			// An exception other then InstanceNotFoundException should have been thrown,
 			// since there aren't any operations and we just tried to invoke one.

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestCompilationMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestCompilationMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -197,7 +197,7 @@ public class TestCompilationMXBean {
 			logger.debug("Exception occurred, as expected: " + "attempting to set a read-only attribute.");
 		}
 
-		attr = new Attribute("TotalCompilationTime", new Long(65533));
+		attr = new Attribute("TotalCompilationTime", Long.valueOf(65533));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Unreacheable code: should have thrown an exception.");
@@ -206,7 +206,7 @@ public class TestCompilationMXBean {
 			logger.debug("Exception occurred, as expected: " + "attempting to set a read-only attribute.");
 		}
 
-		attr = new Attribute("CompilationTimeMonitoringSupported", new Boolean(true));
+		attr = new Attribute("CompilationTimeMonitoringSupported", Boolean.valueOf(true));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Unreacheable code: should have thrown an exception.");
@@ -216,7 +216,7 @@ public class TestCompilationMXBean {
 		}
 
 		// Try and set the Name attribute with an incorrect type.
-		attr = new Attribute("Name", new Long(42));
+		attr = new Attribute("Name", Long.valueOf(42));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Unreacheable code: should have thrown an exception");
@@ -305,7 +305,7 @@ public class TestCompilationMXBean {
 	public final void testInvoke() {
 		// CompilationMXBean has no operations to invoke...
 		try {
-			Object retVal = mbs.invoke(objName, "KissTheBlarney", new Object[] { new Long(7446), new Long(54) },
+			Object retVal = mbs.invoke(objName, "KissTheBlarney", new Object[] { Long.valueOf(7446), Long.valueOf(54) },
 					new String[] { "java.lang.Long", "java.lang.Long" });
 			Assert.fail("Unreacheable code: should have thrown an exception.");
 		} catch (InstanceNotFoundException e) {

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestGarbageCollectorMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestGarbageCollectorMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -398,7 +398,7 @@ public class TestGarbageCollectorMXBean {
 			logger.debug("Exception occurred, as expected: " + "attempting to set a read-only attribute.");
 		}
 
-		attr = new Attribute("Valid", new Boolean(true));
+		attr = new Attribute("Valid", Boolean.valueOf(true));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Unreacheable code: should have thrown an exception.");
@@ -416,7 +416,7 @@ public class TestGarbageCollectorMXBean {
 			logger.debug("Exception occurred, as expected: " + "attempting to set a read-only attribute.");
 		}
 
-		attr = new Attribute("CollectionCount", new Long(233));
+		attr = new Attribute("CollectionCount", Long.valueOf(233));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Unreacheable code: should have thrown an exception.");
@@ -425,7 +425,7 @@ public class TestGarbageCollectorMXBean {
 			logger.debug("Exception occurred, as expected: " + "attempting to set a read-only attribute.");
 		}
 
-		attr = new Attribute("CollectionTime", new Long(233));
+		attr = new Attribute("CollectionTime", Long.valueOf(233));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Unreacheable code: should have thrown an exception.");
@@ -439,7 +439,7 @@ public class TestGarbageCollectorMXBean {
 	public final void testInvoke() {
 		// No operations to invoke...
 		try {
-			Object retVal = mbs.invoke(objName, "KissTheRoadOfRoratonga", new Object[] { new Long(7446), new Long(54) },
+			Object retVal = mbs.invoke(objName, "KissTheRoadOfRoratonga", new Object[] { Long.valueOf(7446), Long.valueOf(54) },
 					new String[] { "java.lang.Long", "java.lang.Long" });
 			Assert.fail("Unreacheable code: should have thrown an exception.");
 		} catch (Exception e) {

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestLockInfo.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestLockInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 IBM Corp. and others
+ * Copyright (c) 2013, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -124,7 +124,7 @@ public class TestLockInfo {
 		String[] names = { "className", "identityHashCode" };
 		Object[] values = {
 				/* className */new String(GOOD_CD_CLASSNAME),
-				/* identityHashCode */new Integer(GOOD_CD_IDHASHCODE) };
+				/* identityHashCode */Integer.valueOf(GOOD_CD_IDHASHCODE) };
 		CompositeType cType = createGoodLockInfoCompositeType();
 		try {
 			result = new CompositeDataSupport(cType, names, values);
@@ -147,7 +147,7 @@ public class TestLockInfo {
 		String[] names = { "className", "identityHashCode" };
 		// intentionally mix up the order of the values...
 		Object[] values = {
-				/* className */new Integer(GOOD_CD_IDHASHCODE),
+				/* className */Integer.valueOf(GOOD_CD_IDHASHCODE),
 				/* identityHashCode */new String(GOOD_CD_CLASSNAME) };
 		CompositeType cType = createBadLockInfoCompositeTypeObject();
 		try {
@@ -170,7 +170,7 @@ public class TestLockInfo {
 		CompositeData result = null;
 		String[] names = { "className", "identityHashCode" };
 		// intentionally mix up the order of the values...
-		Object[] values = { /* className */null, /* identityHashCode */new Integer(GOOD_CD_IDHASHCODE) };
+		Object[] values = { /* className */null, /* identityHashCode */Integer.valueOf(GOOD_CD_IDHASHCODE) };
 		CompositeType cType = createGoodLockInfoCompositeType();
 		try {
 			result = new CompositeDataSupport(cType, names, values);

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestLoggingMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestLoggingMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2019 IBM Corp. and others
+ * Copyright (c) 2005, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -436,7 +436,7 @@ public class TestLoggingMXBean {
 			if (sb != null) {
 				// Call getParentLoggerName(String) again with a bad argument type.
 				try {
-					Object retVal = sb.invoke("getParentLoggerName", new Object[] { new Long(311) },
+					Object retVal = sb.invoke("getParentLoggerName", new Object[] { Long.valueOf(311) },
 							new String[] { Long.TYPE.getName() });
 					Assert.fail("Should have thrown exception !!");
 				} catch (ReflectionException e) {
@@ -464,7 +464,7 @@ public class TestLoggingMXBean {
 		if (sb != null) {
 			// Try invoking a bogus operation ...
 			try {
-				Object retVal = sb.invoke("GetUpStandUp", new Object[] { new Long(7446), new Long(54) },
+				Object retVal = sb.invoke("GetUpStandUp", new Object[] { Long.valueOf(7446), Long.valueOf(54) },
 						new String[] { "java.lang.Long", "java.lang.Long" });
 				Assert.fail("Unreacheable code: should have thrown an exception.");
 			} catch (ReflectionException e) {

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryMXBean.java
@@ -260,7 +260,7 @@ public class TestMemoryMXBean {
 		// The only writable attribute of this type of bean
 		Attribute attr = null;
 		try {
-			attr = new Attribute("Verbose", new Boolean(true));
+			attr = new Attribute("Verbose", Boolean.valueOf(true));
 			mbs.setAttribute(objName, attr);
 		} catch (AttributeNotFoundException e) {
 			// An unlikely exception - if this occurs, we can't proceed with the test.
@@ -312,7 +312,7 @@ public class TestMemoryMXBean {
 			logger.debug("Exception occurred, as expected: " + e1.getMessage());
 		}
 
-		attr = new Attribute("ObjectPendingFinalizationCount", new Long(38));
+		attr = new Attribute("ObjectPendingFinalizationCount", Long.valueOf(38));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Unreacheable code: should have thrown an exception.");
@@ -329,7 +329,7 @@ public class TestMemoryMXBean {
 		}
 
 		// Try and set the Verbose attribute with an incorrect type.
-		attr = new Attribute("Verbose", new Long(42));
+		attr = new Attribute("Verbose", Long.valueOf(42));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Unreacheable code: should have thrown an exception.");
@@ -346,7 +346,7 @@ public class TestMemoryMXBean {
 
 		//set Verbose back to false
 		try {
-			attr = new Attribute("Verbose", new Boolean(false));
+			attr = new Attribute("Verbose", Boolean.valueOf(false));
 			mbs.setAttribute(objName, attr);
 		} catch (AttributeNotFoundException e) {
 			// An unlikely exception - if this occurs, we can't proceed with the test.
@@ -618,7 +618,7 @@ public class TestMemoryMXBean {
 			}
 		}
 		AttributeList attList = new AttributeList();
-		Attribute heapSize = new Attribute("MaxHeapSize", new Long(newHeapSize));
+		Attribute heapSize = new Attribute("MaxHeapSize", Long.valueOf(newHeapSize));
 		attList.add(heapSize);
 		AttributeList setAttrs = null;
 		try {
@@ -648,7 +648,7 @@ public class TestMemoryMXBean {
 	public final void testSetAttributes() {
 		// Ideal scenario...
 		AttributeList attList = new AttributeList();
-		Attribute verbose = new Attribute("Verbose", new Boolean(false));
+		Attribute verbose = new Attribute("Verbose", Boolean.valueOf(false));
 		attList.add(verbose);
 		AttributeList setAttrs = null;
 		try {
@@ -665,7 +665,7 @@ public class TestMemoryMXBean {
 
 		// A failure scenario - a non-existent attribute...
 		AttributeList badList = new AttributeList();
-		Attribute garbage = new Attribute("H.R. Puffenstuff", new Long(2888));
+		Attribute garbage = new Attribute("H.R. Puffenstuff", Long.valueOf(2888));
 		badList.add(garbage);
 		try {
 			setAttrs = mbs.setAttributes(objName, badList);
@@ -680,7 +680,7 @@ public class TestMemoryMXBean {
 
 		// Another failure scenario - a non-writable attribute...
 		badList = new AttributeList();
-		garbage = new Attribute("ObjectPendingFinalizationCount", new Integer(2888));
+		garbage = new Attribute("ObjectPendingFinalizationCount", Integer.valueOf(2888));
 		badList.add(garbage);
 		try {
 			setAttrs = mbs.setAttributes(objName, badList);
@@ -695,7 +695,7 @@ public class TestMemoryMXBean {
 
 		// Yet another failure scenario - a wrongly-typed attribute...
 		badList = new AttributeList();
-		garbage = new Attribute("Verbose", new Long(2888));
+		garbage = new Attribute("Verbose", Long.valueOf(2888));
 		badList.add(garbage);
 		try {
 			setAttrs = mbs.setAttributes(objName, badList);

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryManagerMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryManagerMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -349,7 +349,7 @@ public class TestMemoryManagerMXBean {
 			logger.debug("Exception occurred, as expected: " + e1.getMessage());
 		}
 
-		attr = new Attribute("Valid", new Boolean(true));
+		attr = new Attribute("Valid", Boolean.valueOf(true));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Unreacheable code: should have thrown an exception.");
@@ -384,7 +384,7 @@ public class TestMemoryManagerMXBean {
 	public final void testInvoke() {
 		// No operations to invoke...
 		try {
-			Object retVal = mbs.invoke(objName, "KissTheRoadOfRoratonga", new Object[] { new Long(7446), new Long(54) },
+			Object retVal = mbs.invoke(objName, "KissTheRoadOfRoratonga", new Object[] { Long.valueOf(7446), Long.valueOf(54) },
 					new String[] { "java.lang.Long", "java.lang.Long" });
 			Assert.fail("Unreacheable code: should have thrown an exception.");
 		} catch (Exception e) {

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryPoolMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryPoolMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2019 IBM Corp. and others
+ * Copyright (c) 2005, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -267,7 +267,7 @@ public class TestMemoryPoolMXBean {
 		// - UsageThreshold and CollectionUsageThreshold
 		MemoryPoolMXBean testImpl = testBean;
 		AttributeList attList = new AttributeList();
-		Attribute newUT = new Attribute("UsageThreshold", new Long(100 * 1024));
+		Attribute newUT = new Attribute("UsageThreshold", Long.valueOf(100 * 1024));
 		attList.add(newUT);
 		AttributeList setAttrs = null;
 		try {
@@ -288,7 +288,7 @@ public class TestMemoryPoolMXBean {
 		}
 
 		attList = new AttributeList();
-		Attribute newCUT = new Attribute("CollectionUsageThreshold", new Long(250 * 1024));
+		Attribute newCUT = new Attribute("CollectionUsageThreshold", Long.valueOf(250 * 1024));
 		attList.add(newCUT);
 		try {
 			setAttrs = mbs.setAttributes(objName, attList);
@@ -309,7 +309,7 @@ public class TestMemoryPoolMXBean {
 
 		// A failure scenario - a non-existent attribute...
 		AttributeList badList = new AttributeList();
-		Attribute garbage = new Attribute("Bantry", new Long(2888));
+		Attribute garbage = new Attribute("Bantry", Long.valueOf(2888));
 		badList.add(garbage);
 		try {
 			setAttrs = mbs.setAttributes(objName, badList);
@@ -345,7 +345,7 @@ public class TestMemoryPoolMXBean {
 
 		// Yet another failure scenario - a wrongly-typed attribute...
 		badList = new AttributeList();
-		garbage = new Attribute("CollectionUsageThreshold", new Boolean(true));
+		garbage = new Attribute("CollectionUsageThreshold", Boolean.valueOf(true));
 		badList.add(garbage);
 		try {
 			setAttrs = mbs.setAttributes(objName, badList);
@@ -676,10 +676,10 @@ public class TestMemoryPoolMXBean {
 			try {
 				long originalUT = (Long)mbs.getAttribute(objName, "UsageThreshold");
 				long newUT = originalUT + 1024;
-				Attribute newUTAttr = new Attribute("UsageThreshold", new Long(newUT));
+				Attribute newUTAttr = new Attribute("UsageThreshold", Long.valueOf(newUT));
 				mbs.setAttribute(objName, newUTAttr);
 
-				AssertJUnit.assertEquals(new Long(newUT), (Long)mbs.getAttribute(objName, "UsageThreshold"));
+				AssertJUnit.assertEquals(Long.valueOf(newUT), (Long)mbs.getAttribute(objName, "UsageThreshold"));
 			} catch (AttributeNotFoundException e) {
 				e.printStackTrace();
 				Assert.fail("Unexpected AttributeNotFoundException occurred: " + e.getMessage());
@@ -698,7 +698,7 @@ public class TestMemoryPoolMXBean {
 			}
 		} else {
 			try {
-				Attribute newUTAttr = new Attribute("UsageThreshold", new Long(100 * 1024));
+				Attribute newUTAttr = new Attribute("UsageThreshold", Long.valueOf(100 * 1024));
 				mbs.setAttribute(objName, newUTAttr);
 				Assert.fail("Unreacheable code: should have thrown exception!");
 			} catch (Exception e) {
@@ -716,10 +716,10 @@ public class TestMemoryPoolMXBean {
 			try {
 				long originalCUT = (Long)mbs.getAttribute(objName, "CollectionUsageThreshold");
 				long newCUT = originalCUT + 1024;
-				Attribute newCUTAttr = new Attribute("CollectionUsageThreshold", new Long(newCUT));
+				Attribute newCUTAttr = new Attribute("CollectionUsageThreshold", Long.valueOf(newCUT));
 				mbs.setAttribute(objName, newCUTAttr);
 
-				AssertJUnit.assertEquals(new Long(newCUT), (Long)mbs.getAttribute(objName, "CollectionUsageThreshold"));
+				AssertJUnit.assertEquals(Long.valueOf(newCUT), (Long)mbs.getAttribute(objName, "CollectionUsageThreshold"));
 			} catch (AttributeNotFoundException e) {
 				e.printStackTrace();
 				Assert.fail("Unexpected AttributeNotFoundException occurred: " + e.getMessage());
@@ -738,7 +738,7 @@ public class TestMemoryPoolMXBean {
 			}
 		} else {
 			try {
-				Attribute newCUTAttr = new Attribute("CollectionUsageThreshold", new Long(100 * 1024));
+				Attribute newCUTAttr = new Attribute("CollectionUsageThreshold", Long.valueOf(100 * 1024));
 				mbs.setAttribute(objName, newCUTAttr);
 				Assert.fail("Unreacheable code: should have thrown exception!");
 			} catch (Exception e) {
@@ -753,7 +753,7 @@ public class TestMemoryPoolMXBean {
 		MemoryPoolMXBean testImpl = testBean;
 
 		// Let's try and set some non-writable attributes.
-		Attribute attr = new Attribute("UsageThresholdCount", new Long(25));
+		Attribute attr = new Attribute("UsageThresholdCount", Long.valueOf(25));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Unreacheable code: should have thrown an exception.");

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryUsage.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryUsage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2019 IBM Corp. and others
+ * Copyright (c) 2005, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -206,7 +206,7 @@ public class TestMemoryUsage {
 	private static CompositeData createBadCompositeDataObject() {
 		CompositeData result = null;
 		String[] names = { "init", "max", "incorrect", "committed" };
-		Object[] values = { new Long(100), new Long(1000), new Long(150), new Long(500) };
+		Object[] values = { Long.valueOf(100), Long.valueOf(1000), Long.valueOf(150), Long.valueOf(500) };
 		CompositeType cType = createBadCompositeTypeObject();
 		try {
 			result = new CompositeDataSupport(cType, names, values);

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMonitorInfo.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMonitorInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -220,8 +220,8 @@ public class TestMonitorInfo {
 		// i.e. lockedStackDepth and lockedStackFrame have been switched around
 		Object[] values = {
 				/* className */new String(GOOD_CD_CLASSNAME),
-				/* identityHashCode */new Integer(GOOD_CD_IDHASHCODE),
-				/* lockedStackDepth */new Integer(GOOD_CD_STACKDEPTH),
+				/* identityHashCode */Integer.valueOf(GOOD_CD_IDHASHCODE),
+				/* lockedStackDepth */Integer.valueOf(GOOD_CD_STACKDEPTH),
 				/* lockedStackFrame */createGoodStackTraceElementCompositeData() };
 		CompositeType cType = createBadMonitorInfoCompositeTypeObject();
 		try {
@@ -267,9 +267,9 @@ public class TestMonitorInfo {
 		String[] names = { "className", "identityHashCode", "lockedStackFrame", "lockedStackDepth" };
 		Object[] values = {
 				/* className */new String(GOOD_CD_CLASSNAME),
-				/* identityHashCode */new Integer(GOOD_CD_IDHASHCODE),
+				/* identityHashCode */Integer.valueOf(GOOD_CD_IDHASHCODE),
 				/* lockedStackFrame */null,
-				/* lockedStackDepth */new Integer(GOOD_CD_STACKDEPTH) };
+				/* lockedStackDepth */Integer.valueOf(GOOD_CD_STACKDEPTH) };
 		CompositeType cType = createGoodMonitorInfoCompositeType();
 		try {
 			result = new CompositeDataSupport(cType, names, values);
@@ -284,9 +284,9 @@ public class TestMonitorInfo {
 		String[] names = { "className", "identityHashCode", "lockedStackFrame", "lockedStackDepth" };
 		Object[] values = {
 				/* className */null,
-				/* identityHashCode */new Integer(GOOD_CD_IDHASHCODE),
+				/* identityHashCode */Integer.valueOf(GOOD_CD_IDHASHCODE),
 				/* lockedStackFrame */createGoodStackTraceElementCompositeData(),
-				/* lockedStackDepth */new Integer(GOOD_CD_STACKDEPTH) };
+				/* lockedStackDepth */Integer.valueOf(GOOD_CD_STACKDEPTH) };
 		CompositeType cType = createGoodMonitorInfoCompositeType();
 		try {
 			result = new CompositeDataSupport(cType, names, values);
@@ -342,9 +342,9 @@ public class TestMonitorInfo {
 		String[] names = { "className", "identityHashCode", "lockedStackFrame", "lockedStackDepth" };
 		Object[] values = {
 				/* className */new String(GOOD_CD_CLASSNAME),
-				/* identityHashCode */new Integer(GOOD_CD_IDHASHCODE),
+				/* identityHashCode */Integer.valueOf(GOOD_CD_IDHASHCODE),
 				/* lockedStackFrame */createGoodStackTraceElementCompositeData(),
-				/* lockedStackDepth */new Integer(GOOD_CD_STACKDEPTH) };
+				/* lockedStackDepth */Integer.valueOf(GOOD_CD_STACKDEPTH) };
 		CompositeType cType = createGoodMonitorInfoCompositeType();
 		try {
 			result = new CompositeDataSupport(cType, names, values);
@@ -370,8 +370,8 @@ public class TestMonitorInfo {
 					new String("foo.bar.Blobby"),
 					new String("takeOverWorld"),
 					new String("Blobby.java"),
-					new Integer(2100),
-					new Boolean(false),
+					Integer.valueOf(2100),
+					Boolean.valueOf(false),
 					new String("myModuleName"),
 					new String("myModuleVersion"),
 					new String("myClassLoaderName") };
@@ -383,8 +383,8 @@ public class TestMonitorInfo {
 					new String("foo.bar.Blobby"),
 					new String("takeOverWorld"),
 					new String("Blobby.java"),
-					new Integer(2100),
-					new Boolean(false) };
+					Integer.valueOf(2100),
+					Boolean.valueOf(false) };
 			names = namesTmp;
 			values = valuesTmp;
 		}

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOperatingSystemMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOperatingSystemMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2019 IBM Corp. and others
+ * Copyright (c) 2005, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -271,7 +271,7 @@ public class TestOperatingSystemMXBean {
 			// expected
 		}
 
-		attr = new Attribute("AvailableProcessors", new Integer(2));
+		attr = new Attribute("AvailableProcessors", Integer.valueOf(2));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Should have thrown an exception.");
@@ -280,7 +280,7 @@ public class TestOperatingSystemMXBean {
 		}
 
 		// Try and set the Name attribute with an incorrect type.
-		attr = new Attribute("Name", new Long(42));
+		attr = new Attribute("Name", Long.valueOf(42));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Should have thrown an exception");
@@ -529,7 +529,7 @@ public class TestOperatingSystemMXBean {
 	public final void testInvoke() {
 		// OperatingSystemMXBean has no operations to invoke...
 		try {
-			Object retVal = mbs.invoke(objName, "DoTheRightThing", new Object[] { new Long(7446), new Long(54) },
+			Object retVal = mbs.invoke(objName, "DoTheRightThing", new Object[] { Long.valueOf(7446), Long.valueOf(54) },
 					new String[] { "java.lang.Long", "java.lang.Long" });
 			Assert.fail("Should have thrown an exception.");
 		} catch (Exception e) {

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestRuntimeMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestRuntimeMXBean.java
@@ -403,7 +403,7 @@ public class TestRuntimeMXBean {
 		} catch (Exception e1) {
 		}
 
-		attr = new Attribute("StartTime", new Long(2333));
+		attr = new Attribute("StartTime", Long.valueOf(2333));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Should have thrown an exception.");
@@ -417,7 +417,7 @@ public class TestRuntimeMXBean {
 		} catch (Exception e1) {
 		}
 
-		attr = new Attribute("Uptime", new Long(1979));
+		attr = new Attribute("Uptime", Long.valueOf(1979));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Should have thrown an exception.");
@@ -445,7 +445,7 @@ public class TestRuntimeMXBean {
 		} catch (Exception e1) {
 		}
 
-		attr = new Attribute("BootClassPathSupported", new Boolean(false));
+		attr = new Attribute("BootClassPathSupported", Boolean.valueOf(false));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Should have thrown an exception.");
@@ -453,7 +453,7 @@ public class TestRuntimeMXBean {
 		}
 
 		// Try and set the Name attribute with an incorrect type.
-		attr = new Attribute("Name", new Long(42));
+		attr = new Attribute("Name", Long.valueOf(42));
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Should have thrown an exception");
@@ -571,7 +571,7 @@ public class TestRuntimeMXBean {
 		try {
 			Object retVal = null;
 			try {
-				retVal = mbs.invoke(objName, "DoTheStrand", new Object[] { new Long(7446), new Long(54) },
+				retVal = mbs.invoke(objName, "DoTheStrand", new Object[] { Long.valueOf(7446), Long.valueOf(54) },
 						new String[] { "java.lang.Long", "java.lang.Long" });
 			} catch (InstanceNotFoundException e) {
 				// An unlikely exception - if this occurs, we can't proceed with the test.

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestThreadMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestThreadMXBean.java
@@ -786,7 +786,7 @@ public class TestThreadMXBean {
 	public final void testSetAttribute() {
 		// There are only two writable attributes in this type.
 
-		Attribute attr = new Attribute("ThreadContentionMonitoringEnabled", new Boolean(true));
+		Attribute attr = new Attribute("ThreadContentionMonitoringEnabled", Boolean.valueOf(true));
 
 		if (tb.isThreadContentionMonitoringSupported()) {
 			try {
@@ -808,7 +808,7 @@ public class TestThreadMXBean {
 			}
 		}
 
-		attr = new Attribute("ThreadCpuTimeEnabled", new Boolean(true));
+		attr = new Attribute("ThreadCpuTimeEnabled", Boolean.valueOf(true));
 		if (tb.isThreadCpuTimeSupported()) {
 			try {
 				// TODO : Set - test - Reset, when VM permits
@@ -934,7 +934,7 @@ public class TestThreadMXBean {
 		}
 
 		// Try and set an attribute with an incorrect type.
-		attr = new Attribute("ThreadContentionMonitoringEnabled", new Long(42));
+		attr = new Attribute("ThreadContentionMonitoringEnabled", Long.valueOf(42));
 		if (tb.isThreadContentionMonitoringSupported()) {
 			try {
 				mbs.setAttribute(objName, attr);
@@ -1025,8 +1025,8 @@ public class TestThreadMXBean {
 	public final void testSetAttributes() {
 		// Ideal scenario...
 		AttributeList attList = new AttributeList();
-		Attribute tcme = new Attribute("ThreadContentionMonitoringEnabled", new Boolean(false));
-		Attribute tcte = new Attribute("ThreadCpuTimeEnabled", new Boolean(true));
+		Attribute tcme = new Attribute("ThreadContentionMonitoringEnabled", Boolean.valueOf(false));
+		Attribute tcte = new Attribute("ThreadCpuTimeEnabled", Boolean.valueOf(true));
 		attList.add(tcme);
 		attList.add(tcte);
 		AttributeList setAttrs = null;
@@ -1049,7 +1049,7 @@ public class TestThreadMXBean {
 
 		// A failure scenario - a non-existent attribute...
 		AttributeList badList = new AttributeList();
-		Attribute garbage = new Attribute("Auchenback", new Long(2888));
+		Attribute garbage = new Attribute("Auchenback", Long.valueOf(2888));
 		badList.add(garbage);
 		try {
 			setAttrs = mbs.setAttributes(objName, badList);
@@ -1067,7 +1067,7 @@ public class TestThreadMXBean {
 
 		// Another failure scenario - a non-writable attribute...
 		badList = new AttributeList();
-		garbage = new Attribute("ThreadCount", new Long(2888));
+		garbage = new Attribute("ThreadCount", Long.valueOf(2888));
 		badList.add(garbage);
 		try {
 			setAttrs = mbs.setAttributes(objName, badList);
@@ -1085,7 +1085,7 @@ public class TestThreadMXBean {
 
 		// Yet another failure scenario - a wrongly-typed attribute...
 		badList = new AttributeList();
-		garbage = new Attribute("ThreadCpuTimeEnabled", new Long(2888));
+		garbage = new Attribute("ThreadCpuTimeEnabled", Long.valueOf(2888));
 		badList.add(garbage);
 		try {
 			setAttrs = mbs.setAttributes(objName, badList);
@@ -1121,7 +1121,7 @@ public class TestThreadMXBean {
 		// Good case.
 		try {
 			Object retVal = mbs.invoke(objName, "getThreadCpuTime",
-					new Object[] { new Long(Thread.currentThread().getId()) }, new String[] { Long.TYPE.getName() });
+					new Object[] { Long.valueOf(Thread.currentThread().getId()) }, new String[] { Long.TYPE.getName() });
 			AssertJUnit.assertNotNull(retVal);
 			AssertJUnit.assertTrue(retVal instanceof Long);
 		} catch (Exception e) {
@@ -1131,7 +1131,7 @@ public class TestThreadMXBean {
 
 		// Force exception by passing in a negative Thread id
 		try {
-			Object retVal = mbs.invoke(objName, "getThreadCpuTime", new Object[] { new Long(-757) },
+			Object retVal = mbs.invoke(objName, "getThreadCpuTime", new Object[] { Long.valueOf(-757) },
 					new String[] { Long.TYPE.getName() });
 			Assert.fail("Should have thrown an exception!");
 		} catch (Exception e) {
@@ -1150,7 +1150,7 @@ public class TestThreadMXBean {
 		// Good case. long
 		try {
 			Object retVal = mbs.invoke(objName, "getThreadInfo",
-					new Object[] { new Long(Thread.currentThread().getId()) }, new String[] { Long.TYPE.getName() });
+					new Object[] { Long.valueOf(Thread.currentThread().getId()) }, new String[] { Long.TYPE.getName() });
 			// TODO Can't test until we can get back ThreadInfo objects
 			// from the getThreadInfo(long) method.
 			AssertJUnit.assertNotNull(retVal);
@@ -1167,7 +1167,7 @@ public class TestThreadMXBean {
 
 		// Force exception by passing in a negative Thread id. long
 		try {
-			Object retVal = mbs.invoke(objName, "getThreadInfo", new Object[] { new Long(-5353) },
+			Object retVal = mbs.invoke(objName, "getThreadInfo", new Object[] { Long.valueOf(-5353) },
 					new String[] { Long.TYPE.getName() });
 			Assert.fail("Should have thrown an exception!");
 		} catch (Exception e) {
@@ -1177,7 +1177,7 @@ public class TestThreadMXBean {
 		// Good case. long, int
 		try {
 			Object retVal = mbs.invoke(objName, "getThreadInfo",
-					new Object[] { new Long(Thread.currentThread().getId()), new Integer(0) },
+					new Object[] { Long.valueOf(Thread.currentThread().getId()), Integer.valueOf(0) },
 					new String[] { Long.TYPE.getName(), Integer.TYPE.getName() });
 			// TODO Can't test until we can get back ThreadInfo objects
 			// from the getThreadInfo(long) method.
@@ -1195,7 +1195,7 @@ public class TestThreadMXBean {
 
 		// Force exception by passing in a negative Thread id. long, int
 		try {
-			Object retVal = mbs.invoke(objName, "getThreadInfo", new Object[] { new Long(-8467), new Integer(0) },
+			Object retVal = mbs.invoke(objName, "getThreadInfo", new Object[] { Long.valueOf(-8467), Integer.valueOf(0) },
 					new String[] { Long.TYPE.getName(), Integer.TYPE.getName() });
 			Assert.fail("Should have thrown an exception!");
 		} catch (Exception e) {
@@ -1205,7 +1205,7 @@ public class TestThreadMXBean {
 		// Good case. long[], int
 		try {
 			Object retVal = mbs.invoke(objName, "getThreadInfo",
-					new Object[] { new long[] { Thread.currentThread().getId() }, new Integer(0) },
+					new Object[] { new long[] { Thread.currentThread().getId() }, Integer.valueOf(0) },
 					new String[] { "[J", Integer.TYPE.getName() });
 			// TODO Can't test until we can get back ThreadInfo objects
 			// from the getThreadInfo(long) method.
@@ -1224,7 +1224,7 @@ public class TestThreadMXBean {
 		// Force exception by passing in a negative Thread id. long[], int
 		try {
 			Object retVal = mbs.invoke(objName, "getThreadInfo",
-					new Object[] { new long[] { -54321L }, new Integer(0) },
+					new Object[] { new long[] { -54321L }, Integer.valueOf(0) },
 					new String[] { "[J", Integer.TYPE.getName() });
 			Assert.fail("Should have thrown an exception!");
 		} catch (Exception e) {
@@ -1263,7 +1263,7 @@ public class TestThreadMXBean {
 		// Good case.
 		try {
 			Object retVal = mbs.invoke(objName, "getThreadUserTime",
-					new Object[] { new Long(Thread.currentThread().getId()) }, new String[] { Long.TYPE.getName() });
+					new Object[] { Long.valueOf(Thread.currentThread().getId()) }, new String[] { Long.TYPE.getName() });
 			AssertJUnit.assertNotNull(retVal);
 			AssertJUnit.assertTrue(retVal instanceof Long);
 		} catch (Exception e) {
@@ -1272,7 +1272,7 @@ public class TestThreadMXBean {
 
 		// Force exception by passing in a negative Thread id
 		try {
-			Object retVal = mbs.invoke(objName, "getThreadUserTime", new Object[] { new Long(-757) },
+			Object retVal = mbs.invoke(objName, "getThreadUserTime", new Object[] { Long.valueOf(-757) },
 					new String[] { Long.TYPE.getName() });
 			Assert.fail("Should have thrown an exception!");
 		} catch (Exception e) {

--- a/test/functional/JLM_Tests/src_80/org/openj9/test/java/lang/management/TestThreadInfo.java
+++ b/test/functional/JLM_Tests/src_80/org/openj9/test/java/lang/management/TestThreadInfo.java
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -149,18 +148,18 @@ public class TestThreadInfo {
 		typeDescsGlobal = typeDescsGlobalTmp;
 
 		Object[] valuesCompositeDataGlobalTmp = {
-				/* threadId */new Long(GOOD_THREAD_ID),
+				/* threadId */Long.valueOf(GOOD_THREAD_ID),
 				/* threadName */new String(GOOD_THREAD_NAME),
 				/* threadState */new String(GOOD_THREAD_STATE),
-				/* suspended */new Boolean(GOOD_SUSPENDED),
-				/* inNative */new Boolean(GOOD_IN_NATIVE),
-				/* blockedCount */new Long(GOOD_BLOCKED_COUNT),
-				/* blockedTime */new Long(GOOD_BLOCKED_TIME),
-				/* waitedCount */new Long(GOOD_WAITED_COUNT),
-				/* waitedTime */new Long(GOOD_WAITED_TIME),
+				/* suspended */Boolean.valueOf(GOOD_SUSPENDED),
+				/* inNative */Boolean.valueOf(GOOD_IN_NATIVE),
+				/* blockedCount */Long.valueOf(GOOD_BLOCKED_COUNT),
+				/* blockedTime */Long.valueOf(GOOD_BLOCKED_TIME),
+				/* waitedCount */Long.valueOf(GOOD_WAITED_COUNT),
+				/* waitedTime */Long.valueOf(GOOD_WAITED_TIME),
 				/* lockInfo */TestLockInfo.createGoodCompositeData(),
 				/* lockName */new String(GOOD_LOCK_NAME),
-				/* lockOwnerId */new Long(GOOD_LOCK_OWNER_ID),
+				/* lockOwnerId */Long.valueOf(GOOD_LOCK_OWNER_ID),
 				/* lockOwnerName */new String(GOOD_LOCK_OWNER_NAME),
 				/* stackTrace */createGoodStackTraceCompositeData(),
 				/* lockedMonitors */monitors,
@@ -168,18 +167,18 @@ public class TestThreadInfo {
 		valuesCompositeDataGlobal = valuesCompositeDataGlobalTmp;
 
 		Object[] valuesGoodCompositeDataNoLockInfoTmp = {
-				/* threadId */new Long(GOOD_THREAD_ID),
+				/* threadId */Long.valueOf(GOOD_THREAD_ID),
 				/* threadName */new String(GOOD_THREAD_NAME),
 				/* threadState */new String(GOOD_THREAD_STATE),
-				/* suspended */new Boolean(GOOD_SUSPENDED),
-				/* inNative */new Boolean(GOOD_IN_NATIVE),
-				/* blockedCount */new Long(GOOD_BLOCKED_COUNT),
-				/* blockedTime */new Long(GOOD_BLOCKED_TIME),
-				/* waitedCount */new Long(GOOD_WAITED_COUNT),
-				/* waitedTime */new Long(GOOD_WAITED_TIME),
+				/* suspended */Boolean.valueOf(GOOD_SUSPENDED),
+				/* inNative */Boolean.valueOf(GOOD_IN_NATIVE),
+				/* blockedCount */Long.valueOf(GOOD_BLOCKED_COUNT),
+				/* blockedTime */Long.valueOf(GOOD_BLOCKED_TIME),
+				/* waitedCount */Long.valueOf(GOOD_WAITED_COUNT),
+				/* waitedTime */Long.valueOf(GOOD_WAITED_TIME),
 				/* lockInfo */createDummyCompositeData(),
 				/* lockName */new String(GOOD_LOCK_NAME),
-				/* lockOwnerId */new Long(GOOD_LOCK_OWNER_ID),
+				/* lockOwnerId */Long.valueOf(GOOD_LOCK_OWNER_ID),
 				/* lockOwnerName */new String(GOOD_LOCK_OWNER_NAME),
 				/* stackTrace */createGoodStackTraceCompositeData(),
 				/* lockedMonitors */monitors,
@@ -544,7 +543,7 @@ public class TestThreadInfo {
 		String[] names = { "className", "identityHashCode" };
 		Object[] values = {
 				/* className */new String(GOOD_LOCK_CLASSNAME),
-				/* identityHashCode */new Integer(GOOD_LOCK_HASH) };
+				/* identityHashCode */Integer.valueOf(GOOD_LOCK_HASH) };
 		CompositeType cType = TestLockInfo.createGoodLockInfoCompositeType();
 		try {
 			result = new CompositeDataSupport(cType, names, values);
@@ -645,8 +644,8 @@ public class TestThreadInfo {
 				new String("foo.bar.Blobby"),
 				new String("takeOverWorld"),
 				new String("Blobby.java"),
-				new Integer(2100),
-				new Boolean(false) };
+				Integer.valueOf(2100),
+				Boolean.valueOf(false) };
 
 		for (int i = 0; i < result.length; i++) {
 			try {

--- a/test/functional/JLM_Tests/src_90/org/openj9/test/java/lang/management/TestThreadInfo.java
+++ b/test/functional/JLM_Tests/src_90/org/openj9/test/java/lang/management/TestThreadInfo.java
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -153,45 +152,45 @@ public class TestThreadInfo {
 		typeDescsGlobal = typeDescsGlobalTmp;
 
 		Object[] valuesCompositeDataGlobalTmp = {
-				/* threadId */new Long(GOOD_THREAD_ID),
+				/* threadId */Long.valueOf(GOOD_THREAD_ID),
 				/* threadName */new String(GOOD_THREAD_NAME),
 				/* threadState */new String(GOOD_THREAD_STATE),
-				/* suspended */new Boolean(GOOD_SUSPENDED),
-				/* inNative */new Boolean(GOOD_IN_NATIVE),
-				/* blockedCount */new Long(GOOD_BLOCKED_COUNT),
-				/* blockedTime */new Long(GOOD_BLOCKED_TIME),
-				/* waitedCount */new Long(GOOD_WAITED_COUNT),
-				/* waitedTime */new Long(GOOD_WAITED_TIME),
+				/* suspended */Boolean.valueOf(GOOD_SUSPENDED),
+				/* inNative */Boolean.valueOf(GOOD_IN_NATIVE),
+				/* blockedCount */Long.valueOf(GOOD_BLOCKED_COUNT),
+				/* blockedTime */Long.valueOf(GOOD_BLOCKED_TIME),
+				/* waitedCount */Long.valueOf(GOOD_WAITED_COUNT),
+				/* waitedTime */Long.valueOf(GOOD_WAITED_TIME),
 				/* lockInfo */TestLockInfo.createGoodCompositeData(),
 				/* lockName */new String(GOOD_LOCK_NAME),
-				/* lockOwnerId */new Long(GOOD_LOCK_OWNER_ID),
+				/* lockOwnerId */Long.valueOf(GOOD_LOCK_OWNER_ID),
 				/* lockOwnerName */new String(GOOD_LOCK_OWNER_NAME),
 				/* stackTrace */createGoodStackTraceCompositeData(),
 				/* lockedMonitors */monitors,
 				/* lockedSynchronizers */synchronizers,
-				/* daemon */new Boolean(GOOD_DAEMON),
-				/* priority */new Integer(GOOD_PRIORITY) };
+				/* daemon */Boolean.valueOf(GOOD_DAEMON),
+				/* priority */Integer.valueOf(GOOD_PRIORITY) };
 		valuesCompositeDataGlobal = valuesCompositeDataGlobalTmp;
 
 		Object[] valuesGoodCompositeDataNoLockInfoTmp = {
-				/* threadId */new Long(GOOD_THREAD_ID),
+				/* threadId */Long.valueOf(GOOD_THREAD_ID),
 				/* threadName */new String(GOOD_THREAD_NAME),
 				/* threadState */new String(GOOD_THREAD_STATE),
-				/* suspended */new Boolean(GOOD_SUSPENDED),
-				/* inNative */new Boolean(GOOD_IN_NATIVE),
-				/* blockedCount */new Long(GOOD_BLOCKED_COUNT),
-				/* blockedTime */new Long(GOOD_BLOCKED_TIME),
-				/* waitedCount */new Long(GOOD_WAITED_COUNT),
-				/* waitedTime */new Long(GOOD_WAITED_TIME),
+				/* suspended */Boolean.valueOf(GOOD_SUSPENDED),
+				/* inNative */Boolean.valueOf(GOOD_IN_NATIVE),
+				/* blockedCount */Long.valueOf(GOOD_BLOCKED_COUNT),
+				/* blockedTime */Long.valueOf(GOOD_BLOCKED_TIME),
+				/* waitedCount */Long.valueOf(GOOD_WAITED_COUNT),
+				/* waitedTime */Long.valueOf(GOOD_WAITED_TIME),
 				/* lockInfo */createDummyCompositeData(),
 				/* lockName */new String(GOOD_LOCK_NAME),
-				/* lockOwnerId */new Long(GOOD_LOCK_OWNER_ID),
+				/* lockOwnerId */Long.valueOf(GOOD_LOCK_OWNER_ID),
 				/* lockOwnerName */new String(GOOD_LOCK_OWNER_NAME),
 				/* stackTrace */createGoodStackTraceCompositeData(),
 				/* lockedMonitors */monitors,
 				/* lockedSynchronizers */synchronizers,
-				/* daemon */new Boolean(GOOD_DAEMON),
-				/* priority */new Integer(GOOD_PRIORITY) };
+				/* daemon */Boolean.valueOf(GOOD_DAEMON),
+				/* priority */Integer.valueOf(GOOD_PRIORITY) };
 		valuesGoodCompositeDataNoLockInfo = valuesGoodCompositeDataNoLockInfoTmp;
 
 		try {
@@ -570,7 +569,7 @@ public class TestThreadInfo {
 		String[] names = { "className", "identityHashCode" };
 		Object[] values = {
 				/* className */new String(GOOD_LOCK_CLASSNAME),
-				/* identityHashCode */new Integer(GOOD_LOCK_HASH) };
+				/* identityHashCode */Integer.valueOf(GOOD_LOCK_HASH) };
 		CompositeType cType = TestLockInfo.createGoodLockInfoCompositeType();
 		try {
 			result = new CompositeDataSupport(cType, names, values);
@@ -674,8 +673,8 @@ public class TestThreadInfo {
 				new String("foo.bar.Blobby"),
 				new String("takeOverWorld"),
 				new String("Blobby.java"),
-				new Integer(2100),
-				new Boolean(false),
+				Integer.valueOf(2100),
+				Boolean.valueOf(false),
 				new String("myModuleName"),
 				new String("myModuleVersion"),
 				new String("myClassLoaderName") };

--- a/test/functional/Java10andUp/src/org/openj9/test/stackWalker/StackWalkerTestJava10.java
+++ b/test/functional/Java10andUp/src/org/openj9/test/stackWalker/StackWalkerTestJava10.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,7 +52,7 @@ public class StackWalkerTestJava10 {
 	}
 
 	void sanityMethod_1(int i) {
-		if (i > 0) sanityMethod_1(i-1); else sanityMethod_2(new Integer(42));
+		if (i > 0) sanityMethod_1(i-1); else sanityMethod_2(Integer.valueOf(42));
 	}
 
 	private void sanityMethod_2(Integer in) {

--- a/test/functional/Java15andUp/src/org/openj9/test/records/RecordFinalFieldTests.java
+++ b/test/functional/Java15andUp/src/org/openj9/test/records/RecordFinalFieldTests.java
@@ -150,7 +150,7 @@ public class RecordFinalFieldTests {
         Field finalRecordField = TestRecord.class.getDeclaredField("recordComponent");
         finalRecordField.setAccessible(true);
         VarHandle finalRecordFieldHandle = MethodHandles.lookup().unreflectVarHandle(finalRecordField);
-        finalRecordFieldHandle.set(new Integer(5));
+        finalRecordFieldHandle.set(Integer.valueOf(5));
     }
 
     /* VarHandle.set is not supported for records. */

--- a/test/functional/Java8andUp/src/j9vm/test/hashCode/HashTest.java
+++ b/test/functional/Java8andUp/src/j9vm/test/hashCode/HashTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -151,7 +151,7 @@ public class HashTest {
 			if (randomPadding) {
 				int r = rand.nextInt(128);
 				while (r > 0) {
-					Integer foo = new Integer(r);
+					Integer foo = Integer.valueOf(r);
 					r--;
 				}
 			}

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/MemoryExhauster.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/MemoryExhauster.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,7 +37,7 @@ public class MemoryExhauster {
 	public MemoryExhauster(MemoryExhauster predecessor, long i) {
 		try {
 			link = predecessor;
-			bloat = new Long(i);
+			bloat = Long.valueOf(i);
 		} catch (OutOfMemoryError e) {
 			bloat = null;
 			link = null;

--- a/test/functional/Java8andUp/src/org/openj9/test/contendedfields/FieldUtilities.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/contendedfields/FieldUtilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -98,7 +98,7 @@ public class FieldUtilities  {
 				case "long": f.setLong(testObject, longValue + fieldCount);
 				break;
 				case "Object": {
-					f.set(testObject, new Integer(fieldCount));
+					f.set(testObject, Integer.valueOf(fieldCount));
 				}
 				break;
 				default: if (strict) {

--- a/test/functional/Java8andUp/src/org/openj9/test/fileLock/NativeFileLock.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/fileLock/NativeFileLock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,7 +40,7 @@ public class NativeFileLock extends GenericFileLock {
 		Constructor<?> nflConstructor = nativeFileLock.getDeclaredConstructor(
 				java.lang.String.class, int.class);
 		nflConstructor.setAccessible(true);
-		fileLockObject = nflConstructor.newInstance(lockFile.getAbsolutePath(), new Integer(mode));
+		fileLockObject = nflConstructor.newInstance(lockFile.getAbsolutePath(), Integer.valueOf(mode));
 		lockFileMethod = nativeFileLock.getDeclaredMethod("lockFile",
 				boolean.class);
 		lockFileMethod.setAccessible(true);
@@ -51,9 +51,9 @@ public class NativeFileLock extends GenericFileLock {
 
 	@Override
 	public boolean lockFile(boolean blocking) throws Exception {
-		Boolean result = new Boolean(true);
+		Boolean result = Boolean.valueOf(true);
 		TestFileLocking.logger.debug("lockfile blocking =" + blocking);
-		result = (Boolean) lockFileMethod.invoke(fileLockObject, new Boolean(blocking));
+		result = (Boolean) lockFileMethod.invoke(fileLockObject, Boolean.valueOf(blocking));
 		return result.booleanValue();
 	}
 

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/ref/Test_PhantomReference.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/ref/Test_PhantomReference.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.lang.ref;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,7 +42,7 @@ public class Test_PhantomReference {
 	@Test
 	public void test_get() {
 		ReferenceQueue rq = new ReferenceQueue();
-		bool = new Boolean(false);
+		bool = Boolean.valueOf(false);
 		PhantomReference pr = new PhantomReference(bool, rq);
 		AssertJUnit.assertTrue("Same object returned.", pr.get() == null);
 	}
@@ -53,7 +53,7 @@ public class Test_PhantomReference {
 	@Test
 	public void test_Constructor() {
 		ReferenceQueue rq = new ReferenceQueue();
-		bool = new Boolean(true);
+		bool = Boolean.valueOf(true);
 		try {
 			PhantomReference pr = new PhantomReference(bool, rq);
 			// Allow the finalizer to run to potentially enqueue

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/ref/Test_ReferenceQueue.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/ref/Test_ReferenceQueue.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.lang.ref;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,7 +55,7 @@ public class Test_ReferenceQueue {
 			synchronized (rq) {
 				// store in a static so it won't be gc'ed because the jit
 				// optimized it out
-				integer = new Integer(667);
+				integer = Integer.valueOf(667);
 				SoftReference sr = new SoftReference(integer, rq);
 				sr.enqueue();
 				rq.notify();
@@ -74,7 +74,7 @@ public class Test_ReferenceQueue {
 	public void test_poll() {
 		// store in a static so it won't be gc'ed because the jit
 		// optimized it out
-		b = new Boolean(true);
+		b = Boolean.valueOf(true);
 		//SM
 		SoftReference sr = new SoftReference(b, rq);
 		sr.enqueue();
@@ -96,7 +96,7 @@ public class Test_ReferenceQueue {
 	public void test_remove() {
 		// store in a static so it won't be gc'ed because the jit
 		// optimized it out
-		b = new Boolean(true);
+		b = Boolean.valueOf(true);
 		//SM
 		SoftReference sr = new SoftReference(b, rq);
 		sr.enqueue();

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/ref/Test_SoftReference.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/ref/Test_SoftReference.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.lang.ref;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,7 +42,7 @@ public class Test_SoftReference {
 	public void test_Constructor() {
 		//SM.
 		ReferenceQueue rq = new ReferenceQueue();
-		bool = new Boolean(true);
+		bool = Boolean.valueOf(true);
 		try {
 			SoftReference sr = new SoftReference(bool, rq);
 			AssertJUnit.assertTrue("Initialization failed.", ((Boolean)sr.get()).booleanValue());
@@ -65,7 +65,7 @@ public class Test_SoftReference {
 	@Test
 	public void test_Constructor2() {
 		//SM.
-		bool = new Boolean(true);
+		bool = Boolean.valueOf(true);
 		try {
 			SoftReference sr = new SoftReference(bool);
 			AssertJUnit.assertTrue("Initialization failed.", ((Boolean)sr.get()).booleanValue());
@@ -80,7 +80,7 @@ public class Test_SoftReference {
 	@Test
 	public void test_get() {
 		//SM.
-		bool = new Boolean(false);
+		bool = Boolean.valueOf(false);
 		SoftReference sr = new SoftReference(bool);
 		AssertJUnit.assertTrue("Same object not returned.", bool == sr.get());
 	}

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/ref/Test_WeakReference.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/ref/Test_WeakReference.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.lang.ref;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,7 +43,7 @@ public class Test_WeakReference {
 	public void test_Constructor() {
 		// SM.
 		ReferenceQueue rq = new ReferenceQueue();
-		bool = new Boolean(true);
+		bool = Boolean.valueOf(true);
 		try {
 			// Allow the finalizer to run to potentially enqueue
 			WeakReference wr = new WeakReference(bool, rq);
@@ -70,7 +70,7 @@ public class Test_WeakReference {
 	@Test
 	public void test_Constructor2() {
 		// SM.
-		bool = new Boolean(true);
+		bool = Boolean.valueOf(true);
 		try {
 			WeakReference wr = new WeakReference(bool);
 			// Allow the finalizer to run to potentially enqueue

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/reflect/Test_Array.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/reflect/Test_Array.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.lang.reflect;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -499,7 +499,7 @@ public class Test_Array {
 		Object ret = null;
 		boolean thrown = false;
 		try {
-			Array.set(x, 0, new Integer(1));
+			Array.set(x, 0, Integer.valueOf(1));
 		} catch (Exception e) {
 			AssertJUnit.assertTrue("Exception during get test: " + e.toString(), false);
 		}
@@ -514,7 +514,7 @@ public class Test_Array {
 			AssertJUnit.assertTrue("Passing non-array failed to throw exception", false);
 		thrown = false;
 		try {
-			Array.set(x, 4, new Integer(1));
+			Array.set(x, 4, Integer.valueOf(1));
 		} catch (ArrayIndexOutOfBoundsException e) {
 			// Correct behaviour
 			thrown = true;

--- a/test/functional/Java8andUp/src/org/openj9/test/java/security/Test_AccessController.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/security/Test_AccessController.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.security;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -93,9 +93,9 @@ public class Test_AccessController {
 			public Object run() {
 				try {
 					AccessController.checkPermission(new AllPermission());
-					return new Boolean(false);
+					return Boolean.valueOf(false);
 				} catch (SecurityException ex) {
-					return new Boolean(true);
+					return Boolean.valueOf(true);
 				}
 			}
 		}, null);

--- a/test/functional/Java8andUp/src/org/openj9/test/vmArguments/VmArgumentTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/vmArguments/VmArgumentTests.java
@@ -1689,7 +1689,7 @@ public class VmArgumentTests {
 			int p = 0;
 			for (String a: actualArguments) {
 				if (a.startsWith(op)) {
-					argPositions.put(op, new Integer(p));
+					argPositions.put(op, Integer.valueOf(p));
 					break;
 				} else {
 					++p;

--- a/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_System.java
+++ b/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_System.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.lang;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -97,7 +97,7 @@ public class Test_System {
 		Integer b[] = new Integer[20];
 		int i = 0;
 		while (i < a.length) {
-			a[i] = new Integer(i);
+			a[i] = Integer.valueOf(i);
 			++i;
 		}
 		System.arraycopy(a, 0, b, 0, a.length);

--- a/test/functional/Java8andUp/src_80/org/openj9/test/java/lang/Test_System.java
+++ b/test/functional/Java8andUp/src_80/org/openj9/test/java/lang/Test_System.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.lang;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -95,7 +95,7 @@ public class Test_System {
 		Integer b[] = new Integer[20];
 		int i = 0;
 		while (i < a.length) {
-			a[i] = new Integer(i);
+			a[i] = Integer.valueOf(i);
 			++i;
 		}
 		System.arraycopy(a, 0, b, 0, a.length);

--- a/test/functional/Java8andUp/src_90/org/openj9/test/java/lang/Test_System.java
+++ b/test/functional/Java8andUp/src_90/org/openj9/test/java/lang/Test_System.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.lang;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -97,7 +97,7 @@ public class Test_System {
 		Integer b[] = new Integer[20];
 		int i = 0;
 		while (i < a.length) {
-			a[i] = new Integer(i);
+			a[i] = Integer.valueOf(i);
 			++i;
 		}
 		System.arraycopy(a, 0, b, 0, a.length);

--- a/test/functional/Java9andUp/src/org/openj9/test/varhandle/VarHandleInvokerTest.java
+++ b/test/functional/Java9andUp/src/org/openj9/test/varhandle/VarHandleInvokerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,19 +71,19 @@ public class VarHandleInvokerTest {
 		MethodHandle setHandle = MethodHandles.varHandleInvoker(AccessMode.SET, MethodType.methodType(void.class, VarHandleInvokerTest.class, Integer.class));
 		MethodHandle casHandle = MethodHandles.varHandleInvoker(AccessMode.COMPARE_AND_SET, MethodType.methodType(Boolean.class, VarHandleInvokerTest.class, Integer.class, Integer.class));
 
-		setHandle.invoke(varHandle, vhit, new Integer(12345));
+		setHandle.invoke(varHandle, vhit, Integer.valueOf(12345));
 		Assert.assertEquals(12345, getHandle.invoke(varHandle, vhit));
-		Assert.assertEquals(false, casHandle.invoke(varHandle, vhit, new Integer(54321), new Integer(111)));
+		Assert.assertEquals(false, casHandle.invoke(varHandle, vhit, Integer.valueOf(54321), Integer.valueOf(111)));
 		Assert.assertEquals(12345, getHandle.invoke(varHandle, vhit));
-		Assert.assertEquals(true, casHandle.invoke(varHandle, vhit, new Integer(12345), new Integer(54321)));
+		Assert.assertEquals(true, casHandle.invoke(varHandle, vhit, Integer.valueOf(12345), Integer.valueOf(54321)));
 		Assert.assertEquals(54321, getHandle.invoke(varHandle, vhit));
 
-		setHandle.invokeExact(varHandle, vhit, new Integer(12345));
-		Assert.assertEquals(new Integer(12345), (Integer)getHandle.invokeExact(varHandle, vhit));
-		Assert.assertEquals(new Boolean(false), (Boolean)casHandle.invokeExact(varHandle, vhit, new Integer(54321), new Integer(111)));
-		Assert.assertEquals(new Integer(12345), (Integer)getHandle.invokeExact(varHandle, vhit));
-		Assert.assertEquals(new Boolean(true), (Boolean)casHandle.invokeExact(varHandle, vhit, new Integer(12345), new Integer(54321)));
-		Assert.assertEquals(new Integer(54321), (Integer)getHandle.invokeExact(varHandle, vhit));
+		setHandle.invokeExact(varHandle, vhit, Integer.valueOf(12345));
+		Assert.assertEquals(Integer.valueOf(12345), (Integer)getHandle.invokeExact(varHandle, vhit));
+		Assert.assertEquals(Boolean.valueOf(false), (Boolean)casHandle.invokeExact(varHandle, vhit, Integer.valueOf(54321), Integer.valueOf(111)));
+		Assert.assertEquals(Integer.valueOf(12345), (Integer)getHandle.invokeExact(varHandle, vhit));
+		Assert.assertEquals(Boolean.valueOf(true), (Boolean)casHandle.invokeExact(varHandle, vhit, Integer.valueOf(12345), Integer.valueOf(54321)));
+		Assert.assertEquals(Integer.valueOf(54321), (Integer)getHandle.invokeExact(varHandle, vhit));
 
 		/* Using exact types */
 		getHandle = MethodHandles.varHandleInvoker(AccessMode.GET, MethodType.methodType(int.class, VarHandleInvokerTest.class));
@@ -111,13 +111,13 @@ public class VarHandleInvokerTest {
 	@Test(expectedExceptions = WrongMethodTypeException.class)
 	public void testExactWrongType() throws Throwable {
 		MethodHandle setHandle = MethodHandles.varHandleExactInvoker(AccessMode.SET, MethodType.methodType(void.class, VarHandleInvokerTest.class, Integer.class));
-		setHandle.invoke(varHandle, vhit, new Integer(12345));
+		setHandle.invoke(varHandle, vhit, Integer.valueOf(12345));
 	}
 
 	@Test(expectedExceptions = WrongMethodTypeException.class)
 	public void testExactInvokeExactWrongType() throws Throwable {
 		MethodHandle setHandle = MethodHandles.varHandleExactInvoker(AccessMode.SET, MethodType.methodType(void.class, VarHandleInvokerTest.class, Integer.class));
-		setHandle.invokeExact(varHandle, vhit, new Integer(12345));
+		setHandle.invokeExact(varHandle, vhit, Integer.valueOf(12345));
 	}
 
 	@Test(expectedExceptions = WrongMethodTypeException.class)
@@ -167,12 +167,12 @@ public class VarHandleInvokerTest {
 	@Test(expectedExceptions = NullPointerException.class)
 	public void testGenericNPE3() throws Throwable {
 		MethodHandle setHandle = MethodHandles.varHandleInvoker(AccessMode.SET, MethodType.methodType(void.class, VarHandleInvokerTest.class, Integer.class));
-		setHandle.invoke(null, vhit, new Integer(12345));
+		setHandle.invoke(null, vhit, Integer.valueOf(12345));
 	}
 
 	@Test(expectedExceptions = NullPointerException.class)
 	public void testGenericInvokeExactNPE3() throws Throwable {
 		MethodHandle setHandle = MethodHandles.varHandleInvoker(AccessMode.SET, MethodType.methodType(void.class, VarHandleInvokerTest.class, Integer.class));
-		setHandle.invoke((VarHandle)null, vhit, new Integer(12345));
+		setHandle.invoke((VarHandle)null, vhit, Integer.valueOf(12345));
 	}
 }

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/AsTypeTest.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/AsTypeTest.java
@@ -2,7 +2,7 @@ package com.ibm.j9.jsr292;
 
 
 /*******************************************************************************
- * Copyright (c) 2011, 2018 IBM Corp. and others
+ * Copyright (c) 2011, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -103,8 +103,8 @@ public class AsTypeTest {
 	}
 
 	static boolean floatsEqual(float a, float b) {
-		Float f1 = new Float(a);
-		Float f2 = new Float(b);
+		Float f1 = Float.valueOf(a);
+		Float f2 = Float.valueOf(b);
 
 		if (f1.isNaN()) {
 			return f2.isNaN();
@@ -116,8 +116,8 @@ public class AsTypeTest {
 	}
 
 	static boolean floatsEqual(double a, double b) {
-		Double d1 = new Double(a);
-		Double d2 = new Double(b);
+		Double d1 = Double.valueOf(a);
+		Double d2 = Double.valueOf(b);
 
 		if (d1.isNaN()) {
 			return d2.isNaN();
@@ -957,7 +957,7 @@ public class AsTypeTest {
 		MethodHandle s;
 		MethodHandle c;
 		MethodType mt;
-		Object o = new Boolean(v);
+		Object o = Boolean.valueOf(v);
 
 		s = MethodHandles.lookup().findVirtual(AsTypeTest.class, "doTest", MethodType.fromMethodDescriptorString("(I)I", null));
 		mt = MethodType.fromMethodDescriptorString("(Lcom/ibm/j9/jsr292/AsTypeTest;Z)I", null);
@@ -1538,7 +1538,7 @@ public class AsTypeTest {
 		MethodHandle s;
 		MethodHandle c;
 		MethodType mt;
-		Object o = new Byte(v);
+		Object o = Byte.valueOf(v);
 
 		s = MethodHandles.lookup().findVirtual(AsTypeTest.class, "doTest", MethodType.fromMethodDescriptorString("(I)I", null));
 		mt = MethodType.fromMethodDescriptorString("(Lcom/ibm/j9/jsr292/AsTypeTest;B)I", null);
@@ -2000,7 +2000,7 @@ public class AsTypeTest {
 		MethodHandle s;
 		MethodHandle c;
 		MethodType mt;
-		Object o = new Short(v);
+		Object o = Short.valueOf(v);
 
 		s = MethodHandles.lookup().findVirtual(AsTypeTest.class, "doTest", MethodType.fromMethodDescriptorString("(I)I", null));
 		mt = MethodType.fromMethodDescriptorString("(Lcom/ibm/j9/jsr292/AsTypeTest;S)I", null);
@@ -2487,7 +2487,7 @@ public class AsTypeTest {
 		MethodHandle s;
 		MethodHandle c;
 		MethodType mt;
-		Object o = new Character(v);
+		Object o = Character.valueOf(v);
 
 		s = MethodHandles.lookup().findVirtual(AsTypeTest.class, "doTest", MethodType.fromMethodDescriptorString("(I)I", null));
 		mt = MethodType.fromMethodDescriptorString("(Lcom/ibm/j9/jsr292/AsTypeTest;C)I", null);
@@ -2971,7 +2971,7 @@ public class AsTypeTest {
 		MethodHandle s;
 		MethodHandle c;
 		MethodType mt;
-		Object o = new Float(v);
+		Object o = Float.valueOf(v);
 
 		s = MethodHandles.lookup().findVirtual(AsTypeTest.class, "doTest", MethodType.fromMethodDescriptorString("(I)I", null));
 		mt = MethodType.fromMethodDescriptorString("(Lcom/ibm/j9/jsr292/AsTypeTest;F)I", null);
@@ -3533,7 +3533,7 @@ public class AsTypeTest {
 		MethodHandle s;
 		MethodHandle c;
 		MethodType mt;
-		Object o = new Double(v);
+		Object o = Double.valueOf(v);
 
 		s = MethodHandles.lookup().findVirtual(AsTypeTest.class, "doTest", MethodType.fromMethodDescriptorString("(I)I", null));
 		mt = MethodType.fromMethodDescriptorString("(Lcom/ibm/j9/jsr292/AsTypeTest;D)I", null);
@@ -4119,7 +4119,7 @@ public class AsTypeTest {
 		MethodHandle s;
 		MethodHandle c;
 		MethodType mt;
-		Object o = new Integer(v);
+		Object o = Integer.valueOf(v);
 
 		s = MethodHandles.lookup().findVirtual(AsTypeTest.class, "doTest", MethodType.fromMethodDescriptorString("(I)I", null));
 		mt = MethodType.fromMethodDescriptorString("(Lcom/ibm/j9/jsr292/AsTypeTest;I)I", null);
@@ -4579,7 +4579,7 @@ public class AsTypeTest {
 		MethodHandle s;
 		MethodHandle c;
 		MethodType mt;
-		Object o = new Long(v);
+		Object o = Long.valueOf(v);
 
 		s = MethodHandles.lookup().findVirtual(AsTypeTest.class, "doTest", MethodType.fromMethodDescriptorString("(I)I", null));
 		mt = MethodType.fromMethodDescriptorString("(Lcom/ibm/j9/jsr292/AsTypeTest;J)I", null);

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/FilterArgumentsTest.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/FilterArgumentsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corp. and others
+ * Copyright (c) 2014, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -112,63 +112,63 @@ public class FilterArgumentsTest {
 		
 		/* Leading null filters */
 		MethodHandle out = filterArguments(target, 0, null, null, null, f2, f3, f4);
-		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, constByte1, constByte2, filterByte2(constByte3), (long) constByte4, new Byte(constByte5), Byte.MIN_VALUE, constByte6), 
+		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, constByte1, constByte2, filterByte2(constByte3), (long) constByte4, Byte.valueOf(constByte5), Byte.MIN_VALUE, constByte6), 
 				(byte) out.invokeExact(Byte.MAX_VALUE, constByte1, constByte2, constByte3, constByte4, constByte5, Byte.MIN_VALUE, constByte6));
 		
 		/* Intermediate null filters */
 		out = filterArguments(target, 1, f0, null, null, f3, f4);
-		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, filterByte0(constByte1), constByte2, constByte3, (long) constByte4, new Byte(constByte5), Byte.MIN_VALUE, constByte6), 
+		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, filterByte0(constByte1), constByte2, constByte3, (long) constByte4, Byte.valueOf(constByte5), Byte.MIN_VALUE, constByte6), 
 				(byte) out.invokeExact(Byte.MAX_VALUE, constByte1, constByte2, constByte3, constByte4, constByte5, Byte.MIN_VALUE, constByte6));
 		
 		/* Trailing null filters */
 		out = filterArguments(target, 2, f1, f2, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetByte(constByte1, Byte.MAX_VALUE, filterByte1(constByte2), filterByte2(constByte3), (long) constByte4, new Byte(constByte5), Byte.MIN_VALUE, constByte6), 
+		AssertJUnit.assertEquals (targetByte(constByte1, Byte.MAX_VALUE, filterByte1(constByte2), filterByte2(constByte3), (long) constByte4, Byte.valueOf(constByte5), Byte.MIN_VALUE, constByte6), 
 				(byte) out.invokeExact(constByte1, Byte.MAX_VALUE, constByte2, constByte3, constByte4, constByte5, Byte.MIN_VALUE, constByte6));
 		
 		/* Leading and intermediate null filters */
 		out = filterArguments(target, 0, null, f0, null, null, f3, f4);
-		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, filterByte0(constByte1), constByte2, constByte3, (long) constByte4, new Byte(constByte5), Byte.MIN_VALUE, constByte6), 
+		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, filterByte0(constByte1), constByte2, constByte3, (long) constByte4, Byte.valueOf(constByte5), Byte.MIN_VALUE, constByte6), 
 				(byte) out.invokeExact(Byte.MAX_VALUE, constByte1, constByte2, constByte3, constByte4, constByte5, Byte.MIN_VALUE, constByte6));
 		
 		/* Leading and trailing null filters */
 		out = filterArguments(target, 0, null, null, null, f2, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, constByte1, constByte2, filterByte2(constByte3), (long) constByte4, new Byte(constByte5), Byte.MIN_VALUE, constByte6), 
+		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, constByte1, constByte2, filterByte2(constByte3), (long) constByte4, Byte.valueOf(constByte5), Byte.MIN_VALUE, constByte6), 
 				(byte) out.invokeExact(Byte.MAX_VALUE, constByte1, constByte2, constByte3, constByte4, constByte5, Byte.MIN_VALUE, constByte6));
 		
 		/* Intermediate and trailing null filters */
 		out = filterArguments(target, 1, f0, null, null, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, filterByte0(constByte1), constByte2, constByte3, (long) constByte4, new Byte(constByte5), Byte.MIN_VALUE, constByte6), 
+		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, filterByte0(constByte1), constByte2, constByte3, (long) constByte4, Byte.valueOf(constByte5), Byte.MIN_VALUE, constByte6), 
 				(byte) out.invokeExact(Byte.MAX_VALUE, constByte1, constByte2, constByte3, constByte4, constByte5, Byte.MIN_VALUE, constByte6));
 		
 		/* Leading, intermediate and trailing null filters */
 		out = filterArguments(target, 0, null, null, f0, null, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, constByte1, filterByte0(constByte2), constByte3, (long) constByte4, new Byte(constByte5), Byte.MIN_VALUE, constByte6), 
+		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, constByte1, filterByte0(constByte2), constByte3, (long) constByte4, Byte.valueOf(constByte5), Byte.MIN_VALUE, constByte6), 
 				(byte) out.invokeExact(Byte.MAX_VALUE, constByte1, constByte2, constByte3, constByte4, constByte5, Byte.MIN_VALUE, constByte6));
 		
 		/* Only null filters */
 		out = filterArguments(target, 0, null, null, null, null, null, null, null, null);
-		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, constByte1, constByte2, constByte3, (long) constByte4, new Byte(constByte5), Byte.MIN_VALUE, constByte6), 
-				(byte) out.invokeExact(Byte.MAX_VALUE, constByte1, constByte2, constByte3, (long) constByte4, new Byte(constByte5), Byte.MIN_VALUE, constByte6));
+		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, constByte1, constByte2, constByte3, (long) constByte4, Byte.valueOf(constByte5), Byte.MIN_VALUE, constByte6), 
+				(byte) out.invokeExact(Byte.MAX_VALUE, constByte1, constByte2, constByte3, (long) constByte4, Byte.valueOf(constByte5), Byte.MIN_VALUE, constByte6));
 		
 		out = filterArguments(target, 4, null, null, null, null);
-		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, constByte1, constByte2, constByte3, (long) constByte4, new Byte(constByte5), Byte.MIN_VALUE, constByte6), 
-				(byte) out.invokeExact(Byte.MAX_VALUE, constByte1, constByte2, constByte3, (long) constByte4, new Byte(constByte5), Byte.MIN_VALUE, constByte6));
+		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, constByte1, constByte2, constByte3, (long) constByte4, Byte.valueOf(constByte5), Byte.MIN_VALUE, constByte6), 
+				(byte) out.invokeExact(Byte.MAX_VALUE, constByte1, constByte2, constByte3, (long) constByte4, Byte.valueOf(constByte5), Byte.MIN_VALUE, constByte6));
 		
 		out = filterArguments(target, 2, null, null);
-		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, constByte1, constByte2, constByte3, (long) constByte4, new Byte(constByte5), Byte.MIN_VALUE, constByte6), 
-				(byte) out.invokeExact(Byte.MAX_VALUE, constByte1, constByte2, constByte3, (long) constByte4, new Byte(constByte5), Byte.MIN_VALUE, constByte6));
+		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, constByte1, constByte2, constByte3, (long) constByte4, Byte.valueOf(constByte5), Byte.MIN_VALUE, constByte6), 
+				(byte) out.invokeExact(Byte.MAX_VALUE, constByte1, constByte2, constByte3, (long) constByte4, Byte.valueOf(constByte5), Byte.MIN_VALUE, constByte6));
 		
 		/* No Null filters */
 		out = filterArguments(target, 0, f0, f1, f2, f2, f3, f4, f0, f1);
-		AssertJUnit.assertEquals (targetByte(filterByte0(Byte.MAX_VALUE), filterByte1(constByte1), filterByte2(constByte2), filterByte2(constByte3), (long) constByte4, new Byte(constByte5), filterByte0(Byte.MIN_VALUE), filterByte1(constByte6)), 
+		AssertJUnit.assertEquals (targetByte(filterByte0(Byte.MAX_VALUE), filterByte1(constByte1), filterByte2(constByte2), filterByte2(constByte3), (long) constByte4, Byte.valueOf(constByte5), filterByte0(Byte.MIN_VALUE), filterByte1(constByte6)), 
 				(byte) out.invokeExact(Byte.MAX_VALUE, constByte1, constByte2, constByte3, constByte4, constByte5, Byte.MIN_VALUE, constByte6));
 		
 		out = filterArguments(target, 3, f2, f3, f4, f0, f1);
-		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, constByte1, constByte2, filterByte2(constByte3), (long) constByte4, new Byte(constByte5), filterByte0(Byte.MIN_VALUE), filterByte1(constByte6)), 
+		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, constByte1, constByte2, filterByte2(constByte3), (long) constByte4, Byte.valueOf(constByte5), filterByte0(Byte.MIN_VALUE), filterByte1(constByte6)), 
 				(byte) out.invokeExact(Byte.MAX_VALUE, constByte1, constByte2, constByte3, constByte4, constByte5, Byte.MIN_VALUE, constByte6));
 		
 		out = filterArguments(target, 5, f4, f0, f1);
-		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, constByte1, constByte2, constByte3, (long) constByte4, new Byte(constByte5), filterByte0(Byte.MIN_VALUE), filterByte1(constByte6)), 
+		AssertJUnit.assertEquals (targetByte(Byte.MAX_VALUE, constByte1, constByte2, constByte3, (long) constByte4, Byte.valueOf(constByte5), filterByte0(Byte.MIN_VALUE), filterByte1(constByte6)), 
 				(byte) out.invokeExact(Byte.MAX_VALUE, constByte1, constByte2, constByte3, (long) constByte4, constByte5, Byte.MIN_VALUE, constByte6));
 	}
 	
@@ -219,63 +219,63 @@ public class FilterArgumentsTest {
 		
 		/* Leading null filters */
 		MethodHandle out = filterArguments(target, 0, null, null, null, f2, f3, f4);
-		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, constShort1, constShort2, filterShort2(constShort3), (long) constShort4, new Short(constShort5), Short.MIN_VALUE, constShort6), 
+		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, constShort1, constShort2, filterShort2(constShort3), (long) constShort4, Short.valueOf(constShort5), Short.MIN_VALUE, constShort6), 
 				(short) out.invokeExact(Short.MAX_VALUE, constShort1, constShort2, constShort3, constShort4, constShort5, Short.MIN_VALUE, constShort6));
 		
 		/* Intermediate null filters */
 		out = filterArguments(target, 1, f0, null, null, f3, f4);
-		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, filterShort0(constShort1), constShort2, constShort3, (long) constShort4, new Short(constShort5), Short.MIN_VALUE, constShort6), 
+		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, filterShort0(constShort1), constShort2, constShort3, (long) constShort4, Short.valueOf(constShort5), Short.MIN_VALUE, constShort6), 
 				(short) out.invokeExact(Short.MAX_VALUE, constShort1, constShort2, constShort3, constShort4, constShort5, Short.MIN_VALUE, constShort6));
 		
 		/* Trailing null filters */
 		out = filterArguments(target, 2, f1, f2, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetShort(constShort1, Short.MAX_VALUE, filterShort1(constShort2), filterShort2(constShort3), (long) constShort4, new Short(constShort5), Short.MIN_VALUE, constShort6), 
+		AssertJUnit.assertEquals (targetShort(constShort1, Short.MAX_VALUE, filterShort1(constShort2), filterShort2(constShort3), (long) constShort4, Short.valueOf(constShort5), Short.MIN_VALUE, constShort6), 
 				(short) out.invokeExact(constShort1, Short.MAX_VALUE, constShort2, constShort3, constShort4, constShort5, Short.MIN_VALUE, constShort6));
 		
 		/* Leading and intermediate null filters */
 		out = filterArguments(target, 0, null, f0, null, null, f3, f4);
-		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, filterShort0(constShort1), constShort2, constShort3, (long) constShort4, new Short(constShort5), Short.MIN_VALUE, constShort6), 
+		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, filterShort0(constShort1), constShort2, constShort3, (long) constShort4, Short.valueOf(constShort5), Short.MIN_VALUE, constShort6), 
 				(short) out.invokeExact(Short.MAX_VALUE, constShort1, constShort2, constShort3, constShort4, constShort5, Short.MIN_VALUE, constShort6));
 		
 		/* Leading and trailing null filters */
 		out = filterArguments(target, 0, null, null, null, f2, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, constShort1, constShort2, filterShort2(constShort3), (long) constShort4, new Short(constShort5), Short.MIN_VALUE, constShort6), 
+		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, constShort1, constShort2, filterShort2(constShort3), (long) constShort4, Short.valueOf(constShort5), Short.MIN_VALUE, constShort6), 
 				(short) out.invokeExact(Short.MAX_VALUE, constShort1, constShort2, constShort3, constShort4, constShort5, Short.MIN_VALUE, constShort6));
 		
 		/* Intermediate and trailing null filters */
 		out = filterArguments(target, 1, f0, null, null, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, filterShort0(constShort1), constShort2, constShort3, (long) constShort4, new Short(constShort5), Short.MIN_VALUE, constShort6), 
+		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, filterShort0(constShort1), constShort2, constShort3, (long) constShort4, Short.valueOf(constShort5), Short.MIN_VALUE, constShort6), 
 				(short) out.invokeExact(Short.MAX_VALUE, constShort1, constShort2, constShort3, constShort4, constShort5, Short.MIN_VALUE, constShort6));
 		
 		/* Leading, intermediate and trailing null filters */
 		out = filterArguments(target, 0, null, null, f0, null, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, constShort1, filterShort0(constShort2), constShort3, (long) constShort4, new Short(constShort5), Short.MIN_VALUE, constShort6), 
+		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, constShort1, filterShort0(constShort2), constShort3, (long) constShort4, Short.valueOf(constShort5), Short.MIN_VALUE, constShort6), 
 				(short) out.invokeExact(Short.MAX_VALUE, constShort1, constShort2, constShort3, constShort4, constShort5, Short.MIN_VALUE, constShort6));
 		
 		/* Only null filters */
 		out = filterArguments(target, 0, null, null, null, null, null, null, null, null);
-		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, constShort1, constShort2, constShort3, (long) constShort4, new Short(constShort5), Short.MIN_VALUE, constShort6), 
-				(short) out.invokeExact(Short.MAX_VALUE, constShort1, constShort2, constShort3, (long) constShort4, new Short(constShort5), Short.MIN_VALUE, constShort6));
+		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, constShort1, constShort2, constShort3, (long) constShort4, Short.valueOf(constShort5), Short.MIN_VALUE, constShort6), 
+				(short) out.invokeExact(Short.MAX_VALUE, constShort1, constShort2, constShort3, (long) constShort4, Short.valueOf(constShort5), Short.MIN_VALUE, constShort6));
 		
 		out = filterArguments(target, 4, null, null, null, null);
-		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, constShort1, constShort2, constShort3, (long) constShort4, new Short(constShort5), Short.MIN_VALUE, constShort6), 
-				(short) out.invokeExact(Short.MAX_VALUE, constShort1, constShort2, constShort3, (long) constShort4, new Short(constShort5), Short.MIN_VALUE, constShort6));
+		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, constShort1, constShort2, constShort3, (long) constShort4, Short.valueOf(constShort5), Short.MIN_VALUE, constShort6), 
+				(short) out.invokeExact(Short.MAX_VALUE, constShort1, constShort2, constShort3, (long) constShort4, Short.valueOf(constShort5), Short.MIN_VALUE, constShort6));
 		
 		out = filterArguments(target, 2, null, null);
-		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, constShort1, constShort2, constShort3, (long) constShort4, new Short(constShort5), Short.MIN_VALUE, constShort6), 
-				(short) out.invokeExact(Short.MAX_VALUE, constShort1, constShort2, constShort3, (long) constShort4, new Short(constShort5), Short.MIN_VALUE, constShort6));
+		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, constShort1, constShort2, constShort3, (long) constShort4, Short.valueOf(constShort5), Short.MIN_VALUE, constShort6), 
+				(short) out.invokeExact(Short.MAX_VALUE, constShort1, constShort2, constShort3, (long) constShort4, Short.valueOf(constShort5), Short.MIN_VALUE, constShort6));
 		
 		/* No Null filters */
 		out = filterArguments(target, 0, f0, f1, f2, f2, f3, f4, f0, f1);
-		AssertJUnit.assertEquals (targetShort(filterShort0(Short.MAX_VALUE), filterShort1(constShort1), filterShort2(constShort2), filterShort2(constShort3), (long) constShort4, new Short(constShort5), filterShort0(Short.MIN_VALUE), filterShort1(constShort6)), 
+		AssertJUnit.assertEquals (targetShort(filterShort0(Short.MAX_VALUE), filterShort1(constShort1), filterShort2(constShort2), filterShort2(constShort3), (long) constShort4, Short.valueOf(constShort5), filterShort0(Short.MIN_VALUE), filterShort1(constShort6)), 
 				(short) out.invokeExact(Short.MAX_VALUE, constShort1, constShort2, constShort3, constShort4, constShort5, Short.MIN_VALUE, constShort6));
 		
 		out = filterArguments(target, 3, f2, f3, f4, f0, f1);
-		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, constShort1, constShort2, filterShort2(constShort3), (long) constShort4, new Short(constShort5), filterShort0(Short.MIN_VALUE), filterShort1(constShort6)), 
+		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, constShort1, constShort2, filterShort2(constShort3), (long) constShort4, Short.valueOf(constShort5), filterShort0(Short.MIN_VALUE), filterShort1(constShort6)), 
 				(short) out.invokeExact(Short.MAX_VALUE, constShort1, constShort2, constShort3, constShort4, constShort5, Short.MIN_VALUE, constShort6));
 		
 		out = filterArguments(target, 5, f4, f0, f1);
-		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, constShort1, constShort2, constShort3, (long) constShort4, new Short(constShort5), filterShort0(Short.MIN_VALUE), filterShort1(constShort6)), 
+		AssertJUnit.assertEquals (targetShort(Short.MAX_VALUE, constShort1, constShort2, constShort3, (long) constShort4, Short.valueOf(constShort5), filterShort0(Short.MIN_VALUE), filterShort1(constShort6)), 
 				(short) out.invokeExact(Short.MAX_VALUE, constShort1, constShort2, constShort3, (long) constShort4, constShort5, Short.MIN_VALUE, constShort6));
 	}
 	
@@ -326,63 +326,63 @@ public class FilterArgumentsTest {
 		
 		/* Leading null filters */
 		MethodHandle out = filterArguments(target, 0, null, null, null, f2, f3, f4);
-		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, constCharacter1, constCharacter2, filterCharacter2(constCharacter3), (long) constCharacter4, new Character(constCharacter5), Character.MIN_VALUE, constCharacter6), 
+		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, constCharacter1, constCharacter2, filterCharacter2(constCharacter3), (long) constCharacter4, Character.valueOf(constCharacter5), Character.MIN_VALUE, constCharacter6), 
 				(char) out.invokeExact(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, constCharacter4, constCharacter5, Character.MIN_VALUE, constCharacter6));
 		
 		/* Intermediate null filters */
 		out = filterArguments(target, 1, f0, null, null, f3, f4);
-		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, filterCharacter0(constCharacter1), constCharacter2, constCharacter3, (long) constCharacter4, new Character(constCharacter5), Character.MIN_VALUE, constCharacter6), 
+		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, filterCharacter0(constCharacter1), constCharacter2, constCharacter3, (long) constCharacter4, Character.valueOf(constCharacter5), Character.MIN_VALUE, constCharacter6), 
 				(char) out.invokeExact(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, constCharacter4, constCharacter5, Character.MIN_VALUE, constCharacter6));
 		
 		/* Trailing null filters */
 		out = filterArguments(target, 2, f1, f2, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetCharacter(constCharacter1, Character.MAX_VALUE, filterCharacter1(constCharacter2), filterCharacter2(constCharacter3), (long) constCharacter4, new Character(constCharacter5), Character.MIN_VALUE, constCharacter6), 
+		AssertJUnit.assertEquals (targetCharacter(constCharacter1, Character.MAX_VALUE, filterCharacter1(constCharacter2), filterCharacter2(constCharacter3), (long) constCharacter4, Character.valueOf(constCharacter5), Character.MIN_VALUE, constCharacter6), 
 				(char) out.invokeExact(constCharacter1, Character.MAX_VALUE, constCharacter2, constCharacter3, constCharacter4, constCharacter5, Character.MIN_VALUE, constCharacter6));
 		
 		/* Leading and intermediate null filters */
 		out = filterArguments(target, 0, null, f0, null, null, f3, f4);
-		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, filterCharacter0(constCharacter1), constCharacter2, constCharacter3, (long) constCharacter4, new Character(constCharacter5), Character.MIN_VALUE, constCharacter6), 
+		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, filterCharacter0(constCharacter1), constCharacter2, constCharacter3, (long) constCharacter4, Character.valueOf(constCharacter5), Character.MIN_VALUE, constCharacter6), 
 				(char) out.invokeExact(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, constCharacter4, constCharacter5, Character.MIN_VALUE, constCharacter6));
 		
 		/* Leading and trailing null filters */
 		out = filterArguments(target, 0, null, null, null, f2, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, constCharacter1, constCharacter2, filterCharacter2(constCharacter3), (long) constCharacter4, new Character(constCharacter5), Character.MIN_VALUE, constCharacter6), 
+		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, constCharacter1, constCharacter2, filterCharacter2(constCharacter3), (long) constCharacter4, Character.valueOf(constCharacter5), Character.MIN_VALUE, constCharacter6), 
 				(char) out.invokeExact(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, constCharacter4, constCharacter5, Character.MIN_VALUE, constCharacter6));
 		
 		/* Intermediate and trailing null filters */
 		out = filterArguments(target, 1, f0, null, null, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, filterCharacter0(constCharacter1), constCharacter2, constCharacter3, (long) constCharacter4, new Character(constCharacter5), Character.MIN_VALUE, constCharacter6), 
+		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, filterCharacter0(constCharacter1), constCharacter2, constCharacter3, (long) constCharacter4, Character.valueOf(constCharacter5), Character.MIN_VALUE, constCharacter6), 
 				(char) out.invokeExact(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, constCharacter4, constCharacter5, Character.MIN_VALUE, constCharacter6));
 		
 		/* Leading, intermediate and trailing null filters */
 		out = filterArguments(target, 0, null, null, f0, null, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, constCharacter1, filterCharacter0(constCharacter2), constCharacter3, (long) constCharacter4, new Character(constCharacter5), Character.MIN_VALUE, constCharacter6), 
+		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, constCharacter1, filterCharacter0(constCharacter2), constCharacter3, (long) constCharacter4, Character.valueOf(constCharacter5), Character.MIN_VALUE, constCharacter6), 
 				(char) out.invokeExact(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, constCharacter4, constCharacter5, Character.MIN_VALUE, constCharacter6));
 		
 		/* Only null filters */
 		out = filterArguments(target, 0, null, null, null, null, null, null, null, null);
-		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, (long) constCharacter4, new Character(constCharacter5), Character.MIN_VALUE, constCharacter6), 
-				(char) out.invokeExact(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, (long) constCharacter4, new Character(constCharacter5), Character.MIN_VALUE, constCharacter6));
+		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, (long) constCharacter4, Character.valueOf(constCharacter5), Character.MIN_VALUE, constCharacter6), 
+				(char) out.invokeExact(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, (long) constCharacter4, Character.valueOf(constCharacter5), Character.MIN_VALUE, constCharacter6));
 		
 		out = filterArguments(target, 4, null, null, null, null);
-		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, (long) constCharacter4, new Character(constCharacter5), Character.MIN_VALUE, constCharacter6), 
-				(char) out.invokeExact(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, (long) constCharacter4, new Character(constCharacter5), Character.MIN_VALUE, constCharacter6));
+		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, (long) constCharacter4, Character.valueOf(constCharacter5), Character.MIN_VALUE, constCharacter6), 
+				(char) out.invokeExact(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, (long) constCharacter4, Character.valueOf(constCharacter5), Character.MIN_VALUE, constCharacter6));
 		
 		out = filterArguments(target, 2, null, null);
-		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, (long) constCharacter4, new Character(constCharacter5), Character.MIN_VALUE, constCharacter6), 
-				(char) out.invokeExact(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, (long) constCharacter4, new Character(constCharacter5), Character.MIN_VALUE, constCharacter6));
+		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, (long) constCharacter4, Character.valueOf(constCharacter5), Character.MIN_VALUE, constCharacter6), 
+				(char) out.invokeExact(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, (long) constCharacter4, Character.valueOf(constCharacter5), Character.MIN_VALUE, constCharacter6));
 		
 		/* No Null filters */
 		out = filterArguments(target, 0, f0, f1, f2, f2, f3, f4, f0, f1);
-		AssertJUnit.assertEquals (targetCharacter(filterCharacter0(Character.MAX_VALUE), filterCharacter1(constCharacter1), filterCharacter2(constCharacter2), filterCharacter2(constCharacter3), (long) constCharacter4, new Character(constCharacter5), filterCharacter0(Character.MIN_VALUE), filterCharacter1(constCharacter6)), 
+		AssertJUnit.assertEquals (targetCharacter(filterCharacter0(Character.MAX_VALUE), filterCharacter1(constCharacter1), filterCharacter2(constCharacter2), filterCharacter2(constCharacter3), (long) constCharacter4, Character.valueOf(constCharacter5), filterCharacter0(Character.MIN_VALUE), filterCharacter1(constCharacter6)), 
 				(char) out.invokeExact(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, constCharacter4, constCharacter5, Character.MIN_VALUE, constCharacter6));
 		
 		out = filterArguments(target, 3, f2, f3, f4, f0, f1);
-		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, constCharacter1, constCharacter2, filterCharacter2(constCharacter3), (long) constCharacter4, new Character(constCharacter5), filterCharacter0(Character.MIN_VALUE), filterCharacter1(constCharacter6)), 
+		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, constCharacter1, constCharacter2, filterCharacter2(constCharacter3), (long) constCharacter4, Character.valueOf(constCharacter5), filterCharacter0(Character.MIN_VALUE), filterCharacter1(constCharacter6)), 
 				(char) out.invokeExact(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, constCharacter4, constCharacter5, Character.MIN_VALUE, constCharacter6));
 		
 		out = filterArguments(target, 5, f4, f0, f1);
-		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, (long) constCharacter4, new Character(constCharacter5), filterCharacter0(Character.MIN_VALUE), filterCharacter1(constCharacter6)), 
+		AssertJUnit.assertEquals (targetCharacter(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, (long) constCharacter4, Character.valueOf(constCharacter5), filterCharacter0(Character.MIN_VALUE), filterCharacter1(constCharacter6)), 
 				(char) out.invokeExact(Character.MAX_VALUE, constCharacter1, constCharacter2, constCharacter3, (long) constCharacter4, constCharacter5, Character.MIN_VALUE, constCharacter6));
 	}
 	
@@ -433,63 +433,63 @@ public class FilterArgumentsTest {
 		
 		/* Leading null filters */
 		MethodHandle out = filterArguments(target, 0, null, null, null, f2, f3, f4);
-		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, constInteger1, constInteger2, filterInteger2(constInteger3), (long) constInteger4, new Integer(constInteger5), Integer.MIN_VALUE, constInteger6), 
+		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, constInteger1, constInteger2, filterInteger2(constInteger3), (long) constInteger4, Integer.valueOf(constInteger5), Integer.MIN_VALUE, constInteger6), 
 				(int) out.invokeExact(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, constInteger4, constInteger5, Integer.MIN_VALUE, constInteger6));
 		
 		/* Intermediate null filters */
 		out = filterArguments(target, 1, f0, null, null, f3, f4);
-		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, filterInteger0(constInteger1), constInteger2, constInteger3, (long) constInteger4, new Integer(constInteger5), Integer.MIN_VALUE, constInteger6), 
+		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, filterInteger0(constInteger1), constInteger2, constInteger3, (long) constInteger4, Integer.valueOf(constInteger5), Integer.MIN_VALUE, constInteger6), 
 				(int) out.invokeExact(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, constInteger4, constInteger5, Integer.MIN_VALUE, constInteger6));
 		
 		/* Trailing null filters */
 		out = filterArguments(target, 2, f1, f2, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetInteger(constInteger1, Integer.MAX_VALUE, filterInteger1(constInteger2), filterInteger2(constInteger3), (long) constInteger4, new Integer(constInteger5), Integer.MIN_VALUE, constInteger6), 
+		AssertJUnit.assertEquals (targetInteger(constInteger1, Integer.MAX_VALUE, filterInteger1(constInteger2), filterInteger2(constInteger3), (long) constInteger4, Integer.valueOf(constInteger5), Integer.MIN_VALUE, constInteger6), 
 				(int) out.invokeExact(constInteger1, Integer.MAX_VALUE, constInteger2, constInteger3, constInteger4, constInteger5, Integer.MIN_VALUE, constInteger6));
 		
 		/* Leading and intermediate null filters */
 		out = filterArguments(target, 0, null, f0, null, null, f3, f4);
-		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, filterInteger0(constInteger1), constInteger2, constInteger3, (long) constInteger4, new Integer(constInteger5), Integer.MIN_VALUE, constInteger6), 
+		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, filterInteger0(constInteger1), constInteger2, constInteger3, (long) constInteger4, Integer.valueOf(constInteger5), Integer.MIN_VALUE, constInteger6), 
 				(int) out.invokeExact(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, constInteger4, constInteger5, Integer.MIN_VALUE, constInteger6));
 		
 		/* Leading and trailing null filters */
 		out = filterArguments(target, 0, null, null, null, f2, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, constInteger1, constInteger2, filterInteger2(constInteger3), (long) constInteger4, new Integer(constInteger5), Integer.MIN_VALUE, constInteger6), 
+		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, constInteger1, constInteger2, filterInteger2(constInteger3), (long) constInteger4, Integer.valueOf(constInteger5), Integer.MIN_VALUE, constInteger6), 
 				(int) out.invokeExact(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, constInteger4, constInteger5, Integer.MIN_VALUE, constInteger6));
 		
 		/* Intermediate and trailing null filters */
 		out = filterArguments(target, 1, f0, null, null, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, filterInteger0(constInteger1), constInteger2, constInteger3, (long) constInteger4, new Integer(constInteger5), Integer.MIN_VALUE, constInteger6), 
+		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, filterInteger0(constInteger1), constInteger2, constInteger3, (long) constInteger4, Integer.valueOf(constInteger5), Integer.MIN_VALUE, constInteger6), 
 				(int) out.invokeExact(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, constInteger4, constInteger5, Integer.MIN_VALUE, constInteger6));
 		
 		/* Leading, intermediate and trailing null filters */
 		out = filterArguments(target, 0, null, null, f0, null, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, constInteger1, filterInteger0(constInteger2), constInteger3, (long) constInteger4, new Integer(constInteger5), Integer.MIN_VALUE, constInteger6), 
+		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, constInteger1, filterInteger0(constInteger2), constInteger3, (long) constInteger4, Integer.valueOf(constInteger5), Integer.MIN_VALUE, constInteger6), 
 				(int) out.invokeExact(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, constInteger4, constInteger5, Integer.MIN_VALUE, constInteger6));
 		
 		/* Only null filters */
 		out = filterArguments(target, 0, null, null, null, null, null, null, null, null);
-		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, (long) constInteger4, new Integer(constInteger5), Integer.MIN_VALUE, constInteger6), 
-				(int) out.invokeExact(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, (long) constInteger4, new Integer(constInteger5), Integer.MIN_VALUE, constInteger6));
+		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, (long) constInteger4, Integer.valueOf(constInteger5), Integer.MIN_VALUE, constInteger6), 
+				(int) out.invokeExact(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, (long) constInteger4, Integer.valueOf(constInteger5), Integer.MIN_VALUE, constInteger6));
 		
 		out = filterArguments(target, 4, null, null, null, null);
-		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, (long) constInteger4, new Integer(constInteger5), Integer.MIN_VALUE, constInteger6), 
-				(int) out.invokeExact(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, (long) constInteger4, new Integer(constInteger5), Integer.MIN_VALUE, constInteger6));
+		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, (long) constInteger4, Integer.valueOf(constInteger5), Integer.MIN_VALUE, constInteger6), 
+				(int) out.invokeExact(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, (long) constInteger4, Integer.valueOf(constInteger5), Integer.MIN_VALUE, constInteger6));
 		
 		out = filterArguments(target, 2, null, null);
-		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, (long) constInteger4, new Integer(constInteger5), Integer.MIN_VALUE, constInteger6), 
-				(int) out.invokeExact(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, (long) constInteger4, new Integer(constInteger5), Integer.MIN_VALUE, constInteger6));
+		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, (long) constInteger4, Integer.valueOf(constInteger5), Integer.MIN_VALUE, constInteger6), 
+				(int) out.invokeExact(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, (long) constInteger4, Integer.valueOf(constInteger5), Integer.MIN_VALUE, constInteger6));
 		
 		/* No Null filters */
 		out = filterArguments(target, 0, f0, f1, f2, f2, f3, f4, f0, f1);
-		AssertJUnit.assertEquals (targetInteger(filterInteger0(Integer.MAX_VALUE), filterInteger1(constInteger1), filterInteger2(constInteger2), filterInteger2(constInteger3), (long) constInteger4, new Integer(constInteger5), filterInteger0(Integer.MIN_VALUE), filterInteger1(constInteger6)), 
+		AssertJUnit.assertEquals (targetInteger(filterInteger0(Integer.MAX_VALUE), filterInteger1(constInteger1), filterInteger2(constInteger2), filterInteger2(constInteger3), (long) constInteger4, Integer.valueOf(constInteger5), filterInteger0(Integer.MIN_VALUE), filterInteger1(constInteger6)), 
 				(int) out.invokeExact(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, constInteger4, constInteger5, Integer.MIN_VALUE, constInteger6));
 		
 		out = filterArguments(target, 3, f2, f3, f4, f0, f1);
-		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, constInteger1, constInteger2, filterInteger2(constInteger3), (long) constInteger4, new Integer(constInteger5), filterInteger0(Integer.MIN_VALUE), filterInteger1(constInteger6)), 
+		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, constInteger1, constInteger2, filterInteger2(constInteger3), (long) constInteger4, Integer.valueOf(constInteger5), filterInteger0(Integer.MIN_VALUE), filterInteger1(constInteger6)), 
 				(int) out.invokeExact(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, constInteger4, constInteger5, Integer.MIN_VALUE, constInteger6));
 		
 		out = filterArguments(target, 5, f4, f0, f1);
-		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, (long) constInteger4, new Integer(constInteger5), filterInteger0(Integer.MIN_VALUE), filterInteger1(constInteger6)), 
+		AssertJUnit.assertEquals (targetInteger(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, (long) constInteger4, Integer.valueOf(constInteger5), filterInteger0(Integer.MIN_VALUE), filterInteger1(constInteger6)), 
 				(int) out.invokeExact(Integer.MAX_VALUE, constInteger1, constInteger2, constInteger3, (long) constInteger4, constInteger5, Integer.MIN_VALUE, constInteger6));
 	}
 	
@@ -540,63 +540,63 @@ public class FilterArgumentsTest {
 		
 		/* Leading null filters */
 		MethodHandle out = filterArguments(target, 0, null, null, null, f2, f3, f4);
-		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, constLong1, constLong2, filterLong2(constLong3), constInteger4, new Long(constLong5), Long.MIN_VALUE, constLong6), 
+		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, constLong1, constLong2, filterLong2(constLong3), constInteger4, Long.valueOf(constLong5), Long.MIN_VALUE, constLong6), 
 				(long) out.invokeExact(Long.MAX_VALUE, constLong1, constLong2, constLong3, (long) constInteger4, constLong5, Long.MIN_VALUE, constLong6));
 		
 		/* Intermediate null filters */
 		out = filterArguments(target, 1, f0, null, null, f3, f4);
-		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, filterLong0(constLong1), constLong2, constLong3, constInteger4, new Long(constLong5), Long.MIN_VALUE, constLong6), 
+		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, filterLong0(constLong1), constLong2, constLong3, constInteger4, Long.valueOf(constLong5), Long.MIN_VALUE, constLong6), 
 				(long) out.invokeExact(Long.MAX_VALUE, constLong1, constLong2, constLong3, (long) constInteger4, constLong5, Long.MIN_VALUE, constLong6));
 		
 		/* Trailing null filters */
 		out = filterArguments(target, 2, f1, f2, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetLong(constLong1, Long.MAX_VALUE, filterLong1(constLong2), filterLong2(constLong3), constInteger4, new Long(constLong5), Long.MIN_VALUE, constLong6), 
+		AssertJUnit.assertEquals (targetLong(constLong1, Long.MAX_VALUE, filterLong1(constLong2), filterLong2(constLong3), constInteger4, Long.valueOf(constLong5), Long.MIN_VALUE, constLong6), 
 				(long) out.invokeExact(constLong1, Long.MAX_VALUE, constLong2, constLong3, (long) constInteger4, constLong5, Long.MIN_VALUE, constLong6));
 		
 		/* Leading and intermediate null filters */
 		out = filterArguments(target, 0, null, f0, null, null, f3, f4);
-		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, filterLong0(constLong1), constLong2, constLong3, constInteger4, new Long(constLong5), Long.MIN_VALUE, constLong6), 
+		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, filterLong0(constLong1), constLong2, constLong3, constInteger4, Long.valueOf(constLong5), Long.MIN_VALUE, constLong6), 
 				(long) out.invokeExact(Long.MAX_VALUE, constLong1, constLong2, constLong3, (long) constInteger4, constLong5, Long.MIN_VALUE, constLong6));
 		
 		/* Leading and trailing null filters */
 		out = filterArguments(target, 0, null, null, null, f2, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, constLong1, constLong2, filterLong2(constLong3), constInteger4, new Long(constLong5), Long.MIN_VALUE, constLong6), 
+		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, constLong1, constLong2, filterLong2(constLong3), constInteger4, Long.valueOf(constLong5), Long.MIN_VALUE, constLong6), 
 				(long) out.invokeExact(Long.MAX_VALUE, constLong1, constLong2, constLong3, (long) constInteger4, constLong5, Long.MIN_VALUE, constLong6));
 		
 		/* Intermediate and trailing null filters */
 		out = filterArguments(target, 1, f0, null, null, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, filterLong0(constLong1), constLong2, constLong3, constInteger4, new Long(constLong5), Long.MIN_VALUE, constLong6), 
+		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, filterLong0(constLong1), constLong2, constLong3, constInteger4, Long.valueOf(constLong5), Long.MIN_VALUE, constLong6), 
 				(long) out.invokeExact(Long.MAX_VALUE, constLong1, constLong2, constLong3, (long) constInteger4, constLong5, Long.MIN_VALUE, constLong6));
 		
 		/* Leading, intermediate and trailing null filters */
 		out = filterArguments(target, 0, null, null, f0, null, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, constLong1, filterLong0(constLong2), constLong3, constInteger4, new Long(constLong5), Long.MIN_VALUE, constLong6), 
+		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, constLong1, filterLong0(constLong2), constLong3, constInteger4, Long.valueOf(constLong5), Long.MIN_VALUE, constLong6), 
 				(long) out.invokeExact(Long.MAX_VALUE, constLong1, constLong2, constLong3, (long) constInteger4, constLong5, Long.MIN_VALUE, constLong6));
 		
 		/* Only null filters */
 		out = filterArguments(target, 0, null, null, null, null, null, null, null, null);
-		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, constLong1, constLong2, constLong3, constInteger4, new Long(constLong5), Long.MIN_VALUE, constLong6), 
-				(long) out.invokeExact(Long.MAX_VALUE, constLong1, constLong2, constLong3, constInteger4, new Long(constLong5), Long.MIN_VALUE, constLong6));
+		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, constLong1, constLong2, constLong3, constInteger4, Long.valueOf(constLong5), Long.MIN_VALUE, constLong6), 
+				(long) out.invokeExact(Long.MAX_VALUE, constLong1, constLong2, constLong3, constInteger4, Long.valueOf(constLong5), Long.MIN_VALUE, constLong6));
 		
 		out = filterArguments(target, 4, null, null, null, null);
-		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, constLong1, constLong2, constLong3, constInteger4, new Long(constLong5), Long.MIN_VALUE, constLong6), 
-				(long) out.invokeExact(Long.MAX_VALUE, constLong1, constLong2, constLong3, constInteger4, new Long(constLong5), Long.MIN_VALUE, constLong6));
+		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, constLong1, constLong2, constLong3, constInteger4, Long.valueOf(constLong5), Long.MIN_VALUE, constLong6), 
+				(long) out.invokeExact(Long.MAX_VALUE, constLong1, constLong2, constLong3, constInteger4, Long.valueOf(constLong5), Long.MIN_VALUE, constLong6));
 		
 		out = filterArguments(target, 2, null, null);
-		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, constLong1, constLong2, constLong3, constInteger4, new Long(constLong5), Long.MIN_VALUE, constLong6), 
-				(long) out.invokeExact(Long.MAX_VALUE, constLong1, constLong2, constLong3, constInteger4, new Long(constLong5), Long.MIN_VALUE, constLong6));
+		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, constLong1, constLong2, constLong3, constInteger4, Long.valueOf(constLong5), Long.MIN_VALUE, constLong6), 
+				(long) out.invokeExact(Long.MAX_VALUE, constLong1, constLong2, constLong3, constInteger4, Long.valueOf(constLong5), Long.MIN_VALUE, constLong6));
 		
 		/* No Null filters */
 		out = filterArguments(target, 0, f0, f1, f2, f2, f3, f4, f0, f1);
-		AssertJUnit.assertEquals (targetLong(filterLong0(Long.MAX_VALUE), filterLong1(constLong1), filterLong2(constLong2), filterLong2(constLong3), constInteger4, new Long(constLong5), filterLong0(Long.MIN_VALUE), filterLong1(constLong6)), 
+		AssertJUnit.assertEquals (targetLong(filterLong0(Long.MAX_VALUE), filterLong1(constLong1), filterLong2(constLong2), filterLong2(constLong3), constInteger4, Long.valueOf(constLong5), filterLong0(Long.MIN_VALUE), filterLong1(constLong6)), 
 				(long) out.invokeExact(Long.MAX_VALUE, constLong1, constLong2, constLong3, (long) constInteger4, constLong5, Long.MIN_VALUE, constLong6));
 		
 		out = filterArguments(target, 3, f2, f3, f4, f0, f1);
-		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, constLong1, constLong2, filterLong2(constLong3), constInteger4, new Long(constLong5), filterLong0(Long.MIN_VALUE), filterLong1(constLong6)), 
+		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, constLong1, constLong2, filterLong2(constLong3), constInteger4, Long.valueOf(constLong5), filterLong0(Long.MIN_VALUE), filterLong1(constLong6)), 
 				(long) out.invokeExact(Long.MAX_VALUE, constLong1, constLong2, constLong3, (long) constInteger4, constLong5, Long.MIN_VALUE, constLong6));
 		
 		out = filterArguments(target, 5, f4, f0, f1);
-		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, constLong1, constLong2, constLong3, constInteger4, new Long(constLong5), filterLong0(Long.MIN_VALUE), filterLong1(constLong6)), 
+		AssertJUnit.assertEquals (targetLong(Long.MAX_VALUE, constLong1, constLong2, constLong3, constInteger4, Long.valueOf(constLong5), filterLong0(Long.MIN_VALUE), filterLong1(constLong6)), 
 				(long) out.invokeExact(Long.MAX_VALUE, constLong1, constLong2, constLong3, constInteger4, constLong5, Long.MIN_VALUE, constLong6));
 	}
 	
@@ -653,63 +653,63 @@ public class FilterArgumentsTest {
 		
 		/* Leading null filters */
 		MethodHandle out = filterArguments(target, 0, null, null, null, f2, f3, f4);
-		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, constFloat1, constFloat2, filterFloat2(constFloat3), (double) constFloat4, new Float(constFloat5), Float.MIN_VALUE, constFloat6), 
+		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, constFloat1, constFloat2, filterFloat2(constFloat3), (double) constFloat4, Float.valueOf(constFloat5), Float.MIN_VALUE, constFloat6), 
 				(float) out.invokeExact(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, constFloat4, constFloat5, Float.MIN_VALUE, constFloat6));
 		
 		/* Intermediate null filters */
 		out = filterArguments(target, 1, f0, null, null, f3, f4);
-		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, filterFloat0(constFloat1), constFloat2, constFloat3, (double) constFloat4, new Float(constFloat5), Float.MIN_VALUE, constFloat6), 
+		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, filterFloat0(constFloat1), constFloat2, constFloat3, (double) constFloat4, Float.valueOf(constFloat5), Float.MIN_VALUE, constFloat6), 
 				(float) out.invokeExact(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, constFloat4, constFloat5, Float.MIN_VALUE, constFloat6));
 		
 		/* Trailing null filters */
 		out = filterArguments(target, 2, f1, f2, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetFloat(constFloat1, Float.MAX_VALUE, filterFloat1(constFloat2), filterFloat2(constFloat3), (double) constFloat4, new Float(constFloat5), Float.MIN_VALUE, constFloat6), 
+		AssertJUnit.assertEquals (targetFloat(constFloat1, Float.MAX_VALUE, filterFloat1(constFloat2), filterFloat2(constFloat3), (double) constFloat4, Float.valueOf(constFloat5), Float.MIN_VALUE, constFloat6), 
 				(float) out.invokeExact(constFloat1, Float.MAX_VALUE, constFloat2, constFloat3, constFloat4, constFloat5, Float.MIN_VALUE, constFloat6));
 		
 		/* Leading and intermediate null filters */
 		out = filterArguments(target, 0, null, f0, null, null, f3, f4);
-		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, filterFloat0(constFloat1), constFloat2, constFloat3, (double) constFloat4, new Float(constFloat5), Float.MIN_VALUE, constFloat6), 
+		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, filterFloat0(constFloat1), constFloat2, constFloat3, (double) constFloat4, Float.valueOf(constFloat5), Float.MIN_VALUE, constFloat6), 
 				(float) out.invokeExact(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, constFloat4, constFloat5, Float.MIN_VALUE, constFloat6));
 		
 		/* Leading and trailing null filters */
 		out = filterArguments(target, 0, null, null, null, f2, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, constFloat1, constFloat2, filterFloat2(constFloat3), (double) constFloat4, new Float(constFloat5), Float.MIN_VALUE, constFloat6), 
+		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, constFloat1, constFloat2, filterFloat2(constFloat3), (double) constFloat4, Float.valueOf(constFloat5), Float.MIN_VALUE, constFloat6), 
 				(float) out.invokeExact(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, constFloat4, constFloat5, Float.MIN_VALUE, constFloat6));
 		
 		/* Intermediate and trailing null filters */
 		out = filterArguments(target, 1, f0, null, null, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, filterFloat0(constFloat1), constFloat2, constFloat3, (double) constFloat4, new Float(constFloat5), Float.MIN_VALUE, constFloat6), 
+		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, filterFloat0(constFloat1), constFloat2, constFloat3, (double) constFloat4, Float.valueOf(constFloat5), Float.MIN_VALUE, constFloat6), 
 				(float) out.invokeExact(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, constFloat4, constFloat5, Float.MIN_VALUE, constFloat6));
 		
 		/* Leading, intermediate and trailing null filters */
 		out = filterArguments(target, 0, null, null, f0, null, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, constFloat1, filterFloat0(constFloat2), constFloat3, (double) constFloat4, new Float(constFloat5), Float.MIN_VALUE, constFloat6), 
+		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, constFloat1, filterFloat0(constFloat2), constFloat3, (double) constFloat4, Float.valueOf(constFloat5), Float.MIN_VALUE, constFloat6), 
 				(float) out.invokeExact(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, constFloat4, constFloat5, Float.MIN_VALUE, constFloat6));
 		
 		/* Only null filters */
 		out = filterArguments(target, 0, null, null, null, null, null, null, null, null);
-		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, (double) constFloat4, new Float(constFloat5), Float.MIN_VALUE, constFloat6), 
-				(float) out.invokeExact(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, (double) constFloat4, new Float(constFloat5), Float.MIN_VALUE, constFloat6));
+		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, (double) constFloat4, Float.valueOf(constFloat5), Float.MIN_VALUE, constFloat6), 
+				(float) out.invokeExact(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, (double) constFloat4, Float.valueOf(constFloat5), Float.MIN_VALUE, constFloat6));
 		
 		out = filterArguments(target, 4, null, null, null, null);
-		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, (double) constFloat4, new Float(constFloat5), Float.MIN_VALUE, constFloat6), 
-				(float) out.invokeExact(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, (double) constFloat4, new Float(constFloat5), Float.MIN_VALUE, constFloat6));
+		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, (double) constFloat4, Float.valueOf(constFloat5), Float.MIN_VALUE, constFloat6), 
+				(float) out.invokeExact(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, (double) constFloat4, Float.valueOf(constFloat5), Float.MIN_VALUE, constFloat6));
 		
 		out = filterArguments(target, 2, null, null);
-		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, (double) constFloat4, new Float(constFloat5), Float.MIN_VALUE, constFloat6), 
-				(float) out.invokeExact(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, (double) constFloat4, new Float(constFloat5), Float.MIN_VALUE, constFloat6));
+		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, (double) constFloat4, Float.valueOf(constFloat5), Float.MIN_VALUE, constFloat6), 
+				(float) out.invokeExact(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, (double) constFloat4, Float.valueOf(constFloat5), Float.MIN_VALUE, constFloat6));
 		
 		/* No Null filters */
 		out = filterArguments(target, 0, f0, f1, f2, f2, f3, f4, f0, f1);
-		AssertJUnit.assertEquals (targetFloat(filterFloat0(Float.MAX_VALUE), filterFloat1(constFloat1), filterFloat2(constFloat2), filterFloat2(constFloat3), (double) constFloat4, new Float(constFloat5), filterFloat0(Float.MIN_VALUE), filterFloat1(constFloat6)), 
+		AssertJUnit.assertEquals (targetFloat(filterFloat0(Float.MAX_VALUE), filterFloat1(constFloat1), filterFloat2(constFloat2), filterFloat2(constFloat3), (double) constFloat4, Float.valueOf(constFloat5), filterFloat0(Float.MIN_VALUE), filterFloat1(constFloat6)), 
 				(float) out.invokeExact(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, constFloat4, constFloat5, Float.MIN_VALUE, constFloat6));
 		
 		out = filterArguments(target, 3, f2, f3, f4, f0, f1);
-		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, constFloat1, constFloat2, filterFloat2(constFloat3), (double) constFloat4, new Float(constFloat5), filterFloat0(Float.MIN_VALUE), filterFloat1(constFloat6)), 
+		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, constFloat1, constFloat2, filterFloat2(constFloat3), (double) constFloat4, Float.valueOf(constFloat5), filterFloat0(Float.MIN_VALUE), filterFloat1(constFloat6)), 
 				(float) out.invokeExact(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, constFloat4, constFloat5, Float.MIN_VALUE, constFloat6));
 		
 		out = filterArguments(target, 5, f4, f0, f1);
-		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, (double) constFloat4, new Float(constFloat5), filterFloat0(Float.MIN_VALUE), filterFloat1(constFloat6)), 
+		AssertJUnit.assertEquals (targetFloat(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, (double) constFloat4, Float.valueOf(constFloat5), filterFloat0(Float.MIN_VALUE), filterFloat1(constFloat6)), 
 				(float) out.invokeExact(Float.MAX_VALUE, constFloat1, constFloat2, constFloat3, (double) constFloat4, constFloat5, Float.MIN_VALUE, constFloat6));
 	}
 	
@@ -760,63 +760,63 @@ public class FilterArgumentsTest {
 		
 		/* Leading null filters */
 		MethodHandle out = filterArguments(target, 0, null, null, null, f2, f3, f4);
-		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, constDouble1, constDouble2, filterDouble2(constDouble3), constFloat4, new Double(constDouble5), Double.MIN_VALUE, constDouble6), 
+		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, constDouble1, constDouble2, filterDouble2(constDouble3), constFloat4, Double.valueOf(constDouble5), Double.MIN_VALUE, constDouble6), 
 				(double) out.invokeExact(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, (double) constFloat4, constDouble5, Double.MIN_VALUE, constDouble6));
 		
 		/* Intermediate null filters */
 		out = filterArguments(target, 1, f0, null, null, f3, f4);
-		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, filterDouble0(constDouble1), constDouble2, constDouble3, constFloat4, new Double(constDouble5), Double.MIN_VALUE, constDouble6), 
+		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, filterDouble0(constDouble1), constDouble2, constDouble3, constFloat4, Double.valueOf(constDouble5), Double.MIN_VALUE, constDouble6), 
 				(double) out.invokeExact(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, (double) constFloat4, constDouble5, Double.MIN_VALUE, constDouble6));
 		
 		/* Trailing null filters */
 		out = filterArguments(target, 2, f1, f2, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetDouble(constDouble1, Double.MAX_VALUE, filterDouble1(constDouble2), filterDouble2(constDouble3), constFloat4, new Double(constDouble5), Double.MIN_VALUE, constDouble6), 
+		AssertJUnit.assertEquals (targetDouble(constDouble1, Double.MAX_VALUE, filterDouble1(constDouble2), filterDouble2(constDouble3), constFloat4, Double.valueOf(constDouble5), Double.MIN_VALUE, constDouble6), 
 				(double) out.invokeExact(constDouble1, Double.MAX_VALUE, constDouble2, constDouble3, (double) constFloat4, constDouble5, Double.MIN_VALUE, constDouble6));
 		
 		/* Leading and intermediate null filters */
 		out = filterArguments(target, 0, null, f0, null, null, f3, f4);
-		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, filterDouble0(constDouble1), constDouble2, constDouble3, constFloat4, new Double(constDouble5), Double.MIN_VALUE, constDouble6), 
+		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, filterDouble0(constDouble1), constDouble2, constDouble3, constFloat4, Double.valueOf(constDouble5), Double.MIN_VALUE, constDouble6), 
 				(double) out.invokeExact(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, (double) constFloat4, constDouble5, Double.MIN_VALUE, constDouble6));
 		
 		/* Leading and trailing null filters */
 		out = filterArguments(target, 0, null, null, null, f2, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, constDouble1, constDouble2, filterDouble2(constDouble3), constFloat4, new Double(constDouble5), Double.MIN_VALUE, constDouble6), 
+		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, constDouble1, constDouble2, filterDouble2(constDouble3), constFloat4, Double.valueOf(constDouble5), Double.MIN_VALUE, constDouble6), 
 				(double) out.invokeExact(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, (double) constFloat4, constDouble5, Double.MIN_VALUE, constDouble6));
 		
 		/* Intermediate and trailing null filters */
 		out = filterArguments(target, 1, f0, null, null, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, filterDouble0(constDouble1), constDouble2, constDouble3, constFloat4, new Double(constDouble5), Double.MIN_VALUE, constDouble6), 
+		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, filterDouble0(constDouble1), constDouble2, constDouble3, constFloat4, Double.valueOf(constDouble5), Double.MIN_VALUE, constDouble6), 
 				(double) out.invokeExact(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, (double) constFloat4, constDouble5, Double.MIN_VALUE, constDouble6));
 		
 		/* Leading, intermediate and trailing null filters */
 		out = filterArguments(target, 0, null, null, f0, null, f3, f4, null, null);
-		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, constDouble1, filterDouble0(constDouble2), constDouble3, constFloat4, new Double(constDouble5), Double.MIN_VALUE, constDouble6), 
+		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, constDouble1, filterDouble0(constDouble2), constDouble3, constFloat4, Double.valueOf(constDouble5), Double.MIN_VALUE, constDouble6), 
 				(double) out.invokeExact(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, (double) constFloat4, constDouble5, Double.MIN_VALUE, constDouble6));
 		
 		/* Only null filters */
 		out = filterArguments(target, 0, null, null, null, null, null, null, null, null);
-		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, constFloat4, new Double(constDouble5), Double.MIN_VALUE, constDouble6), 
-				(double) out.invokeExact(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, constFloat4, new Double(constDouble5), Double.MIN_VALUE, constDouble6));
+		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, constFloat4, Double.valueOf(constDouble5), Double.MIN_VALUE, constDouble6), 
+				(double) out.invokeExact(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, constFloat4, Double.valueOf(constDouble5), Double.MIN_VALUE, constDouble6));
 		
 		out = filterArguments(target, 4, null, null, null, null);
-		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, constFloat4, new Double(constDouble5), Double.MIN_VALUE, constDouble6), 
-				(double) out.invokeExact(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, constFloat4, new Double(constDouble5), Double.MIN_VALUE, constDouble6));
+		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, constFloat4, Double.valueOf(constDouble5), Double.MIN_VALUE, constDouble6), 
+				(double) out.invokeExact(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, constFloat4, Double.valueOf(constDouble5), Double.MIN_VALUE, constDouble6));
 		
 		out = filterArguments(target, 2, null, null);
-		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, constFloat4, new Double(constDouble5), Double.MIN_VALUE, constDouble6), 
-				(double) out.invokeExact(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, constFloat4, new Double(constDouble5), Double.MIN_VALUE, constDouble6));
+		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, constFloat4, Double.valueOf(constDouble5), Double.MIN_VALUE, constDouble6), 
+				(double) out.invokeExact(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, constFloat4, Double.valueOf(constDouble5), Double.MIN_VALUE, constDouble6));
 		
 		/* No Null filters */
 		out = filterArguments(target, 0, f0, f1, f2, f2, f3, f4, f0, f1);
-		AssertJUnit.assertEquals (targetDouble(filterDouble0(Double.MAX_VALUE), filterDouble1(constDouble1), filterDouble2(constDouble2), filterDouble2(constDouble3), constFloat4, new Double(constDouble5), filterDouble0(Double.MIN_VALUE), filterDouble1(constDouble6)), 
+		AssertJUnit.assertEquals (targetDouble(filterDouble0(Double.MAX_VALUE), filterDouble1(constDouble1), filterDouble2(constDouble2), filterDouble2(constDouble3), constFloat4, Double.valueOf(constDouble5), filterDouble0(Double.MIN_VALUE), filterDouble1(constDouble6)), 
 				(double) out.invokeExact(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, (double) constFloat4, constDouble5, Double.MIN_VALUE, constDouble6));
 		
 		out = filterArguments(target, 3, f2, f3, f4, f0, f1);
-		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, constDouble1, constDouble2, filterDouble2(constDouble3), constFloat4, new Double(constDouble5), filterDouble0(Double.MIN_VALUE), filterDouble1(constDouble6)), 
+		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, constDouble1, constDouble2, filterDouble2(constDouble3), constFloat4, Double.valueOf(constDouble5), filterDouble0(Double.MIN_VALUE), filterDouble1(constDouble6)), 
 				(double) out.invokeExact(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, (double) constFloat4, constDouble5, Double.MIN_VALUE, constDouble6));
 		
 		out = filterArguments(target, 5, f4, f0, f1);
-		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, constFloat4, new Double(constDouble5), filterDouble0(Double.MIN_VALUE), filterDouble1(constDouble6)), 
+		AssertJUnit.assertEquals (targetDouble(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, constFloat4, Double.valueOf(constDouble5), filterDouble0(Double.MIN_VALUE), filterDouble1(constDouble6)), 
 				(double) out.invokeExact(Double.MAX_VALUE, constDouble1, constDouble2, constDouble3, constFloat4, constDouble5, Double.MIN_VALUE, constDouble6));
 	}
 	
@@ -944,19 +944,19 @@ public class FilterArgumentsTest {
 	/* Divide by 2 */
 	public static Double filterDoubleObject0 (Double a) {
 		System.gc();
-		return new Double(a/2);
+		return Double.valueOf(a/2);
 	}
 	
 	/* Subtract 1 */
 	public static Double filterDoubleObject1 (Double a) {
 		System.gc();
-		return new Double(a-1); 
+		return Double.valueOf(a-1); 
 	}
 	
 	/* Add 1 */
 	public static Double filterDoubleObject2 (Double a) {
 		System.gc();
-		return new Double(a+1); 
+		return Double.valueOf(a+1); 
 	}
 
 	/* Convert into 1 stack-slot primitive data-type */
@@ -968,7 +968,7 @@ public class FilterArgumentsTest {
 	/* Target - returns average of input parameters */
 	public static Double targetDoubleObject (Double a, Double b, Double c, Double d, float e, double f, Double g, Double h) {
 		System.gc();
-		return averageDoubleObject (a, b, c, d, new Double((double) e), new Double(f), g, h);
+		return averageDoubleObject (a, b, c, d, Double.valueOf((double) e), Double.valueOf(f), g, h);
 	}
 	
 	public static Double averageDoubleObject (Double... args) {
@@ -976,7 +976,7 @@ public class FilterArgumentsTest {
 		for(Double arg : args) {
 			total += (arg.doubleValue()/(args.length));
 		}
-		return new Double(total);
+		return Double.valueOf(total);
 	}
 	
    /* Test filterArguments: data-type -> boolean */

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/indyn/ComplexIndyTest.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/indyn/ComplexIndyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,7 +33,7 @@ public class ComplexIndyTest{
 	}
 	@Test(groups = { "level.extended" })
 	public void test_gwtTest_Integer() {
-		String s = com.ibm.j9.jsr292.indyn.ComplexIndy.gwtTest(new Integer(1));
+		String s = com.ibm.j9.jsr292.indyn.ComplexIndy.gwtTest(Integer.valueOf(1));
 		if (!s.equals("2")) Assert.fail("Wrong string returned'" + s +"'");
 	}
 	@Test(groups = { "level.extended" })

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/indyn/IndyTest.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/indyn/IndyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -102,7 +102,7 @@ public class IndyTest {
 	//findSpecial test
 	@Test(groups = { "level.extended" })
 	public void test_indyn_findSpecial() {
-		String s = com.ibm.j9.jsr292.indyn.GenIndyn.call_tostring_of( new Integer( 1 ) );
+		String s = com.ibm.j9.jsr292.indyn.GenIndyn.call_tostring_of( Integer.valueOf( 1 ) );
 		if ( !s.equals( "1" ) ) Assert.fail( "Wrong int returned'" + s +"'" );
 	}
 	

--- a/test/functional/Jsr335/src/org/openj9/test/jsr335/defineAnonClass/TestUnsafeDefineAnonClass.java
+++ b/test/functional/Jsr335/src/org/openj9/test/jsr335/defineAnonClass/TestUnsafeDefineAnonClass.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -135,7 +135,7 @@ public class TestUnsafeDefineAnonClass {
 	private void testIntField(String fieldName, Object anonInstance, Class<?> anonClass, boolean illegalAccess) {
 		try {
 			Field f = anonClass.getDeclaredField(fieldName);
-			f.set(anonInstance, new Integer(CORRECT_ANSWER));
+			f.set(anonInstance, Integer.valueOf(CORRECT_ANSWER));
 			AssertJUnit.assertFalse("Expected IllegalAccessExcpetion, but exception did not occur!", illegalAccess);
 			AssertJUnit.assertEquals("Field is not set to the correct value", CORRECT_ANSWER, f.getInt(anonInstance));
 		} catch (NoSuchFieldException | SecurityException | IllegalArgumentException e) {

--- a/test/functional/SharedCPEntryInvokerTests/src/org/openj9/test/invoker/InvalidateSplitTableRetransformationTest.java
+++ b/test/functional/SharedCPEntryInvokerTests/src/org/openj9/test/invoker/InvalidateSplitTableRetransformationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -86,7 +86,7 @@ public class InvalidateSplitTableRetransformationTest {
 
 		characteristics.clear();
 		characteristics.put(ClassGenerator.VERSION, "V1");
-		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, new Boolean(true));
+		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] { DummyClassGenerator.INVOKE_INTERFACE, DummyClassGenerator.INVOKE_STATIC });
 		dummyClassGenerator.setCharacteristics(characteristics);
@@ -118,7 +118,7 @@ public class InvalidateSplitTableRetransformationTest {
 		logger.debug("Redefining Interface to V2");
 		characteristics.clear();
 		characteristics.put(ClassGenerator.VERSION, "V2");
-		characteristics.put(ClassGenerator.INTF_HAS_DEFAULT_METHOD, new Boolean(true));
+		characteristics.put(ClassGenerator.INTF_HAS_DEFAULT_METHOD, Boolean.valueOf(true));
 		if (!redefineInterface(intfClass, testName, characteristics)) {
 			Assert.fail("Failed to redefine interface");
 		}
@@ -148,7 +148,7 @@ public class InvalidateSplitTableRetransformationTest {
 		logger.debug("Redefining Interface to V3");
 		characteristics.clear();
 		characteristics.put(ClassGenerator.VERSION, "V3");
-		characteristics.put(ClassGenerator.INTF_HAS_STATIC_METHOD, new Boolean(true));
+		characteristics.put(ClassGenerator.INTF_HAS_STATIC_METHOD, Boolean.valueOf(true));
 		if (!redefineInterface(intfClass, testName, characteristics)) {
 			Assert.fail("Failed to redefine interface");
 		}
@@ -233,8 +233,8 @@ public class InvalidateSplitTableRetransformationTest {
 
 		characteristics.clear();
 		characteristics.put(ClassGenerator.VERSION, "V1");
-		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, new Boolean(true));
-		characteristics.put(ClassGenerator.EXTENDS_HELPER_CLASS, new Boolean(true));
+		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, Boolean.valueOf(true));
+		characteristics.put(ClassGenerator.EXTENDS_HELPER_CLASS, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] { DummyClassGenerator.INVOKE_INTERFACE, DummyClassGenerator.INVOKE_SPECIAL });
 		characteristics.put(ClassGenerator.SHARED_INVOKERS_TARGET, "INTERFACE");
@@ -267,7 +267,7 @@ public class InvalidateSplitTableRetransformationTest {
 		logger.debug("Redefining Interface to V2");
 		characteristics.clear();
 		characteristics.put(ClassGenerator.VERSION, "V2");
-		characteristics.put(ClassGenerator.INTF_HAS_DEFAULT_METHOD, new Boolean(true));
+		characteristics.put(ClassGenerator.INTF_HAS_DEFAULT_METHOD, Boolean.valueOf(true));
 		if (!redefineInterface(intfClass, testName, characteristics)) {
 			Assert.fail("Failed to redefine interface");
 		}
@@ -299,8 +299,8 @@ public class InvalidateSplitTableRetransformationTest {
 		logger.debug("Redefining Dummy class to V2");
 		characteristics.clear();
 		characteristics.put(ClassGenerator.VERSION, "V2");
-		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, new Boolean(true));
-		characteristics.put(ClassGenerator.EXTENDS_HELPER_CLASS, new Boolean(true));
+		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, Boolean.valueOf(true));
+		characteristics.put(ClassGenerator.EXTENDS_HELPER_CLASS, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] { DummyClassGenerator.INVOKE_INTERFACE, DummyClassGenerator.INVOKE_SPECIAL });
 		characteristics.put(ClassGenerator.SHARED_INVOKERS_TARGET, "SUPER");
@@ -332,7 +332,7 @@ public class InvalidateSplitTableRetransformationTest {
 
 		characteristics.clear();
 		characteristics.put(ClassGenerator.VERSION, "V1");
-		characteristics.put(ClassGenerator.EXTENDS_HELPER_CLASS, new Boolean(true));
+		characteristics.put(ClassGenerator.EXTENDS_HELPER_CLASS, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] { DummyClassGenerator.INVOKE_STATIC, DummyClassGenerator.INVOKE_SPECIAL });
 		dummyClassGenerator.setCharacteristics(characteristics);
@@ -450,8 +450,8 @@ public class InvalidateSplitTableRetransformationTest {
 
 		characteristics.clear();
 		characteristics.put(ClassGenerator.VERSION, "V1");
-		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, new Boolean(true));
-		characteristics.put(ClassGenerator.EXTENDS_HELPER_CLASS, new Boolean(true));
+		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, Boolean.valueOf(true));
+		characteristics.put(ClassGenerator.EXTENDS_HELPER_CLASS, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] {
 						DummyClassGenerator.INVOKE_INTERFACE,
@@ -497,7 +497,7 @@ public class InvalidateSplitTableRetransformationTest {
 		logger.debug("Redefining Interface to V2");
 		characteristics.clear();
 		characteristics.put(ClassGenerator.VERSION, "V2");
-		characteristics.put(ClassGenerator.INTF_HAS_DEFAULT_METHOD, new Boolean(true));
+		characteristics.put(ClassGenerator.INTF_HAS_DEFAULT_METHOD, Boolean.valueOf(true));
 		if (!redefineInterface(intfClass, testName, characteristics)) {
 			Assert.fail("Failed to redefine interface");
 		}
@@ -540,7 +540,7 @@ public class InvalidateSplitTableRetransformationTest {
 		logger.debug("Redefining Interface to V3");
 		characteristics.clear();
 		characteristics.put(ClassGenerator.VERSION, "V3");
-		characteristics.put(ClassGenerator.INTF_HAS_STATIC_METHOD, new Boolean(true));
+		characteristics.put(ClassGenerator.INTF_HAS_STATIC_METHOD, Boolean.valueOf(true));
 		if (!redefineInterface(intfClass, testName, characteristics)) {
 			Assert.fail("Failed to redefine interface");
 		}
@@ -581,8 +581,8 @@ public class InvalidateSplitTableRetransformationTest {
 		logger.debug("Redefining Dummy class to V2");
 		characteristics.clear();
 		characteristics.put(ClassGenerator.VERSION, "V2");
-		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, new Boolean(true));
-		characteristics.put(ClassGenerator.EXTENDS_HELPER_CLASS, new Boolean(true));
+		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, Boolean.valueOf(true));
+		characteristics.put(ClassGenerator.EXTENDS_HELPER_CLASS, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] {
 						DummyClassGenerator.INVOKE_INTERFACE,

--- a/test/functional/SharedCPEntryInvokerTests/src/org/openj9/test/invoker/MutateOnStackSplitTableRetransformationTest.java
+++ b/test/functional/SharedCPEntryInvokerTests/src/org/openj9/test/invoker/MutateOnStackSplitTableRetransformationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -85,7 +85,7 @@ public class MutateOnStackSplitTableRetransformationTest {
 		expected = ClassGenerator.DUMMY_CLASS_NAME + "_V1." + DummyClassGenerator.INVOKE_STATIC;
 		method = dummyClass.getMethod("invokeStatic", new Class[] { boolean.class });
 		try {
-			rc = (String)method.invoke(dummyClass.newInstance(), new Object[] { new Boolean(true) });
+			rc = (String)method.invoke(dummyClass.newInstance(), new Object[] { Boolean.valueOf(true) });
 			logger.debug("Returned " + rc);
 			AssertJUnit.assertEquals("Did not get expected value: ", expected, rc);
 		} catch (Exception e) {
@@ -95,7 +95,7 @@ public class MutateOnStackSplitTableRetransformationTest {
 		expected = ClassGenerator.DUMMY_CLASS_NAME + "_V2." + DummyClassGenerator.INVOKE_STATIC;
 		method = dummyClass.getMethod("invokeStatic", new Class[] { boolean.class });
 		try {
-			rc = (String)method.invoke(dummyClass.newInstance(), new Object[] { new Boolean(false) });
+			rc = (String)method.invoke(dummyClass.newInstance(), new Object[] { Boolean.valueOf(false) });
 			logger.debug("Returned " + rc);
 			AssertJUnit.assertEquals("Did not get expected value: ", expected, rc);
 		} catch (Exception e) {
@@ -114,7 +114,7 @@ public class MutateOnStackSplitTableRetransformationTest {
 		expected = ClassGenerator.DUMMY_CLASS_NAME + "_V2." + DummyClassGenerator.INVOKE_STATIC;
 		method = dummyClass.getMethod("invokeStatic", new Class[] { boolean.class });
 		try {
-			rc = (String)method.invoke(dummyClass.newInstance(), new Object[] { new Boolean(true) });
+			rc = (String)method.invoke(dummyClass.newInstance(), new Object[] { Boolean.valueOf(true) });
 			logger.debug("Returned " + rc);
 			AssertJUnit.assertEquals("Did not get expected value: ", expected, rc);
 		} catch (Exception e) {
@@ -124,7 +124,7 @@ public class MutateOnStackSplitTableRetransformationTest {
 		expected = ClassGenerator.DUMMY_CLASS_NAME + "_V1." + DummyClassGenerator.INVOKE_STATIC;
 		method = dummyClass.getMethod("invokeStatic", new Class[] { boolean.class });
 		try {
-			rc = (String)method.invoke(dummyClass.newInstance(), new Object[] { new Boolean(false) });
+			rc = (String)method.invoke(dummyClass.newInstance(), new Object[] { Boolean.valueOf(false) });
 			logger.debug("Returned " + rc);
 			AssertJUnit.assertEquals("Did not get expected value: ", expected, rc);
 		} catch (Exception e) {
@@ -170,7 +170,7 @@ public class MutateOnStackSplitTableRetransformationTest {
 		expected = ClassGenerator.DUMMY_CLASS_NAME + "_V1." + DummyClassGenerator.INVOKE_SPECIAL;
 		method = dummyClass.getMethod("invokeSpecial", new Class[] { boolean.class });
 		try {
-			rc = (String)method.invoke(dummyClass.newInstance(), new Object[] { new Boolean(true) });
+			rc = (String)method.invoke(dummyClass.newInstance(), new Object[] { Boolean.valueOf(true) });
 			logger.debug("Returned " + rc);
 			AssertJUnit.assertEquals("Did not get expected value: ", expected, rc);
 		} catch (Exception e) {
@@ -180,7 +180,7 @@ public class MutateOnStackSplitTableRetransformationTest {
 		expected = ClassGenerator.DUMMY_CLASS_NAME + "_V2." + DummyClassGenerator.INVOKE_SPECIAL;
 		method = dummyClass.getMethod("invokeSpecial", new Class[] { boolean.class });
 		try {
-			rc = (String)method.invoke(dummyClass.newInstance(), new Object[] { new Boolean(false) });
+			rc = (String)method.invoke(dummyClass.newInstance(), new Object[] { Boolean.valueOf(false) });
 			logger.debug("Returned " + rc);
 			AssertJUnit.assertEquals("Did not get expected value: ", expected, rc);
 		} catch (Exception e) {
@@ -199,7 +199,7 @@ public class MutateOnStackSplitTableRetransformationTest {
 		expected = ClassGenerator.DUMMY_CLASS_NAME + "_V2." + DummyClassGenerator.INVOKE_SPECIAL;
 		method = dummyClass.getMethod("invokeSpecial", new Class[] { boolean.class });
 		try {
-			rc = (String)method.invoke(dummyClass.newInstance(), new Object[] { new Boolean(true) });
+			rc = (String)method.invoke(dummyClass.newInstance(), new Object[] { Boolean.valueOf(true) });
 			logger.debug("Returned " + rc);
 			AssertJUnit.assertEquals("Did not get expected value: ", expected, rc);
 		} catch (Exception e) {
@@ -209,7 +209,7 @@ public class MutateOnStackSplitTableRetransformationTest {
 		expected = ClassGenerator.DUMMY_CLASS_NAME + "_V1." + DummyClassGenerator.INVOKE_SPECIAL;
 		method = dummyClass.getMethod("invokeSpecial", new Class[] { boolean.class });
 		try {
-			rc = (String)method.invoke(dummyClass.newInstance(), new Object[] { new Boolean(false) });
+			rc = (String)method.invoke(dummyClass.newInstance(), new Object[] { Boolean.valueOf(false) });
 			logger.debug("Returned " + rc);
 			AssertJUnit.assertEquals("Did not get expected value: ", expected, rc);
 		} catch (Exception e) {

--- a/test/functional/SharedCPEntryInvokerTests/src/org/openj9/test/invoker/MutateSplitTableRetransformationTest.java
+++ b/test/functional/SharedCPEntryInvokerTests/src/org/openj9/test/invoker/MutateSplitTableRetransformationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -96,7 +96,7 @@ public class MutateSplitTableRetransformationTest {
 
 			characteristics.clear();
 			characteristics.put(ClassGenerator.VERSION, classVersion);
-			characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, new Boolean(true));
+			characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, Boolean.valueOf(true));
 			/*
 			 * Generate shared invokers based on invokers encoded in class
 			 * version

--- a/test/functional/SharedCPEntryInvokerTests/src/org/openj9/test/invoker/SharedCPEntryInvokerTestCases.java
+++ b/test/functional/SharedCPEntryInvokerTests/src/org/openj9/test/invoker/SharedCPEntryInvokerTestCases.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,7 +61,7 @@ public class SharedCPEntryInvokerTestCases {
 		Class.forName(intfClassName.replace('/', '.'), true, classLoader);
 
 		characteristics.clear();
-		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, new Boolean(true));
+		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] { DummyClassGenerator.INVOKE_INTERFACE, DummyClassGenerator.INVOKE_STATIC });
 
@@ -103,13 +103,13 @@ public class SharedCPEntryInvokerTestCases {
 		ClassGenerator intfGenerator = new InterfaceGenerator(testName, PKG_NAME);
 		ClassGenerator dummyClassGenerator = new DummyClassGenerator(testName, PKG_NAME);
 
-		characteristics.put(ClassGenerator.INTF_HAS_DEFAULT_METHOD, new Boolean(true));
+		characteristics.put(ClassGenerator.INTF_HAS_DEFAULT_METHOD, Boolean.valueOf(true));
 		intfGenerator.setCharacteristics(characteristics);
 		classLoader.setClassData(intfGenerator.getClassData());
 		Class.forName(intfClassName.replace('/', '.'), true, classLoader);
 
 		characteristics.clear();
-		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, new Boolean(true));
+		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] { DummyClassGenerator.INVOKE_INTERFACE, DummyClassGenerator.INVOKE_STATIC });
 
@@ -151,13 +151,13 @@ public class SharedCPEntryInvokerTestCases {
 		ClassGenerator intfGenerator = new InterfaceGenerator(testName, PKG_NAME);
 		ClassGenerator dummyClassGenerator = new DummyClassGenerator(testName, PKG_NAME);
 
-		characteristics.put(ClassGenerator.INTF_HAS_STATIC_METHOD, new Boolean(true));
+		characteristics.put(ClassGenerator.INTF_HAS_STATIC_METHOD, Boolean.valueOf(true));
 		intfGenerator.setCharacteristics(characteristics);
 		classLoader.setClassData(intfGenerator.getClassData());
 		Class.forName(intfClassName.replace('/', '.'), true, classLoader);
 
 		characteristics.clear();
-		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, new Boolean(true));
+		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] { DummyClassGenerator.INVOKE_INTERFACE, DummyClassGenerator.INVOKE_STATIC });
 
@@ -205,7 +205,7 @@ public class SharedCPEntryInvokerTestCases {
 		Class.forName(intfClassName.replace('/', '.'), true, classLoader);
 
 		characteristics.clear();
-		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, new Boolean(true));
+		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] { DummyClassGenerator.INVOKE_INTERFACE, DummyClassGenerator.INVOKE_SPECIAL });
 
@@ -248,13 +248,13 @@ public class SharedCPEntryInvokerTestCases {
 		ClassGenerator intfGenerator = new InterfaceGenerator(testName, PKG_NAME);
 		ClassGenerator dummyClassGenerator = new DummyClassGenerator(testName, PKG_NAME);
 
-		characteristics.put(ClassGenerator.INTF_HAS_DEFAULT_METHOD, new Boolean(true));
+		characteristics.put(ClassGenerator.INTF_HAS_DEFAULT_METHOD, Boolean.valueOf(true));
 		intfGenerator.setCharacteristics(characteristics);
 		classLoader.setClassData(intfGenerator.getClassData());
 		Class.forName(intfClassName.replace('/', '.'), true, classLoader);
 
 		characteristics.clear();
-		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, new Boolean(true));
+		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] { DummyClassGenerator.INVOKE_INTERFACE, DummyClassGenerator.INVOKE_SPECIAL });
 
@@ -304,7 +304,7 @@ public class SharedCPEntryInvokerTestCases {
 		Class.forName(helperClassName.replace('/', '.'), true, classLoader);
 
 		characteristics.clear();
-		characteristics.put(ClassGenerator.EXTENDS_HELPER_CLASS, new Boolean(true));
+		characteristics.put(ClassGenerator.EXTENDS_HELPER_CLASS, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] { DummyClassGenerator.INVOKE_STATIC, DummyClassGenerator.INVOKE_SPECIAL });
 
@@ -353,7 +353,7 @@ public class SharedCPEntryInvokerTestCases {
 		Class.forName(helperClassName.replace('/', '.'), true, classLoader);
 
 		characteristics.clear();
-		characteristics.put(ClassGenerator.EXTENDS_HELPER_CLASS, new Boolean(true));
+		characteristics.put(ClassGenerator.EXTENDS_HELPER_CLASS, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] { DummyClassGenerator.INVOKE_STATIC, DummyClassGenerator.INVOKE_SPECIAL });
 
@@ -402,7 +402,7 @@ public class SharedCPEntryInvokerTestCases {
 		Class.forName(helperClassName.replace('/', '.'), true, classLoader);
 
 		characteristics.clear();
-		characteristics.put(ClassGenerator.USE_HELPER_CLASS, new Boolean(true));
+		characteristics.put(ClassGenerator.USE_HELPER_CLASS, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] { DummyClassGenerator.INVOKE_STATIC, DummyClassGenerator.INVOKE_VIRTUAL });
 
@@ -451,7 +451,7 @@ public class SharedCPEntryInvokerTestCases {
 		Class.forName(helperClassName.replace('/', '.'), true, classLoader);
 
 		characteristics.clear();
-		characteristics.put(ClassGenerator.USE_HELPER_CLASS, new Boolean(true));
+		characteristics.put(ClassGenerator.USE_HELPER_CLASS, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] { DummyClassGenerator.INVOKE_STATIC, DummyClassGenerator.INVOKE_VIRTUAL });
 
@@ -500,7 +500,7 @@ public class SharedCPEntryInvokerTestCases {
 		Class.forName(helperClassName.replace('/', '.'), true, classLoader);
 
 		characteristics.clear();
-		characteristics.put(ClassGenerator.EXTENDS_HELPER_CLASS, new Boolean(true));
+		characteristics.put(ClassGenerator.EXTENDS_HELPER_CLASS, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] { DummyClassGenerator.INVOKE_SPECIAL, DummyClassGenerator.INVOKE_VIRTUAL });
 
@@ -549,7 +549,7 @@ public class SharedCPEntryInvokerTestCases {
 		Class.forName(intfClassName.replace('/', '.'), true, classLoader);
 
 		characteristics.clear();
-		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, new Boolean(true));
+		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] {
 						DummyClassGenerator.INVOKE_INTERFACE,
@@ -606,13 +606,13 @@ public class SharedCPEntryInvokerTestCases {
 		ClassGenerator intfGenerator = new InterfaceGenerator(testName, PKG_NAME);
 		ClassGenerator dummyClassGenerator = new DummyClassGenerator(testName, PKG_NAME);
 
-		characteristics.put(ClassGenerator.INTF_HAS_DEFAULT_METHOD, new Boolean("true"));
+		characteristics.put(ClassGenerator.INTF_HAS_DEFAULT_METHOD, Boolean.valueOf("true"));
 		intfGenerator.setCharacteristics(characteristics);
 		classLoader.setClassData(intfGenerator.getClassData());
 		Class.forName(intfClassName.replace('/', '.'), true, classLoader);
 
 		characteristics.clear();
-		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, new Boolean(true));
+		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] {
 						DummyClassGenerator.INVOKE_INTERFACE,
@@ -670,13 +670,13 @@ public class SharedCPEntryInvokerTestCases {
 		ClassGenerator intfGenerator = new InterfaceGenerator(testName, PKG_NAME);
 		ClassGenerator dummyClassGenerator = new DummyClassGenerator(testName, PKG_NAME);
 
-		characteristics.put(ClassGenerator.INTF_HAS_STATIC_METHOD, new Boolean("true"));
+		characteristics.put(ClassGenerator.INTF_HAS_STATIC_METHOD, Boolean.valueOf("true"));
 		intfGenerator.setCharacteristics(characteristics);
 		classLoader.setClassData(intfGenerator.getClassData());
 		Class.forName(intfClassName.replace('/', '.'), true, classLoader);
 
 		characteristics.clear();
-		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, new Boolean(true));
+		characteristics.put(ClassGenerator.IMPLEMENTS_INTERFACE, Boolean.valueOf(true));
 		characteristics.put(ClassGenerator.SHARED_INVOKERS,
 				new String[] {
 						DummyClassGenerator.INVOKE_INTERFACE,

--- a/test/functional/UnsafeTest/src_80/org/openj9/test/unsafe/UnsafeTestBase.java
+++ b/test/functional/UnsafeTest/src_80/org/openj9/test/unsafe/UnsafeTestBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -413,7 +413,7 @@ public class UnsafeTestBase implements ITest {
 				myUnsafe.putByteVolatile(base(target, i), offset, modelByte[i]);
 			}
 			if (method.equals(ORDERED)) {
-				myUnsafe.putOrderedObject(base(target, i), offset, new Byte(
+				myUnsafe.putOrderedObject(base(target, i), offset, Byte.valueOf(
 						(byte) -1));
 			} else {
 				myUnsafe.putByte(base(target, i), offset, modelByte[i]);

--- a/test/functional/VM_Test/src/com/ibm/oti/jvmtests/GetNanoTimeAdjustment.java
+++ b/test/functional/VM_Test/src/com/ibm/oti/jvmtests/GetNanoTimeAdjustment.java
@@ -4,7 +4,7 @@ package com.ibm.oti.jvmtests;
 import junit.framework.TestCase;
 
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,8 +44,8 @@ public class GetNanoTimeAdjustment extends TestCase {
 	 * Make getNanoTime returns a value similar to System.currentTimeMillis()
 	 */
 	public void test_EnsureWallClockTime() {
-		String nanoTime = new Long(SupportJVM.GetNanoTimeAdjustment(0)).toString();
-		String milliTime = new Long(System.currentTimeMillis()).toString();
+		String nanoTime = Long.valueOf(SupportJVM.GetNanoTimeAdjustment(0)).toString();
+		String milliTime = Long.valueOf(System.currentTimeMillis()).toString();
 		
 		/* accuracy of 1 second */
 		milliTime = milliTime.substring(0, milliTime.length() - 3);
@@ -59,7 +59,7 @@ public class GetNanoTimeAdjustment extends TestCase {
 	 */
 	public void test_EnsureResultIsNanoSecondGranularity() {
 		long result = SupportJVM.GetNanoTimeAdjustment(0);
-		assertEquals("GetNanoTimeAdjustment did not return 19 digits", NANO_TIME_DIGITS, new Long(result).toString().length());
+		assertEquals("GetNanoTimeAdjustment did not return 19 digits", NANO_TIME_DIGITS, Long.valueOf(result).toString().length());
 	}
 	
 	/*

--- a/test/functional/VM_Test/src/j9vm/test/classunloading/FinalizationIndicator.java
+++ b/test/functional/VM_Test/src/j9vm/test/classunloading/FinalizationIndicator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2012 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,14 +62,14 @@ public class FinalizationIndicator {
 
 public FinalizationIndicator(String name) {
 		//System.out.println("FinalizationIndicator instantiated for " + name);
-		isInstanceFinalized.put(name, new Boolean(false));
+		isInstanceFinalized.put(name, Boolean.valueOf(false));
 		this.name = name;
 }
 public static void setLock(Counter counterLock) {
 	FinalizationIndicator.counterLock = counterLock;
 }
 protected void finalize() {
-	isInstanceFinalized.put(name, new Boolean(true));
+	isInstanceFinalized.put(name, Boolean.valueOf(true));
 	System.out.println(name + " unloaded");
 	counterLock.increment();
 	if(counterLock.atDesiredValue())

--- a/test/functional/VM_Test/src/j9vm/test/multipleorphans/InvokeDynamicTestGenerator.java
+++ b/test/functional/VM_Test/src/j9vm/test/multipleorphans/InvokeDynamicTestGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,7 +78,7 @@ public class InvokeDynamicTestGenerator {
 			mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "addIntegers", "(II)I", null, null);
 			mv.visitCode();
 			//mv.visitIntInsn(BIPUSH, value);
-			mv.visitLdcInsn(new Integer(value));
+			mv.visitLdcInsn(Integer.valueOf(value));
 			mv.visitFieldInsn(PUTSTATIC, GENERATED_CLASS_NAME.replace('.', '/'), "random", "I");
 			mv.visitVarInsn(ILOAD, 0);
 			mv.visitVarInsn(ILOAD, 1);

--- a/test/functional/VM_Test/src/j9vm/test/multipleorphans/InvokeDynamicWithMultipleOrphanComparisonTest.java
+++ b/test/functional/VM_Test/src/j9vm/test/multipleorphans/InvokeDynamicWithMultipleOrphanComparisonTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,7 +48,7 @@ public class InvokeDynamicWithMultipleOrphanComparisonTest {
 		Class<?> cls = Class.forName(InvokeDynamicTestGenerator.GENERATED_CLASS_NAME, true, classLoader);
 		Method m = cls.getMethod("addIntegers", new Class[] { int.class, int.class });
 		try {
-			int result = ((Integer)m.invoke(null, new Object[] { new Integer(10), new Integer(10) })).intValue();
+			int result = ((Integer)m.invoke(null, new Object[] { Integer.valueOf(10), Integer.valueOf(10) })).intValue();
 			System.err.println("Result = " + result);
 			System.err.println(PASS_STRING);
 		} catch (Exception e) {

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -191,7 +191,7 @@ public class ValueTypeGenerator extends ClassLoader {
 		mv.visitTypeInsn(NEW, className);
 		mv.visitInsn(DUP);
 		mv.visitMethodInsn(INVOKESPECIAL, className, "<init>", "()V", false);
-		mv.visitLdcInsn(new Long(123L));
+		mv.visitLdcInsn(Long.valueOf(123L));
 		mv.visitFieldInsn(WITHFIELD, className, "longField", "J");
 		mv.visitInsn(ARETURN);
 		mv.visitMaxs(1, 2);
@@ -206,7 +206,7 @@ public class ValueTypeGenerator extends ClassLoader {
 		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testWithFieldOnNull", "()Ljava/lang/Object;", null, null);
 		mv.visitCode();
 		mv.visitInsn(ACONST_NULL);
-		mv.visitLdcInsn(new Long(123L));
+		mv.visitLdcInsn(Long.valueOf(123L));
 		mv.visitFieldInsn(WITHFIELD, className, "longField", "J");
 		mv.visitInsn(ARETURN);
 		mv.visitMaxs(1, 2);
@@ -223,7 +223,7 @@ public class ValueTypeGenerator extends ClassLoader {
 		mv.visitTypeInsn(NEW, className);
 		mv.visitInsn(DUP);
 		mv.visitMethodInsn(INVOKESPECIAL, className, "<init>", "()V", false);
-		mv.visitLdcInsn(new Long(123L));
+		mv.visitLdcInsn(Long.valueOf(123L));
 		mv.visitFieldInsn(WITHFIELD, "NonExistentClass", "longField", "J");
 		mv.visitInsn(ARETURN);
 		mv.visitMaxs(1, 2);

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/ResolveFrameMain.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/ResolveFrameMain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@ package com.ibm.jvmti.tests.decompResolveFrame;
 
 public class ResolveFrameMain 
 {
-    static Integer i1 = new Integer(1234);
+    static Integer i1 = Integer.valueOf(1234);
     static double  d1 = 2863311530.0;
     static long    l1 = 1234567;
 

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/ResolveFrame_TestInterfaceMethod.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/ResolveFrame_TestInterfaceMethod.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,7 +39,7 @@ class ResolveFrame_TestInterfaceMethod implements ResolveFrame_Interface
                               float f4, float f5, float f6, float f7, float f8, float f9, float f10, float f11, float f12, float f13) 
     {
      
-        Integer r_i1 = new Integer(1234);
+        Integer r_i1 = Integer.valueOf(1234);
         double  r_d1 = 2863311530.0;
         long    r_l1 = 1234567;
 

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/ResolveFrame_TestMethod.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/ResolveFrame_TestMethod.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,7 @@ public class ResolveFrame_TestMethod
                               float f4, float f5, float f6, float f7, float f8, float f9, float f10, float f11, float f12, float f13) 
     {
      
-        Integer r_i1 = new Integer(1234);
+        Integer r_i1 = Integer.valueOf(1234);
         double  r_d1 = 2863311530.0;
         long    r_l1 = 1234567;
 

--- a/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/PartitioningURLClassPathHelperURLHelperStaleEntryCompatibilityTest.java
+++ b/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/PartitioningURLClassPathHelperURLHelperStaleEntryCompatibilityTest.java
@@ -69,7 +69,7 @@ public class PartitioningURLClassPathHelperURLHelperStaleEntryCompatibilityTest 
 		String partition = props.getProperty("Partition");
 		
 		String ctl = props.getProperty("NumberOfClassesToLoad");
-		Integer intctl = new Integer(ctl);
+		Integer intctl = Integer.valueOf(ctl);
 		int numberOfClassesToLoad = intctl.intValue();
 		
 		String classesString = props.getProperty("LoadClasses");
@@ -79,7 +79,7 @@ public class PartitioningURLClassPathHelperURLHelperStaleEntryCompatibilityTest 
 		}
 		
 		String numberOfUrlsString = props.getProperty("NumberOfUrls");
-		Integer tempNumberOfUrls = new Integer(numberOfUrlsString);
+		Integer tempNumberOfUrls = Integer.valueOf(numberOfUrlsString);
 		int numberOfUrls = tempNumberOfUrls.intValue();
 		
 		int maxClassesToFind = 0;		
@@ -89,7 +89,7 @@ public class PartitioningURLClassPathHelperURLHelperStaleEntryCompatibilityTest 
 			urls[index] = props.getProperty("Url"+index);
 			partitionStrings[index] = props.getProperty("urlPartition"+index);
 			String ctf = props.getProperty("NumberOfClassesToFind"+index);
-			Integer intctf = new Integer(ctl);
+			Integer intctf = Integer.valueOf(ctl);
 			maxClassesToFind = ((intctl.intValue() > maxClassesToFind) ? intctl.intValue() : maxClassesToFind);
 		}
 		
@@ -100,7 +100,7 @@ public class PartitioningURLClassPathHelperURLHelperStaleEntryCompatibilityTest 
 			String findClasses = props.getProperty("FindClasses"+urlIndex);
 			String result = props.getProperty("Results"+urlIndex);
 			String ctf = props.getProperty("NumberOfClassesToFind"+urlIndex);
-			Integer intctf = new Integer(ctf);
+			Integer intctf = Integer.valueOf(ctf);
 			int numberOfClassesToFind = intctf.intValue();
 			for(int classToFindIndex = 0; classToFindIndex < numberOfClassesToFind; classToFindIndex++){
 				classesToFind[urlIndex][classToFindIndex] = manipulator.getStringElement(classToFindIndex, findClasses);

--- a/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/PartitioningURLHelperURLClassPathHelperStaleEntryCompatibilityTest.java
+++ b/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/PartitioningURLHelperURLClassPathHelperStaleEntryCompatibilityTest.java
@@ -68,7 +68,7 @@ public class PartitioningURLHelperURLClassPathHelperStaleEntryCompatibilityTest 
 		}
 		
 		String numberOfUrlsString = props.getProperty("NumberOfUrls");
-		Integer tempNumberOfUrls = new Integer(numberOfUrlsString);
+		Integer tempNumberOfUrls = Integer.valueOf(numberOfUrlsString);
 		int numberOfUrls = tempNumberOfUrls.intValue();
 		
 		int maxClassesToLoad = 0;		
@@ -78,7 +78,7 @@ public class PartitioningURLHelperURLClassPathHelperStaleEntryCompatibilityTest 
 			urls[index] = props.getProperty("Url"+index);
 			partitionStrings[index] = props.getProperty("urlPartition"+index);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+index);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			maxClassesToLoad = ((intctl.intValue() > maxClassesToLoad) ? intctl.intValue() : maxClassesToLoad);
 		}
 		
@@ -87,7 +87,7 @@ public class PartitioningURLHelperURLClassPathHelperStaleEntryCompatibilityTest 
 		for(int urlIndex = 0; urlIndex < numberOfUrls; urlIndex++){
 			String loadClasses = props.getProperty("LoadClasses"+urlIndex);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+urlIndex);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			int numberOfClassesToLoad = intctl.intValue();
 			for(int classToLoadIndex = 0; classToLoadIndex < numberOfClassesToLoad; classToLoadIndex++){
 				classesToLoad[urlIndex][classToLoadIndex] = manipulator.getStringElement(classToLoadIndex, loadClasses);
@@ -98,7 +98,7 @@ public class PartitioningURLHelperURLClassPathHelperStaleEntryCompatibilityTest 
 		String partition = props.getProperty("Partition");
 		
 		String ctf = props.getProperty("NumberOfClassesToFind");
-		Integer intctf = new Integer(ctf);
+		Integer intctf = Integer.valueOf(ctf);
 		int numberOfClassesToFind = intctf.intValue();
 		
 		String classesString = props.getProperty("FindClasses");

--- a/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/URLClassPathHelperURLHelperCompatibilityTest.java
+++ b/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/URLClassPathHelperURLHelperCompatibilityTest.java
@@ -65,7 +65,7 @@ public class URLClassPathHelperURLHelperCompatibilityTest {
 		String classPath = props.getProperty("Classpath");
 		
 		String ctl = props.getProperty("NumberOfClassesToLoad");
-		Integer intctl = new Integer(ctl);
+		Integer intctl = Integer.valueOf(ctl);
 		int numberOfClassesToLoad = intctl.intValue();
 		
 		String classesString = props.getProperty("LoadClasses");
@@ -75,7 +75,7 @@ public class URLClassPathHelperURLHelperCompatibilityTest {
 		}
 		
 		String numberOfUrlsString = props.getProperty("NumberOfUrls");
-		Integer tempNumberOfUrls = new Integer(numberOfUrlsString);
+		Integer tempNumberOfUrls = Integer.valueOf(numberOfUrlsString);
 		int numberOfUrls = tempNumberOfUrls.intValue();
 		
 		int maxClassesToFind = 0;		
@@ -83,7 +83,7 @@ public class URLClassPathHelperURLHelperCompatibilityTest {
 		for(int index = 0; index < numberOfUrls; index++){
 			urls[index] = props.getProperty("Url"+index);
 			String ctf = props.getProperty("NumberOfClassesToFind"+index);
-			Integer intctf = new Integer(ctf);
+			Integer intctf = Integer.valueOf(ctf);
 			maxClassesToFind = ((intctf.intValue() > maxClassesToFind) ? intctf.intValue() : maxClassesToFind);
 		}
 		
@@ -94,7 +94,7 @@ public class URLClassPathHelperURLHelperCompatibilityTest {
 			String findClasses = props.getProperty("FindClasses"+urlIndex);
 			String result = props.getProperty("Results"+urlIndex);
 			String ctf = props.getProperty("NumberOfClassesToFind"+urlIndex);
-			Integer intctf = new Integer(ctf);
+			Integer intctf = Integer.valueOf(ctf);
 			int numberOfClassesToFind = intctf.intValue();
 			for(int classToFindIndex = 0; classToFindIndex < numberOfClassesToFind; classToFindIndex++){
 				classesToFind[urlIndex][classToFindIndex] = manipulator.getStringElement(classToFindIndex, findClasses);

--- a/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/URLClassPathHelperURLHelperStaleEntryCompatibilityTest.java
+++ b/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/URLClassPathHelperURLHelperStaleEntryCompatibilityTest.java
@@ -68,7 +68,7 @@ public class URLClassPathHelperURLHelperStaleEntryCompatibilityTest {
 		String classPath = props.getProperty("Classpath");
 		
 		String ctl = props.getProperty("NumberOfClassesToLoad");
-		Integer intctl = new Integer(ctl);
+		Integer intctl = Integer.valueOf(ctl);
 		int numberOfClassesToLoad = intctl.intValue();
 		
 		String classesString = props.getProperty("LoadClasses");
@@ -78,7 +78,7 @@ public class URLClassPathHelperURLHelperStaleEntryCompatibilityTest {
 		}
 		
 		String numberOfUrlsString = props.getProperty("NumberOfUrls");
-		Integer tempNumberOfUrls = new Integer(numberOfUrlsString);
+		Integer tempNumberOfUrls = Integer.valueOf(numberOfUrlsString);
 		int numberOfUrls = tempNumberOfUrls.intValue();
 		
 		int maxClassesToFind = 0;		
@@ -86,7 +86,7 @@ public class URLClassPathHelperURLHelperStaleEntryCompatibilityTest {
 		for(int index = 0; index < numberOfUrls; index++){
 			urls[index] = props.getProperty("Url"+index);
 			String ctf = props.getProperty("NumberOfClassesToFind"+index);
-			Integer intctf = new Integer(ctf);
+			Integer intctf = Integer.valueOf(ctf);
 			maxClassesToFind = ((intctf.intValue() > maxClassesToFind) ? intctf.intValue() : maxClassesToFind);
 		}
 		
@@ -97,7 +97,7 @@ public class URLClassPathHelperURLHelperStaleEntryCompatibilityTest {
 			String findClasses = props.getProperty("FindClasses"+urlIndex);
 			String result = props.getProperty("Results"+urlIndex);
 			String ctf = props.getProperty("NumberOfClassesToFind"+urlIndex);
-			Integer intctf = new Integer(ctf);
+			Integer intctf = Integer.valueOf(ctf);
 			int numberOfClassesToFind = intctf.intValue();
 			for(int classToFindIndex = 0; classToFindIndex < numberOfClassesToFind; classToFindIndex++){
 				classesToFind[urlIndex][classToFindIndex] = manipulator.getStringElement(classToFindIndex, findClasses);

--- a/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/URLHelperURLClassPathHelperCompatibilityTest.java
+++ b/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/URLHelperURLClassPathHelperCompatibilityTest.java
@@ -65,7 +65,7 @@ public class URLHelperURLClassPathHelperCompatibilityTest {
 		}
 		
 		String numberOfUrlsString = props.getProperty("NumberOfUrls");
-		Integer tempNumberOfUrls = new Integer(numberOfUrlsString);
+		Integer tempNumberOfUrls = Integer.valueOf(numberOfUrlsString);
 		int numberOfUrls = tempNumberOfUrls.intValue();
 		
 		int maxClassesToLoad = 0;		
@@ -73,7 +73,7 @@ public class URLHelperURLClassPathHelperCompatibilityTest {
 		for(int index = 0; index < numberOfUrls; index++){
 			urls[index] = props.getProperty("Url"+index);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+index);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			maxClassesToLoad = ((intctl.intValue() > maxClassesToLoad) ? intctl.intValue() : maxClassesToLoad);
 		}
 		
@@ -82,7 +82,7 @@ public class URLHelperURLClassPathHelperCompatibilityTest {
 		for(int urlIndex = 0; urlIndex < numberOfUrls; urlIndex++){
 			String loadClasses = props.getProperty("LoadClasses"+urlIndex);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+urlIndex);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			int numberOfClassesToLoad = intctl.intValue();
 			for(int classToLoadIndex = 0; classToLoadIndex < numberOfClassesToLoad; classToLoadIndex++){
 				classesToLoad[urlIndex][classToLoadIndex] = manipulator.getStringElement(classToLoadIndex, loadClasses);
@@ -92,7 +92,7 @@ public class URLHelperURLClassPathHelperCompatibilityTest {
 		String classPath = props.getProperty("Classpath");
 		
 		String ctf = props.getProperty("NumberOfClassesToFind");
-		Integer intctf = new Integer(ctf);
+		Integer intctf = Integer.valueOf(ctf);
 		int numberOfClassesToFind = intctf.intValue();
 		
 		String classesString = props.getProperty("FindClasses");

--- a/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/URLHelperURLClassPathHelperStaleEntryCompatibilityTest.java
+++ b/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/URLHelperURLClassPathHelperStaleEntryCompatibilityTest.java
@@ -68,7 +68,7 @@ public class URLHelperURLClassPathHelperStaleEntryCompatibilityTest {
 		}
 		
 		String numberOfUrlsString = props.getProperty("NumberOfUrls");
-		Integer tempNumberOfUrls = new Integer(numberOfUrlsString);
+		Integer tempNumberOfUrls = Integer.valueOf(numberOfUrlsString);
 		int numberOfUrls = tempNumberOfUrls.intValue();
 		
 		int maxClassesToLoad = 0;		
@@ -76,7 +76,7 @@ public class URLHelperURLClassPathHelperStaleEntryCompatibilityTest {
 		for(int index = 0; index < numberOfUrls; index++){
 			urls[index] = props.getProperty("Url"+index);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+index);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			maxClassesToLoad = ((intctl.intValue() > maxClassesToLoad) ? intctl.intValue() : maxClassesToLoad);
 		}
 		
@@ -85,7 +85,7 @@ public class URLHelperURLClassPathHelperStaleEntryCompatibilityTest {
 		for(int urlIndex = 0; urlIndex < numberOfUrls; urlIndex++){
 			String loadClasses = props.getProperty("LoadClasses"+urlIndex);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+urlIndex);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			int numberOfClassesToLoad = intctl.intValue();
 			for(int classToLoadIndex = 0; classToLoadIndex < numberOfClassesToLoad; classToLoadIndex++){
 				classesToLoad[urlIndex][classToLoadIndex] = manipulator.getStringElement(classToLoadIndex, loadClasses);
@@ -95,7 +95,7 @@ public class URLHelperURLClassPathHelperStaleEntryCompatibilityTest {
 		String classPath = props.getProperty("Classpath");
 		
 		String ctf = props.getProperty("NumberOfClassesToFind");
-		Integer intctf = new Integer(ctf);
+		Integer intctf = Integer.valueOf(ctf);
 		int numberOfClassesToFind = intctf.intValue();
 		
 		String classesString = props.getProperty("FindClasses");

--- a/test/functional/cmdLineTests/shareClassTests/TokenHelperTests/StaleMarkingTests/StaleMarkingTest.java
+++ b/test/functional/cmdLineTests/shareClassTests/TokenHelperTests/StaleMarkingTests/StaleMarkingTest.java
@@ -62,21 +62,21 @@ public class StaleMarkingTest {
 		}
 		
 		String clc = props.getProperty("NumberOfClassloaders");
-		Integer c = new Integer(clc);
+		Integer c = Integer.valueOf(clc);
 		int classloaderCount = c.intValue();
 		String [] classLoaderPaths = new String[classloaderCount];
 		int maxClassesToLoad =0;
 		for(int index = 0; index < classloaderCount; index++){
 			classLoaderPaths[index] = props.getProperty("ClassPath"+index);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+index);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			maxClassesToLoad = ((intctl.intValue() > maxClassesToLoad) ? intctl.intValue() : maxClassesToLoad);
 		}
 
 		String [][] classesToLoad = new String[classloaderCount][maxClassesToLoad];
 		for(int loaderIndex = 0; loaderIndex < classloaderCount; loaderIndex++){
 			String nctls = props.getProperty("NumberOfClassesToLoad"+loaderIndex);
-			Integer i = new Integer(nctls);
+			Integer i = Integer.valueOf(nctls);
 			int classesToLoadCount = i.intValue();
 			String classesString = props.getProperty("ClassesToLoad"+loaderIndex);
 			for (int classesIndex = 0; classesIndex < classesToLoadCount; classesIndex++){
@@ -86,7 +86,7 @@ public class StaleMarkingTest {
 		
 		String findPath = props.getProperty("FindPath");
 		String ctf = props.getProperty("NumberOfClassesToFind");
-		Integer intctf = new Integer(ctf);
+		Integer intctf = Integer.valueOf(ctf);
 		int numberOfClassesToFind = intctf.intValue();
 		
 		String classesString = props.getProperty("FindClasses");

--- a/test/functional/cmdLineTests/shareClassTests/TokenHelperTests/TimeStampingTests/TimeStampingTest.java
+++ b/test/functional/cmdLineTests/shareClassTests/TokenHelperTests/TimeStampingTests/TimeStampingTest.java
@@ -63,7 +63,7 @@ public class TimeStampingTest {
 		}
 		
 		String numberOfUrlsString = props.getProperty("NumberOfUrls");
-		Integer tempNumberOfUrls = new Integer(numberOfUrlsString);
+		Integer tempNumberOfUrls = Integer.valueOf(numberOfUrlsString);
 		int numberOfUrls = tempNumberOfUrls.intValue();
 		
 		int maxClassesToLoad = 0;
@@ -72,10 +72,10 @@ public class TimeStampingTest {
 		for(int index = 0; index < numberOfUrls; index++){
 			urls[index] = props.getProperty("Url"+index);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+index);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			maxClassesToLoad = ((intctl.intValue() > maxClassesToLoad) ? intctl.intValue() : maxClassesToLoad);
 			String ctf = props.getProperty("NumberOfClassesToFind"+index);
-			Integer intctf = new Integer(ctl);
+			Integer intctf = Integer.valueOf(ctl);
 			maxClassesToFind = ((intctl.intValue() > maxClassesToFind) ? intctl.intValue() : maxClassesToFind);
 		}
 		
@@ -88,10 +88,10 @@ public class TimeStampingTest {
 			String findClasses = props.getProperty("FindClasses"+urlIndex);
 			String result = props.getProperty("Results"+urlIndex);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+urlIndex);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			int numberOfClassesToLoad = intctl.intValue();
 			String ctf = props.getProperty("NumberOfClassesToFind"+urlIndex);
-			Integer intctf = new Integer(ctl);
+			Integer intctf = Integer.valueOf(ctl);
 			int numberOfClassesToFind = intctf.intValue();
 			for(int classToLoadIndex = 0; classToLoadIndex < numberOfClassesToLoad; classToLoadIndex++){
 				classesToLoad[urlIndex][classToLoadIndex] = manipulator.getStringElement(classToLoadIndex, loadClasses);

--- a/test/functional/cmdLineTests/shareClassTests/URLHelperTests/ClassPathMatchingTests/MultiLoadURLClassPathMatchingTest.java
+++ b/test/functional/cmdLineTests/shareClassTests/URLHelperTests/ClassPathMatchingTests/MultiLoadURLClassPathMatchingTest.java
@@ -64,7 +64,7 @@ public class MultiLoadURLClassPathMatchingTest {
 		}
 
 		String numberOfUrlsString = props.getProperty("NumberOfUrls");
-		Integer tempNumberOfUrls = new Integer(numberOfUrlsString);
+		Integer tempNumberOfUrls = Integer.valueOf(numberOfUrlsString);
 		int numberOfUrls = tempNumberOfUrls.intValue();
 		
 		int maxClassesToLoad = 0;
@@ -73,10 +73,10 @@ public class MultiLoadURLClassPathMatchingTest {
 		for(int index = 0; index < numberOfUrls; index++){
 			urls[index] = props.getProperty("Url"+index);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+index);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			maxClassesToLoad = ((intctl.intValue() > maxClassesToLoad) ? intctl.intValue() : maxClassesToLoad);
 			String ctf = props.getProperty("NumberOfClassesToFind"+index);
-			Integer intctf = new Integer(ctf);
+			Integer intctf = Integer.valueOf(ctf);
 			maxClassesToFind = ((intctf.intValue() > maxClassesToFind) ? intctf.intValue() : maxClassesToFind);
 		}
 		
@@ -89,10 +89,10 @@ public class MultiLoadURLClassPathMatchingTest {
 			String findClasses = props.getProperty("FindClasses"+urlIndex);
 			String result = props.getProperty("Results"+urlIndex);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+urlIndex);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			int numberOfClassesToLoad = intctl.intValue();
 			String ctf = props.getProperty("NumberOfClassesToFind"+urlIndex);
-			Integer intctf = new Integer(ctf);
+			Integer intctf = Integer.valueOf(ctf);
 			int numberOfClassesToFind = intctf.intValue();
 			for(int classToLoadIndex = 0; classToLoadIndex < numberOfClassesToLoad; classToLoadIndex++){
 				classesToLoad[urlIndex][classToLoadIndex] = manipulator.getStringElement(classToLoadIndex, loadClasses);

--- a/test/functional/cmdLineTests/shareClassTests/URLHelperTests/ClassPathMatchingTests/URLClassPathMatchingTest.java
+++ b/test/functional/cmdLineTests/shareClassTests/URLHelperTests/ClassPathMatchingTests/URLClassPathMatchingTest.java
@@ -64,7 +64,7 @@ public class URLClassPathMatchingTest {
 		}
 
 		String numberOfUrlsString = props.getProperty("NumberOfUrls");
-		Integer tempNumberOfUrls = new Integer(numberOfUrlsString);
+		Integer tempNumberOfUrls = Integer.valueOf(numberOfUrlsString);
 		int numberOfUrls = tempNumberOfUrls.intValue();
 		
 		int maxClassesToLoad = 0;
@@ -73,10 +73,10 @@ public class URLClassPathMatchingTest {
 		for(int index = 0; index < numberOfUrls; index++){
 			urls[index] = props.getProperty("Url"+index);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+index);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			maxClassesToLoad = ((intctl.intValue() > maxClassesToLoad) ? intctl.intValue() : maxClassesToLoad);
 			String ctf = props.getProperty("NumberOfClassesToFind"+index);
-			Integer intctf = new Integer(ctf);
+			Integer intctf = Integer.valueOf(ctf);
 			maxClassesToFind = ((intctf.intValue() > maxClassesToFind) ? intctf.intValue() : maxClassesToFind);
 		}
 		
@@ -89,10 +89,10 @@ public class URLClassPathMatchingTest {
 			String findClasses = props.getProperty("FindClasses"+urlIndex);
 			String result = props.getProperty("Results"+urlIndex);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+urlIndex);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			int numberOfClassesToLoad = intctl.intValue();
 			String ctf = props.getProperty("NumberOfClassesToFind"+urlIndex);
-			Integer intctf = new Integer(ctf);
+			Integer intctf = Integer.valueOf(ctf);
 			int numberOfClassesToFind = intctf.intValue();
 			for(int classToLoadIndex = 0; classToLoadIndex < numberOfClassesToLoad; classToLoadIndex++){
 				classesToLoad[urlIndex][classToLoadIndex] = manipulator.getStringElement(classToLoadIndex, loadClasses);

--- a/test/functional/cmdLineTests/shareClassTests/URLHelperTests/PartitioningTests/URLPartitioningStoreFindTest.java
+++ b/test/functional/cmdLineTests/shareClassTests/URLHelperTests/PartitioningTests/URLPartitioningStoreFindTest.java
@@ -65,7 +65,7 @@ public class URLPartitioningStoreFindTest {
 		}
 		
 		String numberOfUrlsString = props.getProperty("NumberOfUrls");
-		Integer tempNumberOfUrls = new Integer(numberOfUrlsString);
+		Integer tempNumberOfUrls = Integer.valueOf(numberOfUrlsString);
 		int numberOfUrls = tempNumberOfUrls.intValue();
 		
 		int maxClassesToLoad = 0;
@@ -76,10 +76,10 @@ public class URLPartitioningStoreFindTest {
 			urls[index] = props.getProperty("Url"+index);
 			partitionStrings[index] = props.getProperty("Partition"+index);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+index);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			maxClassesToLoad = ((intctl.intValue() > maxClassesToLoad) ? intctl.intValue() : maxClassesToLoad);
 			String ctf = props.getProperty("NumberOfClassesToFind"+index);
-			Integer intctf = new Integer(ctl);
+			Integer intctf = Integer.valueOf(ctl);
 			maxClassesToFind = ((intctl.intValue() > maxClassesToFind) ? intctl.intValue() : maxClassesToFind);
 		}
 		
@@ -92,10 +92,10 @@ public class URLPartitioningStoreFindTest {
 			String findClasses = props.getProperty("FindClasses"+urlIndex);
 			String result = props.getProperty("Results"+urlIndex);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+urlIndex);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			int numberOfClassesToLoad = intctl.intValue();
 			String ctf = props.getProperty("NumberOfClassesToFind"+urlIndex);
-			Integer intctf = new Integer(ctl);
+			Integer intctf = Integer.valueOf(ctl);
 			int numberOfClassesToFind = intctf.intValue();
 			for(int classToLoadIndex = 0; classToLoadIndex < numberOfClassesToLoad; classToLoadIndex++){
 				classesToLoad[urlIndex][classToLoadIndex] = manipulator.getStringElement(classToLoadIndex, loadClasses);

--- a/test/functional/cmdLineTests/shareClassTests/URLHelperTests/StaleClassPathEntryTests/URLStaleClassPathEntryTest.java
+++ b/test/functional/cmdLineTests/shareClassTests/URLHelperTests/StaleClassPathEntryTests/URLStaleClassPathEntryTest.java
@@ -66,7 +66,7 @@ public class URLStaleClassPathEntryTest {
 		}
 
 		String numberOfUrlsString = props.getProperty("NumberOfUrls");
-		Integer tempNumberOfUrls = new Integer(numberOfUrlsString);
+		Integer tempNumberOfUrls = Integer.valueOf(numberOfUrlsString);
 		int numberOfUrls = tempNumberOfUrls.intValue();
 		
 		int maxClassesToLoad = 0;
@@ -75,10 +75,10 @@ public class URLStaleClassPathEntryTest {
 		for(int index = 0; index < numberOfUrls; index++){
 			urls[index] = props.getProperty("Url"+index);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+index);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			maxClassesToLoad = ((intctl.intValue() > maxClassesToLoad) ? intctl.intValue() : maxClassesToLoad);
 			String ctf = props.getProperty("NumberOfClassesToFind"+index);
-			Integer intctf = new Integer(ctl);
+			Integer intctf = Integer.valueOf(ctl);
 			maxClassesToFind = ((intctl.intValue() > maxClassesToFind) ? intctl.intValue() : maxClassesToFind);
 		}
 		
@@ -91,10 +91,10 @@ public class URLStaleClassPathEntryTest {
 			String findClasses = props.getProperty("FindClasses"+urlIndex);
 			String result = props.getProperty("Results"+urlIndex);
 			String ctl = props.getProperty("NumberOfClassesToLoad"+urlIndex);
-			Integer intctl = new Integer(ctl);
+			Integer intctl = Integer.valueOf(ctl);
 			int numberOfClassesToLoad = intctl.intValue();
 			String ctf = props.getProperty("NumberOfClassesToFind"+urlIndex);
-			Integer intctf = new Integer(ctl);
+			Integer intctf = Integer.valueOf(ctl);
 			int numberOfClassesToFind = intctf.intValue();
 			for(int classToLoadIndex = 0; classToLoadIndex < numberOfClassesToLoad; classToLoadIndex++){
 				classesToLoad[urlIndex][classToLoadIndex] = manipulator.getStringElement(classToLoadIndex, loadClasses);

--- a/test/functional/cmdLineTests/shareClassTests/utils/src/Utilities/Loader.java
+++ b/test/functional/cmdLineTests/shareClassTests/utils/src/Utilities/Loader.java
@@ -67,7 +67,7 @@ public class Loader {
 		String classPath = props.getProperty("ClassPath");
 		
 		String nctls = props.getProperty("NumberOfClassesToLoad");
-		Integer i = new Integer(nctls);
+		Integer i = Integer.valueOf(nctls);
 		int classesToLoadCount = i.intValue();
 		
 		String[] classesToLoad = new String[classesToLoadCount];

--- a/test/functional/cmdLineTests/shareClassTests/utils/src/Utilities/Verifier.java
+++ b/test/functional/cmdLineTests/shareClassTests/utils/src/Utilities/Verifier.java
@@ -66,7 +66,7 @@ public class Verifier {
 		String classPath = props.getProperty("ClassPath");
 		
 		String nctls = props.getProperty("NumberOfClassesToVerify");
-		Integer i = new Integer(nctls);
+		Integer i = Integer.valueOf(nctls);
 		int classesToVerifyCount = i.intValue();
 		
 		String[] classesToVerify = new String[classesToVerifyCount];

--- a/test/functional/cmdLineTests/vmRuntimeState/src/ActiveIdleTest.java
+++ b/test/functional/cmdLineTests/vmRuntimeState/src/ActiveIdleTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -152,7 +152,7 @@ public class ActiveIdleTest {
 			// create a list of numbers
 			for (int i = 0; i < 1000; i++) {
 				long number = System.nanoTime() % 1000000;
-				list.add(new Long(number));
+				list.add(Long.valueOf(number));
 			}
 
 			// find the prime numbers in the list

--- a/test/functional/cmdline_options_tester/src/TestSuite.java
+++ b/test/functional/cmdline_options_tester/src/TestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2019 IBM Corp. and others
+ * Copyright (c) 2004, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -261,13 +261,13 @@ public class TestSuite {
 					if (tokens.isEmpty()) {
 						varStartIndex = i + 1;
 					}
-					tokens.push(new Character('$'));
+					tokens.push(Character.valueOf('$'));
 				}
 				break;
 				
 			case '{':
 				if (!tokens.isEmpty()) {
-					tokens.push(new Character('{'));
+					tokens.push(Character.valueOf('{'));
 				}
 				break;
 				
@@ -357,7 +357,7 @@ public class TestSuite {
 					if (tokens.isEmpty()) {
 						varStartIndex = i + 1;
 					}
-					tokens.push(new Character('$'));
+					tokens.push(Character.valueOf('$'));
 				}
 				break;
 				
@@ -365,7 +365,7 @@ public class TestSuite {
 				if (tokens.isEmpty()) {
 					varStartIndex = i + 1;
 				}
-				tokens.push(new Character('{'));
+				tokens.push(Character.valueOf('{'));
 				break;
 				
 			case '}':


### PR DESCRIPTION
Search and replace of `new PrimitiveType(` with `PrimitiveType.valueOf(`

Fix the vich test so that it continues to ensure 32 unique objects.

Fixes: #10937

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>