### PR TITLE
Support surrogate pairs in case insensitive string comparison

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -316,6 +316,12 @@ public class Test_String {
 		AssertJUnit.assertTrue("0xbf should not compare = to 'ss'", "\u00df".compareToIgnoreCase("ss") != 0);
 		AssertJUnit.assertTrue("0x130 should compare = to 'i'", "\u0130".compareToIgnoreCase("i") == 0);
 		AssertJUnit.assertTrue("0x131 should compare = to 'i'", "\u0131".compareToIgnoreCase("i") == 0);
+		if (VersionCheck.major() >= 16) {
+			AssertJUnit.assertTrue("DESERET CAPITAL LETTER LONG I should compare == to DESERET SMALL LETTER LONG I",
+				"\ud801\udc00".compareToIgnoreCase("\ud801\udc28") == 0);
+			AssertJUnit.assertTrue("low surrogate only of a Deseret capital/small letter pair at end of string should compare unequal",
+				"A\udc00".compareToIgnoreCase("A\udc28") != 0);
+		}
 
 		Locale defLocale = Locale.getDefault();
 		try {
@@ -579,6 +585,12 @@ public class Test_String {
 	@Test
 	public void test_equalsIgnoreCase() {
 		AssertJUnit.assertTrue("lc version returned unequal to uc", hwlc.equalsIgnoreCase(hwuc));
+		if (VersionCheck.major() >= 16) {
+			AssertJUnit.assertTrue("DESERET CAPITAL LETTER LONG I returned unequal to DESERET SMALL LETTER LONG I",
+				"\ud801\udc00".equalsIgnoreCase("\ud801\udc28"));
+			AssertJUnit.assertFalse("low surrogate only of a Deseret capital/small letter pair at end of string should return unequal",
+				"A\udc00".equalsIgnoreCase("A\udc28"));
+		}
 	}
 
 	/**
@@ -1031,6 +1043,12 @@ public class Test_String {
 		AssertJUnit.assertTrue("Different regions returned true", !hw1.regionMatches(true, 2, bogusString, 2, 5));
 		AssertJUnit.assertTrue("identical regions failed comparison with different cases",
 				hw1.regionMatches(false, 2, hw2, 2, 5));
+		if (VersionCheck.major() >= 16) {
+			AssertJUnit.assertTrue("DESERET CAPITAL LETTER LONG I and DESERET SMALL LETTER LONG I should match when case insensitive",
+				"\ud801\udc00".regionMatches(true, 0, "\ud801\udc28", 0 ,2));
+			AssertJUnit.assertFalse("low surrogate only of a Deseret capital/small letter pair at end of region should not match when case insensitive",
+				"A\udc00B".regionMatches(true, 0, "A\udc28B", 0 ,2));
+		}
 	}
 
 	/**


### PR DESCRIPTION
Changed for the following methods:
equalsIgnoreCase
compareToIgnoreCase
regionMatches with ignoreCase parameter set to true

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Fixes https://github.com/eclipse/openj9/issues/10758
fyi: @tajila 