### PR TITLE
Fix testSCCMLSnapshot_1 test for JITServer

### DIFF
--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSnapshot.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSnapshot.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2012, 2018 IBM Corp. and others
+  Copyright (c) 2012, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -318,8 +318,8 @@
 	</test>
 	
 	<test id="Test 15: Restore a non-persistent cache from a corrupted snapshot" timeout="600" runPath=".">
-		<exec command="$JAVA_EXE$ $currentMode$C,printSnapshotFilename" captureStderr="FILENAME" platforms="aix.*,linux.*,osx.*" />
-		<exec command="$JAVA_EXE$ $currentMode$C,printSnapshotFilename -Xifa:off" captureStderr="FILENAME" platforms="zos.*" />
+		<exec command="$JAVA_EXE$ $currentMode$C,printSnapshotFilename -XX:-JITServerTechPreviewMessage" captureStderr="FILENAME" platforms="aix.*,linux.*,osx.*" />
+		<exec command="$JAVA_EXE$ $currentMode$C,printSnapshotFilename -Xifa:off -XX:-JITServerTechPreviewMessage" captureStderr="FILENAME" platforms="zos.*" />
 		<exec command="touch $FILENAME$" />
 		
 		<command>$JAVA_EXE$ $currentMode$C,nonpersistent,restoreFromSnapshot</command>


### PR DESCRIPTION
The test requires for stderr to contain the
exact name of the snapshot file, which was
not working for JITServer, due to tech preview
message being printed to stderr as well.
Fix it by passing the option to disable the message.