### PR TITLE
Rename workflow to generic name, fix name of MH assigner

### DIFF
--- a/.github/workflows/assign-to-project.yml
+++ b/.github/workflows/assign-to-project.yml
@@ -46,7 +46,7 @@ jobs:
 
   assign_mh_project:
     runs-on: ubuntu-latest
-    name: Assign to Snapshot Project
+    name: Assign to MH Project
     if: github.event.label.name == 'project:MH'
     steps:
     - name: MH project assigner


### PR DESCRIPTION
[ci skip]

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>