### PR TITLE
Add Java11 support for snapshot/restore

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -93,9 +93,11 @@ final class J9VMInternals {
 									"sun.nio.ch.IOUtil", //$NON-NLS-1$
 									"sun.nio.ch.FileChannelImpl", //$NON-NLS-1$
 									"sun.nio.ch.ServerSocketChannelImpl", //$NON-NLS-1$
+	/*[IF !Java11]*/
 									"java.util.zip.ZipFile", //$NON-NLS-1$
 									"java.util.zip.Inflater", //$NON-NLS-1$
 									"java.util.zip.Deflater", //$NON-NLS-1$
+	/*[ENDIF]*/
 									"java.io.UnixFileSystem", //$NON-NLS-1$
 									"java.io.RandomAccessFile"}; //$NON-NLS-1$
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4829,6 +4829,7 @@ typedef struct J9InternalVMFunctions {
 	void ( *storeFlattenableArrayElement)(struct J9VMThread *currentThread, j9object_t receiverObject, U_32 index, j9object_t paramObject);
 	j9object_t ( *loadFlattenableArrayElement)(struct J9VMThread *currentThread, j9object_t receiverObject, U_32 index, BOOLEAN fast);
 	UDATA ( *jniIsInternalClassRef)(struct J9JavaVM *vm, jobject ref);
+	void (JNICALL *sendInitEncodings)(struct J9VMThread *vmContext) ;
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1307,6 +1307,7 @@ extern J9_CFUNC void  JNICALL sendResolveConstantDynamic (J9VMThread *vmThread, 
 extern J9_CFUNC void  JNICALL sendResolveInvokeDynamic (J9VMThread *vmThread, J9ConstantPool *ramCP, UDATA callSiteIndex, J9ROMNameAndSignature* nameAndSig, U_16* bsmData);
 extern J9_CFUNC void  JNICALL jitFillOSRBuffer (struct J9VMThread *vmContext, void *osrBlock);
 extern J9_CFUNC void  JNICALL sendRunThread(J9VMThread *vmContext, j9object_t tenantContext);
+extern J9_CFUNC void  JNICALL sendInitEncodings (J9VMThread *vmContext);
 #endif /* _J9VMJAVAINTERPRETERSTARTUP_ */
 
 /* J9VMNativeHelpersLarge*/

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -384,6 +384,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	This is a limitation of the tool as it would otherwise need to encode the class multiple times - once
 	for each combination of method flags.
 -->
+	<staticmethodref class="java/lang/System" name="initEncodings" signature="()V"/>
 	<staticmethodref class="java/lang/J9VMInternals" name="completeInitialization" signature="()V"/>
 	<staticmethodref class="java/lang/J9VMInternals" name="checkPackageAccess" signature="(Ljava/lang/Class;Ljava/security/ProtectionDomain;)V"/>
 	<staticmethodref class="java/lang/J9VMInternals" name="threadCleanup" signature="(Ljava/lang/Thread;)V"/>

--- a/runtime/util/modularityHelper.c
+++ b/runtime/util/modularityHelper.c
@@ -133,7 +133,16 @@ addUTFNameToPackage(J9VMThread *currentThread, J9Package *j9package, const char 
 	j9package->packageName = (J9UTF8*)buf;
 	packageNameLength = (UDATA) strlen(packageName);
 	if ((NULL == j9package->packageName) || ((packageNameLength + sizeof(J9UTF8) + 1) > bufLen)) {
-		j9package->packageName = j9mem_allocate_memory(packageNameLength + sizeof(J9UTF8) + 1, OMRMEM_CATEGORY_VM);
+#if defined(J9VM_OPT_SNAPSHOTS)
+		if ((NULL == buf) && IS_SNAPSHOTTING_ENABLED(vm)) {
+			VMSNAPSHOTIMPLPORT_ACCESS_FROM_JAVAVM(vm);
+			j9package->packageName = vmsnapshot_allocate_memory(packageNameLength + sizeof(J9UTF8) + 1, OMRMEM_CATEGORY_VM);
+		} else
+#endif /* defined(J9VM_OPT_SNAPSHOTS) */
+		{
+			j9package->packageName = j9mem_allocate_memory(packageNameLength + sizeof(J9UTF8) + 1, OMRMEM_CATEGORY_VM);
+		}
+
 		if (NULL == j9package->packageName) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 			return FALSE;

--- a/runtime/vm/ModularityHashTables.c
+++ b/runtime/vm/ModularityHashTables.c
@@ -139,7 +139,14 @@ hashModulePointerTableNew(J9JavaVM *javaVM, U_32 initialSize)
 {
 	U_32 flags = J9HASH_TABLE_ALLOW_SIZE_OPTIMIZATION;
 
-	return hashTableNew(OMRPORT_FROM_J9PORT(javaVM->portLibrary), J9_GET_CALLSITE(), initialSize, sizeof(void*), sizeof(void*), flags, J9MEM_CATEGORY_MODULES, modulePointerHashFn, modulePointerHashEqualFn, NULL, javaVM);
+	OMRPortLibrary* privatePortLibrary = OMRPORT_FROM_J9PORT(javaVM->portLibrary);
+#if defined(J9VM_OPT_SNAPSHOTS)
+	if (IS_SNAPSHOT_RUN(javaVM)) {
+		privatePortLibrary = VMSNAPSHOTIMPL_OMRPORT_FROM_JAVAVM(javaVM);
+	}
+#endif /* defined(J9VM_OPT_SNAPSHOTS) */
+
+	return hashTableNew(privatePortLibrary, J9_GET_CALLSITE(), initialSize, sizeof(void*), sizeof(void*), flags, J9MEM_CATEGORY_MODULES, modulePointerHashFn, modulePointerHashEqualFn, NULL, javaVM);
 }
 
 J9HashTable *

--- a/runtime/vm/callin.cpp
+++ b/runtime/vm/callin.cpp
@@ -737,6 +737,21 @@ sendCompleteInitialization(J9VMThread *currentThread)
 	Trc_VM_sendCompleteInitialization_Exit(currentThread);
 }
 
+void JNICALL
+sendInitEncodings(J9VMThread *currentThread)
+{
+	Trc_VM_sendCompleteInitialization_Entry(currentThread);
+	J9VMEntryLocalStorage newELS;
+	if (buildCallInStackFrame(currentThread, &newELS, false, true)) {
+		/* Run the method */
+		currentThread->returnValue = J9_BCLOOP_RUN_METHOD;
+		currentThread->returnValue2 = (UDATA)J9VMJAVALANGSYSTEM_INITENCODINGS_METHOD(currentThread->javaVM);
+		c_cInterpreter(currentThread);
+		restoreCallInFrame(currentThread);
+	}
+	Trc_VM_sendCompleteInitialization_Exit(currentThread);
+}
+
 static bool
 isAccessibleToAllModulesViaReflection(J9VMThread *currentThread, J9Class *clazz, bool javaBaseLoaded) {
 	J9JavaVM *vm = currentThread->javaVM;

--- a/runtime/vm/classallocation.c
+++ b/runtime/vm/classallocation.c
@@ -422,7 +422,15 @@ freeClassLoader(J9ClassLoader *classLoader, J9JavaVM *javaVM, J9VMThread *vmThre
 			packagePtr = (J9Package**)hashTableNextDo(&packageWalkState);
 			cleanPackage(packageDel);
 			hashTableFree(packageDel->exportsHashTable);
-			j9mem_free_memory(packageDel->packageName);
+#if defined(J9VM_OPT_SNAPSHOTS)
+			if (IS_SNAPSHOTTING_ENABLED(javaVM)) {
+				VMSNAPSHOTIMPLPORT_ACCESS_FROM_JAVAVM(javaVM);
+				vmsnapshot_free_memory(packageDel->packageName);
+			} else
+#endif /* defined(J9VM_OPT_SNAPSHOTS) */
+			{
+				j9mem_free_memory(packageDel->packageName);
+			}
 			pool_removeElement(javaVM->modularityPool, packageDel);
 		}
 

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -402,5 +402,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 #endif /* JAVA_SPEC_VERSION >= 15 */
 	storeFlattenableArrayElement,
 	loadFlattenableArrayElement,
-	jniIsInternalClassRef
+	jniIsInternalClassRef,
+	sendInitEncodings,
 };


### PR DESCRIPTION
Add Java11 support for snapshot/restore

Add support for persisting the module and packages. Modify the restore
sequence to not initialize classes that aren't used in Java11

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>