### PR TITLE
Use redirectIO() in TestOpenJ9DiagnosticsMXBean

### DIFF
--- a/test/functional/JLM_Tests/playlist.xml
+++ b/test/functional/JLM_Tests/playlist.xml
@@ -1176,36 +1176,6 @@
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
-		<platformRequirements>^os.win</platformRequirements>
-		<levels>
-			<level>extended</level>
-		</levels>
-		<groups>
-			<group>functional</group>
-		</groups>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
-	</test>
-
-	<!-- Exclude testOpenJ9DiagnosticsMXBean test on win32: https://github.com/eclipse/openj9/issues/2213-->
-	<test>
-		<testCaseName>testOpenJ9DiagnosticsMXBean_win</testCaseName>
-		<variations>
-			<variation>NoOptions</variation>
-		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	-Xdump:dynamic \
-	-Dremote.server.option=$(Q)$(JVM_OPTIONS) -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false$(Q) \
-	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jlm_tests.jar$(Q) \
-	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
-	-testnames testOpenJ9DiagnosticsMXBean \
-	-groups $(TEST_GROUP) \
-	-excludegroups $(DEFAULT_EXCLUDE); \
-	$(TEST_STATUS)</command>
-		<platformRequirements>os.win,vm.cmprssptrs</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOpenJ9DiagnosticsMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOpenJ9DiagnosticsMXBean.java
@@ -604,6 +604,7 @@ public class TestOpenJ9DiagnosticsMXBean {
 		ProcessBuilder builder = new ProcessBuilder(processArgs);
 		logger.info(builder.command());
 		lock = new ProcessLocking(tmpFileName);
+		builder.inheritIO();
 		remoteServer = builder.start();
 
 		lock.waitForEvent("child started");


### PR DESCRIPTION
The child process was hanging on Windows due to not reading the child
process IO. Unexclude the test on Windows 32-bit.

Fixes https://github.com/eclipse/openj9/issues/11055
Fixes https://github.com/eclipse/openj9/issues/2213

Tested via grinders using JVMs from the last night's OpenJ9 build, these all passed.
jdk8 Windows https://ci.eclipse.org/openj9/view/Test/job/Grinder/1148
jdk11 Windows https://ci.eclipse.org/openj9/view/Test/job/Grinder/1151
jdk8 Windows 32-bit https://ci.eclipse.org/openj9/view/Test/job/Grinder/1149
jdk8 zLinux https://ci.eclipse.org/openj9/view/Test/job/Grinder/1150