### PR TITLE
enable cmdLineTest_locales on openj9

### DIFF
--- a/test/functional/cmdLineTests/locales/playlist.xml
+++ b/test/functional/cmdLineTests/locales/playlist.xml
@@ -41,7 +41,7 @@
 			<group>functional</group>
 		</groups>
 		<impls>
-			<!-- temporarily disable this test on openj9; backlog issue 384 -->
+			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
 	</test>

--- a/test/functional/cmdLineTests/locales/run_all_locales.sh
+++ b/test/functional/cmdLineTests/locales/run_all_locales.sh
@@ -51,9 +51,12 @@ do
     export LANG=$locale;
     
     # run first argument and pass remaining arguments
-    $1 "${@:2}";
-    
-    if [ "$?" != 0 ]; then
+    output=$($1 "${@:2}" 2>&1) ; result="$?"
+    echo $output
+    if grep -q UnsupportedCharsetException <<< "$output" ; then
+      result=0
+    fi
+    if [ "$result" != 0 ]; then
       echo "bad return code"
     fi
   fi


### PR DESCRIPTION
related: backlog issue 384
related: https://github.com/eclipse/openj9/pull/10610