### PR TITLE
Define placeholder HandleRecompilationOps optimization

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -30,6 +30,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     compiler/optimizer/PreEscapeAnalysis.cpp \
     compiler/optimizer/PostEscapeAnalysis.cpp \
     compiler/optimizer/FearPointAnalysis.cpp \
+    compiler/optimizer/HandleRecompilationOps.cpp \
     compiler/optimizer/HotFieldMarking.cpp \
     compiler/optimizer/HCRGuardAnalysis.cpp \
     compiler/optimizer/IdiomRecognition.cpp \

--- a/runtime/compiler/optimizer/CMakeLists.txt
+++ b/runtime/compiler/optimizer/CMakeLists.txt
@@ -29,6 +29,7 @@ j9jit_files(
 	optimizer/EscapeAnalysisTools.cpp
 	optimizer/EstimateCodeSize.cpp
 	optimizer/FearPointAnalysis.cpp
+	optimizer/HandleRecompilationOps.cpp
 	optimizer/HCRGuardAnalysis.cpp
 	optimizer/HotFieldMarking.cpp
 	optimizer/IdiomRecognition.cpp

--- a/runtime/compiler/optimizer/HandleRecompilationOps.cpp
+++ b/runtime/compiler/optimizer/HandleRecompilationOps.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,19 +20,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*
- * This file will be included within an enum.  Only comments, preprocessor macros,
- * and enumerator definitions are permitted.
- */
+#include "optimizer/HandleRecompilationOps.hpp"
 
-#include "optimizer/OMROptimizations.enum"
+int32_t
+TR_HandleRecompilationOps::perform()
+   {
+   return 0;
+   }
 
-   OPTIMIZATION(profileGenerator)
-   OPTIMIZATION(sequentialStoreSimplification)
-   OPTIMIZATION(osrGuardInsertion)
-   OPTIMIZATION(osrGuardRemoval)
-   OPTIMIZATION(jProfilingBlock)
-   OPTIMIZATION(jProfilingValue)
-   OPTIMIZATION(jProfilingRecompLoopTest)
-   OPTIMIZATION(handleRecompilationOps)
-   OPTIMIZATION(hotFieldMarking)
+const char *
+TR_HandleRecompilationOps::optDetailString() const throw()
+   {
+   return "O^O HANDLE RECOMPILATION OPERATIONS:";
+   }

--- a/runtime/compiler/optimizer/HandleRecompilationOps.hpp
+++ b/runtime/compiler/optimizer/HandleRecompilationOps.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,19 +20,34 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*
- * This file will be included within an enum.  Only comments, preprocessor macros,
- * and enumerator definitions are permitted.
- */
+#ifndef HANDLERECOMPILATINOOPS_INCL
+#define HANDLERECOMPILATINOOPS_INCL
 
-#include "optimizer/OMROptimizations.enum"
+#include <stdint.h>
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 
-   OPTIMIZATION(profileGenerator)
-   OPTIMIZATION(sequentialStoreSimplification)
-   OPTIMIZATION(osrGuardInsertion)
-   OPTIMIZATION(osrGuardRemoval)
-   OPTIMIZATION(jProfilingBlock)
-   OPTIMIZATION(jProfilingValue)
-   OPTIMIZATION(jProfilingRecompLoopTest)
-   OPTIMIZATION(handleRecompilationOps)
-   OPTIMIZATION(hotFieldMarking)
+class TR_HandleRecompilationOps : public TR::Optimization
+   {
+   private:
+
+   TR::ResolvedMethodSymbol *_methodSymbol;
+
+   TR_HandleRecompilationOps(TR::OptimizationManager *manager) : TR::Optimization(manager)
+      {
+      _methodSymbol = comp()->getOwningMethodSymbol(comp()->getCurrentMethod());
+      }
+
+   public:
+
+   static TR::Optimization *create(TR::OptimizationManager *manager)
+      {
+      return new (manager->allocator()) TR_HandleRecompilationOps(manager);
+      }
+
+   virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
+
+   };
+
+#endif // HANDLERECOMPILATINOOPS_INCL

--- a/runtime/compiler/optimizer/J9OptimizationManager.cpp
+++ b/runtime/compiler/optimizer/J9OptimizationManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -117,6 +117,9 @@ J9::OptimizationManager::OptimizationManager(TR::Optimizer *o, OptimizationFacto
          break;
       case OMR::jProfilingRecompLoopTest:
          _flags.set(requiresStructure);
+         break;
+      case OMR::handleRecompilationOps:
+         _flags.set(doesNotRequireAliasSets | supportsIlGenOptLevel);
          break;
       default:
          // do nothing

--- a/runtime/compiler/optimizer/J9Optimizer.cpp
+++ b/runtime/compiler/optimizer/J9Optimizer.cpp
@@ -79,6 +79,7 @@
 #include "optimizer/UnsafeFastPath.hpp"
 #include "optimizer/VarHandleTransformer.hpp"
 #include "optimizer/StaticFinalFieldFolding.hpp"
+#include "optimizer/HandleRecompilationOps.hpp"
 
 
 static const OptimizationStrategy J9EarlyGlobalOpts[] =
@@ -824,6 +825,8 @@ J9::Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *method
       new (comp->allocator()) TR::OptimizationManager(self(), TR_JProfilingValue::create, OMR::jProfilingValue);
    _opts[OMR::staticFinalFieldFolding] =
          new (comp->allocator()) TR::OptimizationManager(self(), TR_StaticFinalFieldFolding::create, OMR::staticFinalFieldFolding);
+   _opts[OMR::handleRecompilationOps] =
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_HandleRecompilationOps::create, OMR::handleRecompilationOps);
    _opts[OMR::hotFieldMarking] =
       new (comp->allocator()) TR::OptimizationManager(self(), TR_HotFieldMarking::create, OMR::hotFieldMarking);
    // NOTE: Please add new J9 optimizations here!


### PR DESCRIPTION
This defines a skeleton for the `HandleRecompilationOps` optimization, to allow for staged changes in OpenJ9 and OMR.

The implementation, which is expected in a subsequent commit, will be used to induce OSR and recompilation for operations involving unresolved value type classes or fields.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>