### PR TITLE
Provide default message if NLS look fails

### DIFF
--- a/runtime/port/aix/j9hypervisor.c
+++ b/runtime/port/aix/j9hypervisor.c
@@ -93,8 +93,8 @@ detect_hypervisor(struct J9PortLibrary *portLibrary)
 	errMsg = omrnls_lookup_message(J9NLS_ERROR | J9NLS_DO_NOT_APPEND_NEWLINE,
 											J9NLS_PORT_UNSUPPORTED_HYPERVISOR__MODULE,
 											J9NLS_PORT_UNSUPPORTED_HYPERVISOR__ID,
-											NULL);
-	omrerror_set_last_error_with_message(J9PORT_ERROR_HYPERVISOR_UNSUPPORTED,errMsg);
+											"Failed to detect a Supported Hypervisor.");
+	omrerror_set_last_error_with_message(J9PORT_ERROR_HYPERVISOR_UNSUPPORTED, errMsg);
 
 	portLibrary->portGlobals->hypervisorData.isVirtual = J9PORT_ERROR_HYPERVISOR_UNSUPPORTED;
 	portLibrary->portGlobals->hypervisorData.vendorDetails.hypervisorName = NULL;

--- a/runtime/port/aix/j9hypervisor.c
+++ b/runtime/port/aix/j9hypervisor.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/port/common/j9hypervisor_i386.c
+++ b/runtime/port/common/j9hypervisor_i386.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/port/common/j9hypervisor_i386.c
+++ b/runtime/port/common/j9hypervisor_i386.c
@@ -98,7 +98,7 @@ detect_hypervisor_i386(struct J9PortLibrary *portLibrary)
 		errMsg = omrnls_lookup_message(J9NLS_ERROR | J9NLS_DO_NOT_APPEND_NEWLINE,
 												J9NLS_PORT_UNSUPPORTED_HYPERVISOR__MODULE,
 												J9NLS_PORT_UNSUPPORTED_HYPERVISOR__ID,
-												NULL);
+												"Failed to detect a Supported Hypervisor.");
 		omrerror_set_last_error_with_message(J9PORT_ERROR_HYPERVISOR_UNSUPPORTED, errMsg);
 		Trc_PRT_virt_j9hypervisor_detect_hypervisor_Exit(J9PORT_ERROR_HYPERVISOR_UNSUPPORTED);
 		return J9PORT_ERROR_HYPERVISOR_UNSUPPORTED;

--- a/runtime/port/linuxppc/j9hypervisor.c
+++ b/runtime/port/linuxppc/j9hypervisor.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/port/linuxppc/j9hypervisor.c
+++ b/runtime/port/linuxppc/j9hypervisor.c
@@ -165,7 +165,7 @@ detect_hypervisor(struct J9PortLibrary *portLibrary)
 	const char* errMsg = omrnls_lookup_message(J9NLS_ERROR | J9NLS_DO_NOT_APPEND_NEWLINE,
 								 J9NLS_PORT_UNSUPPORTED_HYPERVISOR__MODULE,
 							     J9NLS_PORT_UNSUPPORTED_HYPERVISOR__ID,
-							     NULL);
+							     "Failed to detect a Supported Hypervisor.");
 	omrerror_set_last_error_with_message(ret, errMsg);
 	Trc_PRT_virt_j9hypervisor_detect_hypervisor_Exit(-1);
 	return J9PORT_ERROR_HYPERVISOR_UNSUPPORTED;

--- a/runtime/port/linuxs390/j9hypervisor.c
+++ b/runtime/port/linuxs390/j9hypervisor.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/port/linuxs390/j9hypervisor.c
+++ b/runtime/port/linuxs390/j9hypervisor.c
@@ -143,7 +143,7 @@ detect_hypervisor(struct J9PortLibrary *portLibrary)
 			errMsg = omrnls_lookup_message(J9NLS_ERROR | J9NLS_DO_NOT_APPEND_NEWLINE,
 													J9NLS_PORT_HYPERVISOR_OPFAILED__MODULE,
 													J9NLS_PORT_HYPERVISOR_OPFAILED__ID,
-													NULL);
+													"Hypervisor related operation failed.");
 			omrerror_set_last_error_with_message(J9PORT_ERROR_HYPERVISOR_OPFAILED, errMsg);
 			rc = J9PORT_ERROR_HYPERVISOR_OPFAILED;
 		}

--- a/runtime/port/zos390/j9hypervisor.c
+++ b/runtime/port/zos390/j9hypervisor.c
@@ -61,7 +61,7 @@ detect_hypervisor(struct J9PortLibrary *portLibrary)
 		errMsg = omrnls_lookup_message(J9NLS_ERROR | J9NLS_DO_NOT_APPEND_NEWLINE,
 												J9NLS_PORT_CSRSIC_FAILURE__MODULE,
 												J9NLS_PORT_CSRSIC_FAILURE__ID,
-												NULL);
+												"Unexpected return code from CSRSI service on z/OS");
 		omrerror_set_last_error_with_message(J9PORT_ERROR_HYPERVISOR_UNSUPPORTED, errMsg);
 		portLibrary->portGlobals->hypervisorData.isVirtual = J9PORT_ERROR_HYPERVISOR_OPFAILED;
 		portLibrary->portGlobals->hypervisorData.vendorDetails.hypervisorName = NULL;

--- a/runtime/port/zos390/j9hypervisor.c
+++ b/runtime/port/zos390/j9hypervisor.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this


### PR DESCRIPTION
Code immediately passes the looked up NLS message to
`omrerror_set_last_error_with_message` which doesn't expect NULL
and will segfault if passed NULL.

This change uses the english NLS message as a default rather
allowing a crash.

Signed-off-by: Dan Heidinga <heidinga@redhat.com>