### PR TITLE
Exclude waiting objects from owned monitor queries

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4654,6 +4654,7 @@ typedef struct J9InternalVMFunctions {
 	void ( *storeFlattenableArrayElement)(struct J9VMThread *currentThread, j9object_t receiverObject, U_32 index, j9object_t paramObject);
 	j9object_t ( *loadFlattenableArrayElement)(struct J9VMThread *currentThread, j9object_t receiverObject, U_32 index, BOOLEAN fast);
 	UDATA ( *jniIsInternalClassRef)(struct J9JavaVM *vm, jobject ref);
+	BOOLEAN (*objectIsBeingWaitedOn)(struct J9VMThread *currentThread, struct J9VMThread *targetThread, j9object_t obj);
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4244,6 +4244,16 @@ typedef struct J9ObjectMonitorInfo {
 } J9ObjectMonitorInfo;
 
 /**
+ * @brief See if an object is being waited on by targetThread
+ * @param currentThread
+ * @param targetThread
+ * @param obj
+ * @return BOOLEAN
+ */
+BOOLEAN
+objectIsBeingWaitedOn(J9VMThread *currentThread, J9VMThread *targetThread, j9object_t obj);
+
+/**
  * @brief Get the object monitors locked by a thread
  * @param currentThread
  * @param targetThread

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -392,5 +392,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 #endif /* JAVA_SPEC_VERSION >= 15 */
 	storeFlattenableArrayElement,
 	loadFlattenableArrayElement,
-	jniIsInternalClassRef
+	jniIsInternalClassRef,
+	objectIsBeingWaitedOn,
 };


### PR DESCRIPTION
Objects which are the target of a wait() call should not be included in
the list of owned monitors for the waiting thread.

Fixes: #11113

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>