### PR TITLE
Combine isAbstractClass() and isInterfaceClass() into isConcreteClass()

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -5358,10 +5358,7 @@ J9::CodeGenerator::isMonitorValueType(TR::Node* monNode)
    if (clazz == self()->comp()->getObjectClassPointer())
       return TR_no;
 
-   if (TR::Compiler->cls.isInterfaceClass(self()->comp(), clazz))
-      return TR_maybe;
-
-   if (TR::Compiler->cls.isAbstractClass(self()->comp(), clazz))
+   if (!TR::Compiler->cls.isConcreteClass(self()->comp(), clazz))
       return TR_maybe;
 
    if (TR::Compiler->cls.isValueTypeClass(clazz))

--- a/runtime/compiler/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/codegen/J9TreeEvaluator.cpp
@@ -851,7 +851,7 @@ uint32_t J9::TreeEvaluator::calculateInstanceOfOrCheckCastSequences(TR::Node *in
 
          // If the caller doesn't provide the output param don't bother with guessing.
          //
-         if (compileTimeGuessClass && (TR::Compiler->cls.isInterfaceClass(cg->comp(), castClass) || TR::Compiler->cls.isAbstractClass(cg->comp(), castClass)))
+         if (compileTimeGuessClass && !TR::Compiler->cls.isConcreteClass(cg->comp(), castClass))
             {
             // Figuring out that an interface/abstract class has a single concrete implementation is not as useful for instanceof as it is for checkcast.
             // For checkcast we expect the cast to succeed and the single concrete implementation is the logical class to do a quick up front test against.

--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -921,7 +921,7 @@ CollectImplementors::visitSubclass(TR_PersistentClassInfo *cl)
    {
    TR_OpaqueClassBlock *classId = cl->getClassId();
    // verify that our subclass meets all conditions
-   if (!TR::Compiler->cls.isAbstractClass(comp(), classId) && !TR::Compiler->cls.isInterfaceClass(comp(), classId))
+   if (TR::Compiler->cls.isConcreteClass(comp(), classId))
       {
       int32_t length;
       char *clazzName = TR::Compiler->cls.classNameChars(comp(), classId, length);

--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -301,6 +301,12 @@ J9::ClassEnv::isInterfaceClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazz
    }
 
 bool
+J9::ClassEnv::isConcreteClass(TR::Compilation *comp, TR_OpaqueClassBlock * clazzPointer)
+   {
+   return comp->fej9()->isConcreteClass(clazzPointer);
+   }
+
+bool
 J9::ClassEnv::isEnumClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer, TR_ResolvedMethod *method)
    {
    return comp->fej9()->isEnumClass(clazzPointer, method);
@@ -829,7 +835,7 @@ J9::ClassEnv::containsZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_Pers
             }
          else
             {
-            if (!TR::Compiler->cls.isInterfaceClass(comp, clazz) && !TR::Compiler->cls.isAbstractClass(comp, clazz))
+            if (TR::Compiler->cls.isConcreteClass(comp, clazz))
                {
                if (++count > 1)
                   return false;
@@ -841,7 +847,7 @@ J9::ClassEnv::containsZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_Pers
       for (TR_PersistentClassInfo *ptClassInfo = i.getFirst(); ptClassInfo; ptClassInfo = i.getNext())
          {
          TR_OpaqueClassBlock *clazz = ptClassInfo->getClassId();
-         if (!TR::Compiler->cls.isInterfaceClass(comp, clazz) && !TR::Compiler->cls.isAbstractClass(comp, clazz))
+         if (TR::Compiler->cls.isConcreteClass(comp, clazz))
             {
             if (++count > 1)
                return false;
@@ -855,7 +861,7 @@ J9::ClassEnv::containsZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_Pers
       for (TR_PersistentClassInfo *ptClassInfo = i.getFirst(); ptClassInfo; ptClassInfo = i.getNext())
          {
          TR_OpaqueClassBlock *clazz = ptClassInfo->getClassId();
-         if (!TR::Compiler->cls.isInterfaceClass(comp, clazz) && !TR::Compiler->cls.isAbstractClass(comp, clazz))
+         if (TR::Compiler->cls.isConcreteClass(comp, clazz))
             {
             if (++count > 1)
                return false;

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -90,6 +90,7 @@ public:
    bool classHasIllegalStaticFinalFieldModification(TR_OpaqueClassBlock * clazzPointer);
    bool isAbstractClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer);
    bool isInterfaceClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer);
+   bool isConcreteClass(TR::Compilation *comp, TR_OpaqueClassBlock * clazzPointer);
    bool isValueTypeClass(TR_OpaqueClassBlock *);
    bool isValueTypeClassFlattened(TR_OpaqueClassBlock *clazz);
 

--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -214,7 +214,7 @@ FindSingleJittedImplementer::visitSubclass(TR_PersistentClassInfo *cl)
    {
    TR_OpaqueClassBlock * classId = cl->getClassId();
 
-   if (!TR::Compiler->cls.isAbstractClass(comp(), classId) && !TR::Compiler->cls.isInterfaceClass(comp(), classId))
+   if (TR::Compiler->cls.isConcreteClass(comp(), classId))
       {
       TR_ResolvedMethod *method;
       if (_topClassIsInterface)
@@ -615,7 +615,7 @@ TR_PersistentCHTable::findSingleConcreteSubClass(
       for (TR_PersistentClassInfo *subClassInfo = subClassesIt.getFirst(); subClassInfo; subClassInfo = subClassesIt.getNext())
          {
          TR_OpaqueClassBlock *subClass = (TR_OpaqueClassBlock *) subClassInfo->getClassId();
-         if (!TR::Compiler->cls.isAbstractClass(comp, subClass) && !TR::Compiler->cls.isInterfaceClass(comp, subClass))
+         if (TR::Compiler->cls.isConcreteClass(comp, subClass))
             {
             if (concreteSubClass)
                return NULL;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6498,9 +6498,13 @@ TR_J9VMBase::isEnumClass(TR_OpaqueClassBlock * clazzPointer, TR_ResolvedMethod *
 bool
 TR_J9VMBase::isAbstractClass(TR_OpaqueClassBlock * clazzPointer)
    {
-   if (isInterfaceClass(clazzPointer))
-      return false;
-   return (TR::Compiler->cls.romClassOf(clazzPointer)->modifiers & J9AccAbstract) ? true : false;
+   return ((TR::Compiler->cls.romClassOf(clazzPointer)->modifiers & (J9AccInterface | J9AccAbstract)) == J9AccAbstract) ? true : false;
+   }
+
+bool
+TR_J9VMBase::isConcreteClass(TR_OpaqueClassBlock * clazzPointer)
+   {
+   return (TR::Compiler->cls.romClassOf(clazzPointer)->modifiers & (J9AccAbstract | J9AccInterface)) ? false : true;
    }
 
 bool

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -243,6 +243,7 @@ public:
    virtual bool isAbstractClass(TR_OpaqueClassBlock * clazzPointer);
    virtual bool isCloneable(TR_OpaqueClassBlock *);
    virtual bool isInterfaceClass(TR_OpaqueClassBlock * clazzPointer);
+   virtual bool isConcreteClass(TR_OpaqueClassBlock * clazzPointer);
    virtual bool isEnumClass(TR_OpaqueClassBlock * clazzPointer, TR_ResolvedMethod *method);
    virtual bool isPrimitiveClass(TR_OpaqueClassBlock *clazz);
    virtual bool isPrimitiveArray(TR_OpaqueClassBlock *);

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -1207,9 +1207,8 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
 
             // The following classes cannot be instantiated normally, i.e. via the new bytecode
             // InstantiationException will be thrown when calling java/lang/Class.newInstance on the following classes
-            if (comp()->fej9()->isAbstractClass(newClass) ||
+            if (!comp()->fej9()->isConcreteClass(newClass) ||
                 comp()->fej9()->isPrimitiveClass(newClass) ||
-                comp()->fej9()->isInterfaceClass(newClass) ||
                 comp()->fej9()->isClassArray(newClass))
                {
                if (trace())
@@ -1448,7 +1447,7 @@ J9::ValuePropagation::getParmValues()
                TR::ClassTableCriticalSection usesPreexistence(comp()->fe());
 
                prexClass = opaqueClass;
-               if (TR::Compiler->cls.isInterfaceClass(comp(), opaqueClass) || TR::Compiler->cls.isAbstractClass(comp(), opaqueClass))
+               if (!TR::Compiler->cls.isConcreteClass(comp(), opaqueClass))
                   opaqueClass = comp()->getPersistentInfo()->getPersistentCHTable()->findSingleConcreteSubClass(opaqueClass, comp());
 
                if (!opaqueClass)


### PR DESCRIPTION
Combined isAbstractClass() and isInterfaceClass() into one query, isConcreteClass()
to reduce overhead, since each of these queries performs a locking operation.
Issue: #11029

Signed-off-by: Eman Elsabban <eman.elsaban1@gmail.com>