### PR TITLE
Keep treetop after recognized call transformer reduction

### DIFF
--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -47,7 +47,6 @@
 void J9::RecognizedCallTransformer::processIntrinsicFunction(TR::TreeTop* treetop, TR::Node* node, TR::ILOpCodes opcode)
    {
    TR::Node::recreate(node, opcode);
-   TR::TransformUtil::removeTree(comp(), treetop);
    }
 
 void J9::RecognizedCallTransformer::process_java_lang_Class_IsAssignableFrom(TR::TreeTop* treetop, TR::Node* node)

--- a/test/functional/JIT_Test/src/jit/test/recognizedMethod/TestRecognizedCallTransformer.java
+++ b/test/functional/JIT_Test/src/jit/test/recognizedMethod/TestRecognizedCallTransformer.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package jit.test.recognizedMethod;
+
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+public class TestRecognizedCallTransformer {
+	public static class Vector {
+		int x;
+		int y;
+	}
+
+	/**
+	* Tests using the same stack slot for multiple computations results in the correct answer being produced. There
+	* is a bug observed in which a call was recognized and transformed and the treetop on which the call was anchored
+	* was removed. This resulted in the tree swinging down past stores to the same stack slot, which produces incorrect
+	* results.
+	*/
+	@Test(groups = {"level.sanity"}, invocationCount=2)
+	public void testReuseOfSameStackSlotForMultipleCalls() {
+		Vector v = new Vector();
+		v.x = 1;
+		v.y = 2;
+		int s = v.x;
+		s = Math.abs(s) + (s = v.y);
+
+		AssertJUnit.assertEquals(3, s);
+	}
+}

--- a/test/functional/JIT_Test/testng.xml
+++ b/test/functional/JIT_Test/testng.xml
@@ -564,6 +564,7 @@
     <classes>
       <class name="jit.test.recognizedMethod.TestJavaLangStrictMath" />
       <class name="jit.test.recognizedMethod.TestJavaLangMath" />
+      <class name="jit.test.recognizedMethod.TestRecognizedCallTransformer" />
     </classes>
   </test>
 


### PR DESCRIPTION
Removing the treetop after a recognized call transformation can result
in a semantically incorrect transformation because the descendants of
the treetop may have sideeffects. Removing the treetop in this case can
cause such sideeffect trees to swing down which semantically changes the
program.

Fixes: #11032
Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>