### PR TITLE
Use the right symbol for constant string placeholder

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2151,6 +2151,7 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
             case compilationAotThunkReloFailure:
             case compilationAotHasInvokehandle:
             case compilationAotHasInvokeVarHandle:
+            case compilationAotPatchedCPConstant:
             case compilationAotHasInvokeSpecialInterface:
             case compilationAotValidateMethodExitFailure:
             case compilationAotValidateMethodEnterFailure:
@@ -10969,6 +10970,10 @@ TR::CompilationInfoPerThreadBase::processException(
    catch (const J9::FSDHasInvokeHandle &e)
       {
       _methodBeingCompiled->_compErrCode = compilationRestrictedMethod;
+      }
+   catch (const J9::AOTHasPatchedCPConstant &e)
+      {
+      _methodBeingCompiled->_compErrCode = compilationAotPatchedCPConstant;
       }
    catch (const TR::NoRecompilationRecoverableILGenException &e)
       {

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -537,6 +537,12 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, fe->getObjectClass(objectPointer));
          }
          break;
+      case MessageType::VM_getObjectClassAt:
+         {
+         uintptr_t objectAddress = std::get<0>(client->getRecvData<uintptr_t>());
+         client->write(response, fe->getObjectClassAt(objectAddress));
+         }
+         break;
       case MessageType::VM_getStaticReferenceFieldAtAddress:
          {
          TR::VMAccessCriticalSection getStaticReferenceFieldAtAddress(fe);

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -204,6 +204,7 @@ char *compilationErrorNames[]={
    "compilationAOTValidateTMFailure", //52
    "compilationILGenUnsupportedValueTypeOperationFailure", //53
    "compilationAOTRelocationRecordGenerationFailure", //54
+   "compilationAotPatchedCPConstant", //55
 #if defined(J9VM_OPT_JITSERVER)
    "compilationStreamFailure", //55
    "compilationStreamLostMessage", // 56

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -78,6 +78,7 @@ typedef enum {
    compilationAOTValidateTMFailure                 = 52,
    compilationILGenUnsupportedValueTypeOperationFailure = 53,
    compilationAOTRelocationRecordGenerationFailure = 54,
+   compilationAotPatchedCPConstant                 = 55,
 #if defined(J9VM_OPT_JITSERVER)
    compilationFirstJITServerFailure,
    compilationStreamFailure                        = compilationFirstJITServerFailure,

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1110,6 +1110,13 @@ TR_J9VMBase::getObjectClass(uintptr_t objectPointer)
    return convertClassPtrToClassOffset(j9class);
    }
 
+TR_OpaqueClassBlock *
+TR_J9VMBase::getObjectClassAt(uintptr_t objectAddress)
+   {
+   TR::VMAccessCriticalSection getObjectClassAt(this);
+   return getObjectClass(getStaticReferenceFieldAtAddress(objectAddress));
+   }
+
 uintptr_t
 TR_J9VMBase::getStaticReferenceFieldAtAddress(uintptr_t fieldAddress)
    {

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -514,6 +514,7 @@ public:
    virtual uint32_t             getAllocationSize(TR::StaticSymbol *classSym, TR_OpaqueClassBlock * clazz);
 
    virtual TR_OpaqueClassBlock *getObjectClass(uintptr_t objectPointer);
+   virtual TR_OpaqueClassBlock *getObjectClassAt(uintptr_t objectAddress);
    virtual uintptr_t           getReferenceFieldAt(uintptr_t objectPointer, uintptr_t offsetFromHeader);
    virtual uintptr_t           getVolatileReferenceFieldAt(uintptr_t objectPointer, uintptr_t offsetFromHeader);
    virtual uintptr_t           getReferenceFieldAtAddress(uintptr_t fieldAddress);

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -772,6 +772,14 @@ TR_J9ServerVM::getObjectClass(uintptr_t objectPointer)
    return std::get<0>(stream->read<TR_OpaqueClassBlock *>());
    }
 
+TR_OpaqueClassBlock *
+TR_J9ServerVM::getObjectClassAt(uintptr_t objectAddress)
+   {
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(JITServer::MessageType::VM_getObjectClassAt, objectAddress);
+   return std::get<0>(stream->read<TR_OpaqueClassBlock *>());
+   }
+
 uintptr_t
 TR_J9ServerVM::getStaticReferenceFieldAtAddress(uintptr_t fieldAddress)
    {

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -97,6 +97,7 @@ public:
    virtual bool isPrimitiveArray(TR_OpaqueClassBlock *clazz) override;
    virtual uint32_t getAllocationSize(TR::StaticSymbol *classSym, TR_OpaqueClassBlock *clazz) override;
    virtual TR_OpaqueClassBlock * getObjectClass(uintptr_t objectPointer) override;
+   virtual TR_OpaqueClassBlock * getObjectClassAt(uintptr_t objectAddress) override;
    virtual uintptr_t getStaticReferenceFieldAtAddress(uintptr_t fieldAddress) override;
 
    virtual bool stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *clazz) override;

--- a/runtime/compiler/exceptions/AOTFailure.hpp
+++ b/runtime/compiler/exceptions/AOTFailure.hpp
@@ -91,6 +91,16 @@ class AOTHasMethodTypeConstant : public virtual TR::RecoverableILGenException
    };
 
 /**
+ * AOT Has patched CP constant exception type.
+ *
+ * Thrown when a method that has a constant object in CP entry patched to a different type is AOT Compiled.
+ */
+class AOTHasPatchedCPConstant: public virtual TR::RecoverableILGenException
+   {
+   virtual const char* what() const throw() { return "AOT Has Patched CP Constant"; }
+   };
+
+/**
  * AOT Relocation Failure exception type.
  *
  * Thrown when an AOT compilation fails in the relocation phase.

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -109,7 +109,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 14;
+   static const uint16_t MINOR_NUMBER = 15;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -135,6 +135,7 @@ enum MessageType : uint16_t
    VM_isPrimitiveArray,
    VM_getAllocationSize,
    VM_getObjectClass,
+   VM_getObjectClassAt,
    VM_stackWalkerMaySkipFrames,
    VM_hasFinalFieldsInClass,
    VM_getClassNameSignatureFromMethod,
@@ -207,7 +208,7 @@ enum MessageType : uint16_t
    VM_getFields,
 
    // For static TR::CompilationInfo methods
-   CompInfo_isCompiled, // 172
+   CompInfo_isCompiled, // 173
    CompInfo_getPCIfCompiled,
    CompInfo_getInvocationCount,
    CompInfo_setInvocationCount,
@@ -221,7 +222,7 @@ enum MessageType : uint16_t
    CompInfo_getJ9MethodStartPC,
 
    // For J9::ClassEnv Methods
-   ClassEnv_classFlagsValue, // 184
+   ClassEnv_classFlagsValue, // 185
    ClassEnv_classDepthOf,
    ClassEnv_classInstanceSize,
    ClassEnv_superClassesOf,
@@ -234,13 +235,13 @@ enum MessageType : uint16_t
    ClassEnv_getROMClassRefName,
 
    // For TR_J9SharedCache
-   SharedCache_getClassChainOffsetInSharedCache, // 195
+   SharedCache_getClassChainOffsetInSharedCache, // 196
    SharedCache_rememberClass,
    SharedCache_addHint,
    SharedCache_storeSharedData,
 
    // For runFEMacro
-   runFEMacro_invokeCollectHandleNumArgsToCollect, // 199
+   runFEMacro_invokeCollectHandleNumArgsToCollect, // 200
    runFEMacro_invokeExplicitCastHandleConvertArgs,
    runFEMacro_targetTypeL,
    runFEMacro_invokeILGenMacrosInvokeExactAndFixup,
@@ -266,24 +267,24 @@ enum MessageType : uint16_t
    runFEMacro_invokeCollectHandleAllocateArray,
 
    // for JITServerPersistentCHTable
-   CHTable_getAllClassInfo, // 223
+   CHTable_getAllClassInfo, // 224
    CHTable_getClassInfoUpdates,
    CHTable_commit,
    CHTable_clearReservable,
 
    // for JITServerIProfiler
-   IProfiler_profilingSample, // 227
+   IProfiler_profilingSample, // 228
    IProfiler_searchForMethodSample,
    IProfiler_getMaxCallCount,
    IProfiler_setCallCount,
 
-   Recompilation_getExistingMethodInfo, // 231
+   Recompilation_getExistingMethodInfo, // 232
    Recompilation_getJittedBodyInfoFromPC,
 
    ClassInfo_getRemoteROMString,
 
    // for KnownObjectTable
-   KnownObjectTable_getOrCreateIndex, // 234
+   KnownObjectTable_getOrCreateIndex, // 235
    KnownObjectTable_getOrCreateIndexAt,
    KnownObjectTable_getPointer,
    KnownObjectTable_getExistingIndexAt,
@@ -297,7 +298,7 @@ enum MessageType : uint16_t
    KnownObjectTable_invokeDirectHandleDirectCall,
    KnownObjectTable_getKnownObjectTableDumpInfo,
 
-   ClassEnv_isClassRefValueType, // 246
+   ClassEnv_isClassRefValueType, // 247
    MessageType_MAXTYPE
    };
 
@@ -407,6 +408,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "VM_isPrimitiveArray",
    "VM_getAllocationSize",
    "VM_getObjectClass",
+   "VM_getObjectClassAt",
    "VM_stackWalkerMaySkipFrames",
    "VM_hasFinalFieldsInClass",
    "VM_getClassNameSignatureFromMethod",
@@ -477,7 +479,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "VM_getObjectSizeClass",
    "VM_stackWalkerMaySkipFramesSVM",
    "VM_getFields",
-   "CompInfo_isCompiled", // 172
+   "CompInfo_isCompiled", // 173
    "CompInfo_getPCIfCompiled",
    "CompInfo_getInvocationCount",
    "CompInfo_setInvocationCount",
@@ -489,7 +491,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "CompInfo_setInvocationCountAtomic",
    "CompInfo_isClassSpecial",
    "CompInfo_getJ9MethodStartPC",
-   "ClassEnv_classFlagsValue", // 184
+   "ClassEnv_classFlagsValue", // 185
    "ClassEnv_classDepthOf",
    "ClassEnv_classInstanceSize",
    "ClassEnv_superClassesOf",
@@ -500,11 +502,11 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "ClassEnv_getITable",
    "ClassEnv_classHasIllegalStaticFinalFieldModification",
    "ClassEnv_getROMClassRefName",
-   "SharedCache_getClassChainOffsetInSharedCache", // 195
+   "SharedCache_getClassChainOffsetInSharedCache", // 196
    "SharedCache_rememberClass",
    "SharedCache_addHint",
    "SharedCache_storeSharedData",
-   "runFEMacro_invokeCollectHandleNumArgsToCollect", // 199
+   "runFEMacro_invokeCollectHandleNumArgsToCollect", // 200
    "runFEMacro_invokeExplicitCastHandleConvertArgs",
    "runFEMacro_targetTypeL",
    "runFEMacro_invokeILGenMacrosInvokeExactAndFixup",
@@ -528,18 +530,18 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "runFEMacro_invokeFilterArgumentsWithCombinerHandleFilterPosition",
    "runFEMacro_invokeFilterArgumentsWithCombinerHandleArgumentIndices",
    "runFEMacro_invokeCollectHandleAllocateArray",
-   "CHTable_getAllClassInfo", // 223
+   "CHTable_getAllClassInfo", // 224
    "CHTable_getClassInfoUpdates",
    "CHTable_commit",
    "CHTable_clearReservable",
-   "IProfiler_profilingSample", // 227
+   "IProfiler_profilingSample", // 228
    "IProfiler_searchForMethodSample",
    "IProfiler_getMaxCallCount",
    "IProfiler_setCallCount",
-   "Recompilation_getExistingMethodInfo", // 231
+   "Recompilation_getExistingMethodInfo", // 232
    "Recompilation_getJittedBodyInfoFromPC",
    "ClassInfo_getRemoteROMString",
-   "KnownObjectTable_getOrCreateIndex", // 233
+   "KnownObjectTable_getOrCreateIndex", // 234
    "KnownObjectTable_getOrCreateIndexAt",
    "KnownObjectTable_getPointer",
    "KnownObjectTable_getExistingIndexAt",
@@ -551,7 +553,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "KnownObjectTable_getReferenceField",
    "KnownObjectTable_invokeDirectHandleDirectCall",
    "KnownObjectTable_getKnownObjectTableDumpInfo",
-   "ClassEnv_isClassRefValueType", // 246
+   "ClassEnv_isClassRefValueType", // 247
    };
    }; // namespace JITServer
 #endif // MESSAGE_TYPES_HPP


### PR DESCRIPTION
Constant string can be used as a placeholder and be patched to other
object. Set the flag on the symbol according to the actual object type.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>