### PR TITLE
Purge JITServer caches sooner when memory is low

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -122,6 +122,11 @@ int32_t J9::Options::_bigAppSampleThresholdAdjust = 3; //amount to shift the hot
 int32_t J9::Options::_availableCPUPercentage = 100;
 int32_t J9::Options::_cpuCompTimeExpensiveThreshold = 4000;
 uintptr_t J9::Options::_compThreadAffinityMask = 0;
+#if defined(J9VM_OPT_JITSERVER)
+int64_t J9::Options::_oldAge = 1000*60*1000; // 1000 minutes
+int64_t J9::Options::_oldAgeUnderLowMemory = 1000*60*5; // 5 minute
+int64_t J9::Options::_timeBetweenPurges = 1000*60*1; // 1 minute
+#endif /* defined(J9VM_OPT_JITSERVER) */
 
 int32_t J9::Options::_interpreterSamplingThreshold = 300;
 int32_t J9::Options::_interpreterSamplingDivisor = TR_DEFAULT_INTERPRETER_SAMPLING_DIVISOR;
@@ -903,6 +908,12 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_numDLTBufferMatchesToEagerlyIssueCompReq, 0, "F%d", NOT_IN_SUBSET},
    {"numInterpCompReqToExitIdleMode=", "M<nnn>\tNumber of first time comp. req. that takes the JIT out of idle mode",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_numFirstTimeCompilationsToExitIdleMode, 0, "F%d", NOT_IN_SUBSET },
+#if defined(J9VM_OPT_JITSERVER)
+   {"oldAge=", " \tDefines what an old JITServer cache entry means", 
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_oldAge,  0, " %d"},
+   {"oldAgeUnderLowMemory=", " \tDefines what an old JITServer cache entry means when memory is low",
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_oldAgeUnderLowMemory,  0, " %d" },
+#endif /* defined(J9VM_OPT_JITSERVER) */
    {"profileAllTheTime=",    "R<nnn>\tInterpreter profiling will be on all the time",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_profileAllTheTime, 0, " %d", NOT_IN_SUBSET},
    {"queuedInvReqThresholdToDowngradeOptLevel=", "M<nnn>\tDowngrade opt level if too many inv req",
@@ -962,6 +973,10 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_statisticsFrequency, 0, "F%d", NOT_IN_SUBSET},
 #endif /* defined(J9VM_OPT_JITSERVER) */
    {"testMode",           "D\tcompile but do not run the compiled code",  SET_JITCONFIG_RUNTIME_FLAG(J9JIT_TESTMODE) },
+#if defined(J9VM_OPT_JITSERVER)
+   {"timeBetweenPurges=", " \tDefines how often we are willing to scan for old entries to be purged", 
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_timeBetweenPurges,  0, " %d"},
+#endif /* defined(J9VM_OPT_JITSERVER) */
 #if defined(TR_HOST_X86) || defined(TR_HOST_POWER)
    {"tlhPrefetchBoundaryLineCount=",    "O<nnn>\tallocation prefetch boundary line for allocation prefetch",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_TLHPrefetchBoundaryLineCount, 0, "P%d", NOT_IN_SUBSET},

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -257,6 +257,11 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _TLHPrefetchBoundaryLineCount;
    static int32_t _TLHPrefetchTLHEndLineCount;
    static int32_t _numFirstTimeCompilationsToExitIdleMode; // use large number to disable the feature
+#if defined(J9VM_OPT_JITSERVER)
+   static int64_t _oldAge;
+   static int64_t _oldAgeUnderLowMemory;
+   static int64_t _timeBetweenPurges;
+#endif /* defined(J9VM_OPT_JITSERVER) */
 
    static int32_t _waitTimeToEnterIdleMode;
    static int32_t _waitTimeToEnterDeepIdleMode;

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -526,9 +526,11 @@ class ClientSessionHT
    PersistentUnorderedMap<uint64_t, ClientSessionData*> _clientSessionMap;
 
    uint64_t _timeOfLastPurge;
+   TR::CompilationInfo *_compInfo;
    const int64_t TIME_BETWEEN_PURGES; // ms; this defines how often we are willing to scan for old entries to be purged
    const int64_t OLD_AGE;// ms; this defines what an old entry means
                          // This value must be larger than the expected life of a JVM
+   const int64_t OLD_AGE_UNDER_LOW_MEMORY; // ms; this defines what an old entry means when memory is low
    }; // class ClientSessionHT
 
 #endif /* defined(JIT_CLIENT_SESSION_H) */


### PR DESCRIPTION
Added variable OLD_AGE_UNDER_LOW_MEMORY to purge the Client cache at the server sooner
when memory is low. If a client didn't issue a request in more than 5 mins and memory is low, its
caches will be purged from the server.
issue: #11161

Signed-off-by: Eman Elsabban <eman.elsaban1@gmail.com>