### PR TITLE
CMake: minor cleanup

### DIFF
--- a/buildenv/travis/build-on-travis.sh
+++ b/buildenv/travis/build-on-travis.sh
@@ -64,7 +64,7 @@ if test "x$RUN_LINT" = "xyes" ; then
   # so we run cmake and build the targets we need
   mkdir $CMAKE_BUILD_DIR
   cd $CMAKE_BUILD_DIR
-  cmake -C $J9SRC/cmake/caches/linux_x86-64_cmprssptrs.cmake -DBOOT_JDK="$JAVA_HOME" ..
+  cmake -C $J9SRC/cmake/caches/linux_x86-64_cmprssptrs.cmake -DBOOT_JDK="$JAVA_HOME" -DJAVA_SPEC_VERSION=11 ..
   make -j $MAKE_JOBS run_cptool omrgc_hookgen j9vm_hookgen j9jit_tracegen j9vm_nlsgen j9vm_m4gen
 
   # Now we can build the linter plugin

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -100,11 +100,6 @@ if(OPENJ9_BUILD)
 	add_definitions(-DOPENJ9_BUILD)
 endif()
 
-# clean up the variables we used
-set(versionStr)
-set(checkCondition)
-set(conditionalVersionString)
-
 ###
 ### Handle Generated files
 ###
@@ -113,7 +108,6 @@ configure_file(include/j9cfg.h.in j9cfg.h)
 configure_file(include/j9lib.h.in j9lib.h)
 configure_file(include/j9version.h.in j9version.h)
 configure_file(makelib/copyright.c.in copyright.c)
-
 
 # Definition of add_hookgen pulled in from omr/cmake/modules/OmrHookgen.cmake
 # Here we handle all the .hdf files which don't have a more logical home.

--- a/runtime/buildtools.mk
+++ b/runtime/buildtools.mk
@@ -40,67 +40,27 @@ BUILD_ID      ?= 000000
 OS            := $(shell uname)
 TRC_THRESHOLD ?= 1
 FREEMARKER_JAR ?= $(CURDIR)/buildtools/freemarker.jar
-CMAKE_ARGS :=
-
-# We grab the C/C++ compilers detected by autoconf or provided by user, not
-# the CC/CXX variables defined by the makefiles, which potentially include
-# the ccache command which will throw off cmake
-ifneq (,$(OPENJ9_CC))
-  CMAKE_ARGS += "-DCMAKE_C_COMPILER=$(OPENJ9_CC)"
-else
-  CMAKE_ARGS += "-DCMAKE_C_COMPILER=$(ac_cv_prog_CC)"
-endif
-
-ifneq (,$(OPENJ9_CXX))
-  CMAKE_ARGS += "-DCMAKE_CXX_COMPILER=$(OPENJ9_CXX)"
-else
-  CMAKE_ARGS += "-DCMAKE_CXX_COMPILER=$(ac_cv_prog_CXX)"
-endif
-
-ifneq (,$(CCACHE))
-  # Open jdk makefiles add a  bunch of environment variables to the ccache command
-  # cmake will not parse this properly, so we wrap the whole thing in the env command
-  # We also need to add semicolons between arguments or else cmake will treat the whole
-  # thing as one long command name
-
-  # Note: we remove the CCACHE_COMPRESS option that openjdk adds, because it significantly
-  # slows down the build (to the point of erasing any gains from using ccache)
-  CCACHE_NOCOMPRESS := $(filter-out CCACHE_COMPRESS=1,$(CCACHE))
-  ESCAPED_CCACHE :=env$(shell printf ";%s" $(CCACHE_NOCOMPRESS))
-
-  CMAKE_ARGS += "-DCMAKE_CXX_COMPILER_LAUNCHER=$(ESCAPED_CCACHE)"
-  CMAKE_ARGS += "-DCMAKE_C_COMPILER_LAUNCHER=$(ESCAPED_CCACHE)"
-endif
 
 ifneq (,$(or $(findstring Windows,$(OS)),$(findstring CYGWIN,$(OS))))
-	EXEEXT := .exe
-	PATHSEP := ;
+  EXEEXT  := .exe
+  PATHSEP := ;
 else
