### PR TITLE
WIP: Create Shared Cache earlyinit/earlystartup routine

### DIFF
--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -415,7 +415,7 @@ SH_CacheMap::sanityWalkROMClassSegment(J9VMThread* currentThread, SH_CompositeCa
 	Trc_SHR_CM_sanityWalkROMClassSegment_ExitOK(currentThread);
 	return 1;
 }
-	
+
 /**
  * Start up this CacheMap. Should be called after initialization.
  * Sets up access to (or creates) the shared cache and registers it as a ROMClassSegment with the vm.
@@ -497,8 +497,12 @@ SH_CacheMap::startup(J9VMThread* currentThread, J9SharedClassPreinitConfig* pico
 			 	 * remove AUTOKILL so that we start up with the existing cache */
 				*runtimeFlags &= ~J9SHR_RUNTIMEFLAG_AUTOKILL_DIFF_BUILDID;
 			}
+	
+			rc = ccToUse->earlystartup(currentThread, piconfig, cacheMemoryUT, runtimeFlags, _verboseFlags, _cacheName, cacheDirName, cacheDirPerm, true);
+			if (rc == CC_STARTUP_OK) {
+				rc = ccToUse->startup(currentThread, piconfig, cacheMemoryUT, &_actualSize, &_localCrashCntr, true, cacheHasIntegrity);
+			}
 
