### PR TITLE
Reduce the optimization level of bcverify.c in compilation

### DIFF
--- a/runtime/bcverify/CMakeLists.txt
+++ b/runtime/bcverify/CMakeLists.txt
@@ -54,3 +54,9 @@ target_link_libraries(j9bcv
 		j9stackmap
 		j9shrcommon
 )
+
+# special handling bcverify.c to deal with ppcle64-specific crash when compiling with gcc 7.5
+if(OMR_ARCH_POWER AND OMR_ENV_LITTLE_ENDIAN AND OMR_ENV_DATA64 AND OMR_OS_LINUX AND (OMR_TOOLCONFIG STREQUAL "gnu"))
+	set_source_files_properties(bcverify.c PROPERTIES COMPILE_FLAGS -O2)
+endif()
+

--- a/runtime/makelib/targets.mk.linux.inc.ftl
+++ b/runtime/makelib/targets.mk.linux.inc.ftl
@@ -517,6 +517,13 @@ endif
 </#if>
 
 <#if uma.spec.processor.ppc && !uma.spec.type.aix>
+
+<#if uma.spec.flags.env_littleEndian.enabled && uma.spec.flags.env_gcc.enabled>
+# special handling bcverify.c to deal with ppcle64-specific crash when compiling with gcc 7.5
+bcverify$(UMA_DOT_O) : bcverify.c
+	$(CC) $(CFLAGS) -O2 -c -o $@ $<
+</#if>
+
 ifdef USE_PPC_GCC
 
 # special handling MHInterpreterFull.cpp, MHInterpreterCompressed.cpp, BytecodeInterpreterFull.cpp, BytecodeInterpreterCompressed.cpp, DebugBytecodeInterpreterFull.cpp and DebugBytecodeInterpreterCompressed.cpp


### PR DESCRIPTION
The change is to reduce the optimization level in compilation
on PowerPC LE 64bit platform so as to avoid unexpected crash
due to the over-optimization on the verifier-related variables
in creating stackmaps.

Fixes: #10947

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>