### PR TITLE
Uncommon autosimd piv loop stride increment node

### DIFF
--- a/runtime/compiler/optimizer/SPMDParallelizer.cpp
+++ b/runtime/compiler/optimizer/SPMDParallelizer.cpp
@@ -1394,6 +1394,29 @@ bool TR_SPMDKernelParallelizer::reductionLoopExitProcessing(TR::Compilation *com
    return true;
    }
 
+void TR_SPMDKernelParallelizer::replaceAndAnchorOldNode(TR::Compilation *comp, TR::TreeTop *treeTop, TR::Node *parent, TR::Node *oldNode, TR::Node *newNode, int index)
+   {
+   treeTop->insertBefore(TR::TreeTop::create(comp, TR::Node::create(TR::treetop, 1, oldNode)));
+   oldNode->recursivelyDecReferenceCount();
+   parent->setAndIncChild(index, newNode);
+   }
+
+inline bool TR_SPMDKernelParallelizer::matchIVIncrementPattern(TR::Node *node, TR::SymbolReference *pivSymRef)
+   {
+   return (node->getOpCode().isAdd() || node->getOpCode().isSub()) && node->getFirstChild()->getOpCode().isLoad()
+    && node->getFirstChild()->getSymbolReference() == pivSymRef && node->getSecondChild()->getOpCode().isLoadConst();
+   }
+
+TR::Node * TR_SPMDKernelParallelizer::multiplyLoopStride(TR::Node *parent, int32_t multiple)
+   {
+   TR::Node *constNode = parent->getSecondChild()->duplicateTree();
+   constNode->setInt(constNode->getInt() * multiple);
+   TR::Node *oldNode = parent->getSecondChild();
+   parent->getSecondChild()->recursivelyDecReferenceCount();
+   parent->setAndIncChild(1, constNode);
+   return oldNode;
+   }
+
 bool TR_SPMDKernelParallelizer::processSPMDKernelLoopForSIMDize(TR::Compilation *comp, TR::Optimizer *optimizer, TR_RegionStructure *loop,TR_PrimaryInductionVariable *piv, TR_HashTab* reductionHashTab, int32_t peelCount, TR::Block *invariantBlock)
    {
 
@@ -1452,29 +1475,108 @@ bool TR_SPMDKernelParallelizer::processSPMDKernelLoopForSIMDize(TR::Compilation 
    loop->getBlocks(&blocksInLoop);
    ListIterator<TR::Block> blocksIt1(&blocksInLoop);
 
-
-   // SIMD_TODO: improve this code
+   TR_HashTab* entries = new (comp->trStackMemory()) TR_HashTab(comp->trMemory(), stackAlloc);
 
    for (TR::Block *nextBlock = blocksIt1.getCurrent(); nextBlock; nextBlock=blocksIt1.getNext())
       {
       for (TR::TreeTop *tt = nextBlock->getEntry() ; tt != nextBlock->getExit() ; tt = tt->getNextTreeTop())
          {
          // identify operation for primary induction variable
-         TR::Node *storeNode = tt->getNode();
+         TR::Node *curNode = tt->getNode();
+         if (curNode->getOpCode().isBooleanCompare() && curNode->getOpCode().isBranch())
+            {
+            TR_HashId hashOne = 0;
+            TR_HashId hashTwo = 0;
+            if (entries->locate(curNode->getFirstChild(), hashOne) || entries->locate(curNode->getSecondChild(), hashTwo))
+               {
+               int nodeIndex = entries->locate(curNode->getFirstChild(), hashOne) ? 0 : 1;
+               TR::Node *newNode = nodeIndex == 0 ? reinterpret_cast<TR::Node*>(entries->getData(hashOne)) : reinterpret_cast<TR::Node*>(entries->getData(hashTwo));
+               if (trace())
+                  traceMsg(comp, "Parent node n%dn [%p] will be uncommoned to n%dn [%p]\n", curNode->getChild(nodeIndex)->getGlobalIndex(), curNode->getChild(nodeIndex),
+                   newNode->getGlobalIndex(), newNode);
+               replaceAndAnchorOldNode(comp, tt, curNode, curNode->getChild(nodeIndex), newNode, nodeIndex);
+               }
+            else if (curNode->getFirstChild()->getReferenceCount() > 1 || curNode->getSecondChild()->getReferenceCount() > 1)
+               {
+               TR::Node *oldNode = NULL;
+               TR::Node *newNode = NULL;
+               int32_t childIndex = 0;
+               if (curNode->getFirstChild()->getReferenceCount() > 1 && matchIVIncrementPattern(curNode->getFirstChild(), unroller._piv->getSymRef()))
+                  {
+                  oldNode = curNode->getFirstChild();
+                  childIndex = 0;
+                  }
+               else if (curNode->getSecondChild()->getReferenceCount() > 1 && matchIVIncrementPattern(curNode->getSecondChild(), unroller._piv->getSymRef()))
+                  {
+                  oldNode = curNode->getSecondChild();
+                  childIndex = 1;
+                  }
 
-         if (storeNode->getOpCodeValue() == TR::istore && storeNode->getSymbolReference() == unroller._piv->getSymRef())
+               if (oldNode)
+                  {
+                  // We encountered the node for the first time and it is commoned.
+                  // So, we need to adjust the stride by vectorSize and store the mapping {oldNode, newNode} in the hashTable.
+                  newNode = oldNode->duplicateTree(false);
+                  replaceAndAnchorOldNode(comp, tt, curNode, oldNode, newNode, childIndex);
+                  if (trace())
+                     traceMsg(comp, "Parent node n%dn [%p] was uncommoned to n%dn [%p]\n", oldNode->getGlobalIndex(), oldNode, newNode->getGlobalIndex(), newNode);
+                  _visitedNodes.reset(oldNode->getGlobalIndex());
+                  TR::Node *oldConstNode = multiplyLoopStride(newNode, vectorSize);
+                  _visitedNodes.reset(oldConstNode->getGlobalIndex());
+                  TR_HashId entryHash = entries->calculateHash(oldNode);
+                  entries->add(oldNode, entryHash, newNode);
+                  }
+               }
+            }
+
+         if (curNode->getOpCodeValue() == TR::istore && curNode->getSymbolReference() == unroller._piv->getSymRef())
             {
             // increment of PIV
-            traceMsg(comp, "Reducing the number of iterations of the loop %d at storeNode [%p] by vector length %d \n",loop->getNumber(), storeNode, unrollCount);
-            TR::Node *constNode = storeNode->getFirstChild()->getSecondChild()->duplicateTree();
-            constNode->setInt(constNode->getInt() * vectorSize);
-            storeNode->getFirstChild()->getSecondChild()->recursivelyDecReferenceCount();
-            //can visit the commoned node again
-            _visitedNodes.reset(storeNode->getFirstChild()->getSecondChild()->getGlobalIndex());
-            storeNode->getFirstChild()->setAndIncChild(1,constNode);
-
+            traceMsg(comp, "Reducing the number of iterations of the loop %d at storeNode [%p] by vector length %d \n",loop->getNumber(), curNode, unrollCount);
+            TR_ASSERT_FATAL(curNode->getFirstChild()->getOpCode().isAdd() || curNode->getFirstChild()->getOpCode().isSub(), "PIV increment should be simple (either by add or by sub");
+            TR_ASSERT_FATAL(curNode->getFirstChild()->getFirstChild()->getOpCode().isLoad(), "PIV increment should have load");
+            TR_ASSERT_FATAL(curNode->getFirstChild()->getSecondChild()->getOpCode().isLoadConst(), "PIV increment should have const increment value");
+            TR::Node *newNode = NULL;
+            TR::Node *oldNode = NULL;
+            if (curNode->getFirstChild()->getReferenceCount() > 1)
+               {
+               // We need to uncommon the parent node only (isub/iadd), but keep the commoned children (if it has any such child).
+               // Uncommoning of parent node prevents the propagation of loop stride to other parts in the block. For example, if the
+               // parent commoned node was used in address calculation, then changing the stride will introduce bug as the address calculation
+               // will be affected.
+               // Keeping the commoned children prevents unwanted side effect. For example, commoned iload should stay the same,
+               // even if isub/iadd is uncommoned. That way we know it will use the old iload value, not load the value again.
+               // Const node will be uncommoned before changing the stride to match with vector operations, so we don't need to uncommon it
+               // here.
+               oldNode = curNode->getFirstChild();
+               TR_HashId hashOne = 0;
+               if (entries->locate(oldNode, hashOne))
+                  {
+                  newNode = reinterpret_cast<TR::Node *>(entries->getData(hashOne));
+                  replaceAndAnchorOldNode(comp, tt, curNode, oldNode, newNode, 0);
+                  }
+               else
+                  {
+                  newNode = oldNode->duplicateTree(false);
+                  replaceAndAnchorOldNode(comp, tt, curNode, oldNode, newNode, 0);
+                  _visitedNodes.reset(oldNode->getGlobalIndex());
+                  TR::Node *oldConstNode = multiplyLoopStride(newNode, vectorSize);
+                  _visitedNodes.reset(oldConstNode->getGlobalIndex());
+                  TR_HashId entryHash = entries->calculateHash(oldNode);
+                  entries->add(oldNode, entryHash, newNode);
+                  }
+               if (trace())
+                  traceMsg(comp, "Parent node n%dn [%p] was uncommoned to n%dn [%p]\n", oldNode->getGlobalIndex(), oldNode,
+                   newNode->getGlobalIndex(), newNode);
+               }
+            else
+               {
+               TR::Node *oldConstNode = multiplyLoopStride(curNode->getFirstChild(), vectorSize);
+               _visitedNodes.reset(oldConstNode->getGlobalIndex());
+               }
             }
          }
+         entries->clear();
       }
 
    ListIterator<TR::Block> blocksIt(&blocksInLoop);

--- a/runtime/compiler/optimizer/SPMDParallelizer.hpp
+++ b/runtime/compiler/optimizer/SPMDParallelizer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -287,6 +287,11 @@ class TR_SPMDKernelParallelizer : public TR_LoopTransformer
    void insertGPURegionExitInRegionExits(List<TR::Block> *exitBlocks, List<TR::Block> *blocksInLoop,TR::SymbolReference *initSymRef, TR::SymbolReference *liveSymRef, List<TR::TreeTop> *exitPointsList);
    void insertFlushGPU(TR_BitVector *flushGPUBlocks, TR::Block **cfgBlocks, TR::SymbolReference *scopeSymRef);
    TR::Node* insertFlushGPU(TR::Block* flushGPUBlock, TR::SymbolReference *scopeSymRef);
+
+   private:
+   bool matchIVIncrementPattern(TR::Node *node, TR::SymbolReference *pivSymRef);
+   TR::Node * multiplyLoopStride(TR::Node * parent, int32_t multiple);
+   void replaceAndAnchorOldNode(TR::Compilation *comp, TR::TreeTop *treeTop, TR::Node *parent, TR::Node *oldNode, TR::Node *newNode, int index);
    };
 
 #endif

--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -409,6 +409,32 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
+
+	<test>
+                <testCaseName>SIMDCommonedAddressTest</testCaseName>
+                <variations>
+                        <variation>-Xjit:count=50,limit={*testSIMDCommonedAddress*},optLevel=scorching,disableAsyncCompilation</variation>
+                </variations>
+                <command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+        -cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
+        org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+        -testnames \
+        SIMDCommonedAddressTest \
+        -groups $(TEST_GROUP) \
+        -excludegroups $(DEFAULT_EXCLUDE); \
+        $(TEST_STATUS)</command>
+                <levels>
+                        <level>sanity</level>
+                </levels>
+                <groups>
+                        <group>functional</group>
+                </groups>
+                <aot>nonapplicable</aot>
+                <impls>
+                        <impl>openj9</impl>
+                        <impl>ibm</impl>
+                </impls>
+        </test>
 	
 	<test>
 		<testCaseName>SIMDOptTest</testCaseName>

--- a/test/functional/JIT_Test/src/jit/test/tr/SIMDOpts/SIMDCommonedAddressTest.java
+++ b/test/functional/JIT_Test/src/jit/test/tr/SIMDOpts/SIMDCommonedAddressTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package jit.test.tr.SIMDOpts;
+
+import org.testng.annotations.Test;
+import org.testng.AssertJUnit;
+import java.util.Random;
+
+@Test(groups = { "level.sanity","component.jit" })
+public class SIMDCommonedAddressTest {
+	public static final Random rand = new Random();
+	public static int LOWER_BOUND = 200;
+	public static int UPPER_BOUND = 3000;
+	public int [] firstArray;
+	public int [] secondArray;
+
+	private void initArray (int [] array, Random random, int lowBound, int upperBound) {
+		for(int i=0; i<array.length; i++) {
+			array[i] = random.nextInt(upperBound - lowBound + 1) + lowBound;
+		}
+	}
+
+	void allocate() {
+		int size = rand.nextInt(UPPER_BOUND - LOWER_BOUND + 1) + LOWER_BOUND;
+		firstArray = new int[size];
+		secondArray = new int[size];
+	}
+
+
+	void testSIMDCommonedAddress(int [] first, int [] second, int N) {
+		for(int i=0; i<N - 1; i++) {
+			second[i] = first[i+1] * 2;
+		}
+	}
+
+	void verifyArray() {
+		for(int i=0; i<firstArray.length - 1; i++) {
+			AssertJUnit.assertEquals("Wrong value at index : " + (i+1), firstArray[i+1]*2, secondArray[i]); 
+		}
+	}
+
+	@Test
+	public void testSIMDCommonedAddressTest(){
+		for (int i = 0; i < 15; ++i){
+			SIMDCommonedAddressTest obj = new SIMDCommonedAddressTest();
+			for (int j=0; j < 10; ++j) {
+				obj.allocate();
+				obj.initArray(obj.firstArray, obj.rand, LOWER_BOUND, UPPER_BOUND);
+				obj.testSIMDCommonedAddress(obj.firstArray, obj.secondArray, obj.firstArray.length);
+			}
+		}
+		SIMDCommonedAddressTest obj = new SIMDCommonedAddressTest();
+		obj.allocate();
+		obj.initArray(obj.firstArray, obj.rand, LOWER_BOUND, UPPER_BOUND);
+		obj.testSIMDCommonedAddress(obj.firstArray, obj.secondArray, obj.firstArray.length);
+		obj.verifyArray();
+	}
+}

--- a/test/functional/JIT_Test/testng.xml
+++ b/test/functional/JIT_Test/testng.xml
@@ -435,6 +435,11 @@
       <class name="jit.test.tr.signExtensionA.SignExtElimTest" />
     </classes>
   </test>
+  <test name="SIMDCommonedAddressTest">
+         <classes>
+           <class name="jit.test.tr.SIMDOpts.SIMDCommonedAddressTest" />
+         </classes>
+  </test>
   <test name="SIMDOptTest">
 	 <classes>
 	   <class name="jit.test.tr.SIMDOpts.SIMDOptTest" />


### PR DESCRIPTION
If the loop increment node is commoned, then reducing the loop by
changing the value of loop stride can cause unwanted bug. This is
potentially true if the node is commoned for address calculation.
This commit uncommon the PIV increment node so that changing the
stride does not introduce side-effects on commoned nodes.

Fixes #10656

Signed-off-by: Mohammad Nazmul Alam <mohammad.nazmul.alam@ibm.com>