### PR TITLE
Eliminate unnecessary boxing

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/le/Caa.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/le/Caa.java
@@ -89,7 +89,7 @@ public class Caa {
          * of registers found */
         String s = System.getProperty("zebedee.where.skip");
         if (s != null) {
-            whereSkip = Integer.valueOf(s).intValue();
+            whereSkip = Integer.parseInt(s);
         }
     }
 
@@ -142,7 +142,7 @@ public class Caa {
             caaTemplate = new Caa32Template();
             String s = space.getDump().getProductRelease();
             if (s != null) {
-                int release = Integer.valueOf(s).intValue();
+                int release = Integer.parseInt(s);
                 if (release >= 11) {
                     caaTemplate = new Caa32_11Template();
                     log.fine("switched to new caa format");
@@ -156,7 +156,7 @@ public class Caa {
             caaTemplate = new Caa64Template();
             String s = space.getDump().getProductRelease();
             if (s != null) {
-                int release = Integer.valueOf(s).intValue();
+                int release = Integer.parseInt(s);
                 if (release >= 11) {
                     caaTemplate = new Caa64_11Template();
                     log.fine("switched to new caa format");
@@ -167,7 +167,7 @@ public class Caa {
             caaTemplate = new Caa32Template();
             String s = space.getDump().getProductRelease();
             if (s != null) {
-                int release = Integer.valueOf(s).intValue();
+                int release = Integer.parseInt(s);
                 if (release >= 11) {
                     caaTemplate = new Caa32_11Template();
                     log.fine("switched to new caa format");

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/mvs/Tcb.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/mvs/Tcb.java
@@ -136,7 +136,7 @@ public class Tcb {
 
         String s = space.getDump().getProductRelease();
         if (s != null) {
-            release = Integer.valueOf(s).intValue();
+            release = Integer.parseInt(s);
         }
     }
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ByteCodeDumper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ByteCodeDumper.java
@@ -428,7 +428,7 @@ public class ByteCodeDumper {
 
 				nameAndSig = J9ROMNameAndSignaturePointer.cast(callSiteData.add(index).get());
 
-				out.append("bsm #" + String.valueOf(bsmIndices.at(index).longValue()));	/* Bootstrap method index */
+				out.append("bsm #" + bsmIndices.at(index).longValue()); /* Bootstrap method index */
 				out.append(":");
 				out.append(J9UTF8Helper.stringValue(nameAndSig.name())); /* dump name */
 				out.append(J9UTF8Helper.stringValue(nameAndSig.signature())); /* dump signature */

--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/JitAttributes.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/JitAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1999, 2017 IBM Corp. and others
+ * Copyright (c) 1999, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,7 +63,7 @@ import java.util.Map;
  * For Trusted and Untrusted, Arg is an integer indicating for which
  * argument(s) the attribute applies. -1 means all arguments. The number
  * must be formatted such that it can be converted to a Java int using
- * Integer.valueOf().intValue().
+ * Integer.parseInt().
  *
  * eg.
  * [ATTR Trusted -1 com_ibm_oti_Foo]

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestExpireDestroyOnCorruptCache.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestExpireDestroyOnCorruptCache.java
@@ -55,7 +55,7 @@ public class TestExpireDestroyOnCorruptCache extends TestUtils {
 		}
 
 		/* expire all caches not used for past 1 min */
-		expireAllCachesWithTime(Integer.valueOf(1).toString());
+		expireAllCachesWithTime(Integer.toString(1));
 		/* expire does not delete caches detected as corrupt during oscache->startup() */
 		checkFileExistsForPersistentCache("Foo");
 		

--- a/test/functional/JIT_Test/src/jit/test/stringconcat/StringConcatTest.java
+++ b/test/functional/JIT_Test/src/jit/test/stringconcat/StringConcatTest.java
@@ -58,7 +58,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildDefaultStr(){
-		return Integer.valueOf(5).toString() + " of us are going to buy " + Integer.valueOf(1).toString() + " orange " + "each";
+		return Integer.toString(5) + " of us are going to buy " + Integer.toString(1) + " orange " + "each";
 	}
 		
 	public void testDefaultPattern_With_Negative_Integer(){
@@ -68,7 +68,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildDefaultPattern_With_Negative_Integer(){
-		return Integer.valueOf(-5).toString() + " is smaller than " + Integer.valueOf(-1).toString() + " to " + "a sane person";
+		return Integer.toString(-5) + " is smaller than " + Integer.toString(-1) + " to " + "a sane person";
 	}
 		
 	public void testNullStr_Middle(){
@@ -78,7 +78,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildNullStr_Middle(){
-		return Integer.valueOf(-5).toString() + " is bigger than " + Integer.valueOf(1).toString() + null + " to a less than sane person";
+		return Integer.toString(-5) + " is bigger than " + Integer.toString(1) + null + " to a less than sane person";
 	}
 		
 	public void testNullStr_End(){
@@ -88,7 +88,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildNullStr_End(){
-		return Integer.valueOf(-5).toString() + " is bigger than " + Integer.valueOf(-1).toString() + " to a less than sane person " + null;
+		return Integer.toString(-5) + " is bigger than " + Integer.toString(-1) + " to a less than sane person " + null;
 	}
 		
 	public void testAutoboxedInteger(){
@@ -118,7 +118,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildInvalidPattern_SISS(){
-		return "I wrote " + Integer.valueOf(2).toString() + " cliches either side of " + Integer.valueOf(1).toString() + " good verse";
+		return "I wrote " + Integer.toString(2) + " cliches either side of " + Integer.toString(1) + " good verse";
 	}
 	
 	public void testInvalidPattern_ISIS(){
@@ -128,7 +128,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildInvalidPattern_ISIS(){
-		return Integer.valueOf(1).toString() + " of us is going to sleep at " + Integer.valueOf(2).toString() + " am";
+		return Integer.toString(1) + " of us is going to sleep at " + Integer.toString(2) + " am";
 	}
 	
 	public void testInvalidPattern_ISISISIS(){
@@ -144,7 +144,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildInvalidPattern_ISISSS(){
-		return  Integer.valueOf(1).toString() + " side of the moon is good enough for " + Integer.valueOf(1).toString() + " earth " + "full of " + "moonstruck ants";
+		return Integer.toString(1) + " side of the moon is good enough for " + Integer.toString(1) + " earth " + "full of " + "moonstruck ants";
 	}
 	
 	public void testInvalidPattern_ISISSI(){
@@ -154,7 +154,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildInvalidPattern_ISISSI(){
-		return  Integer.valueOf(1).toString() + " side of the moon is good enough for " + Integer.valueOf(1).toString() + " earth " + "full of " + "moonstruck ants but " + Integer.valueOf(1);
+		return Integer.toString(1) + " side of the moon is good enough for " + Integer.toString(1) + " earth " + "full of " + "moonstruck ants but " + Integer.valueOf(1);
 	}
 	
 	public void testInvalidPattern_ISISSISS(){
@@ -164,7 +164,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildInvalidPattern_ISISSISS(){
-		return  Integer.valueOf(1).toString() + " side of the moon is good enough for " + Integer.valueOf(1).toString() + " earth " + "full of " + "moonstruck ants but " + Integer.valueOf(1) + " disagrees with this";
+		return Integer.toString(1) + " side of the moon is good enough for " + Integer.toString(1) + " earth " + "full of " + "moonstruck ants but " + Integer.valueOf(1) + " disagrees with this";
 	}
 	
 	public void testInvalidPattern_ISISSISC(){
@@ -174,7 +174,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildInvalidPattern_ISISSISC(){
-		return  Integer.valueOf(1).toString() + " side of the moon is good enough for " + Integer.valueOf(1).toString() + " earth " + "full of " + "moonstruck ants but " + Integer.valueOf(1) + " disagrees with thi" + Character.valueOf('s');
+		return Integer.toString(1) + " side of the moon is good enough for " + Integer.toString(1) + " earth " + "full of " + "moonstruck ants but " + Integer.valueOf(1) + " disagrees with thi" + Character.valueOf('s');
 	}
 	
 	public void testConstantString(){
@@ -184,7 +184,7 @@ public class StringConcatTest {
 	}
 	
 	private String buildConstantString(){
-		final String s = Integer.valueOf(5).toString() + " of us are going to buy " + Integer.valueOf(1).toString() + " orange " + "each";
+		final String s = Integer.toString(5) + " of us are going to buy " + Integer.toString(1) + " orange " + "each";
 		return s;
 	}
 	
@@ -199,7 +199,7 @@ public class StringConcatTest {
 		String s = null;
 		int c = 0 ; 
 		do{
-			s = "I am " + Integer.valueOf(1).toString() + " therefore I am many";
+			s = "I am " + Integer.toString(1) + " therefore I am many";
 			c++;
 		} while( c < degree );
 		return s;
@@ -233,7 +233,7 @@ public class StringConcatTest {
 		String s = null;
 		int c = 0 ; 
 		do{
-			s = Integer.valueOf(5).toString() + " of us are going to buy " + Integer.valueOf(1).toString() + " orange " + "each";
+			s = Integer.toString(5) + " of us are going to buy " + Integer.toString(1) + " orange " + "each";
 			c++;
 		} while( c < degree );
 		return s;

--- a/test/functional/VM_Test/src/com/ibm/oti/jvmtests/GetNanoTimeAdjustment.java
+++ b/test/functional/VM_Test/src/com/ibm/oti/jvmtests/GetNanoTimeAdjustment.java
@@ -59,7 +59,7 @@ public class GetNanoTimeAdjustment extends TestCase {
 	 */
 	public void test_EnsureResultIsNanoSecondGranularity() {
 		long result = SupportJVM.GetNanoTimeAdjustment(0);
-		assertEquals("GetNanoTimeAdjustment did not return 19 digits", NANO_TIME_DIGITS, Long.valueOf(result).toString().length());
+		assertEquals("GetNanoTimeAdjustment did not return 19 digits", NANO_TIME_DIGITS, Long.toString(result).length());
 	}
 	
 	/*

--- a/test/functional/VM_Test/src/j9vm/runner/Menu.java
+++ b/test/functional/VM_Test/src/j9vm/runner/Menu.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,7 +65,7 @@ public void doCommand(String command)  {
 		return;
 	}
 	try  {
-		int n = Integer.valueOf(command).intValue();
+		int n = Integer.parseInt(command);
 		if (command.equals(String.valueOf(n)))  {
 			n--;
 			if ((n >= 0) && (n < menuItems.size()))  {

--- a/test/functional/cmdLineTests/vmRuntimeState/src/ActiveIdleTest.java
+++ b/test/functional/cmdLineTests/vmRuntimeState/src/ActiveIdleTest.java
@@ -76,14 +76,14 @@ public class ActiveIdleTest {
 					switch (name) {
 						case BUSY_PERIOD:
 							if (value != null) {
-								busyPeriod = Long.valueOf(value).longValue();
+								busyPeriod = Long.parseLong(value);
 							} else {
 								parseResult = ParseResult.OPTION_MISSING_VALUE;
 							}
 							break;
 						case IDLE_PERIOD:
 							if (value != null) {
-								idlePeriod = Long.valueOf(value).longValue();
+								idlePeriod = Long.parseLong(value);
 							} else {
 								parseResult = ParseResult.OPTION_MISSING_VALUE;
 							}


### PR DESCRIPTION
As a follow-up to #10979:
* `Integer.valueOf(s).intValue()` -> `Integer.parseInt(s)`
* `Integer.valueOf(n).toString()` -> `Integer.toString(n)`
* `Long.valueOf(s).longValue()` -> `Long.parseLong(s)`
* `Long.valueOf(n).toString()` -> `Long.toString(n)`
* `StringBuilder.append(String.valueOf(n))` -> `StringBuilder.append(n)`