### PR TITLE
NullPointerException(null).getMessage() returns null

### DIFF
--- a/runtime/vm/extendedMessageNPE.cpp
+++ b/runtime/vm/extendedMessageNPE.cpp
@@ -532,11 +532,9 @@ getCompleteNPEMessage(J9VMThread *vmThread, U_8 *bcCurrentPtr, J9ROMClass *romCl
 
 			if (J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(definingClassFullQualifiedName), J9UTF8_LENGTH(definingClassFullQualifiedName), "java/lang/NullPointerException")) {
 				if (J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(methodName), J9UTF8_LENGTH(methodName), "<init>")) {
-					if (J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(methodSig), J9UTF8_LENGTH(methodSig), "()V")) {
-						/* No message generated for new NullPointerException().getMessage() */
-						npeMsgRequired = false;
-						Trc_VM_GetCompleteNPEMessage_Not_Required(vmThread);
-					}
+					/* No message generated for new NullPointerException().getMessage() or new NullPointerException(null).getMessage() */
+					npeMsgRequired = false;
+					Trc_VM_GetCompleteNPEMessage_Not_Required(vmThread);
 				}
 
 			}

--- a/test/functional/Java14andUp/src/org/openj9/test/jep358/NPEMessageTests.java
+++ b/test/functional/Java14andUp/src/org/openj9/test/jep358/NPEMessageTests.java
@@ -1015,6 +1015,8 @@ public class NPEMessageTests {
 	public void test_creation() throws Exception {
 		Assert.assertNull(new NullPointerException().getMessage(),
 				"new NullPointerException().getMessage() is not null!");
+		Assert.assertNull(new NullPointerException(null).getMessage(),
+				"new NullPointerException(null).getMessage() is not null!");
 		String npeMsg = new String("NPE creation messsage");
 		Assert.assertEquals(new NullPointerException(npeMsg).getMessage(), npeMsg);
 		Exception exception = NullPointerException.class.getDeclaredConstructor().newInstance();


### PR DESCRIPTION
`NullPointerException(null).getMessage()` should return `null`;
Added a test.

fixes #11186 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>