### PR TITLE
Initialize variables so mergeStacks is easier to read

### DIFF
--- a/runtime/bcverify/bcverify.c
+++ b/runtime/bcverify/bcverify.c
@@ -867,16 +867,16 @@ mergeStacks (J9BytecodeVerificationData * verifyData, UDATA target)
 	UDATA maxIndex = J9_ARG_COUNT_FROM_ROM_METHOD(romMethod) + J9_TEMP_COUNT_FROM_ROM_METHOD(romMethod);
 	U_32 *bytecodeMap = verifyData->bytecodeMap;
 	UDATA i = 0;
-	UDATA stackIndex;
+	UDATA stackIndex = bytecodeMap[target] >> BRANCH_INDEX_SHIFT;
 	IDATA rewalk = FALSE;
 	IDATA rc = BCV_SUCCESS;
-	UDATA *targetStackPtr, *targetStackTop, *sourceStackPtr, *sourceStackTop, *sourceStackTemps;
+	UDATA *targetStackPtr = NULL;
+	UDATA *targetStackTop = NULL;
+	UDATA *sourceStackPtr = NULL;
+	UDATA *sourceStackTop = NULL;
+	UDATA *sourceStackTemps = NULL;
 	J9BranchTargetStack *liveStack = (J9BranchTargetStack *) verifyData->liveStack;
-	J9BranchTargetStack *targetStack;
-
-
-	stackIndex = bytecodeMap[target] >> BRANCH_INDEX_SHIFT;
-	targetStack = BCV_INDEX_STACK (stackIndex);
+	J9BranchTargetStack *targetStack = BCV_INDEX_STACK(stackIndex);
 
 	Trc_BCV_mergeStacks_Entry(verifyData->vmStruct,
 			(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
@@ -906,7 +906,6 @@ mergeStacks (J9BytecodeVerificationData * verifyData, UDATA target)
 
 	} else {
 		UDATA mergePC = (UDATA) -1;
-		U_32 resultArrayBase;
 
 		/* Check stack size equality */
 		if (targetStack->stackTopIndex != liveStack->stackTopIndex) {
@@ -925,7 +924,7 @@ mergeStacks (J9BytecodeVerificationData * verifyData, UDATA target)
 
 		/* Now we have to merge stacks */
 		targetStackPtr = targetStack->stackElements;
-		targetStackTop =  RELOAD_STACKTOP(targetStack);
+		targetStackTop = RELOAD_STACKTOP(targetStack);
 		sourceStackPtr = liveStack->stackElements;
 		sourceStackTop = RELOAD_STACKTOP(liveStack);
 
@@ -979,11 +978,11 @@ mergeStacks (J9BytecodeVerificationData * verifyData, UDATA target)
 								*targetStackPtr = *sourceStackPtr;
 								rewalk = TRUE;
 							} else {
-
 								/* Use local mapper to check merge necessity in locals */
 								if ((verifyData->verificationFlags & J9_VERIFY_OPTIMIZE) && (maxIndex <= 32)) {
 									/* Only handle 32 locals or less */
 									UDATA index = (UDATA) (sourceStackPtr - liveStack->stackElements);
+									U_32 resultArrayBase = 0;
 
 									/* Reuse map in this merge if needed for multiple merges at same map */
 									if (mergePC == ((UDATA) -1)) {


### PR DESCRIPTION
While reviewing #11086, I looked at mergeStacks (the
source of the compiler bug) and see that there are a
lot of uninitialized variables.

Updated the code to initialize them and to move some
of them to the smallest possible scope.

Signed-off-by: Dan Heidinga <heidinga@redhat.com>