### PR TITLE
Enable Value Type support for JITServer

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -25,6 +25,7 @@
 #include "control/CompilationRuntime.hpp"
 #include "control/CompilationThread.hpp"
 #include "control/JITServerHelpers.hpp"
+#include "runtime/JITClientSession.hpp"
 #endif /* defined(J9VM_OPT_JITSERVER) */
 #include "env/ClassEnv.hpp"
 #include "env/CompilerEnv.hpp"
@@ -583,13 +584,40 @@ static void addEntryForField(TR_VMField *field, TR::TypeLayoutBuilder &tlb, TR::
 const TR::TypeLayout*
 J9::ClassEnv::enumerateFields(TR::Region &region, TR_OpaqueClassBlock *opaqueClazz, TR::Compilation *comp)
    {
-   TR_VMFieldsInfo fieldsInfo(comp, reinterpret_cast<J9Class*>(opaqueClazz), 1, stackAlloc);
-   ListIterator<TR_VMField> iter(fieldsInfo.getFields());
    TR::TypeLayoutBuilder tlb(region);
-   for (TR_VMField *field = iter.getFirst(); field; field = iter.getNext())
+#if defined(J9VM_OPT_JITSERVER)
+   if (comp->isOutOfProcessCompilation())
       {
-      addEntryForField(field, tlb, region, opaqueClazz, comp);
+      auto stream = TR::CompilationInfo::getStream();
+      stream->write(JITServer::MessageType::ClassEnv_enumerateFields, opaqueClazz);
+      auto recv = stream->read<std::vector<TR::TypeLayoutEntry>, std::vector<std::string>, std::vector<std::string>>();
+      auto entries = std::get<0>(recv);
+      auto fieldNames = std::get<1>(recv);
+      auto typeSignatures = std::get<2>(recv);
+      for (int32_t idx = 0; idx < entries.size(); ++idx)
+         {
+         TR::TypeLayoutEntry entry = entries[idx];
+         char *fieldname = new (region) char[fieldNames[idx].length() + 1];
+         memcpy(fieldname, fieldNames[idx].c_str(), fieldNames[idx].length() + 1);
+         entry._fieldname = fieldname;
+         char *typeSignature = new (region) char[typeSignatures[idx].length() + 1];
+         memcpy(typeSignature, typeSignatures[idx].c_str(), typeSignatures[idx].length() + 1);
+         entry._typeSignature = typeSignature;
+         tlb.add(entry);
+         }
+
       }
+   else
+#endif
+      {
+      TR_VMFieldsInfo fieldsInfo(comp, reinterpret_cast<J9Class*>(opaqueClazz), 1, stackAlloc);
+      ListIterator<TR_VMField> iter(fieldsInfo.getFields());
+      for (TR_VMField *field = iter.getFirst(); field; field = iter.getNext())
+         {
+         addEntryForField(field, tlb, region, opaqueClazz, comp);
+         }
+      }
+   
    return tlb.build();
    }
 

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -2054,6 +2054,33 @@ TR_ResolvedJ9JITServerMethod::archetypeArgPlaceholderSlot()
    return paramSlots;
    }
 
