### PR TITLE
Add option to create diagnostics on error to JNI check 

### DIFF
--- a/runtime/nls/jnck/jnichk.nls
+++ b/runtime/nls/jnck/jnichk.nls
@@ -1032,3 +1032,11 @@ J9NLS_JNICHK_ARGUMENT_IS_NOT_SUBCLASS2.explanation=The named JNI function has be
 J9NLS_JNICHK_ARGUMENT_IS_NOT_SUBCLASS2.system_action=If -Xcheck:jni:nonfatal has been specified, the JVM continues, otherwise it terminates.
 J9NLS_JNICHK_ARGUMENT_IS_NOT_SUBCLASS2.user_response=Correct the JNI function call.
 # END NON-TRANSLATABLE
+
+# abortonerror is not translatable
+J9NLS_JNICHK_HELP_16=\tabortonerror   cause an abort on fatal errors
+# START NON-TRANSLATABLE
+J9NLS_JNICHK_HELP_15.explanation=NOTAG
+J9NLS_JNICHK_HELP_15.system_action=
+J9NLS_JNICHK_HELP_15.user_response=
+# END NON-TRANSLATABLE

--- a/runtime/oti/jnichk_api.h
+++ b/runtime/oti/jnichk_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,17 +40,18 @@
 extern "C" {
 #endif
 
-#define JNICHK_VERBOSE 1
-#define JNICHK_PROFILE 2
-#define JNICHK_NONFATAL 4
-#define JNICHK_PEDANTIC 8
-#define JNICHK_TRACE 16
-#define JNICHK_NOWARN 32
-#define JNICHK_NOADVICE 64
-#define JNICHK_NOBOUNDS 128
-#define JNICHK_NOVALIST 256
-#define JNICHK_INCLUDEBOOT 512
-#define JNICHK_ALWAYSCOPY 1024
+#define JNICHK_VERBOSE 0x1
+#define JNICHK_PROFILE 0x2
+#define JNICHK_NONFATAL 0x4
+#define JNICHK_PEDANTIC 0x8
+#define JNICHK_TRACE 0x10
+#define JNICHK_NOWARN 0x20
+#define JNICHK_NOADVICE 0x40
+#define JNICHK_NOBOUNDS 0x80
+#define JNICHK_NOVALIST 0x100
+#define JNICHK_INCLUDEBOOT 0x200
+#define JNICHK_ALWAYSCOPY 0x400
+#define JNICHK_ABORTONERROR 0x800
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add new `abortonerror` option to cause JNI check to run the RAS abort
handler when a fatal JNI error occurs. The diagnostics created are
controlled by the `-Xdump:abort` configuration.

Fixes: #10995

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>