### PR TITLE
Keep splitPostGRA stores in right block for acmp fast path

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -201,6 +201,10 @@ static TR::Node *lowerCASValues(
  *  |ifacmpeq  -->---------*---------+
  *  |  aload lhs           |         |
  *  |  aload rhs           |         |
+ *  |  GlRegDeps           |         |
+ *  |    PassThrough x     |         |
+ *  |      ==> iconst 1    |         |
+ *  |    PassThrough ...   |         |
  *  |BBEnd                 |         |
  *  +----------------------+         |
  *  |BBStart (extension)   |         |
@@ -209,6 +213,10 @@ static TR::Node *lowerCASValues(
  *  |    aload lhs         |         |
  *  |    aload rhs         |         |
  *  |BBEnd                 |         |
+ *  |  GlRegDeps           |         |
+ *  |    PassThrough x     |         |
+ *  |      ==> icall acmpHelper      |
+ *  |    PassThrough ...   |         |
  *  +----------------------+         |
  *        |                          |
  *        +--------------------------+
@@ -221,6 +229,10 @@ static TR::Node *lowerCASValues(
  *  |  iconst 0       |
  *  |BBEnd            |
  *  +-----------------+
+ *
+ * Any GlRegDeps on the extension block are created by OMR::Block::splitPostGRA
+ * while those on the ifacmpeq at the end of the first block are copies of those,
+ * with the exception of any register (x, above) holding the result of the compare
  *
  */
 void
@@ -251,6 +263,54 @@ J9::CodeGenerator::fastpathAcmpHelper(TR::Node *node, TR::TreeTop *tt, const boo
    // next treetop and then at the current one
    TR::Block* prevBlock = tt->getEnclosingBlock();
    TR::Block* targetBlock = prevBlock->splitPostGRA(tt->getNextTreeTop(), cfg, true, NULL);
+
+   // As the block is split after the helper call node, it is possible that as part of un-commoning
+   // code to store nodes into registers or temp-slots is appended to the original block by the call
+   // to splitPostGRA above.  Move the acmp helper call treetop to the end of prevBlock, along with
+   // any stores resulting from un-commoning of the nodes in the helper call tree so that it can be
+   // split into its own call block.
+   TR::TreeTop* prevBlockExit = prevBlock->getExit();
+   TR::TreeTop* iterTT = tt->getNextTreeTop();
+
+   if (iterTT != prevBlockExit)
+      {
+      if (trace)
+         {
+         traceMsg(comp, "Moving treetop containing node n%dn [%p] for acmp helper call to end of prevBlock in preparation of final block split\n", tt->getNode()->getGlobalIndex(), tt->getNode());
+         }
+
+      // Remove TreeTop for call node, and gather it and the treetops for stores that
+      // resulted from un-commoning in a TreeTop chain from tt to lastTTForCallBlock
+      tt->unlink(false);
+      TR::TreeTop* lastTTForCallBlock = tt;
+
+      while (iterTT != prevBlockExit)
+         {
+         TR::TreeTop* nextTT = iterTT->getNextTreeTop();
+         TR::ILOpCodes op = iterTT->getNode()->getOpCodeValue();
+
+         if ((op == TR::iRegStore || op == TR::istore) && iterTT->getNode()->getFirstChild() == node)
+            {
+            if (trace)
+               {
+               traceMsg(comp, "Moving treetop containing node n%dn [%p] for store of acmp helper result to end of prevBlock in preparation of final block split\n", iterTT->getNode()->getGlobalIndex(), iterTT->getNode());
+               }
+
+            // Remove store node from prevBlock temporarily
+            iterTT->unlink(false);
+            lastTTForCallBlock->join(iterTT);
+            lastTTForCallBlock = iterTT;
+            }
+
+         iterTT = nextTT;
+         }
+
+      // Move the treetops that were gathered for the call and any stores of the
+      // result to the end of the block in preparation for the split of the call block
+      prevBlockExit->getPrevTreeTop()->join(tt);
+      lastTTForCallBlock->join(prevBlockExit);
+      }
+
    TR::Block* callBlock = prevBlock->split(tt, cfg);
    callBlock->setIsExtensionOfPreviousBlock(true);
    if (trace)
@@ -283,38 +343,44 @@ J9::CodeGenerator::fastpathAcmpHelper(TR::Node *node, TR::TreeTop *tt, const boo
       TR_ASSERT_FATAL(false, "Anchord call has been turned into unexpected opcode %s\n", anchoredNode->getOpCode().getName());
    prevBlock->append(TR::TreeTop::create(comp, storeNode));
 
-   // instert acmpeq for fastpath, taking care to set the proper register dependencies
+   // insert acmpeq for fastpath, taking care to set the proper register dependencies
+   // Any register dependencies added by splitPostGRA will now be on the BBExit for
+   // the call block.  As the ifacmpeq branching around the call block will reach the same
+   // target block, copy any GlRegDeps from the end of the call block to the ifacmpeq
    auto* ifacmpeqNode = TR::Node::createif(TR::ifacmpeq, anchoredCallArg1TT->getNode()->getFirstChild(), anchoredCallArg2TT->getNode()->getFirstChild(), targetBlock->getEntry());
-   if (anchoredNode->getOpCodeValue() == TR::iRegLoad)
+   if (callBlock->getExit()->getNode()->getNumChildren() > 0)
       {
-      auto* depNode = TR::Node::create(TR::PassThrough, 1, storeNode->getChild(0));
-      depNode->setGlobalRegisterNumber(storeNode->getGlobalRegisterNumber());
-
       TR::Node* glRegDeps = TR::Node::create(TR::GlRegDeps);
-      glRegDeps->addChildren(&depNode, 1);
+      TR::Node* depNode = NULL;
+
+      if (anchoredNode->getOpCodeValue() == TR::iRegLoad)
+         {
+         depNode = TR::Node::create(TR::PassThrough, 1, storeNode->getChild(0));
+         depNode->setGlobalRegisterNumber(storeNode->getGlobalRegisterNumber());
+         glRegDeps->addChildren(&depNode, 1);
+         }
+
       ifacmpeqNode->addChildren(&glRegDeps, 1);
 
-      if (callBlock->getExit()->getNode()->getNumChildren() > 0)
+      TR::Node* expectedDeps = callBlock->getExit()->getNode()->getFirstChild();
+      for (int i = 0; i < expectedDeps->getNumChildren(); ++i)
          {
-         TR::Node* expectedDeps = callBlock->getExit()->getNode()->getFirstChild();
-         for (int i = 0; i < expectedDeps->getNumChildren(); ++i)
+         TR::Node* temp = expectedDeps->getChild(i);
+         if (depNode && temp->getGlobalRegisterNumber() == depNode->getGlobalRegisterNumber())
+            continue;
+         else if (temp->getOpCodeValue() == TR::PassThrough)
             {
-            TR::Node* temp = expectedDeps->getChild(i);
-            if (temp->getGlobalRegisterNumber() == depNode->getGlobalRegisterNumber())
-               continue;
-            else if (temp->getOpCodeValue() == TR::PassThrough)
-               {
-               // PassThrough nodes cannot be commoned because doing so does not
-               // actually anchor the child, causing it's lifetime to not be extended
-               TR::Node* original = temp;
-               temp = TR::Node::create(original, TR::PassThrough, 1, original->getFirstChild());
-               temp->setLowGlobalRegisterNumber(original->getLowGlobalRegisterNumber());
-               temp->setHighGlobalRegisterNumber(original->getHighGlobalRegisterNumber());
-               }
-            glRegDeps->addChildren(&temp, 1);
+            // PassThrough nodes cannot be commoned because doing so does not
+            // actually anchor the child, causing it's lifetime to not be extended
+            TR::Node* original = temp;
+            temp = TR::Node::create(original, TR::PassThrough, 1, original->getFirstChild());
+            temp->setLowGlobalRegisterNumber(original->getLowGlobalRegisterNumber());
+            temp->setHighGlobalRegisterNumber(original->getHighGlobalRegisterNumber());
             }
+         glRegDeps->addChildren(&temp, 1);
          }
       }
+
    prevBlock->append(TR::TreeTop::create(comp, ifacmpeqNode));
    }
 


### PR DESCRIPTION
When `splitPostGRA` splits a block, it might insert register stores and stores to temporaries at the end of the original block at the split point.  When `splitPostGRA` is called for `fastpathAcmpHelper`, the original block contains the `acmp` helper call that will still need to be moved into a separate "call" block, while any register stores or temporary stores that do not involve the call to `acmp` helper will need to remain in the original block.  Move any treetops, register stores or stores
for the call to the `acmp` helper to the end of the original block so that the trees associated with the call can be split into the new "call" block without pulling any unrelated stores and register stores into the new block.

Also, register dependencies that `splitPostGRA` adds to the end of the "call" block should always be copied to the `ifacmpeq` node that's added to the end of the original block as that represents an edge to the same "target" block.

This fixes a failure with value types enabled running the vmTest_2 test, UnsafeArrayGetTest.

