### PR TITLE
Remove dup cleanWs command on Win/zOS

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -59,7 +59,6 @@ def get_sources() {
     // Temp workaround for Windows clones
     // See #3633 and JENKINS-54612
     if (NODE_LABELS.contains("windows") || NODE_LABELS.contains("zos")) {
-        cleanWs()
 
         CLONE_CMD = "git clone -b ${OPENJDK_BRANCH} ${OPENJDK_REPO} ."
         if (OPENJDK_REFERENCE_REPO) {


### PR DESCRIPTION
We already to a cleanWs on all platforms in biild_all
See #10834

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>