### PR TITLE
Disable TOC for JITServer

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8085,10 +8085,6 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                // to support the relocation of some of those instructions is not available. Thus we disable
                // this option for remote compilations.
                options->setOption(TR_DisableSIMDArrayTranslate);
-
-               // Infrastructure to support the TOC is currently not available for Remote Compilations. We disable the feature
-               // here so that the codegen doesn't generate TOC enabled code as it won't be valid on the client JVM.
-               options->setOption(TR_DisableTOC);
                }
             // Determine if known annotations exist and if so, keep annotations enabled
             if (!that->_methodBeingCompiled->isAotLoad() && !vm->isAOT_DEPRECATED_DO_NOT_USE() && options->getOption(TR_EnableAnnotations))

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2105,6 +2105,13 @@ J9::Options::setupJITServerOptions()
       self()->setOption(TR_DisableJProfilerThread);
       self()->setOption(TR_EnableJProfiling, false);
 
+#if defined(TR_HOST_POWER)
+      // Infrastructure to support the TOC is currently not available for JITServer.
+      // TOC needs to be disabled at setup, even for non-remote client compilations,
+      // because presence of TOC changes trampoline definition.
+      self()->setOption(TR_DisableTOC);
+#endif 
+
       if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
          {
          // The server can compile with VM access in hand because GC is not a factor here


### PR DESCRIPTION
Recent changes to trampolines on Power
caused crashes in JITServer due to TOC now affecting
how helper trampolines are defined.
Previously, we disabled TOC at compile time, which causes
trampolines to be initialized as if TOC is enabled.
Fix this by disabling TOC during VM setup.