### PR TITLE
Add OpenJ9DiagnosticsMXBean queryDumpOptions() and tests

### DIFF
--- a/jcl/src/jdk.management/share/classes/openj9/lang/management/OpenJ9DiagnosticsMXBean.java
+++ b/jcl/src/jdk.management/share/classes/openj9/lang/management/OpenJ9DiagnosticsMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,9 +69,19 @@ public interface OpenJ9DiagnosticsMXBean extends PlatformManagedObject {
 	public void resetDumpOptions() throws ConfigurationUnavailableException;
 
 	/**
+	 * Returns the current dump configuration as an array of Strings, or null if an internal error occurs.
+	 * The syntax of the option Strings is the same as the -Xdump command-line option,
+	 * with the initial -Xdump: omitted. See the -Xdump option section on dump agents in
+	 * the documentation for the OpenJ9 JVM.
+	 *
+	 * @throws SecurityException if there is a security manager and it doesn't allow the checks required to read the dump settings
+	 */
+	public String[] queryDumpOptions();
+
+	/**
 	 * This function sets options for the dump subsystem.
 	 * The dump option is passed in as a String. Use the same syntax as the -Xdump command-line option, with the 
-	 * initial -Xdump: omitted. See Using the -Xdump option as described in the section on dump agents in the 
+	 * initial -Xdump: omitted. See the -Xdump option section on dump agents in the 
 	 * documentation for the OpenJ9 JVM. This method may throw a ConfigurationUnavailableException if the dump
 	 * configuration cannot be altered.
 	 *

--- a/jcl/src/jdk.management/share/classes/openj9/lang/management/internal/OpenJ9DiagnosticsMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/openj9/lang/management/internal/OpenJ9DiagnosticsMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,6 +58,7 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 	private final Method dump_heapDumpToFile;
 	private final Method dump_JavaDump;
 	private final Method dump_javaDumpToFile;
+	private final Method dump_queryDumpOptions;
 	private final Method dump_resetDumpOptions;
 	private final Method dump_setDumpOptions;
 	private final Method dump_SnapDump;
@@ -107,6 +108,23 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 			/*[ENDIF]*/
 		} catch (Exception e) {
 			handleDumpConfigurationUnavailableException(e);
+			throw handleError(e);
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String[] queryDumpOptions() {
+		checkManagementSecurityPermission();
+		try {
+			/*[IF Sidecar19-SE]*/ if (2 > 1) {
+			return (String[])dump_queryDumpOptions.invoke(null);
+			/*[ELSE]*/ }
+			return Dump.queryDumpOptions();
+			/*[ENDIF]*/
+		} catch (Exception e) {
 			throw handleError(e);
 		}
 	}
@@ -320,6 +338,7 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 		dump_heapDumpToFile = dumpClass.getMethod("heapDumpToFile", String.class); //$NON-NLS-1$
 		dump_JavaDump = dumpClass.getMethod("JavaDump"); //$NON-NLS-1$
 		dump_javaDumpToFile = dumpClass.getMethod("javaDumpToFile", String.class); //$NON-NLS-1$
+		dump_queryDumpOptions = dumpClass.getMethod("queryDumpOptions"); //$NON-NLS-1$
 		dump_resetDumpOptions = dumpClass.getMethod("resetDumpOptions"); //$NON-NLS-1$
 		dump_setDumpOptions = dumpClass.getMethod("setDumpOptions", String.class); //$NON-NLS-1$
 		dump_SnapDump = dumpClass.getMethod("SnapDump"); //$NON-NLS-1$

--- a/test/functional/JLM_Tests/playlist.xml
+++ b/test/functional/JLM_Tests/playlist.xml
@@ -1164,8 +1164,7 @@
 	<test>
 		<testCaseName>testOpenJ9DiagnosticsMXBean</testCaseName>
 		<variations>
-			<variation>Mode100</variation>
-			<variation>Mode101</variation>
+			<variation>NoOptions</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) \
@@ -1194,8 +1193,7 @@
 	<test>
 		<testCaseName>testOpenJ9DiagnosticsMXBean_win</testCaseName>
 		<variations>
