### PR TITLE
CMake: add support for cross-compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,5 +40,12 @@ set(Java_JAVA_EXECUTABLE ${CMAKE_Java_RUNTIME})
 set(Java_JAVAC_EXECUTABLE ${CMAKE_Java_COMPILER})
 set(Java_JAR_EXECUTABLE ${CMAKE_Java_AR})
 
+# Native tooling
+if(CMAKE_CROSSCOMPILING)
+	if(NOT OMR_EXE_LAUNCHER)
+		message(FATAL_ERROR "OMR_EXE_LAUNCHER must be specified when cross-compiling")
+	endif()
+endif()
+
 add_subdirectory(sourcetools)
 add_subdirectory(runtime)

--- a/runtime/jilgen/CMakeLists.txt
+++ b/runtime/jilgen/CMakeLists.txt
@@ -41,7 +41,7 @@ target_link_libraries(constgen
 add_custom_command(
 	OUTPUT ${j9vm_BINARY_DIR}/oti/jilconsts.inc ${j9vm_BINARY_DIR}/oti/jilvalues.m4
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${j9vm_BINARY_DIR}/oti
-	COMMAND $<TARGET_FILE:constgen>
+	COMMAND ${OMR_EXE_LAUNCHER} $<TARGET_FILE:constgen>
 	VERBATIM
 	WORKING_DIRECTORY ${j9vm_BINARY_DIR}
 )


### PR DESCRIPTION
This (simple) PR add support for cross-compilation with CMake. 

With this commit I cross-compiled OpenJ9 for RISC-V by doing:

```
mkdir build/riscv64-linux
cd build/riscv64-linux
cat > openj9_version_info.h << EOF
#ifndef OPENJ9_VERSION_INFO_H
#define OPENJ9_VERSION_INFO_H

#define J9COMPILER_VERSION_STRING "X"
#define J9PRODUCT_NAME            "X"
#define J9TARGET_CPU_BITS         "X"
#define J9TARGET_CPU_OSARCH       "X"
#define J9TARGET_OS               "X"
#define J9USERNAME                "X"
#define J9VERSION_STRING          "X"
#define OPENJDK_SHA               "X"
#define OPENJDK_TAG               "X"
#define J9JVM_VERSION_STRING      "X"
#define OPENJ9_TAG                "X"
#define J9JDK_EXT_VERSION         "X"
#define J9JDK_EXT_NAME            "X"

#endif /* OPENJ9_VERSION_INFO_H */
EOF

cmake \
	-C ../../runtime/cmake/caches/linux_riscv64.cmake \
	-DBOOT_JDK=/usr/lib/jvm/java-11-openjdk-amd64 \
	-DJAVA_SPEC_VERSION=11 \
	-DOPENJ9_BUILD=ON \
	-DJ9VM_OMR_DIR=../../../omr \
	-DCMAKE_CROSSCOMPILING_EMULATOR="qemu-riscv64-static -L /opt/riscv/sysroot" \
	-DCMAKE_FIND_ROOT_PATH=/opt/riscv/sysroot \
  	-DCMAKE_TOOLCHAIN_FILE=../../../omr/cmake/toolchains/riscv64-linux-cross.cmake \
  	-DOMR_TOOLS_IMPORTFILE=$(realpath ../x86_64-linux/runtime/omr/tools/ImportTools.cmake) \
	../..
make -j4
```

This PR does not update documentation, I will rebase and documentation as soon as PR #9376 is merged. 
