### PR TITLE
Skip self-storing stores

### DIFF
--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -7165,6 +7165,13 @@ TR_J9ByteCodeIlGenerator::storeAuto(TR::DataType type, int32_t slot, bool isAdju
       }
 
    symRef = symRefTab()->findOrCreateAutoSymbol(_methodSymbol, slot, type, true, false, true, isAdjunct);
+
+   // Self-storing, skip the store
+   if (storeValue->getOpCode().isLoadDirect() && storeValue->getOpCode().hasSymbolReference() && storeValue->getSymbolReference() == symRef)
+      {
+      return;
+      }
+
    if (storeValue->isDualHigh() || storeValue->isSelectHigh() || isAdjunct)
       symRef->setIsDual();
 


### PR DESCRIPTION
Loading an auto, then storing it to the same auto is a self-store.
Leaving the store in the tree will make the auto appear variant in
optimizer.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>