### PR TITLE
Use the non-AOT front-end in VM_getClassFromSignature message handler

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -306,8 +306,8 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto method = std::get<1>(recv);
          bool isVettedForAOT = std::get<2>(recv);
          auto clazz = fej9->getClassFromSignature(sig.c_str(), sig.length(), method, isVettedForAOT);
-         J9ClassLoader *cl = clazz ? reinterpret_cast<J9ClassLoader *>(fe->getClassLoader(clazz)) : NULL;
-         J9ClassLoader *methodCL = reinterpret_cast<J9ClassLoader *>(fe->getClassLoader(fe->getClassOfMethod(method)));
+         J9ClassLoader *cl = clazz ? reinterpret_cast<J9ClassLoader *>(fej9->getClassLoader(clazz)) : NULL;
+         J9ClassLoader *methodCL = reinterpret_cast<J9ClassLoader *>(fej9->getClassLoader(fej9->getClassOfMethod(method)));
          client->write(response, clazz, cl, methodCL);
          }
          break;


### PR DESCRIPTION
When JITServer gets class from signature on the client, it should
always use the non-AOT front-end, even in AOT compilations.
AOT front-end will perform validations that should be done on the server,
possibly returning NULL at unexpected location and resulting in a
segfault.