### PR TITLE
Add ability to activate CH Table at an arbitrary point

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -61,6 +61,7 @@
 #include "env/StackMemoryRegion.hpp"
 #include "env/jittypes.h"
 #include "env/ClassTableCriticalSection.hpp"
+#include "env/PersistentCHTable.hpp"
 #include "env/VMAccessCriticalSection.hpp"
 #include "env/VerboseLog.hpp"
 #include "compile/CompilationException.hpp"
@@ -8062,6 +8063,11 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                   aotCompilationReUpgradedToWarm = true;
                   }
                }
+
+
+            TR_PersistentCHTable *cht = that->_compInfo.getPersistentInfo()->getPersistentCHTable();
+            if (cht && !cht->isActive())
+               p->_optimizationPlan->setDisableCHOpts();
 
             // Set up options for this compilation. An option subset might apply
             // to the method, either via an option set index in the limitfile or

--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -435,8 +435,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
 
             if (isAOT
                 && TR::Options::getAOTCmdLineOptions()->getOption(TR_EnableClassChainValidationCaching)
-                && (!TR::Options::getCmdLineOptions()->allowRecompilation()
-                    || TR::Options::getCmdLineOptions()->getOption(TR_DisableCHOpts)))
+                && (TR::Options::getCmdLineOptions()->getOption(TR_DisableCHOpts)))
                {
                TR::Options::getAOTCmdLineOptions()->setOption(TR_EnableClassChainValidationCaching, false);
                }

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -2379,7 +2379,7 @@ void jitClassesRedefined(J9VMThread * currentThread, UDATA classCount, J9JITRede
       methodList = classPair->methodList;
 
       // Do this before modifying the CHTable
-      if (table && TR::Options::sharedClassCache() && TR::Options::getCmdLineOptions()->getOption(TR_EnableClassChainValidationCaching))
+      if (table && table->isActive() && TR::Options::sharedClassCache() && TR::Options::getCmdLineOptions()->getOption(TR_EnableClassChainValidationCaching))
          {
          table->resetCachedCCVResult(fe, oldClass);
          }

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -1863,7 +1863,7 @@ static void jitHookClassesUnload(J9HookInterface * * hookInterface, UDATA eventN
    if (TR::Options::getCmdLineOptions()->allowRecompilation() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableCHOpts))
       table = persistentInfo->getPersistentCHTable();
 
-   if (table)
+   if (table && table->isActive())
       {
       TR_FrontEnd * fe = TR_J9VMBase::get(jitConfig, vmThread);
 
@@ -2061,10 +2061,6 @@ static void jitHookClassUnload(J9HookInterface * * hookInterface, UDATA eventNum
       TR_VerboseLog::writeLineLocked(TR_Vlog_HD, "Class unloading for class=0x%p\n", j9clazz);
       }
 
-   TR_PersistentCHTable * table = 0;
-   if (TR::Options::getCmdLineOptions()->allowRecompilation() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableCHOpts))
-      table = compInfo->getPersistentInfo()->getPersistentCHTable();
-
    PORT_ACCESS_FROM_JAVAVM(vmThread->javaVM);
 
    // remove from compilation request queue any methods that belong to this class
@@ -2112,7 +2108,10 @@ static void jitHookClassUnload(J9HookInterface * * hookInterface, UDATA eventNum
 
    // END
 
-   if (table)
+   TR_PersistentCHTable * table = 0;
+   if (TR::Options::getCmdLineOptions()->allowRecompilation() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableCHOpts))
+      table = compInfo->getPersistentInfo()->getPersistentCHTable();
+   if (table && table->isActive())
       table->classGotUnloaded(fej9, clazz);
 
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -3517,11 +3517,11 @@ static void checkForLockReservation(J9VMThread *vmThread,
       }
    }
 
