### PR TITLE
CMake: Specify exclude directories for DDR

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -356,6 +356,21 @@ if(OMR_DDR)
 		${CMAKE_CURRENT_BINARY_DIR}/omr/gc
 		${CMAKE_CURRENT_BINARY_DIR}/omr
 	)
+
+	# Specify the directories which shouldn't be searched for debug info.
+	# Currently this is only used on zos, and has no effect elsewhere.
+	# Note: omr/ is excluded since omrddr is responsible for gathering all the
+	# omr related binaries, which we get by adding omrddr to j9ddr.
+	set_property(TARGET j9ddr PROPERTY DDR_OBJECT_EXCLUDES
+		bcutil/test/
+		compiler/
+		gc_tests/
+		jilgen/
+		omr/
+		runtimetools/
+		tests/
+	)
+
 endif()
 
 # Due to CMake technical limitations we can't properly propagate dependencies


### PR DESCRIPTION
Specify directories which are excluded when searching for debug info.
This is the same as DDR_EXCLUDED_FOLDERS from ddr/run_omrddrgen.mk.ftl.

There are some minor differences due to differences between the uma and
cmake builds.

- all of omr/ is excluded as in CMake, omr is responsible for searching
  for its own object files
- compiler/ is excluded as CMake builds generate debug info when building
  the compiler, where as UMA builds do not.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>