### PR TITLE
Fix format string

### DIFF
--- a/test/functional/JIT_Test/src/jit/test/jitserver/JITServerTest.java
+++ b/test/functional/JIT_Test/src/jit/test/jitserver/JITServerTest.java
@@ -56,7 +56,7 @@ public class JITServerTest {
 		final String CLIENT_PROGRAM = System.getProperty("CLIENT_PROGRAM");
 		// -Xjit options may already be on the command line so add extra JIT options via TR_Options instead to avoid one overriding the other.
 		final String JIT_LOG_ENV_OPTION = "verbose={compileEnd|JITServer|heartbeat}";
-		final String JITSERVER_PORT_OPTION_FORMAT_STRING = "-XX:JITServerPort=%0$d";
+		final String JITSERVER_PORT_OPTION_FORMAT_STRING = "-XX:JITServerPort=%d";
 		// Most systems have a specified ephemeral ports range. We're not bothering to find the actual range, just choosing a range that is outside the reserved area, reasonably large, and well-behaved.
 		// The range chosen here is within the actual ephemeral range on recent Linux systems and others (at the time of writing).
 		final int EPHEMERAL_PORTS_START = 33000, EPHEMERAL_PORTS_LAST = 60000;


### PR DESCRIPTION
This fixes the test failures seen in https://ci.eclipse.org/openj9/job/Test_openjdknext_j9_sanity.functional_x86-64_linux_OpenJDK/260/.

Argument indices start at 1 (not 0 - see [1]), so `%0$d` includes an illegal 'argument_index'. An index is not needed as it is only ever used with exactly one argument.

[1] https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html