### PR TITLE
Provided an error code for "compilationAotHasInvokeSpecialInterface" to retry as JIT compilation

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2151,6 +2151,7 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
             case compilationAotThunkReloFailure:
             case compilationAotHasInvokehandle:
             case compilationAotHasInvokeVarHandle:
+            case compilationAotHasInvokeSpecialInterface:
             case compilationAotValidateMethodExitFailure:
             case compilationAotValidateMethodEnterFailure:
             case compilationAotClassChainPersistenceFailure:
@@ -10959,6 +10960,10 @@ TR::CompilationInfoPerThreadBase::processException(
    catch (const J9::AOTHasInvokeVarHandle &e)
       {
       _methodBeingCompiled->_compErrCode = compilationAotHasInvokeVarHandle;
+      }
+   catch (const J9::AOTHasInvokeSpecialInInterface &e)
+      {
+      _methodBeingCompiled->_compErrCode = compilationAotHasInvokeSpecialInterface;
       }
    catch (const J9::FSDHasInvokeHandle &e)
       {

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -211,7 +211,8 @@ char *compilationErrorNames[]={
    "compilationStreamVersionIncompatible", // 58
    "compilationStreamInterrupted", // 59
 #endif /* defined(J9VM_OPT_JITSERVER) */
-   "compilationMaxError"
+   "compilationAotHasInvokeSpecialInterface", //60
+   "compilationMaxError",
 };
 
 int32_t aggressiveOption = 0;

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -86,6 +86,7 @@ typedef enum {
    compilationStreamVersionIncompatible            = compilationFirstJITServerFailure+3,
    compilationStreamInterrupted                    = compilationFirstJITServerFailure+4,
 #endif /* defined(J9VM_OPT_JITSERVER) */
+   compilationAotHasInvokeSpecialInterface, //60
    /* please insert new codes before compilationMaxError which is used in jar2jxe to test the error codes range */
    /* If new codes are added then add the corresponding names in compilationErrorNames table in rossa.cpp */
    compilationMaxError /* must be the last one */


### PR DESCRIPTION
Caught the exception "AOTHasInvokeSpecialInInterface", which is thrown when a method that has an invoke special in an interface is AOT Compiled, in processException to retry the compilation as a JIT compilation.
issue: #11011

Signed-off-by: Eman Elsabban <eman.elsaban1@gmail.com>