### PR TITLE
Cache well-known class chain offsets in JITServer client session

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -183,6 +183,7 @@ J9::Compilation::Compilation(int32_t id,
 #if defined(J9VM_OPT_JITSERVER)
    _remoteCompilation(false),
    _serializedRuntimeAssumptions(getTypedAllocator<SerializedRuntimeAssumption>(self()->allocator())),
+   _clientData(NULL),
 #endif /* defined(J9VM_OPT_JITSERVER) */
    _osrProhibitedOverRangeOfTrees(false)
    {

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -59,6 +59,7 @@ class TR_RelocationRuntime;
 namespace TR { class IlGenRequest; }
 #ifdef J9VM_OPT_JITSERVER
 struct SerializedRuntimeAssumption;
+class ClientSessionData;
 #endif
 
 #define COMPILATION_AOT_HAS_INVOKEHANDLE -9
@@ -323,6 +324,8 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    bool isRemoteCompilation() const { return _remoteCompilation; } // client side
    void setRemoteCompilation() { _remoteCompilation = true; }
    TR::list<SerializedRuntimeAssumption*>& getSerializedRuntimeAssumptions() { return _serializedRuntimeAssumptions; }
+   ClientSessionData *getClientData() const { return _clientData; }
+   void setClientData(ClientSessionData *clientData) { _clientData = clientData; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    TR::SymbolValidationManager *getSymbolValidationManager() { return _symbolValidationManager; }
@@ -424,6 +427,9 @@ private:
    // The following flag is set when a request to complete this compilation
    // has been sent to a remote VM (client side in JITServer)
    bool _remoteCompilation;
+   // Client session data for the client that requested this out-of-process
+   // compilation (at the JITServer); unused (always NULL) at the client side
+   ClientSessionData *_clientData;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    TR::SymbolValidationManager *_symbolValidationManager;

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8554,6 +8554,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
             compiler->setOutOfProcessCompilation();
             // Create the KOT by default at the server as long as it is not disabled at the client.
             compiler->getOrCreateKnownObjectTable();
+            compiler->setClientData(that->getClientData());
             }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -445,6 +445,14 @@ class ClientSessionData
 
    TR::SymbolValidationManager::SystemClassNotWorthRemembering *getSystemClassesNotWorthRemembering() { return _systemClassesNotWorthRemembering; }
 
+   // Returns the cached client-side pointer to well-known class chain offsets
+   // if included classes and their SCC offsets match, otherwise returns NULL
+   const void *getCachedWellKnownClassChainOffsets(unsigned int includedClasses, size_t numClasses,
+                                                   const uintptr_t *classChainOffsets);
+   // Cache the client-side pointer to well-known class chain offsets
+   void cacheWellKnownClassChainOffsets(unsigned int includedClasses, size_t numClasses,
+                                        const uintptr_t *classChainOffsets, const void *wellKnownClassChainOffsets);
+
    private:
    const uint64_t _clientUID;
    int64_t  _timeOfLastAccess; // in ms
@@ -494,6 +502,23 @@ class ClientSessionData
    volatile bool _bClassUnloadingAttempt;
 
    TR::SymbolValidationManager::SystemClassNotWorthRemembering _systemClassesNotWorthRemembering[TR::SymbolValidationManager::SYSTEM_CLASSES_NOT_WORTH_REMEMBERING_COUNT];
+
+   /**
+    * @class WellKnownClassesCache
+    * @brief Stores the most recent version of well-known class chain offsets used by AOT compilations with SVM
+    */
+   struct WellKnownClassesCache
+      {
+      WellKnownClassesCache() { clear(); }
+      void clear() { memset(this, 0, sizeof(*this)); }
+
+      unsigned int _includedClasses;// bitset of indices in the list of well-known classes
+      uintptr_t _classChainOffsets[WELL_KNOWN_CLASS_COUNT];// ROMClass SCC offsets
+      const void *_wellKnownClassChainOffsets;// client-side pointer to "well-known class chain offsets" in SCC
+      };
+
+   WellKnownClassesCache _wellKnownClasses;
+   TR::Monitor *_wellKnownClassesMonitor;
    }; // class ClientSessionData
 
 

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -197,12 +197,13 @@ TR::SymbolValidationManager::getSystemClassNotWorthRemembering(int idx)
 void
 TR::SymbolValidationManager::populateWellKnownClasses()
    {
-#define WELL_KNOWN_CLASS_COUNT 9
 #define REQUIRED_WELL_KNOWN_CLASS_COUNT 0
 
    // Classes must have names only allowed to be defined by the bootstrap loader
    // The first REQUIRED_WELL_KNOWN_CLASS_COUNT entries are required - if any is
    // missing then the compilation will fail.
+   // Number of entries must match WELL_KNOWN_CLASS_COUNT defined in
+   // SymbolValidationManager.hpp
    static const char * const names[] =
       {
       "java/lang/Class",
@@ -285,7 +286,6 @@ TR::SymbolValidationManager::populateWellKnownClasses()
       "Failed to store well-known classes' class chains");
 
 #undef REQUIRED_WELL_KNOWN_CLASS_COUNT
-#undef WELL_KNOWN_CLASS_COUNT
    }
 
 bool

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -646,6 +646,8 @@ public:
       bool _checkIsSuperClass;
       };
 
+   #define WELL_KNOWN_CLASS_COUNT 9
+
    void populateWellKnownClasses();
    bool validateWellKnownClasses(const uintptr_t *wellKnownClassChainOffsets);
    bool isWellKnownClass(TR_OpaqueClassBlock *clazz);


### PR DESCRIPTION
Every AOT compilation using SVM at the JITServer sends a SharedCache_storeSharedData message to the client in SymbolValidationManager::populateWellKnownClasses(). Most of these calls return a pointer to the same existing version of well-known class chain offsets in the client's SCC (after all well-known classes are loaded, which normally happens early on during start-up). To avoid these repeated messages, we cache the pointers to well-known class chain offsets in the ClientSession. The key in the map is a combination of the bit mask describing included classes and the list of ROMClass offsets in the client's SCC, and the value is the client-side pointer to the well-known class chain offsets structure in the SCC. This replicates the behaviour of the underlying SCC store operation: a new structure is created only if the bit mask (used as the SCC key) is different, or if the contents (the list of ROMClass offsets) are different.

Closes: #11137 