-static void jitHookClassLoadHelper(J9VMThread *vmThread,
-                                   J9JITConfig * jitConfig,
-                                   J9Class * cl,
-                                   TR::CompilationInfo *compInfo,
-                                   UDATA *classLoadEventFailed)
+void jitHookClassLoadHelper(J9VMThread *vmThread,
+                            J9JITConfig * jitConfig,
+                            J9Class * cl,
+                            TR::CompilationInfo *compInfo,
+                            UDATA *classLoadEventFailed)
    {
    bool allocFailed = false;
    TR_J9VMBase *vm = TR_J9VMBase::get(jitConfig, vmThread);
@@ -3684,10 +3684,10 @@ static bool chTableOnClassPreinitialize(J9VMThread *vmThread,
    return initFailed;
    }
 
-static void jitHookClassPreinitializeHelper(J9VMThread *vmThread,
-                                            J9JITConfig *jitConfig,
-                                            J9Class *cl,
-                                            UDATA *classPreinitializeEventFailed)
+void jitHookClassPreinitializeHelper(J9VMThread *vmThread,
+                                     J9JITConfig *jitConfig,
+                                     J9Class *cl,
+                                     UDATA *classPreinitializeEventFailed)
    {
    TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
    TR_J9VMBase *vm = TR_J9VMBase::get(jitConfig, vmThread);

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1832,6 +1832,12 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
       return -1;
       }
 
+   if (!TR::Options::getCmdLineOptions()->allowRecompilation() || !TR::Options::getAOTCmdLineOptions()->allowRecompilation())
+      {
+      TR::Options::getCmdLineOptions()->setOption(TR_DisableCHOpts);
+      TR::Options::getAOTCmdLineOptions()->setOption(TR_DisableCHOpts);
+      }
+
    // Get local var names if available (ie. classfile was compiled with -g).
    // We just check getDebug() for lack of a reliable way to check whether there are any methods being logged.
    //

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -108,8 +108,7 @@ TR_YesNoMaybe TR_J9SharedCache::isSharedCacheDisabledBecauseFull(TR::Compilation
 const CCVResult
 TR_J9SharedCache::getCachedCCVResult(TR_OpaqueClassBlock *clazz)
    {
-   if (TR::Options::getCmdLineOptions()->allowRecompilation()
-       && !TR::Options::getCmdLineOptions()->getOption(TR_DisableCHOpts))
+   if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableCHOpts))
       {
       TR::ClassTableCriticalSection cacheResult(_fe);
       TR_PersistentCHTable *table = _compInfo->getPersistentInfo()->getPersistentCHTable();
@@ -122,8 +121,7 @@ TR_J9SharedCache::getCachedCCVResult(TR_OpaqueClassBlock *clazz)
 bool
 TR_J9SharedCache::cacheCCVResult(TR_OpaqueClassBlock *clazz, CCVResult result)
    {
-   if (TR::Options::getCmdLineOptions()->allowRecompilation()
-       && !TR::Options::getCmdLineOptions()->getOption(TR_DisableCHOpts))
+   if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableCHOpts))
       {
       TR::ClassTableCriticalSection cacheResult(_fe);
       TR_PersistentCHTable *table = _compInfo->getPersistentInfo()->getPersistentCHTable();

--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -65,6 +65,8 @@ TR_PersistentCHTable::TR_PersistentCHTable(TR_PersistentMemory *trPersistentMemo
 
    memset(_buffer, 0, sizeof(TR_LinkHead<TR_PersistentClassInfo>) * (CLASSHASHTABLE_SIZE + 1));
    _classes = static_cast<TR_LinkHead<TR_PersistentClassInfo> *>(static_cast<void *>(_buffer));
+
+   setActive();
    }
 
 

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -188,6 +188,17 @@ extern "C" {
    I_32 j9jit_vfprintfId(I_32 fileId, char *format, ...);
    I_32 j9jit_fprintfId(I_32 fileId, char *format, ...);
 
+   void jitHookClassLoadHelper(J9VMThread *vmThread,
+                               J9JITConfig * jitConfig,
+                               J9Class * cl,
+                               TR::CompilationInfo *compInfo,
+                               UDATA *classLoadEventFailed);
+
+   void jitHookClassPreinitializeHelper(J9VMThread *vmThread,
+                                        J9JITConfig *jitConfig,
+                                        J9Class *cl,
+                                        UDATA *classPreinitializeEventFailed);
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/compiler/env/annotations/AnnotationBase.cpp
+++ b/runtime/compiler/env/annotations/AnnotationBase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -115,8 +115,7 @@ bool TR_AnnotationBase::scanForKnownAnnotationsAndRecord(TR::CompilationInfo *co
       }
 
    TR_PersistentClassInfo *classInfo=NULL;
-   if(TR::Options::getCmdLineOptions()->allowRecompilation() &&
-      !TR::Options::getCmdLineOptions()->getOption(TR_DisableCHOpts) &&
+   if(!TR::Options::getCmdLineOptions()->getOption(TR_DisableCHOpts) &&
       compInfo->getPersistentInfo()->getPersistentCHTable())
       {
       TR_OpaqueClassBlock *cl=J9JitMemory::convertClassPtrToClassOffset(clazz);

--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -432,21 +432,24 @@ TR_PersistentCHTable::classGotRedefined(
    // 2. Swap the old and new classes in the hierarchy, and re-hash
    //
 
-   TR_PersistentClassInfo *newClass = findClassInfo(newClassId);
-   uintptr_t oldIndex = TR_RuntimeAssumptionTable::hashCode((uintptr_t)oldClassId) % CLASSHASHTABLE_SIZE;
-   uintptr_t newIndex = TR_RuntimeAssumptionTable::hashCode((uintptr_t)newClassId) % CLASSHASHTABLE_SIZE;
-   _classes[oldIndex].remove(oldClass);
-   oldClass->setClassId(newClassId);
-   _classes[newIndex].add(oldClass);
-
-   // The new class should have had a class load event that would create a CHTable entry.
-   // We'll use it to represent the moribund old class.
-   //
-   if (newClass)
+   if (isActive())
       {
-      _classes[newIndex].remove(newClass);
-      newClass->setClassId(oldClassId);
-      _classes[oldIndex].add(newClass);
+      TR_PersistentClassInfo *newClass = findClassInfo(newClassId);
+      uintptr_t oldIndex = TR_RuntimeAssumptionTable::hashCode((uintptr_t)oldClassId) % CLASSHASHTABLE_SIZE;
+      uintptr_t newIndex = TR_RuntimeAssumptionTable::hashCode((uintptr_t)newClassId) % CLASSHASHTABLE_SIZE;
+      _classes[oldIndex].remove(oldClass);
+      oldClass->setClassId(newClassId);
+      _classes[newIndex].add(oldClass);
+
+      // The new class should have had a class load event that would create a CHTable entry.
+      // We'll use it to represent the moribund old class.
+      //
+      if (newClass)
+         {
+         _classes[newIndex].remove(newClass);
+         newClass->setClassId(oldClassId);
+         _classes[oldIndex].add(newClass);
+         }
       }
    }
 

--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -164,6 +164,7 @@ TR_PersistentCHTable::classGotUnloadedPost(
       TR_FrontEnd *fe,
       TR_OpaqueClassBlock *classId)
    {
+   TR_ASSERT_FATAL(isActive(), "Should not be called if table is not active!");
    TR_PersistentClassInfo * cl;
    int classDepth;
    J9Class *clazzPtr;
@@ -228,6 +229,7 @@ TR_PersistentCHTable::classGotExtended(
       TR_OpaqueClassBlock *superClassId,
       TR_OpaqueClassBlock *subClassId)
    {
+   TR_ASSERT_FATAL(isAccessible(), "Should not be called if table is not accessible!");
    TR_PersistentClassInfo * cl = findClassInfo(superClassId);
    TR_PersistentClassInfo * subClass = findClassInfo(subClassId); // This is actually the class that got loaded extending the superclass
 #if defined(J9VM_OPT_JITSERVER)
@@ -291,6 +293,7 @@ TR_PersistentCHTable::removeClass(
       TR_PersistentClassInfo *info,
       bool removeInfo)
    {
+   TR_ASSERT_FATAL(isAccessible(), "Should not be called if table is not accessible!");
    if (!info)
       return;
 
@@ -349,6 +352,7 @@ TR_PersistentCHTable::classGotInitialized(
       TR_OpaqueClassBlock *classId,
       TR_PersistentClassInfo *clazz)
    {
+   TR_ASSERT_FATAL(isAccessible(), "Should not be called if table is not accessible!");
    if (!clazz) clazz = findClassInfo(classId);
 
    clazz->setInitialized(persistentMemory);
@@ -408,6 +412,7 @@ TR_PersistentCHTable::classGotRedefined(
       TR_OpaqueClassBlock *oldClassId,
       TR_OpaqueClassBlock *newClassId)
    {
+   TR_ASSERT_FATAL(!isActivating(), "Should not be called if table is currently being activated!");
    TR_PersistentClassInfo *oldClass = findClassInfo(oldClassId);
 
    OMR::CriticalSection classGotRedefined(assumptionTableMutex);


### PR DESCRIPTION
The CHT is augmented to have a notion of a state. By default, the state is active. However, this PR adds the infrastructure to allow the CH Table to be initially inactive, and activated at a later point in JVM execution. The API to activate the CH Table assumes a stop the world event where the class hierarchy isn't changing. It then calls a helper method which is recursive, as follows:

1. Add superclasses
2. Add interfaces implemented
3. Trigger class load hook
4. Trigger class preinitialize hook
5. Add array class

This code is mostly a port from the snapshot branch.