-			<variation>Mode100</variation>
-			<variation>Mode101</variation>
+			<variation>NoOptions</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) \

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOpenJ9DiagnosticsMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOpenJ9DiagnosticsMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -252,8 +252,38 @@ public class TestOpenJ9DiagnosticsMXBean {
 		String dir = "." + File.separator + "local";
 		String dumpFileName = "javacore_alloc.txt";
 		String dumpFilePath = dir + File.separator + dumpFileName;
+
 		diagBean.resetDumpOptions();
+
+		String[] resetOptions = diagBean.queryDumpOptions();
+		for (String option : resetOptions) {
+			if (option.startsWith("java:events=allocation")) {
+				Assert.fail("Found unexpected dump option: " + option);
+			}
+		}
+
 		diagBean.setDumpOptions("java:events=allocation,filter=#1k,range=1..1,file=" + dumpFilePath);
+
+		boolean optionFound = false;
+		String[] options = diagBean.queryDumpOptions();
+		for (String option : options) {
+			// The options get reordered and defaults added, check parts separately
+			if (option.startsWith("java:events=allocation,") &&
+				option.contains(",filter=#1k") &&
+				option.contains(",range=1..1") &&
+				option.contains(dumpFilePath)
+			) {
+				optionFound = true;
+				break;
+			}
+		}
+		if (!optionFound) {
+			for (String option : options) {
+				System.out.println(option);
+			}
+			Assert.fail("Failed to find \"java:events=allocation\" dump option");
+		}
+
 		int[] a = new int[1024 * 1024];
 
 		dumpFileName = "javacore_unsupported.txt";
@@ -339,11 +369,50 @@ public class TestOpenJ9DiagnosticsMXBean {
 		String dir = "." + File.separator + "remote";
 		String dumpFileName = "javacore_alloc.txt";
 		String dumpFilePath = dir + File.separator + dumpFileName;
+
 		diagBeanRemote.resetDumpOptions();
+
+		String[] resetOptions = diagBeanRemote.queryDumpOptions();
+		for (String option : resetOptions) {
+			if (option.startsWith("java:events=allocation") || option.startsWith("java:events=catch")) {
+				Assert.fail("Found unexpected dump option: " + option);
+			}
+		}
+
 		diagBeanRemote.setDumpOptions("java:events=allocation,filter=#1k,range=1..1,file=" + dumpFilePath);
 		dumpFileName = "javacore_unsupported.txt";
-		dumpFilePath = dir + File.separator + dumpFileName;
-		diagBeanRemote.setDumpOptions("java:events=catch,filter=java/io/UnsupportedEncodingException,range=1..1,file=" + dumpFilePath);
+		String catchDumpFilePath = dir + File.separator + dumpFileName;
+		diagBeanRemote.setDumpOptions("java:events=catch,filter=java/io/UnsupportedEncodingException,range=1..1,file=" + catchDumpFilePath);
+
+		String[] options = diagBeanRemote.queryDumpOptions();
+		boolean allocOptionFound = false;
+		boolean catchOptionFound = false;
+		for (String option : options) {
+			// The options get reordered and defaults added, check parts separately
+			if (option.startsWith("java:events=allocation,") &&
+				option.contains(",filter=#1k") &&
+				option.contains(",range=1..1") &&
+				option.contains(dumpFilePath)
+			) {
+				allocOptionFound = true;
+				if (catchOptionFound) break;
+			}
+			if (option.startsWith("java:events=catch,") &&
+				option.contains(",filter=java/io/UnsupportedEncodingException") &&
+				option.contains(",range=1..1") &&
+				option.contains(catchDumpFilePath)
+			) {
+				catchOptionFound = true;
+				if (allocOptionFound) break;
+			}
+		}
+		if (!allocOptionFound || !catchOptionFound) {
+			for (String option : options) {
+				System.out.println(option);
+			}
+			Assert.fail("Failed to find expected dump options");
+		}
+
 		lock.notifyEvent("dump settings done");
 		lock.waitForEvent("events occurred");
 


### PR DESCRIPTION
Replace test modes Mode100, Mode101 with NoOptions, otherwise the test only runs in XL mode. Using these modes is historic and unnecessary.

My original plan was to add a getter to correspond with setDumpOptions(), however the Dump.queryDumpOptions() API returns a String[] containing the entire -Xdump configuration, like follows. Using the name getDumpOptions() in the MXBean results in `javax.management.NotCompliantMBeanException: Getter and setter for DumpOptions have inconsistent types`.
```
system:events=gpf+abort+traceassert+corruptcache,file=/home/peter/core.%Y%m%d.%H%M%S.%pid.%seq.dmp,range=1..0,priority=999,request=serial
system:events=systhrow,filter=java/lang/OutOfMemoryError,file=/home/peter/core.%Y%m%d.%H%M%S.%pid.%seq.dmp,range=1..1,priority=999,request=exclusive+compact+prepwalk
heap:events=systhrow,filter=java/lang/OutOfMemoryError,file=/home/peter/heapdump.%Y%m%d.%H%M%S.%pid.%seq.phd,range=1..4,priority=500,request=exclusive+compact+prepwalk,opts=PHD
etc.
```