### PR TITLE
JDK15 enable NPE extended message by default

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2150,13 +2150,14 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				j9port_control(OMRPORT_CTLDATA_VMEM_PERFORM_FULL_MEMORY_SEARCH, 0);
 			}
 
+#if JAVA_SPEC_VERSION >= 15
 			argIndex = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXSHOW_EXTENDED_NPE_MESSAGE, NULL);
 			argIndex2 = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXNOSHOW_EXTENDED_NPE_MESSAGE, NULL);
-			/* Disable NPE extended message by default */
-			if (argIndex2 < argIndex) {
+			if (argIndex2 <= argIndex) {
 				vm->requiredDebugAttributes |= J9VM_DEBUG_ATTRIBUTE_LOCAL_VARIABLE_TABLE;
 				vm->extendedRuntimeFlags2 |= J9_EXTENDED_RUNTIME2_SHOW_EXTENDED_NPEMSG;
 			}
+#endif /* JAVA_SPEC_VERSION >= 15 */
 
 			break;
 


### PR DESCRIPTION
As per earlier discussion https://github.com/eclipse/openj9/issues/10296#issuecomment-668189594
_The cost of retrieving the extended NPE message applies when NullPointerException.getMessage() is invoked, otherwise it is same as previous Java version.
If the exception is caught with no logging, there won't be any penalty._

There is no references to `NullPointerException.getMessage()` within `OpenJ9 JCL` code, there are a few `Throwable.getMessage()` which might invoke `NPE` message if the `Throwable` in question is a `NullPointerException`. 
```
MethodHandles.java
729: e.getCause().getMessage()); 
https://github.com/eclipse/openj9/blob/0aec295571c6c25927af41a629bc915c2129642e/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java#L726-L729
MethodType.java
404: NoClassDefFoundError noClassDefFoundError = new NoClassDefFoundError(cause.getMessage()); 
https://github.com/eclipse/openj9/blob/0aec295571c6c25927af41a629bc915c2129642e/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java#L403-L404
MethodTypeHelper.java
274: NoClassDefFoundError noClassDefFoundError = new NoClassDefFoundError(cause.getMessage()); 
https://github.com/eclipse/openj9/blob/0aec295571c6c25927af41a629bc915c2129642e/jcl/src/java.base/share/classes/java/lang/invoke/MethodTypeHelper.java#L273-L274
``` 
Also searched `OpenJDK` `java.base` code, there is no reference to `NullPointerException.getMessage()` either. Similarly there are references to `Throwable.getMessage()` , `Exception.getMessage()`.

Tested in person builds with this PR and no issue found.

closes #10296 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>