### PR TITLE
JDK16 VarHandle Support

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/ArrayVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ArrayVarHandle.java
@@ -119,9 +119,25 @@ final class ArrayVarHandle extends VarHandle {
 	}
 /*[ENDIF] Java12 */
 
+/*[IF Java16]*/
+	public MethodType accessModeTypeUncached(AccessType type) {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+/*[ELSE]*/
 	public MethodType accessModeTypeUncached(AccessMode accessMode) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
+/*[ENDIF] Java16 */
+
+/*[IF Java16]*/
+	public VarHandle withInvokeExactBehavior() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	public VarHandle withInvokeBehavior() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+/*[ENDIF] Java16 */
 
 	/**
 	 * Type specific methods used by array element VarHandle methods.

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ArrayVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ArrayVarHandle.java
@@ -119,26 +119,6 @@ final class ArrayVarHandle extends VarHandle {
 	}
 /*[ENDIF] Java12 */
 
-/*[IF Java16]*/
-	public MethodType accessModeTypeUncached(AccessType type) {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-	}
-/*[ELSE]*/
-	public MethodType accessModeTypeUncached(AccessMode accessMode) {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-	}
-/*[ENDIF] Java16 */
-
-/*[IF Java16]*/
-	public VarHandle withInvokeExactBehavior() {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-	}
-
-	public VarHandle withInvokeBehavior() {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-	}
-/*[ENDIF] Java16 */
-
 	/**
 	 * Type specific methods used by array element VarHandle methods.
 	 */

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
@@ -177,7 +177,23 @@ abstract class FieldVarHandle extends VarHandle {
 		return fieldName;
 	}
 
+/*[IF Java16]*/
+	public MethodType accessModeTypeUncached(AccessType type) {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+/*[ELSE]*/
 	public MethodType accessModeTypeUncached(AccessMode accessMode) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
+/*[ENDIF] Java16 */
+
+/*[IF Java16]*/
+	public VarHandle withInvokeExactBehavior() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	public VarHandle withInvokeBehavior() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+/*[ENDIF] Java16 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
@@ -176,24 +176,4 @@ abstract class FieldVarHandle extends VarHandle {
 	final String getFieldName() {
 		return fieldName;
 	}
-
-/*[IF Java16]*/
-	public MethodType accessModeTypeUncached(AccessType type) {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-	}
-/*[ELSE]*/
-	public MethodType accessModeTypeUncached(AccessMode accessMode) {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-	}
-/*[ENDIF] Java16 */
-
-/*[IF Java16]*/
-	public VarHandle withInvokeExactBehavior() {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-	}
-
-	public VarHandle withInvokeBehavior() {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-	}
-/*[ENDIF] Java16 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -357,7 +357,11 @@ public abstract class VarHandle extends VarHandleInternal
 /*[IF Java12]*/
 	private int hashCode = 0;
 /*[ENDIF] Java12 */
-	
+
+/*[IF Java16]*/
+	final boolean exact;
+/*[ENDIF] Java16 */
+
 	/**
 	 * Constructs a generic VarHandle instance. 
 	 * 
@@ -371,6 +375,9 @@ public abstract class VarHandle extends VarHandleInternal
 		this.coordinateTypes = coordinateTypes;
 		this.handleTable = handleTable;
 		this.modifiers = modifiers;
+/*[IF Java16]*/
+		this.exact = false;
+/*[ENDIF] Java16 */
 	}
 
 /*[IF Java14]*/
@@ -380,6 +387,19 @@ public abstract class VarHandle extends VarHandleInternal
 	 * @param varForm an instance of VarForm.
 	 */
 	VarHandle(VarForm varForm) {
+		this(varForm, false);
+	}
+
+	/**
+	 * Constructs a generic VarHandle instance.
+	 *
+	 * @param varForm an instance of VarForm.
+	 * @param exact has invokeExact behavior.
+	 */
+	VarHandle(VarForm varForm, boolean exact) {
+/*[IF Java16]*/
+		this.exact = exact;
+/*[ENDIF] Java16 */
 		if (varForm.memberName_table == null) {
 			/* Indirect VarHandle. */
 			MethodType getter = varForm.methodType_table[VarHandle.AccessType.GET.ordinal()];
@@ -394,7 +414,11 @@ public abstract class VarHandle extends VarHandleInternal
 			int numAccessModes = accessModes.length;
 	
 			/* The first argument in AccessType.GET MethodType is the receiver class. */
+/*[IF Java16]*/
+			Class<?> receiverActual = accessModeTypeUncached(AccessMode.GET.at).parameterType(0);
+/*[ELSE]*/
 			Class<?> receiverActual = accessModeTypeUncached(AccessMode.GET).parameterType(0);
+/*[ENDIF] Java16 */
 			Class<?> receiverVarForm = varForm.methodType_table[AccessType.GET.ordinal()].parameterType(0);
 			
 			/* Specify the exact operation method types if the actual receiver doesn't match the
@@ -759,7 +783,11 @@ public abstract class VarHandle extends VarHandleInternal
 		MethodType modifiedType = null;
 		MethodHandle internalHandle = handleTable[accessMode.ordinal()];
 		if (internalHandle == null) {
+/*[IF Java16]*/
+			modifiedType = accessModeTypeUncached(accessMode.at);
+/*[ELSE]*/
 			modifiedType = accessModeTypeUncached(accessMode);
+/*[ENDIF] Java16 */
 		} else {
 			MethodType internalType = internalHandle.type();
 			int numOfArguments = internalType.parameterCount();
@@ -862,7 +890,11 @@ public abstract class VarHandle extends VarHandleInternal
 			if (mh != null) {
 				mt = mh.type();
 			} else {
+/*[IF Java16]*/
+				mt = accessModeTypeUncached(accessMode.at);
+/*[ELSE]*/
 				mt = accessModeTypeUncached(accessMode);
+/*[ENDIF] Java16 */
 				/* accessModeTypeUncached does not return null. It throws InternalError if the method type
 				 * cannot be determined.
 				 */
@@ -1692,5 +1724,24 @@ public abstract class VarHandle extends VarHandleInternal
 	}
 /*[ENDIF] Java15 | OPENJDK_METHODHANDLES */
 
+/*[IF Java16]*/
+	abstract MethodType accessModeTypeUncached(AccessType type);
+/*[ELSE]*/
 	abstract MethodType accessModeTypeUncached(AccessMode accessMode);
+/*[ENDIF] Java16 */
+
+/*[IF Java16]*/
+	final MethodType accessModeTypeUncached(int index) {
+		return accessModeTypeUncached(AccessType.values()[index]);
+	}
+
+	public abstract VarHandle withInvokeExactBehavior();
+
+	public abstract VarHandle withInvokeBehavior();
+
+	public boolean hasInvokeExactBehavior() {
+		return exact;
+	}
+/*[ENDIF] Java16 */
+
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -387,6 +387,7 @@ public abstract class VarHandle extends VarHandleInternal
 	 * @param varForm an instance of VarForm.
 	 */
 	VarHandle(VarForm varForm) {
+/*[IF Java16]*/
 		this(varForm, false);
 	}
 
@@ -397,7 +398,6 @@ public abstract class VarHandle extends VarHandleInternal
 	 * @param exact has invokeExact behavior.
 	 */
 	VarHandle(VarForm varForm, boolean exact) {
-/*[IF Java16]*/
 		this.exact = exact;
 /*[ENDIF] Java16 */
 		if (varForm.memberName_table == null) {
@@ -414,11 +414,14 @@ public abstract class VarHandle extends VarHandleInternal
 			int numAccessModes = accessModes.length;
 	
 			/* The first argument in AccessType.GET MethodType is the receiver class. */
-/*[IF Java16]*/
-			Class<?> receiverActual = accessModeTypeUncached(AccessMode.GET.at).parameterType(0);
-/*[ELSE]*/
-			Class<?> receiverActual = accessModeTypeUncached(AccessMode.GET).parameterType(0);
-/*[ENDIF] Java16 */
+			Class<?> receiverActual = accessModeTypeUncached(
+					/*[IF Java16]*/
+					AccessMode.GET.at
+					/*[ELSE]*/
+					AccessMode.GET
+					/*[ENDIF] Java16 */
+				).parameterType(0);
+
 			Class<?> receiverVarForm = varForm.methodType_table[AccessType.GET.ordinal()].parameterType(0);
 			
 			/* Specify the exact operation method types if the actual receiver doesn't match the
@@ -783,11 +786,13 @@ public abstract class VarHandle extends VarHandleInternal
 		MethodType modifiedType = null;
 		MethodHandle internalHandle = handleTable[accessMode.ordinal()];
 		if (internalHandle == null) {
-/*[IF Java16]*/
-			modifiedType = accessModeTypeUncached(accessMode.at);
-/*[ELSE]*/
-			modifiedType = accessModeTypeUncached(accessMode);
-/*[ENDIF] Java16 */
+			modifiedType = accessModeTypeUncached(
+					/*[IF Java16]*/
+					accessMode.at
+					/*[ELSE]*/
+					accessMode
+					/*[ENDIF] Java16 */
+				);
 		} else {
 			MethodType internalType = internalHandle.type();
 			int numOfArguments = internalType.parameterCount();
@@ -890,11 +895,15 @@ public abstract class VarHandle extends VarHandleInternal
 			if (mh != null) {
 				mt = mh.type();
 			} else {
-/*[IF Java16]*/
-				mt = accessModeTypeUncached(accessMode.at);
-/*[ELSE]*/
-				mt = accessModeTypeUncached(accessMode);
-/*[ENDIF] Java16 */
+
+				mt = accessModeTypeUncached(
+						/*[IF Java16]*/
+						accessMode.at
+						/*[ELSE]*/
+						accessMode
+						/*[ENDIF] Java16 */
+					);
+
 				/* accessModeTypeUncached does not return null. It throws InternalError if the method type
 				 * cannot be determined.
 				 */
@@ -1724,20 +1733,28 @@ public abstract class VarHandle extends VarHandleInternal
 	}
 /*[ENDIF] Java15 | OPENJDK_METHODHANDLES */
 
-/*[IF Java16]*/
-	abstract MethodType accessModeTypeUncached(AccessType type);
-/*[ELSE]*/
-	abstract MethodType accessModeTypeUncached(AccessMode accessMode);
-/*[ENDIF] Java16 */
+	MethodType accessModeTypeUncached(
+		/*[IF Java16]*/
+		AccessType type
+		/*[ELSE]*/
+		AccessMode accessMode
+		/*[ENDIF] Java16 */
+	) {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
 
 /*[IF Java16]*/
 	final MethodType accessModeTypeUncached(int index) {
 		return accessModeTypeUncached(AccessType.values()[index]);
 	}
 
-	public abstract VarHandle withInvokeExactBehavior();
+	public VarHandle withInvokeExactBehavior() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
 
-	public abstract VarHandle withInvokeBehavior();
+	public VarHandle withInvokeBehavior() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
 
 	public boolean hasInvokeExactBehavior() {
 		return exact;

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -341,7 +341,13 @@ public abstract class VarHandle extends VarHandleInternal
 	static final Lookup _lookup = Lookup.IMPL_LOOKUP;
 
 /*[IF Java14]*/
-	static final BiFunction<String, List<Integer>, ArrayIndexOutOfBoundsException> AIOOBE_SUPPLIER = null;
+	static final BiFunction<String,
+				/*[IF Java16]*/
+				List<Number>,
+				/*[ELSE]*/
+				List<Integer>,
+				/*[ENDIF] Java16 */
+				ArrayIndexOutOfBoundsException> AIOOBE_SUPPLIER = null;
 	VarForm vform = null;
 /*[ENDIF] Java14 */
 	

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ViewVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ViewVarHandle.java
@@ -69,10 +69,26 @@ abstract class ViewVarHandle extends VarHandle {
 		}
 	}
 
+/*[IF Java16]*/
+	public MethodType accessModeTypeUncached(AccessType type) {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+/*[ELSE]*/
 	public MethodType accessModeTypeUncached(AccessMode accessMode) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-	
+/*[ENDIF] Java16 */
+
+/*[IF Java16]*/
+	public VarHandle withInvokeExactBehavior() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	public VarHandle withInvokeBehavior() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+/*[ENDIF] Java16 */
+
 	static class ViewVarHandleOperations extends VarHandleOperations {
 		static final char convertEndian(char value) {
 			return Character.reverseBytes(value);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ViewVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ViewVarHandle.java
@@ -69,26 +69,6 @@ abstract class ViewVarHandle extends VarHandle {
 		}
 	}
 
-/*[IF Java16]*/
-	public MethodType accessModeTypeUncached(AccessType type) {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-	}
-/*[ELSE]*/
-	public MethodType accessModeTypeUncached(AccessMode accessMode) {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-	}
-/*[ENDIF] Java16 */
-
-/*[IF Java16]*/
-	public VarHandle withInvokeExactBehavior() {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-	}
-
-	public VarHandle withInvokeBehavior() {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-	}
-/*[ENDIF] Java16 */
-
 	static class ViewVarHandleOperations extends VarHandleOperations {
 		static final char convertEndian(char value) {
 			return Character.reverseBytes(value);

--- a/runtime/jcl/CMakeLists.txt
+++ b/runtime/jcl/CMakeLists.txt
@@ -129,6 +129,7 @@ target_sources(jclse
 		${CMAKE_CURRENT_SOURCE_DIR}/common/jclreflect.c
 		${CMAKE_CURRENT_SOURCE_DIR}/common/jcltrace.c
 		${CMAKE_CURRENT_SOURCE_DIR}/common/jclvm.c
+		${CMAKE_CURRENT_SOURCE_DIR}/common/jdk_internal_misc_ScopedMemoryAccess.cpp
 		${CMAKE_CURRENT_SOURCE_DIR}/common/jithelpers.c
 		${CMAKE_CURRENT_SOURCE_DIR}/common/jniidcacheinit.c
 		${CMAKE_CURRENT_SOURCE_DIR}/common/log.c

--- a/runtime/jcl/common/jdk_internal_misc_ScopedMemoryAccess.cpp
+++ b/runtime/jcl/common/jdk_internal_misc_ScopedMemoryAccess.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "jni.h"
+#include "jcl.h"
+#include "jclglob.h"
+#include "jclprots.h"
+#include "jcl_internal.h"
+
+extern "C" {
+
+#if JAVA_SPEC_VERSION >= 16
+void JNICALL
+Java_jdk_internal_misc_ScopedMemoryAccess_registerNatives(JNIEnv *env, jclass clazz)
+{
+}
+
+jboolean JNICALL
+Java_jdk_internal_misc_ScopedMemoryAccess_closeScope0(JNIEnv *env, jobject instance, jobject scope, jobject exception)
+{
+	Assert_JCL_unimplemented();
+	return JNI_FALSE;
+}
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
+} /* extern "C" */

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -591,5 +591,7 @@ endif()
 if(NOT JAVA_SPEC_VERSION LESS 16)
 	omr_add_exports(jclse
 		Java_java_lang_ref_Reference_refersTo
+		Java_jdk_internal_misc_ScopedMemoryAccess_registerNatives
+		Java_jdk_internal_misc_ScopedMemoryAccess_closeScope0
 	)
 endif()

--- a/runtime/jcl/module.xml
+++ b/runtime/jcl/module.xml
@@ -53,6 +53,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<xi:include href="uma/se8_objects.xml"></xi:include>
 	<xi:include href="uma/se8only_objects.xml"></xi:include>
 	<xi:include href="uma/se9_objects.xml"></xi:include>
+	<xi:include href="uma/se16_objects.xml"></xi:include>
 
 	<!-- vendor_jcl.xml can contain vendor specific configuration -->
 	<xi:include href="uma/vendor_jcl.xml">
@@ -161,6 +162,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 				<include-if condition="spec.java11"/>
 			</group>
 			-->
+			<group name="se16">
+				<include-if condition="spec.java16"/>
+			</group>
 
 			<group name="vendor_jcl"/>
 

--- a/runtime/jcl/uma/se16_objects.xml
+++ b/runtime/jcl/uma/se16_objects.xml
@@ -19,8 +19,6 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-<exports group="se16">
-	<export name="Java_java_lang_ref_Reference_refersTo"/>
-	<export name="Java_jdk_internal_misc_ScopedMemoryAccess_registerNatives"/>
-	<export name="Java_jdk_internal_misc_ScopedMemoryAccess_closeScope0"/>
-</exports>
+<objects group="se16">
+	<object name="jdk_internal_misc_ScopedMemoryAccess" />
+</objects>

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1173,6 +1173,12 @@ Java_com_ibm_oti_vm_VM_markCurrentThreadAsSystemImpl(JNIEnv *env);
 #if JAVA_SPEC_VERSION >= 16
 jboolean JNICALL
 Java_java_lang_ref_Reference_refersTo(JNIEnv *env, jobject reference, jobject target);
+
+void JNICALL
+Java_jdk_internal_misc_ScopedMemoryAccess_registerNatives(JNIEnv *env, jclass clazz);
+
+jboolean JNICALL
+Java_jdk_internal_misc_ScopedMemoryAccess_closeScope0(JNIEnv *env, jobject instance, jobject scope, jobject exception);
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
 #ifdef __cplusplus


### PR DESCRIPTION
1. `abstract MethodType accessModeTypeUncached(...)`
`accessModeTypeUncached` accepts an `AccessType` instance instead of an
`AccessMode` instance as an input argument.

2. `final MethodType accessModeTypeUncached(int index)`
directs a call to
`abstract MethodType accessModeTypeUncached(...)`

3. `public abstract VarHandle withInvokeExactBehavior()`
and its implementation in concrete classes that extend the abstract
`VarHandle`.

4. `public abstract VarHandle withInvokeBehavior()`
and its implementation in concrete classes that extend the abstract
`VarHandle`.

5. `public boolean hasInvokeExactBehavior()`
returns `true` if the `VarHandle` has `invokeExact` behaviour. Otherwise, it
returns `false`.

6. `VarHandle.AIOOBE_SUPPLIER`'s second argument changes from `List<Integer>`
to `List<Number>` in JDK16.

7. Add stubs for the `ScopedMemoryAccess` native methods.

Fixes: https://github.com/eclipse/openj9/issues/11149

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>