### PR TITLE
Move the array check for the new bytecode to the runtime verifier

### DIFF
--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -1804,6 +1804,17 @@ _illegalPrimitiveReturn:
 			switch (bc) {
 			case JBnew:
 			case JBnewdup:
+				index = PARAM_16(bcIndex, 1);
+				info = &constantPool[index];
+				utf8string = J9ROMSTRINGREF_UTF8DATA((J9ROMStringRef *) info);
+				stackTop = pushClassType(verifyData, utf8string, stackTop);
+				type = POP;
+				if (J9_ARE_ANY_BITS_SET(type, BCV_ARITY_MASK)) {
+					errorType = J9NLS_BCV_ERR_BC_NEW_ARRAY__ID;
+					verboseErrorCode = BCV_ERR_NEW_OJBECT_MISMATCH;
+					errorTempData = ((type & BCV_ARITY_MASK) >> BCV_ARITY_SHIFT);
+					goto _miscError;
+				}
 				/* put a uninitialized object of the correct type on the stack */
 				PUSH(BCV_SPECIAL_NEW | (start << BCV_CLASS_INDEX_SHIFT));
 				break;

--- a/runtime/bcverify/staticverify.c
+++ b/runtime/bcverify/staticverify.c
@@ -972,11 +972,6 @@ checkBytecodeStructure (J9CfrClassFile * classfile, UDATA methodIndex, UDATA len
 				errorDataIndex = index;
 				goto _verifyError;
 			}
-			info = &(classfile->constantPool[info->slot1]);
-			if (info->bytes[0] == '[') {
-				errorType = J9NLS_CFR_ERR_BC_NEW_ARRAY__ID;
-				goto _verifyError;
-			}
 			break;
 
 		case CFR_BC_newarray:

--- a/runtime/nls/vrfy/j9bcv.nls
+++ b/runtime/nls/vrfy/j9bcv.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2019 IBM Corp. and others
+# Copyright (c) 2000, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -428,5 +428,13 @@ J9NLS_BCV_ERROR_TEMPLATE_TYPE_MISMATCH.sample_input_15=([Ljava/lang/String;)V
 J9NLS_BCV_ERROR_TEMPLATE_TYPE_MISMATCH.explanation=NOTAG
 J9NLS_BCV_ERROR_TEMPLATE_TYPE_MISMATCH.system_action=
 J9NLS_BCV_ERROR_TEMPLATE_TYPE_MISMATCH.user_response=
+
+# END NON-TRANSLATABLE
+
+J9NLS_BCV_ERR_BC_NEW_ARRAY=new bytecode cannot create arrays
+# START NON-TRANSLATABLE
+J9NLS_BCV_ERR_BC_NEW_ARRAY.explanation=Verification failed due to an incorrect 'new' bytecode
+J9NLS_BCV_ERR_BC_NEW_ARRAY.system_action=The JVM will throw a verification or classloading related exception such as java.lang.VerifyError.
+J9NLS_BCV_ERR_BC_NEW_ARRAY.user_response=Contact the provider of the classfile for a corrected version.  
 
 # END NON-TRANSLATABLE

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -535,6 +535,7 @@ extern "C" {
 #define BCV_ERR_UNEXPECTED_EOF							-32
 #define BCV_ERR_INACCESSIBLE_CLASS						-33
 #define BCV_ERR_BYTECODE_ERROR							-34
+#define BCV_ERR_NEW_OJBECT_MISMATCH						-35
 
 #define J9_GC_OBJ_HEAP_HOLE 0x1
 #define J9_GC_MULTI_SLOT_HOLE 0x1

--- a/runtime/verbose/errormessageframeworkrtv.c
+++ b/runtime/verbose/errormessageframeworkrtv.c
@@ -943,6 +943,9 @@ generateJ9RtvExceptionDetails(J9BytecodeVerificationData* verifyData, U_8* initM
 	case BCV_ERR_BYTECODE_ERROR:
 		printMessage(&msgBuf, "Error exists in the bytecode.");
 		break;
+	case BCV_ERR_NEW_OJBECT_MISMATCH:
+		printMessage(&msgBuf, "The arity (0x%x) of the new object is greater than zero", verifyData->errorTempData);
+		break;
 	default:
 		Assert_VRB_ShouldNeverHappen();
 		break;


### PR DESCRIPTION
The intention of the changes is to skip the array check in the
static verification for the dynamically generated subclasses
of MagicAccessorImpl at runtime.

Fixes: #11067

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>