### PR TITLE
Enable the check for sealed classes for Java 16

### DIFF
--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -502,9 +502,10 @@ ClassFileOracle::walkAttributes()
 			break;
 		}
 		case CFR_ATTRIBUTE_PermittedSubclasses: {
-			/* PermittedSubclasses verification is for Java 15 preview only. Don't record the attribute for other class versions
-			 * since it may be corrupt. */
-			if ((59 == _classFile->majorVersion) && (0 < _classFile->minorVersion)) {
+			/* PermittedSubclasses verification is for Java version >= 15 */
+			if ((_classFile->majorVersion > 59)
+			|| ((59 == _classFile->majorVersion) && (65535 == _classFile->minorVersion))
+			) {
 				_isSealed = true;
 				_permittedSubclassesAttribute = (J9CfrAttributePermittedSubclasses *)attrib;
 				for (U_16 numberOfClasses = 0; numberOfClasses < _permittedSubclassesAttribute->numberOfClasses; numberOfClasses++) {

--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -2376,8 +2376,10 @@ checkAttributes(J9PortLibrary* portLib, J9CfrClassFile* classfile, J9CfrAttribut
 			break;
 
 		case CFR_ATTRIBUTE_PermittedSubclasses:
-			/* PermittedSubclasses verification is for Java 15 preview only. */
-			if ((59 == classfile->majorVersion) && (0 < classfile->minorVersion)) {
+			/* PermittedSubclasses verification is for Java version >= 15 */
+			if ((classfile->majorVersion > 59) 
+			|| ((59 == classfile->majorVersion) && (65535 == classfile->minorVersion))
+			) {
 				enablePermittedSubclassErrors = TRUE;
 			}
 


### PR DESCRIPTION
The change is enable the check for sealed classes
for Java 16 during the static verification.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>