### PR TITLE
Include JAVA_VENDOR, J9PRODUCT_NAME, J9JDK_EXT_VERSION in javacore

### DIFF
--- a/runtime/include/vendor_version.h
+++ b/runtime/include/vendor_version.h
@@ -20,10 +20,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/* This file provides a means to supply vendor specific version info such as 
- * short name, SHA, and version string.
+/* This file provides a means to supply vendor specific version info such as
+ * vendor name, short name, SHA, and version string.
  * These vendor version info can be defined either in this file or other places.
- * 
+ *
  * Example usage for inclusion of a vendor name and repository sha.  These values
  * will be inserted into the java.fullversion and java.vm.info system properties
  * and in a generated javacore file.
@@ -51,15 +51,5 @@
 
 #define JAVA_VM_VENDOR "Eclipse OpenJ9"
 #define JAVA_VM_NAME "Eclipse OpenJ9 VM"
-
-#if JAVA_SPEC_VERSION < 12
-/* Pre-JDK12 versions use following defines to set system properties
- * java.vendor and java.vendor.url within vmprop.c:initializeSystemProperties(vm).
- * JDK12 (assuming future versions as well) sets these properties via java.lang.VersionProps.init(systemProperties) 
- * and following settings within System.ensureProperties().
- */
-#define JAVA_VENDOR "Eclipse OpenJ9"
-#define JAVA_VENDOR_URL "http://www.eclipse.org/openj9"
-#endif /* JAVA_SPEC_VERSION < 12 */
 
 #endif     /* vendor_version_h */

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -1029,6 +1029,15 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 	_OutputStream.writeCharacters("1CIJCLVERSION  " OPENJDK_SHA " based on " OPENJDK_TAG "\n");
 #endif
 
+	/* Write the vendor, product name, and extension version */
+	_OutputStream.writeCharacters("1CIVENDOR      " JAVA_VENDOR "\n");
+#if defined(J9PRODUCT_NAME)
+	_OutputStream.writeCharacters("1CIPRODUCT     " J9PRODUCT_NAME "\n");
+#endif /* defined(J9PRODUCT_NAME) */
+#if defined(J9JDK_EXT_VERSION)
+	_OutputStream.writeCharacters("1CIEXTVERSION  " J9JDK_EXT_VERSION "\n");
+#endif /* defined(J9JDK_EXT_VERSION) */
+
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 	_OutputStream.writeCharacters("1CIJITMODES    ");
 


### PR DESCRIPTION
These defines are set by openj9_version_info.h from the extensions.

Depends on
https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/462
https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/364
https://github.com/ibmruntimes/openj9-openjdk-jdk15/pull/44
https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/251