### PR TITLE
Add missing TR::CodeGenerator() constructor

### DIFF
--- a/runtime/compiler/codegen/CodeGenerator.hpp
+++ b/runtime/compiler/codegen/CodeGenerator.hpp
@@ -35,6 +35,10 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGeneratorConnector
 
    CodeGenerator(TR::Compilation *comp) :
       J9::CodeGeneratorConnector(comp) {}
+
+   CodeGenerator() :
+      J9::CodeGeneratorConnector(TR::comp()) {}
+
    };
 }
 


### PR DESCRIPTION
Fix `snapshot` build break.

Signed-off-by: Dan Heidinga <heidinga@redhat.com>