-			rc = ccToUse->startup(currentThread, piconfig, cacheMemoryUT, runtimeFlags, _verboseFlags, _cacheName, cacheDirName, cacheDirPerm, &_actualSize, &_localCrashCntr, true, cacheHasIntegrity);
 			if (rc == CC_STARTUP_OK) {
 				if (sanityWalkROMClassSegment(currentThread, ccToUse) == 0) {
 					rc = CC_STARTUP_CORRUPT;

--- a/runtime/shared_common/CacheMap.hpp
+++ b/runtime/shared_common/CacheMap.hpp
@@ -87,7 +87,11 @@ public:
 
 	static UDATA getRequiredConstrBytes(bool startupForStats);
 
-	IDATA startup(J9VMThread* currentThread, J9SharedClassPreinitConfig* piconfig, const char* rootName, const char* cacheDirName, UDATA cacheDirPerm, BlockPtr cacheMemoryUT, bool* cacheHasIntegrity);
+	IDATA earlystartup(J9VMThread* currentThread, J9SharedClassPreinitConfig* piconfig, const char* rootName, const char* cacheDirName, UDATA cacheDirPerm, BlockPtr cacheMemoryUT);
+
+	IDATA startup(J9VMThread* currentThread, J9SharedClassPreinitConfig* piconfig, UDATA cacheDirPerm, BlockPtr cacheMemoryUT, bool* cacheHasIntegrity);
+
+	IDATA oldstartup(J9VMThread* currentThread, J9SharedClassPreinitConfig* piconfig, const char* rootName, const char* cacheDirName, UDATA cacheDirPerm, BlockPtr cacheMemoryUT, bool* cacheHasIntegrity);
 
 	/* @see SharedCache.hpp */
 	virtual IDATA enterLocalMutex(J9VMThread* currentThread, omrthread_monitor_t monitor, const char* name, const char* caller);

--- a/runtime/shared_common/CompositeCacheImpl.hpp
+++ b/runtime/shared_common/CompositeCacheImpl.hpp
@@ -83,8 +83,11 @@ public:
 
 	static SH_CompositeCacheImpl* newInstance(J9JavaVM* vm, J9SharedClassConfig* sharedClassConfig, SH_CompositeCacheImpl* memForConstructor, const char* cacheName, I_32 newPersistentCacheReqd, bool startupForStats, I_8 layer);
 	
-	IDATA startup(J9VMThread* currentThread, J9SharedClassPreinitConfig* piconfig, BlockPtr cacheMemoryUT, U_64* runtimeFlags, UDATA verboseFlags,
-			const char* rootName, const char* ctrlDirName, UDATA cacheDirPerm, U_32* actualSize, UDATA* localCrashCntr, bool isFirstStart, bool* cacheHasIntegrity);
+	IDATA earlystartup(J9VMThread* currentThread, J9SharedClassPreinitConfig* piconfig, BlockPtr cacheMemoryUT, U_64* runtimeFlags, UDATA verboseFlags,
+			const char* rootName, const char* ctrlDirName, UDATA cacheDirPerm, bool isFirstStart);
+
+	IDATA startup(J9VMThread* currentThread, J9SharedClassPreinitConfig* piconfig, BlockPtr cacheMemoryUT, U_32* actualSize,
+		UDATA* localCrashCntr, bool isFirstStart, bool *cacheHasIntegrity);
 
 	void cleanup(J9VMThread* currentThread);
 
@@ -482,6 +485,8 @@ private:
 	bool _reduceStoreContentionDisabled;
 
 	bool _initializingNewCache;
+
+	J9PortShcVersion _versionData;
 
 	UDATA  _minimumAccessedShrCacheMetadata;
 

--- a/runtime/shared_common/OSCachesysv.cpp
+++ b/runtime/shared_common/OSCachesysv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2894,7 +2894,10 @@ SH_OSCachesysv::restoreFromSnapshot(J9JavaVM* vm, const char* cacheName, UDATA n
 				vm->sharedClassConfig->runtimeFlags |= J9SHR_RUNTIMEFLAG_RESTORE_CHECK;
 				/* free memory allocated by SH_OSCachesysv::startup() */
 				cleanup();
-				rc = cm->startup(currentThread, piconfig, cacheName, ctrlDirName, vm->sharedCacheAPI->cacheDirPerm, NULL, &cacheHasIntegrity);
+				rc = cm->earlystartup(currentThread, piconfig, cacheName, ctrlDirName, vm->sharedCacheAPI->cacheDirPerm, NULL);
+				if (0 == rc)
+					rc = cm->startup(currentThread, piconfig, vm->sharedCacheAPI->cacheDirPerm, NULL, &cacheHasIntegrity);
+
 				/* verboseFlags might be set to 0 in cm->startup(), set it again to ensure the NLS can be printed out */
 				_verboseFlags = vm->sharedClassConfig->verboseFlags;
 				if (0 == rc) {

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -3437,7 +3437,9 @@ j9shr_init(J9JavaVM *vm, UDATA loadFlags, UDATA* nonfatal)
 			}
 		}
 	} else {
-		rcStartup = cm->startup(currentThread, piconfig, cacheName, ctrlDirName, vm->sharedCacheAPI->cacheDirPerm, NULL, &cacheHasIntegrity);
+		rcStartup = cm->earlystartup(currentThread, piconfig, cacheName, ctrlDirName, vm->sharedCacheAPI->cacheDirPerm, NULL);
+		if (rcStartup == 0)
+			rcStartup = cm->startup(currentThread, piconfig, vm->sharedCacheAPI->cacheDirPerm, NULL, &cacheHasIntegrity);
 	}
 
 	if (rcStartup != 0) {

--- a/runtime/tests/shared/AttachedDataTest.cpp
+++ b/runtime/tests/shared/AttachedDataTest.cpp
@@ -297,8 +297,10 @@ AttachedDataTest::openTestCache(J9JavaVM* vm, BlockPtr preallocatedCache, UDATA 
 	memset(memory, 0, cacheMapSize);
 
 	cacheMap = SH_CacheMap::newInstance(vm, sharedClassConfig, (SH_CacheMap*)memory, "attacheddatacache", cacheType);
-
-	rc = cacheMap->startup(currentThread, piConfig, "attacheddatacache", NULL, J9SH_DIRPERM_ABSENT, cacheMemory, &cacheHasIntegrity);
+	// rc = cacheMap->startup(currentThread, piConfig, "attacheddatacache", NULL, J9SH_DIRPERM_ABSENT, cacheMemory, &cacheHasIntegrity);
+	rc = cacheMap->earlystartup(currentThread, piConfig, "attacheddatacache", NULL, J9SH_DIRPERM_ABSENT, cacheMemory);
+	if (0 == rc)
+		rc = cacheMap->startup(currentThread, piConfig, J9SH_DIRPERM_ABSENT, cacheMemory, &cacheHasIntegrity);
 	if (0 != rc) {
 		ERRPRINTF("openTestCache: CacheMap.startup() failed");
 		rc = FAIL;

--- a/runtime/tests/shared/ByteDataTest.cpp
+++ b/runtime/tests/shared/ByteDataTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -189,7 +189,10 @@ SH_CacheMap* createTestCache(J9JavaVM* vm, UDATA size, char* existingCache, char
 		cache = existingCache;
 	}
 	bool cacheHasIntegrity;
-	rc = returnVal->startup(vm->mainThread, sharedpiConfig, "Root1", NULL, J9SH_DIRPERM_ABSENT, cache, &cacheHasIntegrity);
+	rc = returnVal->earlystartup(vm->mainThread, sharedpiConfig, "Root1", NULL, J9SH_DIRPERM_ABSENT, cache);
+	if (rc == 0)
+		rc = returnVal->startup(vm->mainThread, sharedpiConfig, J9SH_DIRPERM_ABSENT, cache, &cacheHasIntegrity);
+	// rc = returnVal->startup(vm->mainThread, sharedpiConfig, "Root1", NULL, J9SH_DIRPERM_ABSENT, cache, &cacheHasIntegrity);
 	if (rc != 0) {
 		return NULL;
 	}

--- a/runtime/tests/shared/CompiledMethodTest.cpp
+++ b/runtime/tests/shared/CompiledMethodTest.cpp
@@ -203,8 +203,10 @@ IDATA storeAndFindTest(J9JavaVM* vm)
 	cacheObject1 = SH_CacheMap::newInstance(vm, sharedConfig, (SH_CacheMap*)cacheObjectMemory1, "cache1", 0);
 
   	/* Start the cache object */
-
-	rc = cacheObject1->startup(vm->mainThread, sharedpiConfig, "Root1", NULL, J9SH_DIRPERM_ABSENT, cache, &cacheHasIntegrity);
+	// rc = cacheObject1->startup(vm->mainThread, sharedpiConfig, "Root1", NULL, J9SH_DIRPERM_ABSENT, cache, &cacheHasIntegrity);
+	rc = cacheObject1->earlystartup(vm->mainThread, sharedpiConfig, "Root1", NULL, J9SH_DIRPERM_ABSENT, cache);
+	if (0 == rc)
+		rc = cacheObject1->startup(vm->mainThread, sharedpiConfig, J9SH_DIRPERM_ABSENT, cache, &cacheHasIntegrity);
 
 	/* Report progress so far */
 	INFOPRINTF5("Store And Find Test cos=%d cs=%d co=%x cba=%x rc=%d\n", cacheObjectSize, sharedpiConfig->sharedClassCacheSize, cacheObject1, cache, rc);
@@ -320,8 +322,9 @@ IDATA storeAndFindTest(J9JavaVM* vm)
 	cacheObject2 = SH_CacheMap::newInstance(vm, sharedConfig, (SH_CacheMap*)cacheObjectMemory2, "cache1", 0);
 
 	/* Start the cache object */
-	rc = cacheObject2->startup(vm->mainThread, sharedpiConfig, "Root1", NULL, J9SH_DIRPERM_ABSENT, cache, &cacheHasIntegrity);
-
+	rc = cacheObject2->earlystartup(vm->mainThread, sharedpiConfig, "Root1", NULL, J9SH_DIRPERM_ABSENT, cache);
+	if (0 == rc)
+		rc = cacheObject2->startup(vm->mainThread, sharedpiConfig, J9SH_DIRPERM_ABSENT, cache, &cacheHasIntegrity);
 	if (0 != rc) {
 		ERRPRINTF("Failed to startup cacheObject2\n");
 		rc = FAIL;

--- a/runtime/tests/shared/CompositeCacheSizesTests.cpp
+++ b/runtime/tests/shared/CompositeCacheSizesTests.cpp
@@ -80,7 +80,13 @@ createTestCompositeCache (J9JavaVM* vm, SH_CompositeCacheImpl** cc, J9SharedClas
 	/*Request non-persistent cache */
 	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myRoot", false, false, 0);
 	cache = (char*)((char*)actualCC + requiredBytes);
-	if (actualCC->startup(vm->mainThread, piconfig, cache, &runtimeFlags, 1, "myRoot", NULL, J9SH_DIRPERM_ABSENT, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity) != 0) {
+
+	IDATA rc;
+	rc = actualCC->earlystartup(vm->mainThread, piconfig, cache, &runtimeFlags, 1, "myRoot", NULL, J9SH_DIRPERM_ABSENT, true);
+	if (rc == 0) {
+		rc = actualCC->startup(vm->mainThread, piconfig, cache, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity);
+	}
+	if (rc != 0) {
 		ERRPRINTF(("Failed to start the composite cache.\n"));
 		*cc = actualCC;
 		return TEST_ERROR;
@@ -353,7 +359,14 @@ test4(J9JavaVM* vm)
 	cache = (char*)((char*)actualCC + requiredBytes);
 
 	runtimeFlags = J9SHR_RUNTIMEFLAG_ENABLE_REDUCE_STORE_CONTENTION;
-	if (actualCC->startup(vm->mainThread, &piconfig, cache, &runtimeFlags, 1, "myRoot", NULL, J9SH_DIRPERM_ABSENT, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity) != 0) {
+
+	IDATA rc;
+	rc = actualCC->earlystartup(vm->mainThread, &piconfig, cache, &runtimeFlags, 1, "myRoot", NULL, J9SH_DIRPERM_ABSENT, true);
+	if (rc == 0) {
+		rc = actualCC->startup(vm->mainThread, &piconfig, cache, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity);
+	}
+
+	if (rc != 0) {
 		ERRPRINTF(("Could not start cache initially\n"));
 		retval = TEST_ERROR;
 		goto done;

--- a/runtime/tests/shared/CompositeCacheTest.cpp
+++ b/runtime/tests/shared/CompositeCacheTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,7 +92,14 @@ CompositeCacheTest::createTest(J9JavaVM* vm, IDATA testCacheSize, SH_CompositeCa
 	/* Currently requests non-persistent cache */
 	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myRoot", false, false, 0);
 	cache = (char*)((char*)actualCC + requiredBytes);
-	if (actualCC->startup(vm->mainThread, piconfig, cache, runtimeFlags1, 1, "myRoot", NULL, J9SH_DIRPERM_ABSENT, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity) != 0) {
+
+	IDATA rc;
+	rc = actualCC->earlystartup(vm->mainThread, piconfig, cache, runtimeFlags1, 1, "myRoot", NULL, J9SH_DIRPERM_ABSENT, true);
+	if (rc == 0) {
+		rc = actualCC->startup(vm->mainThread, piconfig, cache, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity);
+	}
+
+	if (rc != 0) {
 		return 2;
 	}
 	if (cacheSize != SMALL_CACHE_SIZE) {
@@ -108,7 +115,13 @@ CompositeCacheTest::createTest(J9JavaVM* vm, IDATA testCacheSize, SH_CompositeCa
 	memset((void*)memForCC, 0, totalSize);
 	/* Currently requests non-persistent cache */
 	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myRoot", false, false, 0);
-	if (actualCC->startup(vm->mainThread, piconfig, cache, runtimeFlags1, 1, "myRoot", NULL, J9SH_DIRPERM_ABSENT, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity) != 0) {
+
+	rc = actualCC->earlystartup(vm->mainThread, piconfig, cache, runtimeFlags1, 1, "myRoot", NULL, J9SH_DIRPERM_ABSENT, true);
+	if (rc == 0) {
+		rc = actualCC->startup(vm->mainThread, piconfig, cache, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity);
+	}
+
+	if (rc != 0) {
 		return 5;
 	}
 	totalSize = actualCC->getTotalUsableCacheSize();
@@ -129,7 +142,12 @@ CompositeCacheTest::createTest(J9JavaVM* vm, IDATA testCacheSize, SH_CompositeCa
 	/* Currently requests non-persistent cache */
 	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myCache1", false, false, 0);
 	cache = (char*)((char*)actualCC + requiredBytes);
-	if (actualCC->startup(vm->mainThread, piconfig, cache, runtimeFlags1, 1, "myCache1", NULL, J9SH_DIRPERM_ABSENT, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity) != 0) {
+
+	rc = actualCC->earlystartup(vm->mainThread, piconfig, cache, runtimeFlags1, 1, "myCache1", NULL, J9SH_DIRPERM_ABSENT, true);
+	if (rc == 0) {
+		rc = actualCC->startup(vm->mainThread, piconfig, cache, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity);
+	}
+	if (rc != 0) {
 		return 8;
 	}
 	*cc1 = actualCC;
@@ -140,7 +158,12 @@ CompositeCacheTest::createTest(J9JavaVM* vm, IDATA testCacheSize, SH_CompositeCa
 	}
 	/* Currently requests non-persistent cache */
 	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myCache1a", false, false, 0);
-	if (actualCC->startup(vm->mainThread, piconfig, cache, runtimeFlags0, 1, "myCache1a", NULL, J9SH_DIRPERM_ABSENT, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity) != 0) {
+
+	rc = actualCC->earlystartup(vm->mainThread, piconfig, cache, runtimeFlags0, 1, "myCache1a", NULL, J9SH_DIRPERM_ABSENT, true);
+	if (rc == 0) {
+		rc = actualCC->startup(vm->mainThread, piconfig, cache, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity);
+	}
+	if (rc != 0) {
 		return 10;
 	}
 	*cc1a = actualCC;
@@ -152,7 +175,12 @@ CompositeCacheTest::createTest(J9JavaVM* vm, IDATA testCacheSize, SH_CompositeCa
 	/* Currently requests non-persistent cache */
 	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myCache2", false, false, 0);
 	cache = (char*)((char*)actualCC + requiredBytes);
-	if (actualCC->startup(vm->mainThread, piconfig, cache, runtimeFlags1, 1, "myCache2", NULL, J9SH_DIRPERM_ABSENT, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity) != 0) {
+
+	rc = actualCC->earlystartup(vm->mainThread, piconfig, cache, runtimeFlags1, 1, "myCache2", NULL, J9SH_DIRPERM_ABSENT, true);
+	if (rc == 0) {
+		rc = actualCC->startup(vm->mainThread, piconfig, cache, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity);
+	}
+	if (rc != 0) {
 		return 12;
 	}
 	*cc2 = actualCC;
@@ -163,7 +191,11 @@ CompositeCacheTest::createTest(J9JavaVM* vm, IDATA testCacheSize, SH_CompositeCa
 	}
 	/* Currently requests non-persistent cache */
 	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myCache2a", false, false, 0);
-	if (actualCC->startup(vm->mainThread, piconfig, cache, runtimeFlags0, 1, "myCache2a", NULL, J9SH_DIRPERM_ABSENT, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity) != 0) {
+	rc = actualCC->earlystartup(vm->mainThread, piconfig, cache, runtimeFlags0, 1, "myCache2a", NULL, J9SH_DIRPERM_ABSENT, true);
+	if (rc == 0) {
+		rc = actualCC->startup(vm->mainThread, piconfig, cache, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity);
+	}
+	if (rc != 0) {
 		return 14;
 	}
 	*cc2a = actualCC;

--- a/runtime/tests/shared/CorruptCacheTest.cpp
+++ b/runtime/tests/shared/CorruptCacheTest.cpp
@@ -446,7 +446,10 @@ CorruptCacheTest::openTestCache(J9JavaVM *vm, I_32 cacheType, I_32 cacheSize, U_
 	sharedClassConfig->runtimeFlags |= J9SHR_RUNTIMEFLAG_DISABLE_CORRUPT_CACHE_DUMPS;
 	sharedClassConfig->sharedClassCache = (void*)cacheMap;
 
-	rc = cacheMap->startup(vm->mainThread, piConfig, BROKEN_TEST_CACHE, NULL, J9SH_DIRPERM_ABSENT, NULL, &cacheHasIntegrity);
+	// rc = cacheMap->oldstartup(vm->mainThread, piConfig, BROKEN_TEST_CACHE, NULL, J9SH_DIRPERM_ABSENT, NULL, &cacheHasIntegrity);
+	rc = cacheMap->earlystartup(vm->mainThread, piConfig, BROKEN_TEST_CACHE, NULL, J9SH_DIRPERM_ABSENT, NULL);
+	if (0 == rc)
+		rc = cacheMap->startup(vm->mainThread, piConfig, J9SH_DIRPERM_ABSENT, NULL, &cacheHasIntegrity);
 	if (startupWillFail) {
 		if (0 == rc) {
 			ERRPRINTF("CacheMap.startup() passed when a fail was expected\n");

--- a/runtime/tests/shared/OpenCacheHelper.cpp
+++ b/runtime/tests/shared/OpenCacheHelper.cpp
@@ -197,7 +197,10 @@ OpenCacheHelper::openTestCache(I_32 cacheType, I_32 cacheSize, const char *cache
 			cacheDirPerm = J9SH_DIRPERM_ABSENT_GROUPACCESS;
 		}
 	}
-	rc = cacheMap->startup(vm->mainThread, piConfig, this->cacheName, this->cacheDir, cacheDirPerm, cacheMemory, &cacheHasIntegrity);
+	// rc = cacheMap->startup(vm->mainThread, piConfig, this->cacheName, this->cacheDir, cacheDirPerm, cacheMemory, &cacheHasIntegrity);
+	rc = cacheMap->earlystartup(vm->mainThread, piConfig, this->cacheName, this->cacheDir, cacheDirPerm, cacheMemory);
+	if (0 == rc)
+		rc = cacheMap->startup(vm->mainThread, piConfig, cacheDirPerm, cacheMemory, &cacheHasIntegrity);
 	if (true == startupWillFail) {
 		if (0 == rc) {
 			ERRPRINTF("CacheMap.startup() passed when a fail was expected");

--- a/runtime/tests/shared/SharedCacheAPITest.cpp
+++ b/runtime/tests/shared/SharedCacheAPITest.cpp
@@ -148,7 +148,10 @@ createTestCache(J9JavaVM* vm, J9SharedClassPreinitConfig *piconfig, J9SharedClas
 
 		bool cacheHasIntegrity;
 		UnitTest::unitTest = UnitTest::SHAREDCACHE_API_TEST;
-		rc = cacheMap[i]->startup(vm->mainThread, piconfig, cacheInfoList[i].name, cacheInfoList[i].cacheDir, J9SH_DIRPERM_ABSENT, NULL, &cacheHasIntegrity);
+		// rc = cacheMap[i]->startup(vm->mainThread, piconfig, cacheInfoList[i].name, cacheInfoList[i].cacheDir, J9SH_DIRPERM_ABSENT, NULL, &cacheHasIntegrity);
+		rc = cacheMap[i]->earlystartup(vm->mainThread, piconfig, cacheInfoList[i].name, cacheInfoList[i].cacheDir, J9SH_DIRPERM_ABSENT, NULL);
+		if (0 == rc)
+			rc = cacheMap[i]->startup(vm->mainThread, piconfig, J9SH_DIRPERM_ABSENT, NULL, &cacheHasIntegrity);
 		UnitTest::unitTest = UnitTest::NO_TEST;
 		if (rc != 0) {
 			j9tty_printf(PORTLIB, "CacheMap.startup() failed\n");

--- a/runtime/tests/shared/StartupHintsTest.cpp
+++ b/runtime/tests/shared/StartupHintsTest.cpp
@@ -174,8 +174,10 @@ IDATA storeAndFindHintsTest(J9JavaVM* vm)
 
   	/* Start the cache object */
 
-	rc = cacheObject->startup(currentThread, sharedpiConfig, "Root1", NULL, J9SH_DIRPERM_ABSENT, cache, &cacheHasIntegrity);
-
+	// rc = cacheObject->startup(currentThread, sharedpiConfig, "Root1", NULL, J9SH_DIRPERM_ABSENT, cache, &cacheHasIntegrity);
+	rc = cacheObject->earlystartup(currentThread, sharedpiConfig, "Root1", NULL, J9SH_DIRPERM_ABSENT, cache);
+	if (0 == rc)
+		rc = cacheObject->startup(currentThread, sharedpiConfig, J9SH_DIRPERM_ABSENT, cache, &cacheHasIntegrity);
 	/* Report progress so far */
 	INFOPRINTF5("Store And Find Hints Test cos=%d cs=%d co=%x cba=%x rc=%d\n", cacheObjectSize, sharedpiConfig->sharedClassCacheSize, cacheObject, cache, rc);
 	if (0 != rc) {


### PR DESCRIPTION
- Step 1: Split SH_CompositeCacheImpl::startup() into SH_CompositeCacheImpl::earlystartup() and SH_CompositeCacheImpl::startup()

Issue: https://github.com/eclipse/openj9/pull/11232

Signed-off-by: Harry Yu <harryyu1994@gmail.com>