### PR TITLE
Update the debug flags for the Assembly source

### DIFF
--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -226,7 +226,7 @@ S_DEFINES+=$(HOST_DEFINES) $(TARGET_DEFINES)
 S_DEFINES_DEBUG+=DEBUG
 
 S_FLAGS+=--noexecstack
-S_FLAGS_DEBUG+=--gstabs
+S_FLAGS_DEBUG+=--gstabs+ -g
 
 ifeq ($(HOST_ARCH),p)
     S_FLAGS+=-maltivec


### PR DESCRIPTION
Updated debug flags will add additional debug information for GNU debuggers such as GDB for linux systems about assembly glue code used in JIT.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>