### PR TITLE
Remove redundant null and bound checks in NIO methods

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -241,7 +241,16 @@
    java_nio_Bits_copyFromByteArray,
    java_nio_Bits_keepAlive,
    java_nio_Bits_byteOrder,
+   java_nio_Bits_getCharB,
+   java_nio_Bits_getCharL,
+   java_nio_Bits_getShortB,
+   java_nio_Bits_getShortL,
+   java_nio_Bits_getIntB,
+   java_nio_Bits_getIntL,
+   java_nio_Bits_getLongB,
+   java_nio_Bits_getLongL,
 
+   java_nio_HeapByteBuffer__get,
    java_nio_HeapByteBuffer_put,
 
    java_nio_ByteOrder_nativeOrder,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2552,14 +2552,23 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_nio_Bits_copyFromByteArray,          "copyFromByteArray",          "(Ljava/lang/Object;JJJ)V")},
       {x(TR::java_nio_Bits_keepAlive,                  "keepAlive",                  "(Ljava/lang/Object;)V")},
       {x(TR::java_nio_Bits_byteOrder,                  "byteOrder",                  "()Ljava/nio/ByteOrder;")},
+      {x(TR::java_nio_Bits_getCharB,                   "getCharB",                   "(Ljava/nio/ByteBuffer;I)C")},
+      {x(TR::java_nio_Bits_getCharL,                   "getCharL",                   "(Ljava/nio/ByteBuffer;I)C")},
+      {x(TR::java_nio_Bits_getShortB,                  "getShortB",                  "(Ljava/nio/ByteBuffer;I)S")},
+      {x(TR::java_nio_Bits_getShortL,                  "getShortL",                  "(Ljava/nio/ByteBuffer;I)S")},
+      {x(TR::java_nio_Bits_getIntB,                    "getIntB",                    "(Ljava/nio/ByteBuffer;I)I")},
+      {x(TR::java_nio_Bits_getIntL,                    "getIntL",                    "(Ljava/nio/ByteBuffer;I)I")},
+      {x(TR::java_nio_Bits_getLongB,                   "getLongB",                   "(Ljava/nio/ByteBuffer;I)J")},
+      {x(TR::java_nio_Bits_getLongL,                   "getLongL",                   "(Ljava/nio/ByteBuffer;I)J")},
       {  TR::unknownMethod}
       };
 
    static X HeapByteBufferMethods[] =
-       {
-       {x(TR::java_nio_HeapByteBuffer_put,             "put",                        "(IB)Ljava/nio/ByteBuffer;")},
-       {  TR::unknownMethod}
-       };
+      {
+      {x(TR::java_nio_HeapByteBuffer__get,            "_get",                       "(I)B")},
+      {x(TR::java_nio_HeapByteBuffer_put,             "put",                        "(IB)Ljava/nio/ByteBuffer;")},
+      {  TR::unknownMethod}
+      };
 
    static X MathMethods[] =
       {

--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -197,6 +197,15 @@ static TR::RecognizedMethod canSkipNullChecks[] =
    TR::java_lang_String_init_int_String_int_String_String,
    TR::java_lang_String_init_int_int_char_boolean,
    TR::java_lang_String_split_str_int,
+   TR::java_nio_Bits_getCharB,
+   TR::java_nio_Bits_getCharL,
+   TR::java_nio_Bits_getShortB,
+   TR::java_nio_Bits_getShortL,
+   TR::java_nio_Bits_getIntB,
+   TR::java_nio_Bits_getIntL,
+   TR::java_nio_Bits_getLongB,
+   TR::java_nio_Bits_getLongL,
+   TR::java_nio_HeapByteBuffer__get,
    TR::java_nio_HeapByteBuffer_put,
    TR::unknownMethod
    };
@@ -280,6 +289,15 @@ static TR::RecognizedMethod canSkipBoundChecks[] =
    TR::java_util_HashMap_putImpl,
    TR::java_lang_String_init_int_String_int_String_String,
    TR::java_lang_String_init_int_int_char_boolean,
+   TR::java_nio_Bits_getCharB,
+   TR::java_nio_Bits_getCharL,
+   TR::java_nio_Bits_getShortB,
+   TR::java_nio_Bits_getShortL,
+   TR::java_nio_Bits_getIntB,
+   TR::java_nio_Bits_getIntL,
+   TR::java_nio_Bits_getLongB,
+   TR::java_nio_Bits_getLongL,
+   TR::java_nio_HeapByteBuffer__get,
    TR::java_nio_HeapByteBuffer_put,
    TR::unknownMethod
    };


### PR DESCRIPTION
The following methods are recognized to not need null checks or bound checks:

java/nio/HeapByteBuffer._get(I)B
java/nio/Bits.getCharB(Ljava/nio/ByteBuffer;I)C
java/nio/Bits.getCharL(Ljava/nio/ByteBuffer;I)C
java/nio/Bits.getShortB(Ljava/nio/ByteBuffer;I)S
java/nio/Bits.getShortL(Ljava/nio/ByteBuffer;I)S
java/nio/Bits.getIntB(Ljava/nio/ByteBuffer;I)I
java/nio/Bits.getIntL(Ljava/nio/ByteBuffer;I)I
java/nio/Bits.getLongB(Ljava/nio/ByteBuffer;I)J
java/nio/Bits.getLongL(Ljava/nio/ByteBuffer;I)J

Null checks and bound checks for these methods are redundant. Prior calls to
nextGetIndex or checkIndex would have already thrown an exception if the
access was out of bounds. All calls to the listed methods that use a
ByteBuffer always pass in a non-NULL ByteBuffer.

Issue: #11063
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>