### PR TITLE
Warn of mismatch between jdmpview and producer of core file

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaRuntime.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaRuntime.java
@@ -24,7 +24,6 @@ package com.ibm.j9ddr.vm29.view.dtfj.java;
 import static com.ibm.j9ddr.view.dtfj.J9DDRDTFJUtils.corruptIterator;
 import static com.ibm.j9ddr.vm29.events.EventManager.register;
 import static com.ibm.j9ddr.vm29.events.EventManager.unregister;
-import com.ibm.j9ddr.vm29.j9.ObjectModel;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -56,6 +55,7 @@ import com.ibm.j9ddr.view.dtfj.image.J9DDRCorruptData;
 import com.ibm.j9ddr.view.dtfj.image.J9DDRImageSection;
 import com.ibm.j9ddr.vm29.events.EventManager;
 import com.ibm.j9ddr.vm29.j9.DataType;
+import com.ibm.j9ddr.vm29.j9.ObjectModel;
 import com.ibm.j9ddr.vm29.j9.RootScanner;
 import com.ibm.j9ddr.vm29.j9.gc.GCClassLoaderIterator;
 import com.ibm.j9ddr.vm29.j9.gc.GCVMThreadListIterator;
@@ -66,12 +66,12 @@ import com.ibm.j9ddr.vm29.pointer.VoidPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ClassLoaderPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ClassPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9JITConfigPointer;
-import com.ibm.j9ddr.vm29.pointer.generated.OMRMemCategoryPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ObjectMonitorPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ObjectPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ThreadAbstractMonitorPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9VMThreadPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.MM_MemorySpacePointer;
+import com.ibm.j9ddr.vm29.pointer.generated.OMRMemCategoryPointer;
 import com.ibm.j9ddr.vm29.pointer.helper.J9JavaVMHelper;
 import com.ibm.j9ddr.vm29.structure.J9JITConfig;
 import com.ibm.j9ddr.vm29.structure.J9JavaVM;
