### PR TITLE
Exclude default/forceLazySymbolResolution test for jdk15+ 

### DIFF
--- a/test/functional/cmdLineTests/defaultLazySymbolResolution/playlist.xml
+++ b/test/functional/cmdLineTests/defaultLazySymbolResolution/playlist.xml
@@ -44,6 +44,11 @@
 		<types>
 			<type>native</type>
 		</types>
+		<subsets>
+			<!-- disable for 15+ https://github.com/eclipse/openj9/issues/11076 -->
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>

--- a/test/functional/cmdLineTests/forceLazySymbolResolution/playlist.xml
+++ b/test/functional/cmdLineTests/forceLazySymbolResolution/playlist.xml
@@ -44,6 +44,11 @@
 		<types>
 			<type>native</type>
 		</types>
+		<subsets>
+			<!-- disable for 15+ https://github.com/eclipse/openj9/issues/11076 -->
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>			


### PR DESCRIPTION
Issue https://github.com/eclipse/openj9/issues/11076

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>