### PR TITLE
Resolve issues when restoring with -Xjit

### DIFF
--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -669,12 +669,7 @@ TR_RuntimeAssumptionTable::serialize(J9JITConfig *jitConfig)
                owningMetadata->runtimeAssumptionList = NULL;
                buffer += size;
 
-               OMR::RuntimeAssumption *next = cursor->getNext();
-
-               cursor->dequeueFromListOfAssumptionsForJittedBody();
-               TR_PersistentMemory::jitPersistentFree(cursor);
-
-               cursor = next;
+               cursor = cursor->getNext();
                }
             }
          }

--- a/runtime/compiler/runtime/MethodMetaData.c
+++ b/runtime/compiler/runtime/MethodMetaData.c
@@ -369,7 +369,12 @@ static void fastwalkDebug(J9TR_MethodMetaData * methodMetaData, UDATA offsetPC, 
    else
       {
       UDATA fourByteOffsets = HAS_FOUR_BYTE_OFFSET(methodMetaData);
+#if defined(J9VM_OPT_SNAPSHOTS)
+      J9JITStackAtlas * stackAtlas = J9JITEXCEPTIONTABLE_GCSTACKATLAS_GET(methodMetaData);
+#else /* defined(J9VM_OPT_SNAPSHOTS) */
       J9JITStackAtlas * stackAtlas = (J9JITStackAtlas *) methodMetaData->gcStackAtlas;
+#endif /* defined(J9VM_OPT_SNAPSHOTS) */
+
       void * stackMap1 = 0;
       void * inlineMap1 = 0;
       void * stackMap2 = 0;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5034,6 +5034,10 @@ typedef struct J9VMThread {
 #endif /* OMR_GC_COMPRESSED_POINTERS */
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 	UDATA safePointCount;
+#if defined(J9VM_OPT_SNAPSHOTS)
+	/* BP for the native special frame used when restoring a Java app thread */
+	UDATA *restoreThreadBP;
+#endif /* defined(J9VM_OPT_SNAPSHOTS) */
 } J9VMThread;
 
 #define J9VMTHREAD_ALIGNMENT  0x100

--- a/runtime/oti/j9vm.hdf
+++ b/runtime/oti/j9vm.hdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2006, 2019 IBM Corp. and others
+Copyright (c) 2006, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1298,5 +1298,12 @@ typedef UDATA (* lookupNativeAddressCallback)(struct J9VMThread *currentThread, 
 		<struct>J9VMRuntimeStateChanged</struct>
 		<data type="struct J9VMThread*" name="vmThread" description="current thread" />
 		<data type="U_32" name="state" description="the VM runtime state" />
+	</event>
+	
+	<event>
+		<name>J9HOOK_TRIGGER_SNAPSHOT</name>
+		<description>Triggered just before a snapshot image is about to be written to file. Current thread will have exclusive VM access</description>
+		<struct>J9TriggerSnapshot</struct>
+		<data type="struct J9VMThread*" name="currentThread" description="current thread" />
 	</event>
 </interface>


### PR DESCRIPTION
Resolve issue when restoring with -Xjit

`promotedMethodOnTransitionFromJIT` clobbers the tempslot which is used
to store the restore BP for the thread.

RuntimeAssumptions are serialized at JVM shutdown, need to serialize
them at image gen time.

This PR enables -Xjit as long as direct to JNI is disabled:

Snapshot:
`/java -Xjit:disableDirectToJNI -Xmx16m -Xms8m -Xgcpolicy:optthruput -Xshare:off -Xsnapshot:file=image,trigger=Hello.snapshot -cp ~/. Hello`

Restore:
`./java -Xjit:disableDirectToJNI -Xmx16m -Xms9m -Xgcpolicy:optthruput -Xshare:off -Xrestore:file=image -cp ~/. Hello`



Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>