### PR TITLE
-Xcheck:jni ThrowNew() should check a jclass object

### DIFF
--- a/runtime/jnichk/jnichk_internal.h
+++ b/runtime/jnichk/jnichk_internal.h
@@ -96,6 +96,7 @@
 #define JNIC_GLOBALREF '*'
 #define JNIC_LOCALREF '?'
 #define JNIC_CLASSLOADER 'k'
+#define JNIC_CLASSTHROWABLE 'r'
 
 /* Global Ref tracking hash table entry */
 typedef struct JNICHK_GREF_HASHENTRY {

--- a/runtime/jnichk/jnicwrappers.c
+++ b/runtime/jnichk/jnicwrappers.c
@@ -439,7 +439,7 @@ checkThrowNew(JNIEnv *env, jclass clazz, const char *msg)
 	J9JavaVM* j9vm = ((J9VMThread*)env)->javaVM;
 	jint actualResult;
 	J9JniCheckLocalRefState refTracking;
-	static const U_32 argDescriptor[] = { JNIC_JTHROWABLE, JNIC_STRING, 0 };
+	static const U_32 argDescriptor[] = { JNIC_CLASSTHROWABLE, JNIC_STRING, 0 };
 	static const char function[] = "ThrowNew";
 	U_32 msgCRC;
 


### PR DESCRIPTION
Created a new type `JNIC_CLASSTHROWABLE` to check if a `jclass` object is a subclass of `java.lang.Throwable`;
Added `jniCheckJClassSubclass()` to check if a `jclass` argument is a subclass of an expected super class;
`checkThrowNew()` checks `JNIC_CLASSTHROWABLE`instead of `JNIC_JTHROWABLE`.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>