-	EXEEXT :=
-	PATHSEP := :
-	J9_ROOT := $(shell pwd)
+  EXEEXT  :=
+  PATHSEP := :
+  J9_ROOT := $(shell pwd)
 endif
 
 ifdef BOOT_JDK
-	JAVA := $(subst //,/,$(subst \,/,$(BOOT_JDK)/bin/java))
+  JAVA := $(subst //,/,$(subst \,/,$(BOOT_JDK)/bin/java))
 else
-	JAVA := $(if $(J9_ROOT),java8,$(DEV_TOOLS)\ibm-jdk-1.8.0\bin\java)
-endif
-
-ifneq (,$(VERSION_MAJOR))
-	CMAKE_ARGS += -DJAVA_SPEC_VERSION=$(VERSION_MAJOR)
+  JAVA := $(if $(J9_ROOT),java8,$(DEV_TOOLS)\ibm-jdk-1.8.0\bin\java)
 endif
 
 default : all
 
 all : ddr tools
 
-tools : configure constantpool copya2e nls
-
-# CMake builds don't need hooktool or tracing.
-ifneq (true,$(OPENJ9_ENABLE_CMAKE))
-tools : hooktool tracing
-endif
+tools : configure constantpool copya2e hooktool nls tracing
 
 # OMRTODO
 # A JIT makefile has a hardcoded path to a2e/headers.
@@ -203,12 +163,6 @@ OMRGLUE_INCLUDES = \
   ../gc_trace \
   ../gc_vlhgc
 
-ifeq (true,$(OPENJ9_ENABLE_CMAKE))
-# If we are doing a cmake build, configure won't depend on UMA.
-# However we need to run constantpool and nls tools before invoking cmake.
-configure : constantpool nls
-	mkdir -p build && cd build && $(CMAKE) -C ../cmake/caches/$(SPEC).cmake  $(CMAKE_ARGS) $(EXTRA_CMAKE_ARGS) ..
-else
 .PHONY : j9includegen
 
 j9includegen : uma
@@ -216,7 +170,6 @@ j9includegen : uma
 
 configure : j9includegen
 	$(MAKE) -C omr -f run_configure.mk 'SPEC=$(SPEC)' 'OMRGLUE=$(OMRGLUE)' 'CONFIG_INCL_DIR=$(CONFIG_INCL_DIR)' 'OMRGLUE_INCLUDES=$(OMRGLUE_INCLUDES)' 'EXTRA_CONFIGURE_ARGS=$(EXTRA_CONFIGURE_ARGS)'
-endif
 
 # run UMA to generate makefiles
 J9VM_GIT_DIR := $(firstword $(wildcard $(J9_ROOT)/.git) $(wildcard $(J9_ROOT)/workspace/.git))
@@ -225,7 +178,6 @@ SPEC_DIR     := buildspecs
 UMA_TOOL     := $(JAVA) -cp "$(J9TOOLS_JAR_DIR)/om.jar$(PATHSEP)$(FREEMARKER_JAR)$(PATHSEP)$(J9TOOLS_JAR_DIR)/uma.jar" com.ibm.j9.uma.Main
 UMA_OPTIONS  := -rootDir . -configDir $(SPEC_DIR) -buildSpecId $(SPEC)
 UMA_OPTIONS  += -buildId $(BUILD_ID) -buildTag $(J9VM_SHA) -jvf compiler/jit.version
-UMA_OPTIONS  += $(UMA_OPTIONS_EXTRA)
 ifneq (,$(VERSION_MAJOR))
 UMA_OPTIONS  += -M JAVA_SPEC_VERSION=$(VERSION_MAJOR)
 endif
@@ -237,7 +189,7 @@ UMA_OPTIONS += -ea tracegen,tracemerge
 
 uma : buildtools copya2e
 	@echo J9VM version: $(J9VM_SHA)
-	$(UMA_TOOL) $(UMA_OPTIONS)
+	$(UMA_TOOL) $(UMA_OPTIONS) $(UMA_OPTIONS_EXTRA)
 
 # process constant pool definition file to generate jcl constant pool definitions and header file
 CONSTANTPOOL_TOOL    := $(JAVA) -cp "$(J9TOOLS_JAR_DIR)/om.jar$(PATHSEP)$(J9TOOLS_JAR_DIR)/j9vmcp.jar" com.ibm.oti.VMCPTool.Main
@@ -257,8 +209,8 @@ SUPERSET     := superset.$(SPEC).dat
 
 # Trigger cross-compilation & use linux_x86 DDR configuration
 ifeq (linux_ztpf_390-64, $(SPEC))
-	PLATFORM := linux_x86
-	OS := ztpf
+  PLATFORM := linux_x86
+  OS := ztpf
 endif
 
 # Generate DDR structure blob C files - only functions on module.ddr build specs.
@@ -271,13 +223,11 @@ ddr : constantpool hooktool nls tracing
 	@echo "Platform = $(PLATFORM)"
 	@echo "OS       = $(OS)"
 	@echo "Building $(PLATFORM)"
-	( \
 	if [ -e ddr/j9ddrgen.mk ] ; then \
 		$(MAKE) -C ddr -f ddr_buildtools.mk JAVA=$(ESCAPED_JAVA) PLATFORM=$(PLATFORM) generate_ddr_blob_c ; \
 		echo "Generating updated superset ready for code generation" ; \
 		$(ESCAPED_JAVA) -cp buildtools/j9ddr-autoblob.jar com.ibm.j9ddr.autoblob.GenerateSpecSuperset -d ddr/superset -s ddr,gc_ddr -f $(SUPERSET) ; \
-	fi \
-	)
+	fi
 endif
 
 # Create the lib directory

--- a/runtime/cmake/version.cmake
+++ b/runtime/cmake/version.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,13 +21,10 @@
 ################################################################################
 
 # Set up some default version variables.
-# Note as cache variables these can be overridden on the command line when invoking cmake
-# Using the syntax `-D<VAR_NAME>=<VALUE>`
+# Note as cache variables, these can be overridden on the command line
+# when invoking cmake using the syntax `-D<VAR_NAME>=<VALUE>`.
 
-set(JAVA_SPEC_VERSION "9" CACHE STRING "Version of Java to build")
-# Limit `JAVA_SPEC_VERSION` to reasonable values
-# TODO: this is only a gui thing. It doesn't actually do proper enforcement
-set_property(CACHE JAVA_SPEC_VERSION PROPERTY STRINGS "8" "9" "10" "11" "12" "13")
+set(JAVA_SPEC_VERSION "" CACHE STRING "Version of Java to build")
 
 set(J9VM_VERSION_MAJOR 2 CACHE STRING "")
 set(J9VM_VERSION_MINOR 9 CACHE INTERNAL "")

--- a/runtime/jcl/CMakeLists.txt
+++ b/runtime/jcl/CMakeLists.txt
@@ -194,18 +194,6 @@ if(NOT JAVA_SPEC_VERSION LESS 9)
 	)
 endif()
 
-if(NOT JAVA_SPEC_VERSION LESS 10)
-	# sources for Java 10+
-endif()
-
-if(NOT JAVA_SPEC_VERSION LESS 11)
-	# sources for Java 11+
-endif()
-
-if(NOT JAVA_SPEC_VERSION LESS 12)
-	# sources for Java 12+
-endif()
-
 include(exports.cmake)
 
 target_enable_ddr(jclse)

--- a/runtime/tests/j9vm/CMakeLists.txt
+++ b/runtime/tests/j9vm/CMakeLists.txt
@@ -69,7 +69,6 @@ if(NOT JAVA_SPEC_VERSION LESS 11)
 	omr_add_exports(j9vmtest Java_com_ibm_oti_jvmtests_SupportJVM_GetNanoTimeAdjustment)
 endif()
 
-
 install(
 	TARGETS j9vmtest
 	LIBRARY DESTINATION ${j9vm_SOURCE_DIR}


### PR DESCRIPTION
* remove 'cleanup' for variables that are not used anywhere
* remove empty conditional blocks for JCL
* remove useless default for `JAVA_SPEC_VERSION`
* `buildtools.mk` is not used in cmake builds - cmake specifics
* put `UMA_OPTIONS_EXTRA` at end of UMA command line