+bool
+TR_ResolvedJ9JITServerMethod::isFieldQType(int32_t cpIndex)
+   {
+   if (!TR::Compiler->om.areValueTypesEnabled() ||
+      (-1 == cpIndex))
+      return false;
+
+   auto comp = _fe->_compInfoPT->getCompilation();
+   int32_t sigLen;
+   char *sig = fieldOrStaticSignatureChars(cpIndex, sigLen);
+   J9UTF8 *utfWrapper = str2utf8(sig, sigLen, comp->trMemory(), heapAlloc);
+
+   J9VMThread *vmThread = comp->j9VMThread();
+   return vmThread->javaVM->internalVMFunctions->isNameOrSignatureQtype(utfWrapper);
+   }
+
+bool
+TR_ResolvedJ9JITServerMethod::isFieldFlattened(TR::Compilation *comp, int32_t cpIndex, bool isStatic)
+   {
+   if (!TR::Compiler->om.areValueTypesEnabled() ||
+      (-1 == cpIndex))
+      return false;
+
+   _stream->write(JITServer::MessageType::ResolvedMethod_isFieldFlattened, _remoteMirror, cpIndex, isStatic);
+   return std::get<0>(_stream->read<bool>());
+   }
+
 TR_ResolvedRelocatableJ9JITServerMethod::TR_ResolvedRelocatableJ9JITServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, TR_ResolvedMethod * owner, uint32_t vTableSlot)
    : TR_ResolvedJ9JITServerMethod(aMethod, fe, trMemory, owner, vTableSlot)
    {

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -217,6 +217,8 @@ public:
    virtual void getFaninInfo(uint32_t *count, uint32_t *weight, uint32_t *otherBucketWeight = NULL) override;
    virtual bool getCallerWeight(TR_ResolvedJ9Method *caller, uint32_t *weight, uint32_t pcIndex=~0) override;
    virtual uint16_t archetypeArgPlaceholderSlot() override;
+   virtual bool isFieldQType(int32_t cpIndex) override;
+   virtual bool isFieldFlattened(TR::Compilation *comp, int32_t cpIndex, bool isStatic) override;
 
    TR_ResolvedJ9Method *getRemoteMirror() const { return _remoteMirror; }
    static void createResolvedMethodMirror(TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -109,7 +109,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 15;
+   static const uint16_t MINOR_NUMBER = 16;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -96,14 +96,15 @@ enum MessageType : uint16_t
    ResolvedMethod_dynamicConstant,
    ResolvedMethod_definingClassFromCPFieldRef,
    ResolvedMethod_getResolvedImplementorMethods,
+   ResolvedMethod_isFieldFlattened,
 
-   ResolvedRelocatableMethod_createResolvedRelocatableJ9Method, // 66
+   ResolvedRelocatableMethod_createResolvedRelocatableJ9Method, // 67
    ResolvedRelocatableMethod_fieldAttributes,
    ResolvedRelocatableMethod_staticAttributes,
    ResolvedRelocatableMethod_getFieldType,
 
    // For TR_J9ServerVM methods
-   VM_isClassLibraryClass, // 70
+   VM_isClassLibraryClass, // 71
    VM_isClassLibraryMethod,
    VM_getSuperClass,
    VM_isInstanceOf,
@@ -233,15 +234,16 @@ enum MessageType : uint16_t
    ClassEnv_getITable,
    ClassEnv_classHasIllegalStaticFinalFieldModification,
    ClassEnv_getROMClassRefName,
+   ClassEnv_enumerateFields,
 
    // For TR_J9SharedCache
-   SharedCache_getClassChainOffsetInSharedCache, // 196
+   SharedCache_getClassChainOffsetInSharedCache, // 198
    SharedCache_rememberClass,
    SharedCache_addHint,
    SharedCache_storeSharedData,
 
    // For runFEMacro
-   runFEMacro_invokeCollectHandleNumArgsToCollect, // 200
+   runFEMacro_invokeCollectHandleNumArgsToCollect, // 202
    runFEMacro_invokeExplicitCastHandleConvertArgs,
    runFEMacro_targetTypeL,
    runFEMacro_invokeILGenMacrosInvokeExactAndFixup,
@@ -267,24 +269,24 @@ enum MessageType : uint16_t
    runFEMacro_invokeCollectHandleAllocateArray,
 
    // for JITServerPersistentCHTable
-   CHTable_getAllClassInfo, // 224
+   CHTable_getAllClassInfo, // 226
    CHTable_getClassInfoUpdates,
    CHTable_commit,
    CHTable_clearReservable,
 
    // for JITServerIProfiler
-   IProfiler_profilingSample, // 228
+   IProfiler_profilingSample, // 230
    IProfiler_searchForMethodSample,
    IProfiler_getMaxCallCount,
    IProfiler_setCallCount,
 
-   Recompilation_getExistingMethodInfo, // 232
+   Recompilation_getExistingMethodInfo, // 234
    Recompilation_getJittedBodyInfoFromPC,
 
    ClassInfo_getRemoteROMString,
 
    // for KnownObjectTable
-   KnownObjectTable_getOrCreateIndex, // 235
+   KnownObjectTable_getOrCreateIndex, // 237
    KnownObjectTable_getOrCreateIndexAt,
    KnownObjectTable_getPointer,
    KnownObjectTable_getExistingIndexAt,
@@ -298,7 +300,7 @@ enum MessageType : uint16_t
    KnownObjectTable_invokeDirectHandleDirectCall,
    KnownObjectTable_getKnownObjectTableDumpInfo,
 
-   ClassEnv_isClassRefValueType, // 247
+   ClassEnv_isClassRefValueType, // 249
    MessageType_MAXTYPE
    };
 
@@ -372,11 +374,12 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "ResolvedMethod_dynamicConstant",
    "ResolvedMethod_definingClassFromCPFieldRef",
    "ResolvedMethod_getResolvedImplementorMethods",
-   "ResolvedRelocatableMethod_createResolvedRelocatableJ9Method", // 66
+   "ResolvedMethod_isFieldFlattened",
+   "ResolvedRelocatableMethod_createResolvedRelocatableJ9Method", // 67
    "ResolvedRelocatableMethod_fieldAttributes",
    "ResolvedRelocatableMethod_staticAttributes",
    "ResolvedRelocatableMethod_getFieldType",
-   "VM_isClassLibraryClass", // 70
+   "VM_isClassLibraryClass", // 71
    "VM_isClassLibraryMethod",
    "VM_getSuperClass",
    "VM_isInstanceOf",
@@ -502,11 +505,12 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "ClassEnv_getITable",
    "ClassEnv_classHasIllegalStaticFinalFieldModification",
    "ClassEnv_getROMClassRefName",
-   "SharedCache_getClassChainOffsetInSharedCache", // 196
+   "ClassEnv_enumerateFields",
+   "SharedCache_getClassChainOffsetInSharedCache", // 198
    "SharedCache_rememberClass",
    "SharedCache_addHint",
    "SharedCache_storeSharedData",
-   "runFEMacro_invokeCollectHandleNumArgsToCollect", // 200
+   "runFEMacro_invokeCollectHandleNumArgsToCollect", // 202
    "runFEMacro_invokeExplicitCastHandleConvertArgs",
    "runFEMacro_targetTypeL",
    "runFEMacro_invokeILGenMacrosInvokeExactAndFixup",
@@ -530,18 +534,18 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "runFEMacro_invokeFilterArgumentsWithCombinerHandleFilterPosition",
    "runFEMacro_invokeFilterArgumentsWithCombinerHandleArgumentIndices",
    "runFEMacro_invokeCollectHandleAllocateArray",
-   "CHTable_getAllClassInfo", // 224
+   "CHTable_getAllClassInfo", // 226
    "CHTable_getClassInfoUpdates",
    "CHTable_commit",
    "CHTable_clearReservable",
-   "IProfiler_profilingSample", // 228
+   "IProfiler_profilingSample", // 230
    "IProfiler_searchForMethodSample",
    "IProfiler_getMaxCallCount",
    "IProfiler_setCallCount",
-   "Recompilation_getExistingMethodInfo", // 232
+   "Recompilation_getExistingMethodInfo", // 234
    "Recompilation_getJittedBodyInfoFromPC",
    "ClassInfo_getRemoteROMString",
-   "KnownObjectTable_getOrCreateIndex", // 234
+   "KnownObjectTable_getOrCreateIndex", // 236
    "KnownObjectTable_getOrCreateIndexAt",
    "KnownObjectTable_getPointer",
    "KnownObjectTable_getExistingIndexAt",
@@ -553,7 +557,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "KnownObjectTable_getReferenceField",
    "KnownObjectTable_invokeDirectHandleDirectCall",
    "KnownObjectTable_getKnownObjectTableDumpInfo",
-   "ClassEnv_isClassRefValueType", // 247
+   "ClassEnv_isClassRefValueType", // 249
    };
    }; // namespace JITServer
 #endif // MESSAGE_TYPES_HPP


### PR DESCRIPTION
This commit adapts queries required for value type support
inside JIT for JITServer.
Methods added:
- `TR_ResolvedJ9JITServerMethod::isFieldQType`
- `TR_ResolvedJ9JITServerMethod::isFieldFlattened`
Modified for JITServer:
- `J9::ClassEnv::enumerateFields`