### PR TITLE
Class Unload Scan time should not include Mutex Quiesce Time

### DIFF
--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -2389,7 +2389,7 @@ MM_IncrementalGenerationalGC::unloadDeadClassLoaders(MM_EnvironmentVLHGC *env)
 		U_64 quiesceTime = _extensions->classLoaderManager->enterClassUnloadMutex(env);
 		classUnloadStats->_classUnloadMutexQuiesceTime = quiesceTime;
 
-		classUnloadStats->_startScanTime = classUnloadStats->_endSetupTime;
+		classUnloadStats->_startScanTime = j9time_hires_clock();
 
 		/* The list of classLoaders to be unloaded by cleanUpClassLoadersEnd is rooted in unloadLink */
 		J9ClassLoader *unloadLink = NULL;


### PR DESCRIPTION
There is a minor problem with Class Unloading Time Stats specific for
Balanced gc policy only. There are four time intervals reported for
different stages of class unloading: quiescems, setupms, scanms and
postms. These times suppose to be independent from each other. For
Balanced however quiescems is mistakenly included to scanms.

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>