### PR TITLE
temporarily disable Aarch cmdLineTester_pltest and pltest_j9sig_ext

### DIFF
--- a/test/functional/cmdLineTests/pltest/playlist.xml
+++ b/test/functional/cmdLineTests/pltest/playlist.xml
@@ -32,7 +32,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
 		<!-- temporarily disable this test on windows; https://github.com/eclipse/openj9/issues/3212 -->
-		<platformRequirements>^os.aix,^os.win,^os.osx</platformRequirements>
+		<!-- temporarily disable this test on AArch64; https://github.com/eclipse/openj9/issues/10843 -->
+		<platformRequirements>^os.aix,^os.win,^os.osx,^arch.aarch64</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -378,7 +379,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-config $(Q)$(TEST_RESROOT)$(D)pltest.xml$(Q) -verbose -explainExcludes \
 	-xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
-		<platformRequirements>os.linux</platformRequirements>
+		<!-- temporarily disable this test on AArch64; https://github.com/eclipse/openj9/issues/10843 -->
+		<platformRequirements>os.linux,^arch.aarch64</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
- because of test j9vmem_test_reserveExecutableMemory failure
- related to https://github.com/eclipse/openj9/issues/10843

[ci skip]
Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>