### PR TITLE
Fix DAA creating byteswap and conversion in the wrong order

### DIFF
--- a/runtime/compiler/optimizer/DataAccessAccelerator.cpp
+++ b/runtime/compiler/optimizer/DataAccessAccelerator.cpp
@@ -957,15 +957,15 @@ TR::Node* TR_DataAccessAccelerator::insertIntegerSetIntrinsic(TR::TreeTop* callT
          case 8: op = TR::lstorei; byteswapOp = TR::lbyteswap; break;
          }
 
-      if (requiresByteSwap)
-         {
-         valueNode = TR::Node::create(byteswapOp, 1, valueNode);
-         }
-
       // Create the proper conversion if the source and target sizes are different
       if (sourceDataType != targetDataType)
          {
          valueNode = TR::Node::create(TR::ILOpCode::getProperConversion(sourceDataType, targetDataType, false), 1, valueNode);
+         }
+
+      if (requiresByteSwap)
+         {
+         valueNode = TR::Node::create(byteswapOp, 1, valueNode);
          }
 
       return TR::Node::createWithSymRef(op, 2, 2, createByteArrayElementAddress(callTreeTop, callNode, byteArrayNode, offsetNode), valueNode, comp()->getSymRefTab()->findOrCreateGenericIntShadowSymbolReference(0));


### PR DESCRIPTION
Previously, a DAA optimization for byteswapped stores was creating a
byteswap node if needed before performing the conversion into the
requested type. This would result in invalid IL if a conversion node is
required.

Signed-off-by: Ben Thomas <ben@benthomas.ca>