@@ -950,7 +950,7 @@ public class DTFJJavaRuntime implements JavaRuntime {
 		SystemPropertiesEventListener listener = new SystemPropertiesEventListener();
 		register(listener);
 		try {
-			value = getSystemProperties().getProperty(name);
+			value = getSystemProperties_internal().getProperty(name);
 		} catch (Throwable t) {
 			throw J9DDRDTFJUtils.handleAsCorruptDataException(DTFJContext.getProcess(), t);
 		} finally {
@@ -978,16 +978,23 @@ public class DTFJJavaRuntime implements JavaRuntime {
 			corruption = true;
 			this.exception = e;
 		}
-		
 	}
-	
-	private Properties getSystemProperties() throws com.ibm.j9ddr.CorruptDataException
-	{
+
+	private Properties getSystemProperties_internal() throws com.ibm.j9ddr.CorruptDataException {
 		if (systemProperties == null) {
 			systemProperties = J9JavaVMHelper.getSystemProperties(DTFJContext.getVm());
 		}
-		
+
 		return systemProperties;
+	}
+
+	@Override
+	public Properties getSystemProperties() throws DataUnavailable, CorruptDataException {
+		try {
+			return getSystemProperties_internal();
+		} catch (com.ibm.j9ddr.CorruptDataException e) {
+			throw J9DDRDTFJUtils.newCorruptDataException(DTFJContext.getProcess(), e);
+		}
 	}
 
 	private String getServiceLevel() {

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/java/JavaRuntime.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/java/JavaRuntime.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corp. and others
+ * Copyright (c) 2004, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,13 +23,13 @@
 package com.ibm.dtfj.java;
 
 import java.util.Iterator;
+import java.util.Properties;
 
 import com.ibm.dtfj.image.CorruptDataException;
 import com.ibm.dtfj.image.DataUnavailable;
 import com.ibm.dtfj.image.ImagePointer;
 import com.ibm.dtfj.image.MemoryAccessException;
 import com.ibm.dtfj.runtime.ManagedRuntime;
-import java.util.Properties;
 
 /**
  * Represents a Java runtime.
@@ -42,7 +42,16 @@ public interface JavaRuntime extends ManagedRuntime {
      * @throws CorruptDataException 
      */
     public ImagePointer getJavaVM() throws CorruptDataException;
-    
+
+    /**
+     * Get the system properties of the virtual machine.
+     *
+     * @return the system properties of the virtual machine
+     * @throws DataUnavailable if the system properties are not available
+     * @throws CorruptDataException
+     */
+    public Properties getSystemProperties() throws DataUnavailable, CorruptDataException;
+
     /**
      * Fetch the JavaVMInitArgs which were used to create this VM.
      * See JNI_CreateJavaVM in the JNI Specification for more details.
@@ -165,15 +174,13 @@ public interface JavaRuntime extends ManagedRuntime {
       */
      public Iterator getMemorySections(boolean includeFreed) throws DataUnavailable;
 
-    
 	/**
 	 * @param obj
 	 * @return True if the given object refers to the same Java Runtime in the image
 	 */
 	public boolean equals(Object obj);
 	public int hashCode();
-	
-	
+
 	/**
 	 * Determine if the JIT was enabled for this Java runtime.
 	 * 

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/java/j9/JavaRuntime.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/java/j9/JavaRuntime.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2018 IBM Corp. and others
+ * Copyright (c) 2004, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -400,6 +400,11 @@ public class JavaRuntime implements com.ibm.dtfj.java.JavaRuntime
 	public void setTraceBufferForName(TraceBuffer buffer, String key)
 	{
 		_traceBuffers.put(key, buffer);
+	}
+
+	@Override
+	public Properties getSystemProperties() {
+		return _systemProperties;
 	}
 
 	public String getSystemProperty(String key)

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/java/javacore/JCJavaRuntime.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/java/javacore/JCJavaRuntime.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2017 IBM Corp. and others
+ * Copyright (c) 2007, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -173,6 +173,11 @@ public class JCJavaRuntime implements JavaRuntime {
 	 */
 	public ImagePointer getJavaVM() throws CorruptDataException {
 		throw new CorruptDataException(new JCCorruptData(null));
+	}
+
+	@Override
+	public Properties getSystemProperties() throws DataUnavailable, CorruptDataException {
+		throw new DataUnavailable("System properties are not available for this runtime");
 	}
 
 	/**

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/phd/PHDJavaRuntime.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/phd/PHDJavaRuntime.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2008, 2019 IBM Corp. and others
+ * Copyright (c) 2008, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -187,8 +187,15 @@ class PHDJavaRuntime implements JavaRuntime {
 
 	public ImagePointer getJavaVM() throws CorruptDataException {
 		long addr = 0;
-		if (metaJavaRuntime != null) addr = metaJavaRuntime.getJavaVM().getAddress();
+		if (metaJavaRuntime != null) {
+			addr = metaJavaRuntime.getJavaVM().getAddress();
+		}
 		return space.getPointer(addr);
+	}
+
+	@Override
+	public Properties getSystemProperties() throws DataUnavailable, CorruptDataException {
+		throw new DataUnavailable("System properties are not available for this runtime");
 	}
 
 	public JavaVMInitArgs getJavaVMInitArgs() throws DataUnavailable,

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/DTFJContext.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/DTFJContext.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2011, 2017 IBM Corp. and others
+ * Copyright (c) 2011, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,12 +39,10 @@ import com.ibm.java.diagnostics.utils.plugins.PluginLoader;
 import com.ibm.java.diagnostics.utils.plugins.PluginManager;
 import com.ibm.java.diagnostics.utils.plugins.PluginManagerLocator;
 
-
 /**
  * A DTFJ context within which a DTFJ command executes
  * 
  * @author adam
- *
  */
 public class DTFJContext extends Context implements IDTFJContext, PluginLoader {
 	private final JavaRuntime rt;
@@ -53,12 +51,12 @@ public class DTFJContext extends Context implements IDTFJContext, PluginLoader {
 	private final int major;
 	private final int minor;
 	private final Properties props = new Properties();
-	private DTFJImageBean bean = null;
+	private final DTFJImageBean bean;
 	private final String apiLevel;
 	private final boolean hasImage;
-	private ArrayList<PluginConfig> loadedPlugins = new ArrayList<PluginConfig>();
-	private ArrayList<PluginConfig> failedPlugins = new ArrayList<PluginConfig>();
-	
+	private final ArrayList<PluginConfig> loadedPlugins = new ArrayList<>();
+	private final ArrayList<PluginConfig> failedPlugins = new ArrayList<>();
+
 	public DTFJContext(int major, int minor,Image image, ImageAddressSpace space, ImageProcess proc, JavaRuntime rt) {
 		super();
 		this.rt = rt;
@@ -140,12 +138,10 @@ public class DTFJContext extends Context implements IDTFJContext, PluginLoader {
 		}
 	}
 
-	
-	
 	public DTFJImageBean getImage() {
 		return bean;
 	}
-	
+
 	/**
 	 * Used to determine if a property has been set in the context property
 	 * bag, and that the value of that property is TRUE
@@ -153,17 +149,12 @@ public class DTFJContext extends Context implements IDTFJContext, PluginLoader {
 	 * @return true if the property exists and Boolean.parseValue() returns true
 	 */
 	public boolean hasPropertyBeenSet(String name) {
-		if(getProperties().containsKey(name)) {
-			Object value = getProperties().get(name);
-			if(value == null) {
-				return false;		//not supplied
-			} else {
-				return Boolean.parseBoolean(value.toString());
-			}
-		} else {
-			//this is the default of not being set
-			return false;
+		Object value = getProperties().get(name);
+		if (value != null) {
+			return Boolean.parseBoolean(value.toString());
 		}
+		// this is the default
+		return false;
 	}
 
 	public ArrayList<PluginConfig> getPlugins() {

--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/OpenCommand.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/OpenCommand.java
@@ -34,11 +34,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Iterator;
+import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.ibm.dtfj.image.DataUnavailable;
 import com.ibm.dtfj.image.CorruptData;
+import com.ibm.dtfj.image.CorruptDataException;
+import com.ibm.dtfj.image.DataUnavailable;
 import com.ibm.dtfj.image.Image;
 import com.ibm.dtfj.image.ImageAddressSpace;
 import com.ibm.dtfj.image.ImageFactory;
@@ -57,17 +59,18 @@ import com.ibm.jvm.dtfjview.spi.ISession;
 public class OpenCommand extends BaseJdmpviewCommand {
 	private static final String CMD_NAME = "open";
 	private static final String defaultFactoryName = "com.ibm.dtfj.image.j9.ImageFactory";
-	
+
 	private String factoryName = System.getProperty(SYSPROP_FACTORY, defaultFactoryName);
-	private int apiLevelMajor = 0;					//DTFJ API level from the ImageAddressFactory
+	private int apiLevelMajor = 0; // DTFJ API level from the ImageAddressFactory
 	private int apiLevelMinor = 0;
-	private ImageFactory factory = null;
-	
-	{
-		addCommand(CMD_NAME, "[path to core or zip]","opens the specified core or zip file");
+	private ImageFactory factory;
+
+	public OpenCommand() {
+		addCommand(CMD_NAME, "[path to core or zip]", "opens the specified core or zip file");
 		factory = getFactory();
 	}
-	
+
+	@Override
 	public void run(String command, String[] args, IContext context, PrintStream out) throws CommandException {
 		if (initCommand(command, args, context, out)) {
 			return; // processing already handled by super class
@@ -95,14 +98,14 @@ public class OpenCommand extends BaseJdmpviewCommand {
 
 		out.println(Version.getAllVersionInfo(factory));
 		out.println("Loading image from DTFJ...\n");
-		
+
 		try {
 			if (ctx.hasPropertyBeenSet(VERBOSE_MODE_PROPERTY)) {
 				// If we are using DDR this will enable warnings.
 				// (If not it's irrelevant.)
 				Logger.getLogger("j9ddr.view.dtfj").setLevel(Level.WARNING);
 			}
-			//at this point the existence of either -core or -zip has been checked
+			// at this point the existence of either -core or -zip has been checked
 			long current = System.currentTimeMillis();
 			File file1 = new File(args[0]);
 			Image[] images = new Image[1]; // default to a single image
@@ -151,8 +154,7 @@ public class OpenCommand extends BaseJdmpviewCommand {
 		}
 		return factory;
 	}
-	
-	
+
 	private void createContexts(Image loadedImage, String coreFilePath) {
 		if (loadedImage == null) {
 			// cannot create any contexts as an image has not been obtained
@@ -210,18 +212,30 @@ public class OpenCommand extends BaseJdmpviewCommand {
 				}
 			}
 		}
+
 		if (!hasContexts) {
 			if (ctx.hasPropertyBeenSet(VERBOSE_MODE_PROPERTY)) {
 				out.println("Warning: no contexts were found, is this a valid core file?");
 			}
+		} else if (loadedImage.isTruncated()) {
+			out.println("Warning: dump file is truncated. Extracted information may be incomplete.");
+			out.println();
 		} else {
-			if (loadedImage.isTruncated()) {
-				out.println("Warning: dump file is truncated. Extracted information may be incomplete.");
-				out.println();
+			// check compatibility of this VM with the VM that created the core file
+			String thisVmName = System.getProperty("java.vm.name");
+			String coreVmName = ctx.getProperties().getProperty("java.vm.name");
+
+			if (thisVmName == null || coreVmName == null || !thisVmName.equals(coreVmName)) {
+				out.format("Warning: dump file was produced by a different, possibly incompatible, VM.%n" //$NON-NLS-1$
+						+ "  core file: %s%n" //$NON-NLS-1$
+						+ "  this VM:   %s%n" //$NON-NLS-1$
+						+ "%n", //$NON-NLS-1$
+						coreVmName == null ? "(unknown)" : coreVmName, //$NON-NLS-1$
+						thisVmName == null ? "(unknown)" : thisVmName); //$NON-NLS-1$
 			}
 		}
 	}
-	
+
 	private void createCombinedContext(final Image loadedImage, final int major, final int minor, final ImageAddressSpace space, final ImageProcess proc, final JavaRuntime rt, String coreFilePath) {
 		// take the DTFJ context and attempt to combine it with a DDR interactive one
 		Object obj = ctx.getProperties().get(SessionProperties.SESSION_PROPERTY);
@@ -241,7 +255,25 @@ public class OpenCommand extends BaseJdmpviewCommand {
 		if (ctx.hasPropertyBeenSet(VERBOSE_MODE_PROPERTY)) {
 			cc.getProperties().put(VERBOSE_MODE_PROPERTY, "true");
 		}
-		
+
+		if (rt != null && cc.isDDRAvailable()) {
+			// attempt to retrieve the system property "java.vm.name"
+			// from the VM that produced the core file
+			try {
+				Properties properties = rt.getSystemProperties();
+
+				if (properties != null) {
+					String vmName = properties.getProperty("java.vm.name");
+
+					if (vmName != null) {
+						ctx.getProperties().put("java.vm.name", vmName);
+					}
+				}
+			} catch (CorruptDataException | DataUnavailable e) {
+				// ignore
+			}
+		}
+
 		try {
 			boolean hasLibError = true; // flag to indicate if native libs are required but not present
 			String os = cc.getImage().getSystemType().toLowerCase();


### PR DESCRIPTION
Compare system property "java.vm.name" from core file and from host VM; warn about possible compatibility problems when they aren't the same.