### PR TITLE
Fix issues in compiler after enabling byteswap evaluators

### DIFF
--- a/runtime/compiler/optimizer/DataAccessAccelerator.cpp
+++ b/runtime/compiler/optimizer/DataAccessAccelerator.cpp
@@ -469,7 +469,7 @@ TR::Node* TR_DataAccessAccelerator::insertDecimalGetIntrinsic(TR::TreeTop* callT
    // Determines whether a TR::ByteSwap needs to be inserted before the store to the byteArray
    bool requiresByteSwap = comp()->target().cpu.isBigEndian() != static_cast <bool> (bigEndianNode->getInt());
 
-   if (requiresByteSwap && !comp()->target().cpu.isZ())
+   if (requiresByteSwap && !comp()->cg()->supportsByteswap())
       {
       printInliningStatus (false, callNode, "Unmarshalling is not supported because ByteSwap IL evaluators are not implemented.");
       return NULL;

--- a/runtime/compiler/optimizer/DataAccessAccelerator.cpp
+++ b/runtime/compiler/optimizer/DataAccessAccelerator.cpp
@@ -749,15 +749,6 @@ TR::Node* TR_DataAccessAccelerator::insertIntegerGetIntrinsic(TR::TreeTop* callT
       return NULL;
       }
 
-   // Determines whether a TR::ByteSwap needs to be inserted before the store to the byteArray
-   bool requiresByteSwap = sourceNumBytes != 1 && comp()->target().cpu.isBigEndian() != static_cast <bool> (bigEndianNode->getInt());
-
-   if (requiresByteSwap && !comp()->cg()->supportsByteswap())
-      {
-      printInliningStatus (false, callNode, "Unmarshalling is not supported because ByteSwap IL evaluators are not implemented.");
-      return NULL;
-      }
-
    bool needUnsignedConversion = false;
 
    // This check indicates that the sourceNumBytes value is specified on the callNode, so we must extract it
@@ -798,6 +789,15 @@ TR::Node* TR_DataAccessAccelerator::insertIntegerGetIntrinsic(TR::TreeTop* callT
    else
       {
       sourceNumBytes = targetNumBytes;
+      }
+
+   // Determines whether a TR::ByteSwap needs to be inserted before the store to the byteArray
+   bool requiresByteSwap = sourceNumBytes != 1 && comp()->target().cpu.isBigEndian() != static_cast <bool> (bigEndianNode->getInt());
+
+   if (requiresByteSwap && !comp()->cg()->supportsByteswap())
+      {
+      printInliningStatus (false, callNode, "Unmarshalling is not supported because ByteSwap IL evaluators are not implemented.");
+      return NULL;
       }
 
    if (performTransformation(comp(), "O^O TR_DataAccessAccelerator: genSimpleGetBinary call: %p inlined.\n", callNode))
@@ -878,15 +878,6 @@ TR::Node* TR_DataAccessAccelerator::insertIntegerSetIntrinsic(TR::TreeTop* callT
       return NULL;
       }
 
-   // Determines whether a TR::ByteSwap needs to be inserted before the store to the byteArray
-   bool requiresByteSwap = sourceNumBytes != 1 && comp()->target().cpu.isBigEndian() != static_cast <bool> (bigEndianNode->getInt());
-
-   if (requiresByteSwap && !comp()->cg()->supportsByteswap())
-      {
-      printInliningStatus (false, callNode, "Marshalling is not supported because ByteSwap IL evaluators are not implemented.");
-      return NULL;
-      }
-
    // This check indicates that the targetNumBytes value is specified on the callNode, so we must extract it
    if (targetNumBytes == 0)
       {
@@ -915,6 +906,15 @@ TR::Node* TR_DataAccessAccelerator::insertIntegerSetIntrinsic(TR::TreeTop* callT
    else
       {
       targetNumBytes = sourceNumBytes;
+      }
+
+   // Determines whether a TR::ByteSwap needs to be inserted before the store to the byteArray
+   bool requiresByteSwap = targetNumBytes != 1 && comp()->target().cpu.isBigEndian() != static_cast <bool> (bigEndianNode->getInt());
+
+   if (requiresByteSwap && !comp()->cg()->supportsByteswap())
+      {
+      printInliningStatus (false, callNode, "Marshalling is not supported because ByteSwap IL evaluators are not implemented.");
+      return NULL;
       }
 
    if (performTransformation(comp(), "O^O TR_DataAccessAccelerator: genSimplePutBinary call: %p inlined.\n", callNode))


### PR DESCRIPTION
- Fix compiler assert when byteswap IL is not needed in DAA

The write and read DAA APIs can take as input a `numBytes` argument
which for read operations determines how many bytes to read and for
write operations determines how many bytes to write out to the source or
target byte array respectively. If the user specifies a value of 1 for
this argument no byteswap operation should be performed. For read
operations (unmarshalling) a value of 1 for `numBytes` means that only
a single byte is loaded from the array, so no byteswap is needed. For
write operations a value of 1 for `numBytes` means value to store is
truncated to 1 bytes in length before being written, so no byteswap
is needed.

In both cases we must ensure badIL is not generated.

- Use supportsByteswap instead of a isZ query in insertDecimalGetIntrinsic

We may incorrectly avoid generating a byteswap when running on non-Z
platforms.

Fixes https://github.com/eclipse/openj9/issues/11072
Fixes https://github.com/eclipse/openj9/issues/11080