### PR TITLE
Recognize and transform redundant calls in MH.invokeExact MethodHandle chain

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -1011,6 +1011,8 @@
    java_lang_invoke_InsertHandle_numValuesToInsert,
    java_lang_invoke_InterfaceHandle_interfaceCall,
    java_lang_invoke_InterfaceHandle_invokeExact,
+   java_lang_invoke_Invokers_checkCustomized,
+   java_lang_invoke_Invokers_checkExactType,
    java_lang_invoke_MethodHandle_doCustomizationLogic,
    java_lang_invoke_MethodHandle_asType,
    java_lang_invoke_MethodHandle_asType_instance,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -4037,6 +4037,13 @@ void TR_ResolvedJ9Method::construct()
       {  TR::unknownMethod}
       };
 
+   static X InvokersMethods[] =
+      {
+      {x(TR::java_lang_invoke_Invokers_checkCustomized,                    "checkCustomized",             "(Ljava/lang/invoke/MethodHandle;)V")},
+      {x(TR::java_lang_invoke_Invokers_checkExactType,                     "checkExactType",              "(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)V")},
+      {TR::unknownMethod}
+      };
+
    static X AsTypeHandleMethods[] =
       {
       {  TR::java_lang_invoke_AsTypeHandle_convertArgs,   11, "convertArgs",     (int16_t)-1, "*"},
@@ -4375,6 +4382,7 @@ void TR_ResolvedJ9Method::construct()
 
    static Y class25[] =
       {
+      { "java/lang/invoke/Invokers", InvokersMethods },
       { 0 }
       };
 

--- a/runtime/compiler/optimizer/MethodHandleTransformer.hpp
+++ b/runtime/compiler/optimizer/MethodHandleTransformer.hpp
@@ -123,6 +123,30 @@ class TR_MethodHandleTransformer : public TR::Optimization
    //
    void process_java_lang_invoke_MethodHandle_linkTo(TR::TreeTop* tt, TR::Node* node);
 
+   /** \brief
+    *    Transforms calls to java/lang/invoke/Invokers.checkExactType to ZEROCHK, or eliminated
+    *    entirely if the check can be performed at compile time
+    *
+    *  \param tt
+    *    The treetop of the call node
+    *
+    *  \param node
+    *    The call node representing the call to java/lang/invoke/Invokers.checkExactType
+    */
+   void process_java_lang_invoke_Invokers_checkExactType(TR::TreeTop* tt, TR::Node* node);
+
+   /** \brief
+    *    Eliminates calls to java/lang/invoke/Invokers.checkCustomized when its argument
+    *    is a known object
+    *
+    *  \param tt
+    *    The treetop of the call node
+    *
+    *  \param node
+    *    The call node representing the call to java/lang/invoke/Invokers.checkCustomized
+    */
+   void process_java_lang_invoke_Invokers_checkCustomized(TR::TreeTop* tt, TR::Node* node);
+
    private:
    int32_t _numLocals; // Number of parms, autos and temps
    ObjectInfo * _currentObjectInfo;  // Object info for current block being processed


### PR DESCRIPTION
This changeset includes the following: 
* recognize `java/lang/invoke/Invokers` methods that require handling in RecognizedCallTransformer
* Transform `Invokers.checkExactType` to a ZEROCHK
* Eliminate `Invokers.checkCustomized` calls when MethodHandle is a known object

Issue: #10618 