### PR TITLE
Add Dynamic Breadth First Scan Ordering to Balanced GC

### DIFF
--- a/runtime/gc_base/CMakeLists.txt
+++ b/runtime/gc_base/CMakeLists.txt
@@ -30,6 +30,7 @@ j9vm_add_library(j9gcbase STATIC
 	GCExtensions.cpp
 	GCObjectEvents.cpp
 	GenerationalAccessBarrierComponent.cpp
+	HotFieldUtil.cpp
 	IdleGCManager.cpp
 	IndexableObjectAllocationModel.cpp
 	modronapi.cpp

--- a/runtime/gc_base/HotFieldUtil.cpp
+++ b/runtime/gc_base/HotFieldUtil.cpp
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9.h"
+#include "j9cfg.h"
+
+#if defined(J9VM_GC_MODRON_SCAVENGER) || defined(J9VM_GC_VLHGC)
+
+#include "HotFieldUtil.hpp"
+#include "GCExtensions.hpp"
+
+/* Value used to help with the incrementing of the gc count between hot field sorting for dynamicBreadthFirstScanOrdering */
+#define INCREMENT_GC_COUNT_BETWEEN_HOT_FIELD_SORT 100
+
+/* Minimum hotness value for a third hot field offset if depthCopyThreePaths is enabled for dynamicBreadthFirstScanOrdering */
+#define MINIMUM_THIRD_HOT_FIELD_HOTNESS 50000
+
+void
+MM_HotFieldUtil::sortAllHotFieldData(J9JavaVM *javaVM, uintptr_t gcCount)
+{	
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(javaVM);
+
+	/* update hottest fields for all elements of the hotFieldClassInfoPool where isClassHotFieldListDirty is true */
+	if ((NULL != javaVM->hotFieldClassInfoPool) && ((gcCount  % extensions->gcCountBetweenHotFieldSort) == 0)) {
+		omrthread_monitor_enter(javaVM->hotFieldClassInfoPoolMutex);
+		pool_state hotFieldClassInfoPoolState;
+		J9ClassHotFieldsInfo *hotFieldClassInfoTemp = (struct J9ClassHotFieldsInfo*)pool_startDo(javaVM->hotFieldClassInfoPool, &hotFieldClassInfoPoolState);
+		
+		/* sort hot field list for the class if the hot field list of the class is dirty */
+		while ((NULL != hotFieldClassInfoTemp) && (U_8_MAX != hotFieldClassInfoTemp->consecutiveHotFieldSelections)) {
+			if (hotFieldClassInfoTemp->isClassHotFieldListDirty) {
+				sortClassHotFieldList(javaVM, hotFieldClassInfoTemp);
+			}
+			hotFieldClassInfoTemp = (struct J9ClassHotFieldsInfo*)pool_nextDo(&hotFieldClassInfoPoolState);
+		}
+		omrthread_monitor_exit(javaVM->hotFieldClassInfoPoolMutex);
+	}
+	
+	/* If adaptiveGcCountBetweenHotFieldSort, update the gc count required between sorting all hot fields as the application runs longer */
+	if ((extensions->adaptiveGcCountBetweenHotFieldSort) && (extensions->gcCountBetweenHotFieldSort < extensions->gcCountBetweenHotFieldSortMax) && ((gcCount % INCREMENT_GC_COUNT_BETWEEN_HOT_FIELD_SORT) == 0)) {
+		extensions->gcCountBetweenHotFieldSort++;
+	}
+	
+	/* If hotFieldResettingEnabled, update the gc count required between resetting all hot fields */
+	if ((extensions->hotFieldResettingEnabled) && ((gcCount % extensions->gcCountBetweenHotFieldReset) == 0)) {
+		resetAllHotFieldData(javaVM);
+	}
+}
+
+MMINLINE void
+MM_HotFieldUtil::sortClassHotFieldList(J9JavaVM *javaVM, J9ClassHotFieldsInfo* hotFieldClassInfo)
+{
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(javaVM);
+
+	/* store initial hot field offsets before hotFieldClassInfo hot field offsets are updated */
+	uint8_t initialHotFieldOffset1 = hotFieldClassInfo->hotFieldOffset1;
+	uint8_t initialHotFieldOffset2 = hotFieldClassInfo->hotFieldOffset2;
+	uint8_t initialHotFieldOffset3 = hotFieldClassInfo->hotFieldOffset3;
+
+	/* compute and update the hot fields for each class */
+	if (1 == hotFieldClassInfo->hotFieldListLength) {
+		hotFieldClassInfo->hotFieldOffset1 = hotFieldClassInfo->hotFieldListHead->hotFieldOffset;
+	} else {
+		J9HotField* currentHotField = hotFieldClassInfo->hotFieldListHead;
+		uint64_t hottest = 0;
+		uint64_t secondHottest = 0;
+		uint64_t thirdHottest = 0;
+		uint64_t current = 0;
+		while (NULL != currentHotField) {
+			if(currentHotField->cpuUtil > extensions->minCpuUtil) {
+				current = currentHotField->hotness;
+				/* compute the three hottest fields if depthCopyThreePaths is enabled, or the two hottest fields if only depthCopyTwoPaths is enabled, otherwise, compute just the hottest field if both depthCopyTwoPaths and depthCopyThreePaths are disabled */
+				if (extensions->depthCopyThreePaths) {
+					if (current > hottest) {
+						thirdHottest = secondHottest;
+						hotFieldClassInfo->hotFieldOffset3 = hotFieldClassInfo->hotFieldOffset2;
+						secondHottest = hottest;
+						hotFieldClassInfo->hotFieldOffset2 = hotFieldClassInfo->hotFieldOffset1;
+						hottest = current;
+						hotFieldClassInfo->hotFieldOffset1 = currentHotField->hotFieldOffset;
+					} else if (current > secondHottest) {
+						thirdHottest = secondHottest;
+						hotFieldClassInfo->hotFieldOffset3 = hotFieldClassInfo->hotFieldOffset2;
+						secondHottest = current;
+						hotFieldClassInfo->hotFieldOffset2 = currentHotField->hotFieldOffset;		
+					} else if (current > thirdHottest) {
+						thirdHottest = current;
+						hotFieldClassInfo->hotFieldOffset3 = currentHotField->hotFieldOffset;
+					}
+				} else if (extensions->depthCopyTwoPaths) {
+					if (current > hottest) {
+						secondHottest = hottest;
+						hotFieldClassInfo->hotFieldOffset2 = hotFieldClassInfo->hotFieldOffset1;
+						hottest = current;
+						hotFieldClassInfo->hotFieldOffset1 = currentHotField->hotFieldOffset;
+					} else if (current > secondHottest) {
+						secondHottest = current;
+						hotFieldClassInfo->hotFieldOffset2 = currentHotField->hotFieldOffset;		
+					}
+				} else if (current > hottest) {
+					hottest = current;
+					hotFieldClassInfo->hotFieldOffset1 = currentHotField->hotFieldOffset;
+				}
+			}
+			currentHotField = currentHotField->next;
+		}
+		if (thirdHottest < MINIMUM_THIRD_HOT_FIELD_HOTNESS) { 
+			hotFieldClassInfo->hotFieldOffset3 = U_8_MAX;
+		}
+	}
+	/* if permanantHotFields are allowed, update consecutiveHotFieldSelections counter if hot field offsets are the same as the previous time the class hot field list was sorted  */
+	if (extensions->allowPermanantHotFields) {
+		if ((initialHotFieldOffset1 == hotFieldClassInfo->hotFieldOffset1) && (initialHotFieldOffset2 == hotFieldClassInfo->hotFieldOffset2) && (initialHotFieldOffset3 == hotFieldClassInfo->hotFieldOffset3)) {
+			hotFieldClassInfo->consecutiveHotFieldSelections++;
+			if (hotFieldClassInfo->consecutiveHotFieldSelections == extensions->maxConsecutiveHotFieldSelections) { 
+				hotFieldClassInfo->consecutiveHotFieldSelections = U_8_MAX;
+			}
+		} else {
+			hotFieldClassInfo->consecutiveHotFieldSelections = 0;
+		}
+	}
+	hotFieldClassInfo->isClassHotFieldListDirty = false;
+}
+
+/**
+ * Reset all hot fields for all classes.
+ * Used when dynamicBreadthFirstScanOrdering is enabled and hotFieldResettingEnabled is true.
+ *
+ * @param javaVM[in] pointer to the J9JavaVM
+ */
+MMINLINE void
+MM_HotFieldUtil::resetAllHotFieldData(J9JavaVM *javaVM)
+{
+	omrthread_monitor_enter(javaVM->hotFieldClassInfoPoolMutex);
+	pool_state hotFieldClassInfoPoolState;
+	J9ClassHotFieldsInfo *hotFieldClassInfoTemp = (struct J9ClassHotFieldsInfo *)pool_startDo(javaVM->hotFieldClassInfoPool, &hotFieldClassInfoPoolState);
+	while (NULL != hotFieldClassInfoTemp) {
+		J9HotField* currentHotField = hotFieldClassInfoTemp->hotFieldListHead;
+		while (NULL != currentHotField) {
+			currentHotField->hotness = 0;
+			currentHotField->cpuUtil = 0;
+			currentHotField = currentHotField->next;
+		}
+		hotFieldClassInfoTemp = (struct J9ClassHotFieldsInfo*)pool_nextDo(&hotFieldClassInfoPoolState);
+	}
+	omrthread_monitor_exit(javaVM->hotFieldClassInfoPoolMutex);
+}
+
+#endif /* J9VM_GC_MODRON_SCAVENGER || J9VM_GC_VLHGC */

--- a/runtime/gc_base/HotFieldUtil.hpp
+++ b/runtime/gc_base/HotFieldUtil.hpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup GC_Base
+ */
+
+#if !defined(HOTFIELDUTIL_HPP_)
+#define HOTFIELDUTIL_HPP_
+
+#include "j9.h"
+#include "j9cfg.h"
+
+#if defined(J9VM_GC_MODRON_SCAVENGER) || defined(J9VM_GC_VLHGC)
+
+#include "BaseNonVirtual.hpp"
+#include "GCExtensions.hpp"
+
+
+/**
+ * @todo Provide class documentation
+ * @ingroup GC_Base
+ */
+class MM_HotFieldUtil : public MM_BaseNonVirtual
+{
+public:
+    /**
+	 * Sort all hot fields for all classes.
+	 * Used when scavenger dynamicBreadthFirstScanOrdering is enabled
+	 * 
+	 * @param javaVM[in] pointer to the J9JavaVM
+	 * @param gcCount[in] current PGC/scavenge count
+	 */
+	static void sortAllHotFieldData(J9JavaVM *javaVM, uintptr_t gcCount);
+
+	/**
+	 * Sort all hot fields for a single class.
+	 * Used when scavenger dynamicBreadthFirstScanOrdering is enabled
+	 * 
+	 * @param javaVM[in] pointer to the J9JavaVM
+	 * @param hotFieldClassInfo[in] the hot field information of the class that will be sorted
+	 */
+	MMINLINE static void sortClassHotFieldList(J9JavaVM *javaVM, J9ClassHotFieldsInfo* hotFieldClassInfo);
+
+	/**
+	 * Reset all hot fields for all classes.
+	 * Used when scavenger dynamicBreadthFirstScanOrdering is enabled and hotFieldResettingEnabled is true.
+	 *
+	 * @param javaVM[in] pointer to the J9JavaVM
+	 */
+	MMINLINE static void resetAllHotFieldData(J9JavaVM *javaVM);
+};
+
+#endif /* J9VM_GC_MODRON_SCAVENGER || J9VM_GC_VLHGC */
+#endif /* HOTFIELDUTIL_HPP_ */

--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -70,6 +70,7 @@
 #include "HeapRegionDescriptorStandard.hpp"
 #include "HeapRegionIteratorStandard.hpp"
 #include "HeapWalker.hpp"
+#include "HotFieldUtil.hpp"
 #include "MarkingScheme.hpp"
 #include "MarkingSchemeRootMarker.hpp"
 #include "MarkingSchemeRootClearer.hpp"
@@ -110,12 +111,6 @@
 #include "VMThreadIterator.hpp"
 #include "VMThreadListIterator.hpp"
 #include "VMThreadStackSlotIterator.hpp"
-
-/* Value used to help with the incrementing of the gc count between hot field sorting for dynamicBreadthFirstScanOrdering */
-#define INCREMENT_GC_COUNT_BETWEEN_HOT_FIELD_SORT 100
-
-/* Minimum hotness value for a third hot field offset if depthCopyThreePaths is enabled for dynamicBreadthFirstScanOrdering */
-#define MINIMUM_THIRD_HOT_FIELD_HOTNESS 50000
 
 class MM_AllocationContext;
 
@@ -188,7 +183,7 @@ MM_ScavengerDelegate::mainSetupForGC(MM_EnvironmentBase * envBase)
 
 	/* Sort all hot fields for all classes if scavenger dynamicBreadthFirstScanOrdering is enabled */
 	if (MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST == _extensions->scavengerScanOrdering) {
-		private_SortAllHotFieldData();
+		MM_HotFieldUtil::sortAllHotFieldData(_javaVM, _extensions->scavengerStats._gcCount);
 	}
 
 	return;
@@ -660,125 +655,6 @@ MM_ScavengerDelegate::private_shouldPercolateGarbageCollect_classUnloading(MM_En
 #endif
 
 	return shouldGCPercolate;
-}
-
-void
-MM_ScavengerDelegate::private_SortAllHotFieldData()
-{	
-	/* update hottest fields for all elements of the hotFieldClassInfoPool where isClassHotFieldListDirty is true */
-	if ((NULL != _javaVM->hotFieldClassInfoPool) && ((_extensions->scavengerStats._gcCount  % _extensions->gcCountBetweenHotFieldSort) == 0)) {
-		pool_state hotFieldClassInfoPoolState;
-		J9ClassHotFieldsInfo *hotFieldClassInfoTemp;
-		omrthread_monitor_enter(_javaVM->hotFieldClassInfoPoolMutex);
-		hotFieldClassInfoTemp = (struct J9ClassHotFieldsInfo*)pool_startDo(_javaVM->hotFieldClassInfoPool, &hotFieldClassInfoPoolState);
-		
-		/* sort hot field list for the class if the hot field list of the class is dirty */
-		while ((NULL != hotFieldClassInfoTemp) && (U_8_MAX != hotFieldClassInfoTemp->consecutiveHotFieldSelections)) {
-			if (hotFieldClassInfoTemp->isClassHotFieldListDirty) {
-				private_SortClassHotFieldList(hotFieldClassInfoTemp);
-			}
-			hotFieldClassInfoTemp = (struct J9ClassHotFieldsInfo*)pool_nextDo(&hotFieldClassInfoPoolState);
-		}
-		omrthread_monitor_exit(_javaVM->hotFieldClassInfoPoolMutex);
-	}
-	/* If adaptiveGcCountBetweenHotFieldSort, update the gc count required between sorting all hot fields as the application runs longer */
-	if ((_extensions->adaptiveGcCountBetweenHotFieldSort) && (_extensions->gcCountBetweenHotFieldSort < _extensions->gcCountBetweenHotFieldSortMax) && ((_extensions->scavengerStats._gcCount % INCREMENT_GC_COUNT_BETWEEN_HOT_FIELD_SORT) == 0)) {
-		_extensions->gcCountBetweenHotFieldSort++;
-	}
-	/* If hotFieldResettingEnabled, update the gc count required between resetting all hot fields */
-	if ((_extensions->hotFieldResettingEnabled) && ((_extensions->scavengerStats._gcCount % _extensions->gcCountBetweenHotFieldReset) == 0)) {
-		private_ResetAllHotFieldData();
-	}
-}
-
-void
-MM_ScavengerDelegate::private_SortClassHotFieldList(J9ClassHotFieldsInfo* hotFieldClassInfo) {
-	/* store initial hot field offsets before hotFieldClassInfo hot field offsets are updated */
-	uint8_t initialHotFieldOffset1 = hotFieldClassInfo->hotFieldOffset1;
-	uint8_t initialHotFieldOffset2 = hotFieldClassInfo->hotFieldOffset2;
-	uint8_t initialHotFieldOffset3 = hotFieldClassInfo->hotFieldOffset3;
-
-	/* compute and update the hot fields for each class */
-	if (1 == hotFieldClassInfo->hotFieldListLength) {
-		hotFieldClassInfo->hotFieldOffset1 = hotFieldClassInfo->hotFieldListHead->hotFieldOffset;
-	} else {
-		J9HotField* currentHotField = hotFieldClassInfo->hotFieldListHead;
-		uint64_t hottest = 0;
-		uint64_t secondHottest = 0;
-		uint64_t thirdHottest = 0;
-		uint64_t current = 0;
-		while (NULL != currentHotField) {
-			if(currentHotField->cpuUtil > _extensions->minCpuUtil) {
-				current = currentHotField->hotness;
-				/* compute the three hottest fields if depthCopyThreePaths is enabled, or the two hottest fields if only depthCopyTwoPaths is enabled, otherwise, compute just the hottest field if both depthCopyTwoPaths and depthCopyThreePaths are disabled */
-				if (_extensions->depthCopyThreePaths) {
-					if (current > hottest) {
-						thirdHottest = secondHottest;
-						hotFieldClassInfo->hotFieldOffset3 = hotFieldClassInfo->hotFieldOffset2;
-						secondHottest = hottest;
-						hotFieldClassInfo->hotFieldOffset2 = hotFieldClassInfo->hotFieldOffset1;
-						hottest = current;
-						hotFieldClassInfo->hotFieldOffset1 = currentHotField->hotFieldOffset;
-					} else if (current > secondHottest) {
-						thirdHottest = secondHottest;
-						hotFieldClassInfo->hotFieldOffset3 = hotFieldClassInfo->hotFieldOffset2;
-						secondHottest = current;
-						hotFieldClassInfo->hotFieldOffset2 = currentHotField->hotFieldOffset;		
-					} else if (current > thirdHottest) {
-						thirdHottest = current;
-						hotFieldClassInfo->hotFieldOffset3 = currentHotField->hotFieldOffset;
-					}
-				} else if (_extensions->depthCopyTwoPaths) {
-					if (current > hottest) {
-						secondHottest = hottest;
-						hotFieldClassInfo->hotFieldOffset2 = hotFieldClassInfo->hotFieldOffset1;
-						hottest = current;
-						hotFieldClassInfo->hotFieldOffset1 = currentHotField->hotFieldOffset;
-					} else if (current > secondHottest) {
-						secondHottest = current;
-						hotFieldClassInfo->hotFieldOffset2 = currentHotField->hotFieldOffset;		
-					}
-				} else if (current > hottest) {
-					hottest = current;
-					hotFieldClassInfo->hotFieldOffset1 = currentHotField->hotFieldOffset;
-				}
-			}
-			currentHotField = currentHotField->next;
-		}
-		if (thirdHottest < MINIMUM_THIRD_HOT_FIELD_HOTNESS) { 
-			hotFieldClassInfo->hotFieldOffset3 = U_8_MAX;
-		}
-	}
-	/* if permanantHotFields are allowed, update consecutiveHotFieldSelections counter if hot field offsets are the same as the previous time the class hot field list was sorted  */
-	if (_extensions->allowPermanantHotFields) {
-		if ((initialHotFieldOffset1 == hotFieldClassInfo->hotFieldOffset1) && (initialHotFieldOffset2 == hotFieldClassInfo->hotFieldOffset2) && (initialHotFieldOffset3 == hotFieldClassInfo->hotFieldOffset3)) {
-			hotFieldClassInfo->consecutiveHotFieldSelections++;
-			if (hotFieldClassInfo->consecutiveHotFieldSelections == _extensions->maxConsecutiveHotFieldSelections) { 
-				hotFieldClassInfo->consecutiveHotFieldSelections = U_8_MAX;
-			}
-		} else {
-			hotFieldClassInfo->consecutiveHotFieldSelections = 0;
-		}
-	}
-	hotFieldClassInfo->isClassHotFieldListDirty = false;
-}
-
-void
-MM_ScavengerDelegate::private_ResetAllHotFieldData()
-{
-	pool_state hotFieldClassInfoPoolState;
-	omrthread_monitor_enter(_javaVM->hotFieldClassInfoPoolMutex);
-	J9ClassHotFieldsInfo *hotFieldClassInfoTemp = (J9ClassHotFieldsInfo *)pool_startDo(_javaVM->hotFieldClassInfoPool, &hotFieldClassInfoPoolState);
-	while (NULL != hotFieldClassInfoTemp) {
-		J9HotField* currentHotField = hotFieldClassInfoTemp->hotFieldListHead;
-		while (NULL != currentHotField) {
-			currentHotField->hotness = 0;
-			currentHotField->cpuUtil = 0;
-			currentHotField = currentHotField->next;
-		}
-		hotFieldClassInfoTemp = (struct J9ClassHotFieldsInfo*)pool_nextDo(&hotFieldClassInfoPoolState);
-	}
-	omrthread_monitor_exit(_javaVM->hotFieldClassInfoPoolMutex);
 }
 
 bool

--- a/runtime/gc_glue_java/ScavengerDelegate.hpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.hpp
@@ -102,23 +102,7 @@ private:
 	 */
 	bool private_shouldPercolateGarbageCollect_classUnloading(MM_EnvironmentBase *envBase);
 
-	/**
-	 * Sort all hot fields for all classes.
-	 * Used when scavenger dynamicBreadthFirstScanOrdering is enabled
-	 */
-	void private_SortAllHotFieldData();
 
-	/**
-	 * Reset all hot fields for all classes.
-	 * Used when scavenger dynamicBreadthFirstScanOrdering is enabled and hotFieldResettingEnabled is true
-	 */
-	void private_ResetAllHotFieldData();
-	
-	/**
-	 * Sort all hot fields for a single class.
-	 * Used when scavenger dynamicBreadthFirstScanOrdering is enabled
-	 */
-	void private_SortClassHotFieldList(J9ClassHotFieldsInfo* hotFieldClassInfo);
 
 	/**
 	 * Decide if GC percolation should occur due to active JNI critical

--- a/runtime/gc_modron_startup/mmhelpers.cpp
+++ b/runtime/gc_modron_startup/mmhelpers.cpp
@@ -157,11 +157,11 @@ j9gc_software_read_barrier_enabled(J9JavaVM *javaVM)
 BOOLEAN
 j9gc_hot_reference_field_required(J9JavaVM *javaVM)
 {
-#if defined(J9VM_GC_MODRON_SCAVENGER)
+#if defined(J9VM_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
 	return MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST == MM_GCExtensions::getExtensions(javaVM)->scavengerScanOrdering;
-#else /* J9VM_GC_MODRON_SCAVENGER */
+#else /* J9VM_GC_MODRON_SCAVENGER || OMR_GC_VLHGC */
 	return FALSE;
-#endif /* J9VM_GC_MODRON_SCAVENGER */
+#endif /* defined(J9VM_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC) */
 }
 
 /**

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -715,8 +715,8 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 
-#if defined(J9VM_GC_MODRON_SCAVENGER)
-		/* Start of options relating to dynamicBreadthFirstScanOrdering */
+/* Start of options relating to dynamicBreadthFirstScanOrdering */
+#if defined(J9VM_GC_MODRON_SCAVENGER) || defined (J9VM_GC_VLHGC)	
 		if(try_scan(&scan_start, "dbfGcCountBetweenHotFieldSort=")) {
 			UDATA value;
 			if(!scan_udata_helper(vm, &scan_start, &value, "dbfGcCountBetweenHotFieldSort=")) {
@@ -851,8 +851,10 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			extensions->minCpuUtil = value;
 			continue;
 		}
-		/* End of options relating to dynamicBreadthFirstScanOrdering */
-		
+#endif /* defined(J9VM_GC_MODRON_SCAVENGER) || defined (J9VM_GC_VLHGC) */
+/* End of options relating to dynamicBreadthFirstScanOrdering */
+
+#if defined(J9VM_GC_MODRON_SCAVENGER)	
 		if (try_scan(&scan_start, "scanCacheMinimumSize=")) {
 			/* Read in restricted scan cache size */
 			if(!scan_udata_helper(vm, &scan_start, &extensions->scavengerScanCacheMinimumSize, "scanCacheMinimumSize=")) {

--- a/runtime/gc_modron_startup/mmparseXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXgc.cpp
@@ -1100,6 +1100,16 @@ j9gc_initialize_parse_gc_colon(J9JavaVM *javaVM, char **scan_start)
 #endif /* defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD) */
 #endif /* defined(J9VM_GC_VLHGC) */
 
+#if defined(J9VM_GC_MODRON_SCAVENGER) || defined(J9VM_GC_VLHGC)
+	/* If dynamicBreadthFirstScanOrdering is enabled, set scavengerScanOrdering and other required options */
+	if(try_scan(scan_start, "dynamicBreadthFirstScanOrdering")) {
+		extensions->scavengerScanOrdering = MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST;
+		/* Below options are required options for dynamicBreadthFirstScanOrdering */
+		extensions->scavengerAlignHotFields = false;
+		goto _exit;
+	}
+#endif /* defined(J9VM_GC_MODRON_SCAVENGER) || defined (J9VM_GC_VLHGC) */
+
 #if defined(J9VM_GC_MODRON_SCAVENGER)
 	if (try_scan(scan_start, "scanCacheSize=")) {
 		/* Read in restricted scan cache size */
@@ -1122,14 +1132,6 @@ j9gc_initialize_parse_gc_colon(J9JavaVM *javaVM, char **scan_start)
 		extensions->scavengerScanOrdering = MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_BREADTH_FIRST;
 		goto _exit;
 	}
-		
-	if(try_scan(scan_start, "dynamicBreadthFirstScanOrdering")) {
-		extensions->scavengerScanOrdering = MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST;
-		/* Below options are required options for dynamicBreadthFirstScanOrdering */
-		extensions->scavengerAlignHotFields = false;
-		goto _exit;
-	}
-
 #endif /* J9VM_GC_MODRON_SCAVENGER */
 
 	if(try_scan(scan_start, "alwaysCallWriteBarrier")) {

--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -272,8 +272,15 @@ MM_ConfigurationIncrementalGenerational::initialize(MM_EnvironmentBase *env)
 
 	bool result = MM_Configuration::initialize(env);
 
+	/* By default disable hot field depth copying */
+	env->disableHotFieldDepthCopy();
+
 	if (result) {
-		extensions->scavengerScanOrdering = MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_BREADTH_FIRST;
+		if (extensions->scavengerScanOrdering != MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST) {
+			extensions->scavengerScanOrdering = MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_BREADTH_FIRST;
+		} else {
+			extensions->adaptiveGcCountBetweenHotFieldSort = false;
+		}
 		extensions->setVLHGC(true);
 	}
 

--- a/runtime/gc_vlhgc/CopyForwardScheme.hpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.hpp
@@ -866,6 +866,19 @@ private:
 	J9Object *copy(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, MM_ScavengerForwardedHeader* forwardedHeader, bool leafType = false);
 	void updateInternalLeafPointersAfterCopy(J9IndexableObject *destinationPtr, J9IndexableObject *sourcePtr);
 	
+
+	/* Depth copy the hot fields of an object.
+	 * @param forwardedHeader - forwarded header of an object
+	 * @param destinationObjectPtr - destinationObjectPtr of the object described by the forwardedHeader
+	 */ 
+	MMINLINE void depthCopyHotFields(MM_EnvironmentVLHGC *env, J9Class *clazz, J9Object *destinationObjectPtr, MM_AllocationContextTarok *reservingContext);
+	
+	/* Copy the the hot field of an object.
+	 * Valid if scavenger dynamicBreadthScanOrdering is enabled.
+	 * @param destinationObjectPtr - the object who's hot field will be copied
+	 * @param offset  - the object field offset of the hot field to be copied 
+	 */ 
+	MMINLINE void copyHotField(MM_EnvironmentVLHGC *env, J9Object *destinationObjectPtr, U_8 offset, MM_AllocationContextTarok *reservingContext);
 	/**
 	 * Push any remaining cached mark map data out before the copy scan cache is released.
 	 * @param env GC thread.


### PR DESCRIPTION
Add a gc scavenger scan ordering feature that enables the
copying of a hot field marked by the JIT immediately after the
object containing the hot field is copied for balanced GC policy.

Issue: eclipse/openj9#7552
Signed-off-by: Jonathan Oommen jon.oommen@gmail.com