### PR TITLE
Call correct API in the snapshot mode to get gpuCode

### DIFF
--- a/runtime/compiler/runtime/GPUHelpers.cpp
+++ b/runtime/compiler/runtime/GPUHelpers.cpp
@@ -1097,7 +1097,7 @@ static GpuMetaData* getGPUMetaData(uint8_t* startPC)
    {
       J9VMThread *vmThread = jitConfig->javaVM->internalVMFunctions->currentVMThread(jitConfig->javaVM);
       TR_MethodMetaData * metaData = jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA)startPC);
-      return (GpuMetaData*)metaData->gpuCode;
+      return (GpuMetaData*)J9JITEXCEPTIONTABLE_GPUCODE_GET(metaData);
    }
 
 // load GPU kernel into the cudaInfo structure


### PR DESCRIPTION
In snapshot mode, we store the gpuCodeOffset in J9JITExceptionTable instead of pointer to gpuCode. Use API to get the pointer from the given offset to get the gpuCode pointer.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>