### PR TITLE
Reset Frequencies before setting them

### DIFF
--- a/runtime/compiler/infra/J9Cfg.cpp
+++ b/runtime/compiler/infra/J9Cfg.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -116,7 +116,7 @@ static bool hasJProfilingInfo(TR::Compilation *comp, TR::CFG *cfg)
 bool
 J9::CFG::setFrequencies()
    {
-   if (this == comp()->getFlowGraph() && !comp()->getRecompilationInfo())
+   if (this == comp()->getFlowGraph())
       {
       resetFrequencies();
       }


### PR DESCRIPTION
Changes are to setFrequencies inside J9Cfg.cpp. The algorithm inside
setFrequencies expects that the block and edge frequencies have already been
reset to -1 and 0 respectively. This was not always happening and could lead
to unexpected frequencies that would later feed bad information into later
optimizations.

This change ensures that the block frequencies have been reset before
setFrequencies starts setting updated ones.

Closes: #11127
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>