### PR TITLE
Remove deprecated Java preprocessor flags

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -156,7 +156,6 @@
 	<configuration
 		  label="JAVA16"
 		  outputpath="JAVA16/src"
-		  flags="Java16"
 		  dependencies="JAVA15"
 		  jdkcompliance="1.8">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>

--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -100,7 +100,7 @@
 	<configuration
 		  label="JAVA11"
 		  outputpath="JAVA11/src"
-		  flags="Sidecar18-SE-OpenJ9,DAA,Open-Module-Support,Sidecar19-SE,Sidecar19-SE-OpenJ9,Java10"
+		  flags="Sidecar18-SE-OpenJ9,DAA,Open-Module-Support,Sidecar19-SE,Sidecar19-SE-OpenJ9"
 		  dependencies="SIDECAR18-SE"
 		  jdkcompliance="1.8">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>

--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -100,7 +100,7 @@
 	<configuration
 		  label="JAVA11"
 		  outputpath="JAVA11/src"
-		  flags="Sidecar18-SE-OpenJ9, DAA, Open-Module-Support,Sidecar19-SE,Sidecar19-SE-OpenJ9,Java10,Java11"
+		  flags="Sidecar18-SE-OpenJ9,DAA,Open-Module-Support,Sidecar19-SE,Sidecar19-SE-OpenJ9,Java10"
 		  dependencies="SIDECAR18-SE"
 		  jdkcompliance="1.8">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>

--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -128,7 +128,7 @@
 	<configuration
 		  label="JAVA15"
 		  outputpath="JAVA15/src"
-		  flags="Java12,Java13"
+		  flags="Java12"
 		  dependencies="JAVA11"
 		  jdkcompliance="1.8">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>

--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -128,7 +128,7 @@
 	<configuration
 		  label="JAVA15"
 		  outputpath="JAVA15/src"
-		  flags="Java12,Java13,Java14"
+		  flags="Java12,Java13"
 		  dependencies="JAVA11"
 		  jdkcompliance="1.8">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>

--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -128,7 +128,6 @@
 	<configuration
 		  label="JAVA15"
 		  outputpath="JAVA15/src"
-		  flags="Java12"
 		  dependencies="JAVA11"
 		  jdkcompliance="1.8">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>

--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -128,7 +128,7 @@
 	<configuration
 		  label="JAVA15"
 		  outputpath="JAVA15/src"
-		  flags="Java12,Java13,Java14,Java15"
+		  flags="Java12,Java13,Java14"
 		  dependencies="JAVA11"
 		  jdkcompliance="1.8">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>

--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -100,7 +100,7 @@
 	<configuration
 		  label="JAVA11"
 		  outputpath="JAVA11/src"
-		  flags="Sidecar18-SE-OpenJ9,DAA,Open-Module-Support,Sidecar19-SE,Sidecar19-SE-OpenJ9"
+		  flags="Sidecar18-SE-OpenJ9,DAA,Sidecar19-SE,Sidecar19-SE-OpenJ9"
 		  dependencies="SIDECAR18-SE"
 		  jdkcompliance="1.8">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -23,12 +23,12 @@
 package java.lang;
 
 import java.lang.annotation.Annotation;
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import jdk.internal.misc.Unsafe;
 import java.lang.StringConcatHelper;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
@@ -46,9 +46,9 @@ import java.net.URI;
 import java.security.ProtectionDomain;
 import java.util.Iterator;
 import java.util.List;
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.Set;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 /*[IF Java11]*/
@@ -345,15 +345,15 @@ final class Access implements JavaLangAccess {
 		return clz.getDeclaredPublicMethods(name, types);
 	}
 
-	/*[IF Java15]*/
+	/*[IF JAVA_SPEC_VERSION >= 15]*/
 	public void addOpensToAllUnnamed(Module fromModule, Set<String> concealedPackages, Set<String> exportedPackages) {
 		fromModule.implAddOpensToAllUnnamed(concealedPackages, exportedPackages);
 	}
-	/*[ELSE] Java15 */
+	/*[ELSE] JAVA_SPEC_VERSION >= 15 */
 	public void addOpensToAllUnnamed(Module fromModule, Iterator<String> packages) {
 		fromModule.implAddOpensToAllUnnamed(packages);
 	}
-	/*[ENDIF] Java15 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	public boolean isReflectivelyOpened(Module fromModule, String pkg, Module toModule) {
 		return fromModule.isReflectivelyOpened(pkg, toModule);
@@ -397,7 +397,7 @@ final class Access implements JavaLangAccess {
 	}
 /*[ENDIF] Java14 */
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	public Class<?> defineClass(ClassLoader classLoader, Class<?> clazz, String className, byte[] classRep, ProtectionDomain protectionDomain, boolean init, int flags, Object classData) {
 		ClassLoader targetClassLoader = (null == classLoader) ? ClassLoader.bootstrapClassLoader : classLoader;
 		return targetClassLoader.defineClassInternal(clazz, className, classRep, protectionDomain, init, flags, classData);
@@ -429,7 +429,7 @@ final class Access implements JavaLangAccess {
 	public long stringConcatMix(long arg0, String string) {
 		return StringConcatHelper.mix(arg0, string);
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	/*[IF JAVA_SPEC_VERSION >= 16]*/
 	public void bindToLoader(ModuleLayer ml, ClassLoader cl) {

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -51,10 +51,10 @@ import java.util.Set;
 /*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 import java.nio.charset.Charset;
 import java.nio.charset.CharacterCodingException;
-/*[ENDIF] Java11 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 /*[IF JAVA_SPEC_VERSION >= 12]*/
 import jdk.internal.access.JavaLangAccess;
 /*[ELSE] JAVA_SPEC_VERSION >= 12 */
@@ -78,11 +78,11 @@ final class Access implements JavaLangAccess {
 
 	/** Set thread's blocker field. */
 	public void blockedOn(java.lang.Thread thread, Interruptible interruptable) {
-		/*[IF Java11]*/
+		/*[IF JAVA_SPEC_VERSION >= 11]*/
 		Thread.blockedOn(interruptable);
-		/*[ELSE] Java11 */
+		/*[ELSE] JAVA_SPEC_VERSION >= 11 */
 		thread.blockedOn(interruptable);
-		/*[ENDIF] Java11 */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 	}
 
 	/**
@@ -373,7 +373,7 @@ final class Access implements JavaLangAccess {
 	}
 /*[ENDIF] Java10 */
 
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 	public void blockedOn(Interruptible interruptible) {
 		Thread.blockedOn(interruptible);
 	}
@@ -383,7 +383,7 @@ final class Access implements JavaLangAccess {
 	public String newStringNoRepl(byte[] bytes, Charset charset) throws CharacterCodingException {
 		return StringCoding.newStringNoRepl(bytes, charset);
 	}
-/*[ENDIF] Java11 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
 /*[IF JAVA_SPEC_VERSION >= 12]*/
 	public void setCause(Throwable throwable, Throwable cause) {

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -193,7 +193,7 @@ final class Access implements JavaLangAccess {
 		return result;
 	}
 
-	/*[IF !Java10]*/
+	/*[IF JAVA_SPEC_VERSION < 10]*/
 	/**
 	 * Return a newly created String that uses the passed in char[]
 	 * without copying. The array must not be modified after creating
@@ -207,7 +207,7 @@ final class Access implements JavaLangAccess {
 	public java.lang.String newStringUnsafe(char[] data) {
 		return new String(data, true /*ignored*/);
 	}
-	/*[ENDIF] !Java10 */
+	/*[ENDIF] JAVA_SPEC_VERSION < 10 */
 
 	@Override
 	public void invokeFinalize(java.lang.Object arg0)
@@ -231,12 +231,12 @@ final class Access implements JavaLangAccess {
 		return classLoader.createOrGetServicesCatalog();
 	}
 
-/*[IF !Java10]*/
+/*[IF JAVA_SPEC_VERSION < 10]*/
 	@Deprecated
 	public ServicesCatalog getServicesCatalog(ClassLoader classLoader) {
 		return classLoader.getServicesCatalog();
 	}
-/*[ENDIF] !Java10 */
+/*[ENDIF] JAVA_SPEC_VERSION < 10 */
 
 	public String fastUUID(long param1, long param2) {
 		return Long.fastUUID(param1, param2);
@@ -277,11 +277,11 @@ final class Access implements JavaLangAccess {
 	}
 
 	public void invalidatePackageAccessCache() {
-/*[IF Java10]*/
+/*[IF JAVA_SPEC_VERSION >= 10]*/
 		java.lang.SecurityManager.invalidatePackageAccessCache();
-/*[ELSE] Java10 */
+/*[ELSE] JAVA_SPEC_VERSION >= 10 */
 		return;
-/*[ENDIF] Java10 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 	}
 
 	public Class<?> defineClass(ClassLoader classLoader, String className, byte[] classRep, ProtectionDomain protectionDomain, String str) {
@@ -364,14 +364,14 @@ final class Access implements JavaLangAccess {
 	}
 /*[ENDIF] Sidecar19-SE-OpenJ9 */
 
-/*[IF Java10]*/
+/*[IF JAVA_SPEC_VERSION >= 10]*/
 	public String newStringUTF8NoRepl(byte[] bytes, int offset, int length) {
 		return StringCoding.newStringUTF8NoRepl(bytes, offset, length);
 	}
 	public byte[] getBytesUTF8NoRepl(String str) {
 		return StringCoding.getBytesUTF8NoRepl(str);
 	}
-/*[ENDIF] Java10 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 
 /*[IF JAVA_SPEC_VERSION >= 11]*/
 	public void blockedOn(Interruptible interruptible) {

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -55,11 +55,11 @@ import java.util.stream.Stream;
 import java.nio.charset.Charset;
 import java.nio.charset.CharacterCodingException;
 /*[ENDIF] Java11 */
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import jdk.internal.access.JavaLangAccess;
-/*[ELSE] Java12 */
+/*[ELSE] JAVA_SPEC_VERSION >= 12 */
 import jdk.internal.misc.JavaLangAccess;
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 import jdk.internal.module.ServicesCatalog;
 import jdk.internal.reflect.ConstantPool;
 /*[ELSE] Sidecar19-SE */
@@ -385,11 +385,11 @@ final class Access implements JavaLangAccess {
 	}
 /*[ENDIF] Java11 */
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	public void setCause(Throwable throwable, Throwable cause) {
 		throwable.setCause(cause);
 	}
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 /*[IF JAVA_SPEC_VERSION >= 14]*/
 	public void loadLibrary(Class<?> caller, String library) {

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -391,11 +391,11 @@ final class Access implements JavaLangAccess {
 	}
 /*[ENDIF] Java12 */
 
-/*[IF Java14]*/
+/*[IF JAVA_SPEC_VERSION >= 14]*/
 	public void loadLibrary(Class<?> caller, String library) {
 		System.loadLibrary(library);
 	}
-/*[ENDIF] Java14 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 
 /*[IF JAVA_SPEC_VERSION >= 15]*/
 	public Class<?> defineClass(ClassLoader classLoader, Class<?> clazz, String className, byte[] classRep, ProtectionDomain protectionDomain, boolean init, int flags, Object classData) {

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -430,12 +430,12 @@ final class Access implements JavaLangAccess {
 		return StringConcatHelper.mix(arg0, string);
 	}
 /*[ENDIF] Java15 */
-	
-	/*[IF Java16]*/
+
+	/*[IF JAVA_SPEC_VERSION >= 16]*/
 	public void bindToLoader(ModuleLayer ml, ClassLoader cl) {
 		ml.bindToLoader(cl);
 	}
-	/*[ENDIF] Java16 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 
 /*[ENDIF] Sidecar19-SE */
 }

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -61,9 +61,9 @@ import sun.reflect.generics.scope.ClassScope;
 import sun.reflect.annotation.AnnotationType;
 import java.util.Arrays;
 import com.ibm.oti.vm.VM;
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 import static com.ibm.oti.util.Util.doesClassLoaderDescendFrom;
-/*[ENDIF] Java11*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
 
 /*[IF Sidecar19-SE]
 import jdk.internal.misc.Unsafe;
@@ -262,9 +262,9 @@ public final class Class<T> implements java.io.Serializable, GenericDeclaration,
 		return unsafe;
 	}
 	
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 	private Class<?> nestHost;
-/*[ENDIF] Java11*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
 /*[IF JAVA_SPEC_VERSION >= 15]*/
 	private transient Object classData;
@@ -4688,7 +4688,7 @@ static byte[] getExecutableTypeAnnotationBytes(Executable exec) {
 }
 /*[ENDIF] Sidecar19-SE*/
 
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 /**
  * Answers the host class of the receiver's nest.
  *
@@ -4804,7 +4804,7 @@ SecurityException {
 
 	return members;
 }
-/*[ENDIF] Java11 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
 /*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -27,9 +27,9 @@ import java.security.AccessControlContext;
 import java.security.ProtectionDomain;
 import java.security.AllPermission;
 import java.security.Permissions;
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import java.lang.constant.ClassDesc;
-/*[ENDIF] Java12*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12*/
 import java.lang.reflect.*;
 import java.net.URL;
 import java.lang.annotation.*;
@@ -41,19 +41,19 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import java.util.Optional;
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
 import java.security.PrivilegedAction;
 import java.lang.ref.*;
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import java.lang.constant.ClassDesc;
 import java.lang.constant.Constable;
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 import sun.reflect.generics.repository.ClassRepository;
 import sun.reflect.generics.factory.CoreReflectionFactory;
@@ -136,9 +136,9 @@ import sun.security.util.SecurityConstants;
  * @version		initial
  */
 public final class Class<T> implements java.io.Serializable, GenericDeclaration, Type
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	, Constable, TypeDescriptor, TypeDescriptor.OfField<Class<?>>
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 {
 	private static final long serialVersionUID = 3206093459760846163L;
 	private static ProtectionDomain AllPermissionsPD;
@@ -2511,7 +2511,7 @@ private void appendTypeParameters(StringBuilder nameBuilder) {
 			if (comma) nameBuilder.append(',');
 			nameBuilder.append(t);
 			comma = true;
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 			Type[] types = t.getBounds();
 			if (types.length == 1 && types[0].equals(Object.class)) {
 				// skip in case the only bound is java.lang.Object
@@ -2522,7 +2522,7 @@ private void appendTypeParameters(StringBuilder nameBuilder) {
 					prefix = " & "; //$NON-NLS-1$
 				}
 			}
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 		}
 		nameBuilder.append('>');
 	}
@@ -4806,7 +4806,7 @@ SecurityException {
 }
 /*[ENDIF] Java11 */
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * Create class of an array. The component type will be this Class instance.
 	 * 
@@ -4907,7 +4907,7 @@ SecurityException {
 		}
 		return "L"+ name + ";"; //$NON-NLS-1$ //$NON-NLS-2$
 	}
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 /*[IF JAVA_SPEC_VERSION >= 14]*/
 	/**

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -265,11 +265,11 @@ public final class Class<T> implements java.io.Serializable, GenericDeclaration,
 /*[IF Java11]*/
 	private Class<?> nestHost;
 /*[ENDIF] Java11*/
-	
-/*[IF Java15]*/
+
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	private transient Object classData;
-/*[ENDIF] Java15*/
-	
+/*[ENDIF] JAVA_SPEC_VERSION >= 15*/
+
 /**
  * Prevents this class from being instantiated. Instances
  * created by the virtual machine only.
@@ -3667,12 +3667,12 @@ public String getCanonicalName() {
 			arrayCount++;
 		}
 	}
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	if (baseType.isHidden()) {
 		/* Canonical name is always null for hidden classes. */
 		return null;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 	if (baseType.getEnclosingObjectClass() != null) {
 		// local or anonymous class
 		return null;
@@ -4764,7 +4764,7 @@ public boolean isNestmateOf(Class<?> that) {
  * Answers the nest member classes of the receiver's nest host.
  *
  * @throws SecurityException if a SecurityManager is present and package access is not allowed
-/*[IF !Java15]
+/*[IF JAVA_SPEC_VERSION < 15]
  * @throws LinkageError if there is any problem loading or validating a nest member or the nest host
 /*[ENDIF]
  * @throws SecurityException if a returned class is not the current class, a security manager is enabled,
@@ -4774,9 +4774,9 @@ public boolean isNestmateOf(Class<?> that) {
  */
 @CallerSensitive
 public Class<?>[] getNestMembers() throws
-/*[IF !Java15] */
-LinkageError, 
-/*[ENDIF] */
+/*[IF JAVA_SPEC_VERSION < 15] */
+LinkageError,
+/*[ENDIF] JAVA_SPEC_VERSION < 15 */
 SecurityException {
 	if (isArray() || isPrimitive()) {
 		/* By spec, Class objects representing array types or primitive types
@@ -4840,7 +4840,7 @@ SecurityException {
 	 * @return Optional with a nominal descriptor of Class instance
 	 */
 	public Optional<ClassDesc> describeConstable() {
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 		Class<?> clazz = this;
 		if (isArray()) {
 			clazz = getComponentType();
@@ -4852,8 +4852,8 @@ SecurityException {
 			/* It is always an empty Optional for hidden classes. */
 			return Optional.empty(); 
 		}
-/*[ENDIF] Java15 */		
-		
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
+
 		ClassDesc classDescriptor = ClassDesc.ofDescriptor(this.descriptorString());
 		return Optional.of(classDescriptor);
 	}
@@ -4888,7 +4888,7 @@ SecurityException {
 			}
 		}
 		String name = this.getName().replace('.', '/');
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 		Class<?> clazz = this;
 		if (isArray()) {
 			clazz = getComponentType();
@@ -4901,7 +4901,7 @@ SecurityException {
 			int index = name.lastIndexOf('/');
 			name = name.substring(0, index)+ '.' + name.substring(index + 1,name.length());
 		}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 		if (this.isArray()) {
 			return name;
 		}
@@ -4944,7 +4944,7 @@ SecurityException {
 	private native RecordComponent[] getRecordComponentsImpl();
 /*[ENDIF] Java14 */
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	/**
 	 * Returns true if class or interface is sealed.
 	 * 
@@ -4994,5 +4994,5 @@ SecurityException {
 	Object getClassData() {
 		return classData;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -2456,10 +2456,10 @@ public String toGenericString() {
 		kindOfType = "interface "; //$NON-NLS-1$
 	} else if ((!isArray) && ((modifiers & ENUM) != 0) && (getSuperclass() == Enum.class)) {
 		kindOfType = "enum "; //$NON-NLS-1$
-/*[IF Java14]*/
+/*[IF JAVA_SPEC_VERSION >= 14]*/
 	} else if (isRecord()) {
 		kindOfType = "record "; //$NON-NLS-1$
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 	} else {
 		kindOfType = "class "; //$NON-NLS-1$	
 	}
@@ -4909,7 +4909,7 @@ SecurityException {
 	}
 /*[ENDIF] Java12 */
 
-/*[IF Java14]*/
+/*[IF JAVA_SPEC_VERSION >= 14]*/
 	/**
 	 * Returns true if the class instance is a record.
 	 * 
@@ -4942,7 +4942,7 @@ SecurityException {
 	}
 
 	private native RecordComponent[] getRecordComponentsImpl();
-/*[ENDIF] Java14 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 
 /*[IF JAVA_SPEC_VERSION >= 15]*/
 	/**

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -212,7 +212,7 @@ public abstract class ClassLoader {
 			// ignore
 		}
 
-		/*[IF Java11]*/
+		/*[IF JAVA_SPEC_VERSION >= 11]*/
 		// This static method call ensures jdk.internal.loader.ClassLoaders.BOOT_LOADER initialization first
 		jdk.internal.loader.ClassLoaders.platformClassLoader();
 		if (bootstrapClassLoader.servicesCatalog != null) {
@@ -224,7 +224,7 @@ public abstract class ClassLoader {
 		}
 		bootstrapClassLoader.classLoaderValueMap = BootLoader.getClassLoaderValueMap();
 		applicationClassLoader = ClassLoaders.appClassLoader();
-		/*[ELSE] Java11 */
+		/*[ELSE] JAVA_SPEC_VERSION >= 11 */
 		ClassLoader sysTemp = null;
 		// Proper initialization requires BootstrapLoader is the first loader instantiated
 		String systemLoaderString = System.internalGetProperties().getProperty("systemClassLoader"); //$NON-NLS-1$
@@ -242,7 +242,7 @@ public abstract class ClassLoader {
 		AbstractClassLoader.setBootstrapClassLoader(bootstrapClassLoader);
 		lazyClassLoaderInit = true;
 		applicationClassLoader = bootstrapClassLoader;
-		/*[ENDIF] Java11 */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
 		/* [PR 78889] The creation of this classLoader requires lazy initialization. The internal classLoader struct
 		 * is created in the initAnonClassLoader call. The "new InternalAnonymousClassLoader()" call must be 

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -267,11 +267,11 @@ public abstract class ClassLoader {
 		 * More details are at https://github.com/eclipse/openj9/issues/3399#issuecomment-459004840.
 		 */
 		Modifier.isPublic(Modifier.PUBLIC);
-		/*[IF Java10]*/
+		/*[IF JAVA_SPEC_VERSION >= 10]*/
 		try {
-		/*[ENDIF]*/
+		/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 			System.bootLayer = jdk.internal.module.ModuleBootstrap.boot();
-		/*[IF Java10]*/
+		/*[IF JAVA_SPEC_VERSION >= 10]*/
 		} catch (Exception ex) {
 			System.out.println(ex);
 			Throwable t = ex.getCause();
@@ -281,7 +281,7 @@ public abstract class ClassLoader {
 			}
 			System.exit(1);
 		}
-		/*[ENDIF]*/
+		/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 		jdk.internal.misc.VM.initLevel(2);
 		String javaSecurityManager = System.internalGetProperties().getProperty("java.security.manager"); //$NON-NLS-1$
 		if ((javaSecurityManager != null) 

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -63,10 +63,10 @@ import jdk.internal.loader.BootLoader;
 import sun.reflect.CallerSensitive;
 /*[ENDIF]*/
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import jdk.internal.loader.NativeLibraries;
 import jdk.internal.loader.NativeLibrary;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 /**
  * ClassLoaders are used to dynamically load, link and install
@@ -152,9 +152,9 @@ public abstract class ClassLoader {
 /*[ENDIF]*/	
 	private static boolean specialLoaderInited = false;
 	private static InternalAnonymousClassLoader internalAnonClassLoader;
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	private NativeLibraries nativelibs = null;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 	private static native void initAnonClassLoader(InternalAnonymousClassLoader anonClassLoader);
 	
 	/*[PR JAZZ 73143]: ClassLoader incorrectly discards class loading locks*/
@@ -415,9 +415,9 @@ private ClassLoader(Void staticMethodHolder, String classLoaderName, ClassLoader
 		}
 /*[IF Sidecar19-SE]*/
 		unnamedModule = new Module(this);
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 		this.nativelibs = NativeLibraries.jniNativeLibraries(this);
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 /*[ENDIF]*/
 	} 
 /*[IF Sidecar19-SE]*/	
@@ -427,17 +427,17 @@ private ClassLoader(Void staticMethodHolder, String classLoaderName, ClassLoader
 			unnamedModule = null;
 			bootstrapClassLoader = this;
 			VM.initializeClassLoader(bootstrapClassLoader, VM.J9_CLASSLOADER_TYPE_BOOT, false);
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 			this.nativelibs = NativeLibraries.jniNativeLibraries(null);
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 		} else {
 			// Assuming the second classloader initialized is platform classloader
 			VM.initializeClassLoader(this, VM.J9_CLASSLOADER_TYPE_PLATFORM, false);
 			specialLoaderInited = true;
 			unnamedModule = new Module(this);
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 			this.nativelibs = NativeLibraries.jniNativeLibraries(this);
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 		}
 	}
 	this.classLoaderName = classLoaderName;
@@ -621,7 +621,7 @@ final Class<?> defineClassInternal(
 	return answer;
 }
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 
 private final native Class<?> defineClassImpl1(Class<?> hostClass, String className, byte[] classRep, ProtectionDomain protectionDomain, boolean init, int flags, Object classData);
 final Class<?> defineClassInternal(
@@ -637,7 +637,7 @@ final Class<?> defineClassInternal(
 	Class<?> answer = defineClassImpl1(hostClass, className, classRep, protectionDomain, init, flags, classData);
 	return answer;
 }
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 /*[IF Sidecar19-SE]*/
 /**
@@ -1995,7 +1995,7 @@ static void loadLibrary(Class<?> caller, String name, boolean fullPath) {
 		loadLibraryWithClassLoader(name, caller.getClassLoaderImpl());
 }
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 static void loadLibrary(Class<?> caller, File file) {
 	ClassLoader loader = (caller == null) ? null : caller.getClassLoader();
 	NativeLibraries nls = (loader == null) ? bootstrapClassLoader.nativelibs : loader.nativelibs;
@@ -2046,7 +2046,7 @@ private static long findNative(ClassLoader loader, String entryName) {
 	}
 	return result;
 }
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 /**
  * Sets the assertion status of a class.

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -285,11 +285,11 @@ public abstract class ClassLoader {
 		jdk.internal.misc.VM.initLevel(2);
 		String javaSecurityManager = System.internalGetProperties().getProperty("java.security.manager"); //$NON-NLS-1$
 		if ((javaSecurityManager != null) 
-		/*[IF Java12]*/
+		/*[IF JAVA_SPEC_VERSION >= 12]*/
 			/* See the SecurityManager javadoc for details about special tokens. */
 			&& !javaSecurityManager.equals("disallow") //$NON-NLS-1$ /* special token to disallow SecurityManager */
 			&& !javaSecurityManager.equals("allow") //$NON-NLS-1$ /* special token to allow SecurityManager */
-			/*[ENDIF] Java12 */
+			/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 		) {
 			if (javaSecurityManager.isEmpty() || "default".equals(javaSecurityManager)) { //$NON-NLS-1$
 				System.setSecurityManager(new SecurityManager());

--- a/jcl/src/java.base/share/classes/java/lang/StackWalker.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackWalker.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,9 +23,9 @@
 package java.lang;
 
 import java.lang.StackWalker.StackFrameImpl;
-/*[IF Java10]*/
+/*[IF JAVA_SPEC_VERSION >= 10]*/
 import java.lang.invoke.MethodType;
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 import java.lang.module.ModuleDescriptor;
 import java.lang.module.ModuleDescriptor.Version;
 import java.security.Permission;
@@ -303,7 +303,7 @@ public final class StackWalker {
 		 */
 		StackTraceElement toStackTraceElement();
 
-		/*[IF Java10]*/
+		/*[IF JAVA_SPEC_VERSION >= 10]*/
 		/**
 		 * @throws UnsupportedOperationException if this method is not overridden
 		 * @return MethodType containing the parameter and return types for the associated method.
@@ -323,7 +323,7 @@ public final class StackWalker {
 			throw new UnsupportedOperationException();
 		}
 
-		/*[ENDIF]*/
+		/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 	}
 
 	final static class StackFrameImpl implements StackFrame {
@@ -395,7 +395,7 @@ public final class StackWalker {
 					lineNumber);
 		}
 
-		/*[IF Java10]*/
+		/*[IF JAVA_SPEC_VERSION >= 10]*/
 		/**
 		 * Creates a MethodType object for the method associated with this frame.
 		 * @throws UnsupportedOperationException if the StackWalker object is not configured with RETAIN_CLASS_REFERENCE
@@ -420,8 +420,8 @@ public final class StackWalker {
 		public java.lang.String getDescriptor() {
 			return methodSignature;
 		}
-		/*[ENDIF]*/
-		
+		/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
+
 	}
 
 	static class PermissionSingleton {
@@ -429,4 +429,3 @@ public final class StackWalker {
 				new RuntimePermission("getStackWalkerWithClassReference"); //$NON-NLS-1$
 	}
 }
-

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -33,10 +33,10 @@ import java.util.Formatter;
 import java.util.StringJoiner;
 import java.util.Iterator;
 import java.nio.charset.Charset;
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import java.util.function.Function;
 import java.util.Optional;
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 /*[IF Sidecar19-SE]*/
 import java.util.Spliterator;
 import java.util.stream.StreamSupport;
@@ -51,12 +51,12 @@ import sun.misc.Unsafe;
 import java.util.stream.Stream;
 /*[ENDIF] Java11*/
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import java.lang.constant.Constable;
 import java.lang.constant.ConstantDesc;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 /**
  * Strings are objects which represent immutable arrays of characters.
@@ -67,9 +67,9 @@ import java.lang.invoke.MethodHandles.Lookup;
  * @see StringBuffer
  */
 public final class String implements Serializable, Comparable<String>, CharSequence
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	, Constable, ConstantDesc
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 {
 
 	/*
@@ -8382,7 +8382,7 @@ written authorization of the copyright holder.
 
 /*[ENDIF] Sidecar19-SE*/
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * Apply a function to this string. The function expects a single String input
 	 * and returns an R.
@@ -8473,7 +8473,7 @@ written authorization of the copyright holder.
 
 		return builder.toString();
 	}
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 /*[IF JAVA_SPEC_VERSION >= 13]*/
 	/**

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -8475,7 +8475,7 @@ written authorization of the copyright holder.
 	}
 /*[ENDIF] Java12 */
 
-/*[IF Java13]*/
+/*[IF JAVA_SPEC_VERSION >= 13]*/
 	/**
 	 * Determine if current String object is LATIN1.
 	 *
@@ -8668,5 +8668,5 @@ written authorization of the copyright holder.
 		}
 		return builder.toString();
 	}
-/*[ENDIF] Java13 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 13 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -47,9 +47,9 @@ import java.util.stream.IntStream;
 import sun.misc.Unsafe;
 /*[ENDIF] Sidecar19-SE*/
 
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 import java.util.stream.Stream;
-/*[ENDIF] Java11*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
 /*[IF JAVA_SPEC_VERSION >= 12]*/
 import java.lang.constant.Constable;
@@ -2567,7 +2567,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		return regionMatches(start, prefix, 0, prefix.lengthInternal());
 	}
 
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 	/**
 	 * Strip leading and trailing white space from a string.
 	 *
@@ -2665,7 +2665,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			return StringUTF16.lines(value);
 		}
 	}
-/*[ENDIF] Java11*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
 	/**
 	 * Copies a range of characters into a new String.
@@ -3959,7 +3959,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		return value;
 	}
 
-	/*[IF Java11]*/
+	/*[IF JAVA_SPEC_VERSION >= 11]*/
 	/**
 	 * Returns a string object containing the character (Unicode code point)
 	 * specified.
@@ -4040,7 +4040,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			return new String(buffer, UTF16);
 		}
 	}
-	/*[ENDIF] Java11 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
 /*[ELSE] Sidecar19-SE*/
 	// DO NOT CHANGE OR MOVE THIS LINE

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -1498,7 +1498,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				int codepointAtO2 = charAtO2;
 
 				if (charAtO1 == charAtO2) {
-					/*[IF Java16]*/
+					/*[IF JAVA_SPEC_VERSION >= 16]*/
 					if (Character.isHighSurrogate(charAtO1) && (o1 < end)) {
 						codepointAtO1 = Character.toCodePoint(charAtO1, s1.charAtInternal(o1++, s1Value));
 						codepointAtO2 = Character.toCodePoint(charAtO2, s2.charAtInternal(o2++, s2Value));
@@ -1510,7 +1510,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 					}
 					/*[ELSE]*/
 					continue;
-					/*[ENDIF] Java16 */
+					/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 				}
 
 				int result = compareValue(codepointAtO1) - compareValue(codepointAtO2);
@@ -1792,22 +1792,22 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			if (charAtO1Last != charAtO2Last
 					&& toUpperCase(charAtO1Last) != toUpperCase(charAtO2Last)
 					&& ((charAtO1Last <= 255 && charAtO2Last <= 255) || Character.toLowerCase(charAtO1Last) != Character.toLowerCase(charAtO2Last))
-					/*[IF Java16]*/
+					/*[IF JAVA_SPEC_VERSION >= 16]*/
 					&& (!Character.isLowSurrogate(charAtO1Last) || !Character.isLowSurrogate(charAtO2Last))
-					/*[ENDIF] Java16 */
+					/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 			) {
 				return false;
 			}
 
-			/*[IF Java16]*/
+			/*[IF JAVA_SPEC_VERSION >= 16]*/
 			while (o1 < end) {
 			/*[ELSE]*/
 			while (o1 < end - 1) {
-			/*[ENDIF] Java16 */
+			/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 				char charAtO1 = s1.charAtInternal(o1++, s1Value);
 				char charAtO2 = s2.charAtInternal(o2++, s2Value);
 
-				/*[IF Java16]*/
+				/*[IF JAVA_SPEC_VERSION >= 16]*/
 				if (Character.isHighSurrogate(charAtO1) && Character.isHighSurrogate(charAtO2) && (o1 < end)) {
 					int codepointAtO1 = Character.toCodePoint(charAtO1, s1.charAtInternal(o1++, s1Value));
 					int codepointAtO2 = Character.toCodePoint(charAtO2, s2.charAtInternal(o2++, s2Value));
@@ -1817,7 +1817,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 						continue;
 					}
 				}
-				/*[ENDIF] Java16 */
+				/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 
 				if (charAtO1 != charAtO2 &&
 						toUpperCase(charAtO1) != toUpperCase(charAtO2) &&
@@ -2456,7 +2456,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				char charAtO1 = s1.charAtInternal(o1++, s1Value);
 				char charAtO2 = s2.charAtInternal(o2++, s2Value);
 
-				/*[IF Java16]*/
+				/*[IF JAVA_SPEC_VERSION >= 16]*/
 				if (Character.isHighSurrogate(charAtO1) && Character.isHighSurrogate(charAtO2) && (o1 < end)) {
 					int codepointAtO1 = Character.toCodePoint(charAtO1, s1.charAtInternal(o1++, s1Value));
 					int codepointAtO2 = Character.toCodePoint(charAtO2, s2.charAtInternal(o2++, s2Value));
@@ -2464,7 +2464,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 						return false;
 					}
 				}
-				/*[ENDIF] Java16 */
+				/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 
 				if (charAtO1 != charAtO2 &&
 						toUpperCase(charAtO1) != toUpperCase(charAtO2) &&

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -770,7 +770,7 @@ public static void runFinalization() {
 	RUNTIME.runFinalization();
 }
 
-/*[IF !Java11]*/
+/*[IF JAVA_SPEC_VERSION < 11]*/
 /**
  * Ensure that, when the virtual machine is about to exit,
  * all objects are finalized. Note that all finalization
@@ -789,7 +789,7 @@ public static void runFinalization() {
 public static void runFinalizersOnExit(boolean flag) {
 	Runtime.runFinalizersOnExit(flag);
 }
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION < 11 */
 
 /**
  * Answers the system properties. Note that the object

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -31,11 +31,11 @@ import java.lang.reflect.Method;
 
 /*[IF Sidecar19-SE]*/
 import jdk.internal.misc.Unsafe;
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import jdk.internal.access.SharedSecrets;
-/*[ELSE]
+/*[ELSE] JAVA_SPEC_VERSION >= 12
 import jdk.internal.misc.SharedSecrets;
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 import jdk.internal.misc.VM;
 import java.lang.StackWalker.Option;
 import jdk.internal.reflect.Reflection;
@@ -401,11 +401,11 @@ private static void ensureProperties(boolean isInitialization) {
 	initProperties(new Properties());
 /*[ENDIF] OpenJ9-RawBuild */
 	
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	Map<String, String> initializedProperties = new Hashtable<String, String>();
-/*[ELSE]
+/*[ELSE] JAVA_SPEC_VERSION >= 12
 	Properties initializedProperties = new Properties();
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 	if (osEncoding != null) {
 		initializedProperties.put("os.encoding", osEncoding); //$NON-NLS-1$
@@ -415,10 +415,10 @@ private static void ensureProperties(boolean isInitialization) {
 	initializedProperties.put("sun.jnu.encoding", platformEncoding); //$NON-NLS-1$
 	initializedProperties.put("file.encoding", fileEncoding); //$NON-NLS-1$
 	initializedProperties.put("file.encoding.pkg", "sun.io"); //$NON-NLS-1$ //$NON-NLS-2$
-	/*[IF !Java12]*/
+	/*[IF JAVA_SPEC_VERSION < 12]*/
 	/* System property java.specification.vendor is set via VersionProps.init(systemProperties) since JDK12 */
 	initializedProperties.put("java.specification.vendor", "Oracle Corporation"); //$NON-NLS-1$ //$NON-NLS-2$
-	/*[ENDIF] !Java12 */
+	/*[ENDIF] JAVA_SPEC_VERSION < 12 */
 	initializedProperties.put("java.specification.name", "Java Platform API Specification"); //$NON-NLS-1$ //$NON-NLS-2$
 	initializedProperties.put("com.ibm.oti.configuration", "scar"); //$NON-NLS-1$
 
@@ -435,9 +435,9 @@ private static void ensureProperties(boolean isInitialization) {
 	/* java.lang.VersionProps.init() eventually calls into System.setProperty() where propertiesInitialized needs to be true */
 	propertiesInitialized = true;
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	java.lang.VersionProps.init(initializedProperties);
-/*[ELSE]
+/*[ELSE] JAVA_SPEC_VERSION >= 12
 	/* VersionProps.init requires systemProperties to be set */
 	systemProperties = initializedProperties;
 
@@ -449,47 +449,47 @@ private static void ensureProperties(boolean isInitialization) {
 	StringBuffer.initFromSystemProperties(systemProperties);
 	StringBuilder.initFromSystemProperties(systemProperties);
 /*[ENDIF] Sidecar19-SE */
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	String javaRuntimeVersion = initializedProperties.get("java.runtime.version"); //$NON-NLS-1$
-/*[ELSE]
+/*[ELSE] JAVA_SPEC_VERSION >= 12
 	String javaRuntimeVersion = initializedProperties.getProperty("java.runtime.version"); //$NON-NLS-1$
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 	if (null != javaRuntimeVersion) {
-	/*[IF Java12]*/
+	/*[IF JAVA_SPEC_VERSION >= 12]*/
 		String fullVersion = initializedProperties.get("java.fullversion"); //$NON-NLS-1$
-	/*[ELSE]
+	/*[ELSE] JAVA_SPEC_VERSION >= 12
 		String fullVersion = initializedProperties.getProperty("java.fullversion"); //$NON-NLS-1$
-	/*[ENDIF] Java12 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 		if (null != fullVersion) {
 			initializedProperties.put("java.fullversion", (javaRuntimeVersion + "\n" + fullVersion)); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		rasInitializeVersion(javaRuntimeVersion);
 	}
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	lineSeparator = initializedProperties.getOrDefault("line.separator", "\n"); //$NON-NLS-1$
-/*[ELSE]
+/*[ELSE] JAVA_SPEC_VERSION >= 12
 	lineSeparator = initializedProperties.getProperty("line.separator", "\n"); //$NON-NLS-1$
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 	if (isInitialization) {
 		/*[PR CMVC 179976] System.setProperties(null) throws IllegalStateException */
-		/*[IF Java12]*/
+		/*[IF JAVA_SPEC_VERSION >= 12]*/
 		VM.saveProperties(initializedProperties);
-		/*[ELSE]
+		/*[ELSE] JAVA_SPEC_VERSION >= 12
 		VM.saveAndRemoveProperties(initializedProperties);
-		/*[ENDIF] Java12 */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 	}
 
 	/* create systemProperties from properties Map */
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	initializeSystemProperties(initializedProperties);
-/*[ELSE]
+/*[ELSE] JAVA_SPEC_VERSION >= 12
 	systemProperties = initializedProperties;
-/*[ENDIF] Java12 */
-	
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
+
 	/* Preload system property jdk.serialFilter to prevent later modification */
 	jdk.internal.util.StaticProperty.jdkSerialFilter();
 }
@@ -587,10 +587,10 @@ static Properties internalGetProperties() {
  * The properties currently provided by the virtual
  * machine are:
  * <pre>
-/*[IF !Java12]
+/*[IF JAVA_SPEC_VERSION < 12]
  *     java.vendor
  *     java.vendor.url
- /*[ENDIF] Java12
+ /*[ENDIF] JAVA_SPEC_VERSION < 12
  *     java.class.path
  *     user.home
  *     java.class.version
@@ -822,22 +822,22 @@ public static void setProperties(Properties p) {
  * @param		s			the new security manager
  * 
  * @throws		SecurityException 	if the security manager has already been set and its checkPermission method doesn't allow it to be replaced.
- /*[IF Java12]
+ /*[IF JAVA_SPEC_VERSION >= 12]
  * @throws		UnsupportedOperationException 	if s is non-null and a special token "disallow" has been set for system property "java.security.manager"
  * 												which indicates that a security manager is not allowed to be set dynamically.
- /*[ENDIF] Java12
+ /*[ENDIF] JAVA_SPEC_VERSION >= 12
  */
 public static void setSecurityManager(final SecurityManager s) {
 	/*[PR 113606] security field could be modified by another Thread */
 	final SecurityManager currentSecurity = security;
 	
 	if (s != null) {
-		/*[IF Java12]*/
+		/*[IF JAVA_SPEC_VERSION >= 12]*/
 		if ("disallow".equals(systemProperties.getProperty("java.security.manager"))) { //$NON-NLS-1$ //$NON-NLS-2$
 			/*[MSG "K0B00", "`-Djava.security.manager=disallow` has been specified"]*/
 			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K0B00")); //$NON-NLS-1$
 		}
-		/*[ENDIF] Java12 */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 		if (currentSecurity == null) {
 			// only preload classes when current security manager is null
 			// not adding an extra static field to preload only once

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -727,7 +727,7 @@ public static void load(String pathName) {
 	if (smngr != null) {
 		smngr.checkLink(pathName);
 	}
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	File fileName = new File(pathName);
 	if (fileName.isAbsolute()) {
 		ClassLoader.loadLibrary(getCallerClass(), fileName);
@@ -737,7 +737,7 @@ public static void load(String pathName) {
 	}
 /*[ELSE]
 	ClassLoader.loadLibraryWithPath(pathName, ClassLoader.callerClassLoader(), null);
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 }
 
 /**
@@ -754,11 +754,11 @@ public static void loadLibrary(String libName) {
 	if (smngr != null) {
 		smngr.checkLink(libName);
 	}
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	ClassLoader.loadLibrary(getCallerClass(), libName);
 /*[ELSE]*/
 	ClassLoader.loadLibraryWithClassLoader(libName, ClassLoader.callerClassLoader());
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 }
 
 /**

--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -27,12 +27,12 @@ import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import sun.security.util.SecurityConstants;
-/*[IF Java11]
+/*[IF JAVA_SPEC_VERSION >= 11]
 import jdk.internal.misc.TerminatingThreadLocal;
 import jdk.internal.reflect.CallerSensitive;
-/*[ELSE]*/
+/*[ELSE] JAVA_SPEC_VERSION >= 11 */
 import sun.reflect.CallerSensitive;
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
 /**
  *	A Thread is a unit of concurrent execution in Java. It has its own call stack
@@ -561,11 +561,11 @@ public final void checkAccess() {
  *
  * @deprecated	The semantics of this method are poorly defined and it uses the deprecated suspend() method.
  */
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 @Deprecated(forRemoval=true, since="1.2")
-/*[ELSE] Java11 */
+/*[ELSE] JAVA_SPEC_VERSION >= 11 */
 @Deprecated
-/*[ENDIF] Java11 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 public int countStackFrames() {
 /*[IF JAVA_SPEC_VERSION >= 14]*/
 	throw new UnsupportedOperationException();
@@ -582,7 +582,7 @@ public int countStackFrames() {
  */
 public static native Thread currentThread();
 
-/*[IF !Java11]*/
+/*[IF JAVA_SPEC_VERSION < 11]*/
 /**
  * 	Destroys the receiver without any monitor cleanup. Not implemented.
  * 
@@ -597,8 +597,7 @@ public void destroy() {
 	/*[PR 121318] Should throw NoSuchMethodError */
 	throw new NoSuchMethodError();
 }
-/*[ENDIF]*/
-
+/*[ENDIF] JAVA_SPEC_VERSION < 11 */
 
 /**
  * 	Prints a text representation of the stack for this Thread.
@@ -925,15 +924,15 @@ private synchronized static String newName() {
  *
  * @deprecated	Used with deprecated method Thread.suspend().
  */
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 /*[IF JAVA_SPEC_VERSION >= 14]*/
 @Deprecated(forRemoval=true, since="1.2")
 /*[ELSE] JAVA_SPEC_VERSION >= 14 */
 @Deprecated(forRemoval=false, since="1.2")
 /*[ENDIF] JAVA_SPEC_VERSION >= 14 */
-/*[ELSE] Java11 */
+/*[ELSE] JAVA_SPEC_VERSION >= 11 */
 @Deprecated
-/*[ENDIF] Java11 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 public final void resume() {
 	checkAccess();
 	synchronized(lock) {
@@ -1184,7 +1183,7 @@ public final void stop() {
 	}
 }
 
-/*[IF !Java11]*/
+/*[IF JAVA_SPEC_VERSION < 11]*/
 /**
  * Throws UnsupportedOperationException.
  *
@@ -1199,8 +1198,8 @@ public final void stop() {
 /*[ENDIF]*/
 public final void stop(Throwable throwable) {
 	throw new UnsupportedOperationException();
- }
-/*[ENDIF]*/
+}
+/*[ENDIF] JAVA_SPEC_VERSION < 11 */
 
 private final synchronized void stopWithThrowable(Throwable throwable) {
 	checkAccess();
@@ -1250,15 +1249,15 @@ private native void stopImpl(Throwable throwable);
  *
  * @deprecated May cause deadlocks.
  */
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 /*[IF JAVA_SPEC_VERSION >= 14]*/
 @Deprecated(forRemoval=true, since="1.2")
 /*[ELSE] JAVA_SPEC_VERSION >= 14 */
 @Deprecated(forRemoval=false, since="1.2")
 /*[ENDIF] JAVA_SPEC_VERSION >= 14 */
-/*[ELSE] Java11 */
+/*[ELSE] JAVA_SPEC_VERSION >= 11 */
 @Deprecated
-/*[ENDIF] Java11 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 public final void suspend() { 
 	checkAccess();
 	/*[PR 106321]*/
@@ -1312,16 +1311,16 @@ public static native void yield();
  */
 public static native boolean holdsLock(Object object);
 
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 static
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 void blockedOn(sun.nio.ch.Interruptible interruptible) {
 	Thread currentThread;
-	/*[IF Java11]*/
+	/*[IF JAVA_SPEC_VERSION >= 11]*/
 	currentThread = currentThread();
-	/*[ELSE]
+	/*[ELSE] JAVA_SPEC_VERSION >= 11
 	currentThread = this;
-	/*[ENDIF]*/
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 	synchronized(currentThread.lock) {
 		currentThread.blockOn = interruptible;
 	}
@@ -1539,11 +1538,11 @@ void cleanup() {
 	deadInterrupt = interrupted();
 /*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 	if (threadLocals != null && TerminatingThreadLocal.REGISTRY.isPresent()) {
 		TerminatingThreadLocal.threadTerminated();
 	}
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
 	/*[PR 97317]*/
 	group = null;

--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -79,14 +79,14 @@ public class Thread implements Runnable {
 	// Instance variables
 	private long threadRef;									// Used by the VM
 	long stackSize = 0;
-	/*[IF Java14]*/
+	/*[IF JAVA_SPEC_VERSION >= 14]*/
 	/* deadInterrupt tracks the thread interrupt state when threadRef has no reference (ie thread is not alive). 
 	 * Note that this value need not be updated while the thread is running since the interrupt state will be 
 	 * tracked by the vm during that time. Because of this the value should not be used over calling
 	 * isInterrupted() or interrupted().
 	 */
 	private volatile boolean deadInterrupt;
-	/*[ENDIF] Java14 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 	private volatile boolean started;				// If !isAlive(), tells if Thread died already or hasn't even started
 	private String name;						// The Thread's name
 	private int priority = NORM_PRIORITY;			// The Thread's current priority
@@ -550,14 +550,14 @@ public final void checkAccess() {
  *
  * @return		Number of stack frames
  * 
-/*[IF Java14]
+/*[IF JAVA_SPEC_VERSION >= 14]
  * @exception	UnsupportedOperationException
-/*[ELSE] Java14 
+/*[ELSE] JAVA_SPEC_VERSION >= 14
 /*[IF Java13]
  * @exception	IllegalThreadStateException
  *					if this thread has not been suspended.
 /*[ENDIF] Java13
-/*[ENDIF] Java14 
+/*[ENDIF] JAVA_SPEC_VERSION >= 14
  *
  * @deprecated	The semantics of this method are poorly defined and it uses the deprecated suspend() method.
  */
@@ -567,11 +567,11 @@ public final void checkAccess() {
 @Deprecated
 /*[ENDIF] Java11 */
 public int countStackFrames() {
-/*[IF Java14]*/
+/*[IF JAVA_SPEC_VERSION >= 14]*/
 	throw new UnsupportedOperationException();
-/*[ELSE] Java14 */
+/*[ELSE] JAVA_SPEC_VERSION >= 14 */
 	return 0;
-/*[ENDIF] Java14 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 }
 
 /**
@@ -685,9 +685,9 @@ public final ThreadGroup getThreadGroup() {
 /**
  * Posts an interrupt request to the receiver
  * 
-/*[IF Java14]
+/*[IF JAVA_SPEC_VERSION >= 14]
  * From Java 14, the interrupt state for threads that are not alive is tracked.
-/*[ENDIF]
+/*[ENDIF] JAVA_SPEC_VERSION >= 14
  *
  * @exception	SecurityException
  *					if <code>group.checkAccess()</code> fails with a SecurityException
@@ -733,9 +733,9 @@ public static native boolean interrupted();
 /**
  * Posts an interrupt request to the receiver
  * 
-/*[IF Java14]
+/*[IF JAVA_SPEC_VERSION >= 14]
  * From Java 14, the interrupt state for threads that are not alive is tracked.
-/*[ENDIF]
+/*[ENDIF] JAVA_SPEC_VERSION >= 14
  *
  * @see			Thread#interrupted
  * @see			Thread#isInterrupted 
@@ -926,11 +926,11 @@ private synchronized static String newName() {
  * @deprecated	Used with deprecated method Thread.suspend().
  */
 /*[IF Java11]*/
-/*[IF Java14]*/
+/*[IF JAVA_SPEC_VERSION >= 14]*/
 @Deprecated(forRemoval=true, since="1.2")
-/*[ELSE] Java14 */
+/*[ELSE] JAVA_SPEC_VERSION >= 14 */
 @Deprecated(forRemoval=false, since="1.2")
-/*[ENDIF] Java14 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 /*[ELSE] Java11 */
 @Deprecated
 /*[ENDIF] Java11 */
@@ -1251,11 +1251,11 @@ private native void stopImpl(Throwable throwable);
  * @deprecated May cause deadlocks.
  */
 /*[IF Java11]*/
-/*[IF Java14]*/
+/*[IF JAVA_SPEC_VERSION >= 14]*/
 @Deprecated(forRemoval=true, since="1.2")
-/*[ELSE] Java14 */
+/*[ELSE] JAVA_SPEC_VERSION >= 14 */
 @Deprecated(forRemoval=false, since="1.2")
-/*[ENDIF] Java14 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 /*[ELSE] Java11 */
 @Deprecated
 /*[ENDIF] Java11 */
@@ -1534,10 +1534,10 @@ void uncaughtException(Throwable e) {
  * @see J9VMInternals#threadCleanup()
  */
 void cleanup() {
-/*[IF Java14]*/
+/*[IF JAVA_SPEC_VERSION >= 14]*/
 	/* Refresh deadInterrupt value so it is accurate when thread reference is removed. */	
 	deadInterrupt = interrupted();
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 
 /*[IF Java11]*/
 	if (threadLocals != null && TerminatingThreadLocal.REGISTRY.isPresent()) {

--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -553,10 +553,10 @@ public final void checkAccess() {
 /*[IF JAVA_SPEC_VERSION >= 14]
  * @exception	UnsupportedOperationException
 /*[ELSE] JAVA_SPEC_VERSION >= 14
-/*[IF Java13]
+/*[IF JAVA_SPEC_VERSION >= 13]
  * @exception	IllegalThreadStateException
  *					if this thread has not been suspended.
-/*[ENDIF] Java13
+/*[ENDIF] JAVA_SPEC_VERSION >= 13
 /*[ENDIF] JAVA_SPEC_VERSION >= 14
  *
  * @deprecated	The semantics of this method are poorly defined and it uses the deprecated suspend() method.

--- a/jcl/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/jcl/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -240,11 +240,11 @@ private void add(ThreadGroup g) throws IllegalThreadStateException {
  * @deprecated 	Required deprecated method suspend().
  */
 /*[IF Java11]*/
-/*[IF Java14]*/
+/*[IF JAVA_SPEC_VERSION >= 14]*/
 @Deprecated(forRemoval=true, since="1.2")
-/*[ELSE] Java14 */
+/*[ELSE] JAVA_SPEC_VERSION >= 14 */
 @Deprecated(forRemoval=false, since="1.2")
-/*[ENDIF] Java14 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 /*[ELSE] Java11 */
 @Deprecated
 /*[ENDIF] Java11 */
@@ -729,11 +729,11 @@ private void remove(ThreadGroup g) {
  * @deprecated Requires deprecated method Thread.resume().
  */
 /*[IF Java11]*/
-/*[IF Java14]*/
+/*[IF JAVA_SPEC_VERSION >= 14]*/
 @Deprecated(forRemoval=true, since="1.2")
-/*[ELSE] Java14 */
+/*[ELSE] JAVA_SPEC_VERSION >= 14 */
 @Deprecated(forRemoval=false, since="1.2")
-/*[ENDIF] Java14 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 /*[ELSE] Java11 */
 @Deprecated
 /*[ENDIF] Java11 */
@@ -866,11 +866,11 @@ private final boolean stopHelper() {
  * @deprecated Requires deprecated method Thread.suspend().
  */
 /*[IF Java11]*/
-/*[IF Java14]*/
+/*[IF JAVA_SPEC_VERSION >= 14]*/
 @Deprecated(forRemoval=true, since="1.2")
-/*[ELSE] Java14 */
+/*[ELSE] JAVA_SPEC_VERSION >= 14 */
 @Deprecated(forRemoval=false, since="1.2")
-/*[ENDIF] Java14 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 /*[ELSE] Java11 */
 @Deprecated
 /*[ENDIF] Java11 */

--- a/jcl/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/jcl/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -1,7 +1,4 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
-
-package java.lang;
-
 /*******************************************************************************
  * Copyright (c) 1998, 2020 IBM Corp. and others
  *
@@ -23,7 +20,7 @@ package java.lang;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
- 
+package java.lang;
 
 /**
  * ThreadGroups are containers of Threads and ThreadGroups, therefore providing
@@ -37,7 +34,6 @@ package java.lang;
  * @see			Thread
  * @see			SecurityManager
  */
-
 public class ThreadGroup implements Thread.UncaughtExceptionHandler {
 
 	private String name;					// Name of this ThreadGroup		
@@ -239,15 +235,15 @@ private void add(ThreadGroup g) throws IllegalThreadStateException {
  *
  * @deprecated 	Required deprecated method suspend().
  */
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 /*[IF JAVA_SPEC_VERSION >= 14]*/
 @Deprecated(forRemoval=true, since="1.2")
 /*[ELSE] JAVA_SPEC_VERSION >= 14 */
 @Deprecated(forRemoval=false, since="1.2")
 /*[ENDIF] JAVA_SPEC_VERSION >= 14 */
-/*[ELSE] Java11 */
+/*[ELSE] JAVA_SPEC_VERSION >= 11 */
 @Deprecated
-/*[ENDIF] Java11 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 public boolean allowThreadSuspension(boolean b) {
 	// Does not apply to this VM, no-op
 	/*[PR 1PR4U1E]*/
@@ -728,15 +724,15 @@ private void remove(ThreadGroup g) {
  *
  * @deprecated Requires deprecated method Thread.resume().
  */
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 /*[IF JAVA_SPEC_VERSION >= 14]*/
 @Deprecated(forRemoval=true, since="1.2")
 /*[ELSE] JAVA_SPEC_VERSION >= 14 */
 @Deprecated(forRemoval=false, since="1.2")
 /*[ENDIF] JAVA_SPEC_VERSION >= 14 */
-/*[ELSE] Java11 */
+/*[ELSE] JAVA_SPEC_VERSION >= 11 */
 @Deprecated
-/*[ENDIF] Java11 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 public final void resume() {
 	checkAccess();
 	synchronized (this.childrenThreadsLock) { // Lock this subpart of the tree as we walk
@@ -865,15 +861,15 @@ private final boolean stopHelper() {
  *
  * @deprecated Requires deprecated method Thread.suspend().
  */
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 /*[IF JAVA_SPEC_VERSION >= 14]*/
 @Deprecated(forRemoval=true, since="1.2")
 /*[ELSE] JAVA_SPEC_VERSION >= 14 */
 @Deprecated(forRemoval=false, since="1.2")
 /*[ENDIF] JAVA_SPEC_VERSION >= 14 */
-/*[ELSE] Java11 */
+/*[ELSE] JAVA_SPEC_VERSION >= 11 */
 @Deprecated
-/*[ENDIF] Java11 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 public final void suspend() {
 	if (suspendHelper())
 		Thread.currentThread().suspend();

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ArrayVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ArrayVarHandle.java
@@ -25,10 +25,10 @@ package java.lang.invoke;
 import static java.lang.invoke.MethodType.methodType;
 import static java.lang.invoke.ArrayVarHandle.ArrayVarHandleOperations.*;
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import java.lang.constant.ClassDesc;
 import java.util.Optional;
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 /**
  * {@link VarHandle} subclass for array element {@link VarHandle} instances.
@@ -106,7 +106,7 @@ final class ArrayVarHandle extends VarHandle {
 		super(arrayType.getComponentType(), new Class<?>[] {arrayType, int.class}, populateMHs(arrayType), 0);
 	}
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	@Override
 	public Optional<VarHandleDesc> describeConstable() {
 		VarHandleDesc result = null;
@@ -117,7 +117,7 @@ final class ArrayVarHandle extends VarHandle {
 		}
 		return Optional.ofNullable(result);
 	}
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 	/**
 	 * Type specific methods used by array element VarHandle methods.

--- a/jcl/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
@@ -1,5 +1,4 @@
-/*[INCLUDE-IF Java11 & !OPENJDK_METHODHANDLES]*/
-
+/*[INCLUDE-IF (JAVA_SPEC_VERSION >= 11) & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
  * Copyright (c) 2018, 2020 IBM Corp. and others
  *
@@ -26,7 +25,6 @@ package java.lang.invoke;
 /*
  * Stub class for compilation
  */
-
 class BootstrapMethodInvoker {
 
 	static <T> T invoke(Class<T> clz1, MethodHandle mh, String str, Object obj1, Object obj2, Class<?> clz2) {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
@@ -77,12 +77,12 @@ abstract class BoundMethodHandle extends MethodHandle {
 		LambdaForm.NamedFunction getterFunction(int num) {
 			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
-		
-		/*[IF Java10]*/
+
+		/*[IF JAVA_SPEC_VERSION >= 10]*/
 		MethodHandle factory() {
 			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
-		/*[ENDIF]*/
+		/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 	}
 	
 	abstract BoundMethodHandle copyWithExtendL(MethodType mt, LambdaForm lf, Object obj);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
@@ -1,5 +1,4 @@
 /*[INCLUDE-IF Sidecar18-SE-OpenJ9 & !OPENJDK_METHODHANDLES]*/
-
 /*******************************************************************************
  * Copyright (c) 2017, 2020 IBM Corp. and others
  *
@@ -21,13 +20,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
 package java.lang.invoke;
 
 /*
  * Stub class to compile RI j.l.i.MethodHandleImpl
  */
-
 abstract class BoundMethodHandle extends MethodHandle {
 
 	BoundMethodHandle(MethodType mt, LambdaForm lf) {
@@ -62,7 +59,7 @@ abstract class BoundMethodHandle extends MethodHandle {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	final int fieldCount() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
@@ -70,7 +67,7 @@ abstract class BoundMethodHandle extends MethodHandle {
 	final Object arg(int i) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	class SpeciesData {
 		MethodHandle constructor() {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
@@ -1,5 +1,4 @@
-/*[INCLUDE-IF Java10 & !OPENJDK_METHODHANDLES]*/
-
+/*[INCLUDE-IF (JAVA_SPEC_VERSION >= 10) & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
  * Copyright (c) 2017, 2020 IBM Corp. and others
  *

--- a/jcl/src/java.base/share/classes/java/lang/invoke/CollectHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/CollectHandle.java
@@ -24,9 +24,9 @@ package java.lang.invoke;
 
 import com.ibm.oti.util.Msg;
 import java.lang.reflect.Array;
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 /* CollectHandle is a MethodHandle subclass used to call another MethodHandle.  
  * It accepts the incoming arguments and collects the requested number
@@ -101,13 +101,13 @@ final class CollectHandle extends MethodHandle {
 		return new CollectHandle(this, newType);
 	}
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		relatedMHs.add(next);
 		return true;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	// {{{ JIT support
 
@@ -163,4 +163,3 @@ final class CollectHandle extends MethodHandle {
 		c.compareChildHandle(left.next, this.next);
 	}
 }
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ConstantHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ConstantHandle.java
@@ -24,9 +24,9 @@ package java.lang.invoke;
 
 import static java.lang.invoke.MethodType.*;
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 /*
  * MethodHandle subclass responsible for dealing with constant values.
@@ -128,13 +128,13 @@ abstract class ConstantHandle extends MethodHandle {
 			return new ConstantIntHandle(methodType, value);
 		}
 	}
-	
-/*[IF Java15]*/
+
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		return false;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 }
 
 final class ConstantObjectHandle extends ConstantHandle {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ConvertHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ConvertHandle.java
@@ -24,9 +24,9 @@ package java.lang.invoke;
 
 import java.lang.invoke.MethodHandles.Lookup;
 import java.util.concurrent.ConcurrentHashMap;
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 import com.ibm.oti.util.Msg;
 
@@ -702,14 +702,14 @@ abstract class ConvertHandle extends MethodHandle {
 		static void load(){}
 	}
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		relatedMHs.add(next);
 		return true;
 	}
-/*[ENDIF] Java15 */
-	
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
+
 	// {{{ JIT support
 	static { FilterHelpers.load(); } // JIT will need FilterHelpers loaded to compile thunks
 	// }}} JIT support
@@ -718,4 +718,3 @@ abstract class ConvertHandle extends MethodHandle {
 		c.compareChildHandle(left.next, this.next);
 	}
 }
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/DelegatingMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/DelegatingMethodHandle.java
@@ -1,5 +1,4 @@
 /*[INCLUDE-IF Sidecar18-SE-OpenJ9 & !OPENJDK_METHODHANDLES]*/
-
 /*******************************************************************************
  * Copyright (c) 2017, 2020 IBM Corp. and others
  *
@@ -21,21 +20,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
 package java.lang.invoke;
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 /*
  * Stub class to compile OpenJDK j.l.i.MethodHandleImpl
  */
-
 abstract class DelegatingMethodHandle extends MethodHandle {
-	
+
 	static final LambdaForm.NamedFunction NF_getTarget = null;
-	
+
 	protected DelegatingMethodHandle(MethodHandle mh) {
 		this(mh.type(), mh);
 		OpenJDKCompileStub.OpenJDKCompileStubThrowError();
@@ -60,10 +57,10 @@ abstract class DelegatingMethodHandle extends MethodHandle {
 	}
 	/*[ENDIF]*/
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		return false;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/DelegatingMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/DelegatingMethodHandle.java
@@ -51,11 +51,11 @@ abstract class DelegatingMethodHandle extends MethodHandle {
 	static LambdaForm makeReinvokerForm(MethodHandle mh, int num, Object obj, String str, boolean flag, LambdaForm.NamedFunction nf1, LambdaForm.NamedFunction nf2) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-	/*[IF Java10]*/
+	/*[IF JAVA_SPEC_VERSION >= 10]*/
 	static LambdaForm makeReinvokerForm(MethodHandle mh, int num, Object obj, boolean flag, LambdaForm.NamedFunction nf1, LambdaForm.NamedFunction nf2) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-	/*[ENDIF]*/
+	/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 
 /*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override

--- a/jcl/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -1,5 +1,4 @@
 /*[INCLUDE-IF Sidecar18-SE-OpenJ9 & !OPENJDK_METHODHANDLES]*/
-
 /*******************************************************************************
  * Copyright (c) 2017, 2020 IBM Corp. and others
  *
@@ -21,7 +20,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 package java.lang.invoke;
 
 import java.util.List;
@@ -29,10 +28,9 @@ import java.util.List;
 /*
  * Stub class to compile RI j.l.i.MethodHandleImpl
  */
-
 class DirectMethodHandle extends MethodHandle {
 	MemberName member;
-	
+
 	DirectMethodHandle(MethodType mt, LambdaForm lf) {
 		super(mt, lf);
 		OpenJDKCompileStub.OpenJDKCompileStubThrowError();
@@ -43,4 +41,4 @@ class DirectMethodHandle extends MethodHandle {
 		return false;
 	}
 }
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */

--- a/jcl/src/java.base/share/classes/java/lang/invoke/DynamicInvokerHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/DynamicInvokerHandle.java
@@ -22,9 +22,9 @@
  *******************************************************************************/
 package java.lang.invoke;
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 @VMCONSTANTPOOL_CLASS
 class DynamicInvokerHandle extends MethodHandle {
@@ -41,12 +41,12 @@ class DynamicInvokerHandle extends MethodHandle {
 		this.site = originalHandle.site;
 	}
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		return false;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	// {{{ JIT support
 
@@ -84,4 +84,3 @@ class DynamicInvokerHandle extends MethodHandle {
 		c.compareStructuralParameter(left.site, this.site);
 	}
 }
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FieldHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FieldHandle.java
@@ -20,7 +20,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
 package java.lang.invoke;
 
 import java.lang.reflect.Field;
@@ -95,10 +94,9 @@ abstract class FieldHandle extends PrimitiveHandle {
 		c.compareStructuralParameter(left.vmSlot, this.vmSlot);
 	}
 
-	/*[IF Java11]*/
+	/*[IF JAVA_SPEC_VERSION >= 11]*/
 	boolean isFinal() {
 		return Modifier.isFinal(this.rawModifiers);
 	}
-	/*[ENDIF] Java11 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 }
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
@@ -22,10 +22,10 @@
  *******************************************************************************/
 package java.lang.invoke;
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import java.lang.constant.ClassDesc;
 import java.util.Optional;
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import static java.lang.invoke.MethodType.*;
@@ -83,8 +83,8 @@ abstract class FieldVarHandle extends VarHandle {
 		this.vmslot = unreflectField(field, isStatic) + header;
 		checkSetterFieldFinality(handleTable);
 	}
-	
-	/*[IF Java12]*/
+
+	/*[IF JAVA_SPEC_VERSION >= 12]*/
 	@Override
 	public Optional<VarHandleDesc> describeConstable() {
 		VarHandleDesc result = null;
@@ -100,7 +100,7 @@ abstract class FieldVarHandle extends VarHandle {
 		}
 		return Optional.ofNullable(result);
 	}
-	/*[ENDIF] Java12 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 	/**
 	 * Checks whether the field referenced by this VarHandle, is final. 

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FilterArgumentsHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FilterArgumentsHandle.java
@@ -22,10 +22,10 @@
  *******************************************************************************/
 package java.lang.invoke;
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.Collections;
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 final class FilterArgumentsHandle extends MethodHandle {
 	private final MethodHandle   next;
@@ -94,14 +94,14 @@ final class FilterArgumentsHandle extends MethodHandle {
 			ILGenMacros.lastN(numSuffixArgs(), argPlaceholder)));
 	}
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		relatedMHs.add(next);
 		Collections.addAll(relatedMHs, filters);
 		return true;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	// }}} JIT support
 
@@ -127,4 +127,3 @@ final class FilterArgumentsHandle extends MethodHandle {
 		}
 	}
 }
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FilterArgumentsWithCombinerHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FilterArgumentsWithCombinerHandle.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Java12 & !OPENJDK_METHODHANDLES]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION >= 12) & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
  * Copyright (c) 2018, 2020 IBM Corp. and others
  *

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FilterArgumentsWithCombinerHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FilterArgumentsWithCombinerHandle.java
@@ -22,9 +22,9 @@
  *******************************************************************************/
 package java.lang.invoke;
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 /* 
  * Pseudocode example:
@@ -70,14 +70,14 @@ final class FilterArgumentsWithCombinerHandle extends MethodHandle {
         return new FilterArgumentsWithCombinerHandle(this, newType);
     }
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
     @Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		relatedMHs.add(next);
 		relatedMHs.add(combiner);
 		return true;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
     private static Object[] infoAffectingThunks(MethodType combinerType, int filterPosition, int...argumentIndices) {
         MethodType thunkableType = ThunkKey.computeThunkableType(combinerType);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FilterReturnHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FilterReturnHandle.java
@@ -23,9 +23,9 @@
 package java.lang.invoke;
 
 import java.lang.invoke.MethodHandle.FrameIteratorSkip;
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 @VMCONSTANTPOOL_CLASS
 final class FilterReturnHandle extends ConvertHandle {
@@ -70,15 +70,15 @@ final class FilterReturnHandle extends ConvertHandle {
 		return ILGenMacros.invokeExact_X(filter, ILGenMacros.invokeExact(next, argPlaceholder));
 	}
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		relatedMHs.add(next);
 		relatedMHs.add(filter);
 		return true;
 	}
-/*[ENDIF] Java15 */
-	
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
+
 	// }}} JIT support
 
 	@Override
@@ -99,4 +99,3 @@ final class FilterReturnHandle extends ConvertHandle {
 		c.compareChildHandle(left.filter, this.filter);
 	}
 }
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FoldHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FoldHandle.java
@@ -22,9 +22,9 @@
  *******************************************************************************/
 package java.lang.invoke;
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 abstract class FoldHandle extends MethodHandle {
 	protected final MethodHandle next;
@@ -97,14 +97,14 @@ abstract class FoldHandle extends MethodHandle {
 		c.compareStructuralParameter(left.argumentIndices, this.argumentIndices);
 	}
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		relatedMHs.add(next);
 		relatedMHs.add(combiner);
 		return true;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	// {{{ JIT support
 	protected static native int foldPosition();
@@ -179,4 +179,3 @@ final class FoldVoidHandle extends FoldHandle {
 		return new FoldVoidHandle(this,  newType);
 	}
 }
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/GenerateJLIClassesHelper.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/GenerateJLIClassesHelper.java
@@ -55,9 +55,9 @@ class GenerateJLIClassesHelper {
 	}
 	/*[ENDIF] Java11*/
 
-	/*[IF Java16]*/
+	/*[IF JAVA_SPEC_VERSION >= 16]*/
 	static Map<String, byte[]> generateHolderClasses(Stream<String> traces) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-	/*[ENDIF] Java16*/
+	/*[ENDIF] JAVA_SPEC_VERSION >= 16*/
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/GenerateJLIClassesHelper.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/GenerateJLIClassesHelper.java
@@ -49,11 +49,11 @@ class GenerateJLIClassesHelper {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 
-	/*[IF Java11]*/
+	/*[IF JAVA_SPEC_VERSION >= 11]*/
 	static byte[] generateInvokersHolderClassBytes(String str, MethodType[] invokerMts, MethodType[] callMts) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-	/*[ENDIF] Java11*/
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
 
 	/*[IF JAVA_SPEC_VERSION >= 16]*/
 	static Map<String, byte[]> generateHolderClasses(Stream<String> traces) {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/GuardWithTestHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/GuardWithTestHandle.java
@@ -22,9 +22,9 @@
  *******************************************************************************/
 package java.lang.invoke;
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 final class GuardWithTestHandle extends MethodHandle {
 
@@ -88,7 +88,7 @@ final class GuardWithTestHandle extends MethodHandle {
 		}
 	}
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		relatedMHs.add(guard);
@@ -96,7 +96,7 @@ final class GuardWithTestHandle extends MethodHandle {
 		relatedMHs.add(trueTarget);
 		return true;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	// }}} JIT support
 
@@ -119,4 +119,3 @@ final class GuardWithTestHandle extends MethodHandle {
 		c.compareChildHandle(left.falseTarget, this.falseTarget);
 	}
 }
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/InfoFromMemberName.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/InfoFromMemberName.java
@@ -1,5 +1,4 @@
 /*[INCLUDE-IF Sidecar18-SE-OpenJ9 & !OPENJDK_METHODHANDLES]*/
-
 /*******************************************************************************
  * Copyright (c) 2017, 2020 IBM Corp. and others
  *
@@ -21,7 +20,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 package java.lang.invoke;
 
 import java.lang.invoke.MethodHandles.Lookup;
@@ -45,7 +44,6 @@ class InfoFromMemberName implements MethodHandleInfo {
 	@Override
 	public MethodType getMethodType() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-
 	}
 
 	@Override
@@ -63,5 +61,4 @@ class InfoFromMemberName implements MethodHandleInfo {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 }
-/*[ENDIF] Java15 */
-
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */

--- a/jcl/src/java.base/share/classes/java/lang/invoke/InsertHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/InsertHandle.java
@@ -22,9 +22,9 @@
  *******************************************************************************/
 package java.lang.invoke;
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 class InsertHandle extends MethodHandle {
 	final MethodHandle  next;
@@ -49,13 +49,13 @@ class InsertHandle extends MethodHandle {
 		this.values 		= originalHandle.values;
 	}
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		relatedMHs.add(next);
 		return true;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	// {{{ JIT support
 
@@ -115,4 +115,3 @@ class InsertHandle extends MethodHandle {
 		c.compareChildHandle(left.next, this.next);
 	}
 }
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -1,5 +1,4 @@
 /*[INCLUDE-IF Sidecar18-SE-OpenJ9 & !OPENJDK_METHODHANDLES]*/
-
 /*******************************************************************************
  * Copyright (c) 2017, 2020 IBM Corp. and others
  *
@@ -21,17 +20,15 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
 package java.lang.invoke;
 
 /*
  * Stub class to compile OpenJDK j.l.i.MethodHandleImpl
  */
-
 class InvokerBytecodeGenerator {
-/*[IF Java13]*/
+/*[IF JAVA_SPEC_VERSION >= 13]*/
 	static final String HIDDEN_SIG = null;
-/*[ENDIF] Java13 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 13 */
 	static boolean isStaticallyInvocable(MemberName mn) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -1,5 +1,4 @@
 /*[INCLUDE-IF Sidecar18-SE-OpenJ9 & !OPENJDK_METHODHANDLES]*/
-
 /*******************************************************************************
  * Copyright (c) 2017, 2020 IBM Corp. and others
  *
@@ -21,7 +20,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
 package java.lang.invoke;
 
 import java.lang.reflect.Method;
@@ -30,7 +28,6 @@ import sun.invoke.util.Wrapper;
 /*
  * Stub class to compile OpenJDK j.l.i.MethodHandleImpl
  */
-
 class LambdaForm {
 
 	LambdaForm(String str, int num1, Name[] names, int num2) {
@@ -42,7 +39,7 @@ class LambdaForm {
 	LambdaForm(String str, int num, Name[] names, boolean flag) {
 		OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-	/*[IF Java10]*/
+	/*[IF JAVA_SPEC_VERSION >= 10]*/
 	LambdaForm(int a, Name[] b, int c) {
 		OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
@@ -73,8 +70,8 @@ class LambdaForm {
 	LambdaForm(Name[] a, Name[] b, Name c, boolean d) {
 		OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-	/*[ENDIF]*/
-	
+	/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
+
 	static class NamedFunction {
 		NamedFunction(MethodHandle mh) {
 			OpenJDKCompileStub.OpenJDKCompileStubThrowError();
@@ -88,15 +85,15 @@ class LambdaForm {
 		NamedFunction(Method m) {
 			OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
-		/*[IF Java10]*/
+		/*[IF JAVA_SPEC_VERSION >= 10]*/
 		NamedFunction(MethodHandle a, MethodHandleImpl.Intrinsic b){
 			OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
 		NamedFunction(MemberName a, MethodHandle b, MethodHandleImpl.Intrinsic c){
 			OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
-		/*[ENDIF]*/
-		
+		/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
+
 		MethodHandle resolvedHandle() {
 			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
@@ -143,7 +140,7 @@ class LambdaForm {
 			return basicType;
 		}
 	}
-	/*[IF Java10]*/
+	/*[IF JAVA_SPEC_VERSION >= 10]*/
 	enum Kind {
 		CONVERT,
 		SPREAD,
@@ -153,8 +150,8 @@ class LambdaForm {
 		LOOP,
 		TRY_FINALLY
 	}
-	/*[ENDIF]*/
-	
+	/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
+
 	@interface Hidden{
 	}
 	

--- a/jcl/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
@@ -1,5 +1,4 @@
 /*[INCLUDE-IF Sidecar18-SE-OpenJ9 & !OPENJDK_METHODHANDLES]*/
-
 /*******************************************************************************
  * Copyright (c) 2017, 2020 IBM Corp. and others
  *
@@ -21,20 +20,18 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
 package java.lang.invoke;
 
 /*
  * Stub class to compile OpenJDK j.l.i.MethodHandleImpl
  */
-
 class LambdaFormEditor {
-	
-/*[IF Java12]*/
+
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	LambdaForm filterRepeatedArgumentForm(LambdaForm.BasicType bt, int[] args) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 	LambdaForm filterArgumentForm(int num, LambdaForm.BasicType by) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -22,9 +22,9 @@
  *******************************************************************************/
 package java.lang.invoke;
 
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 import java.lang.reflect.Method;
-/*[ENDIF] Java11 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
 /*
  * Stub class to compile OpenJDK j.l.i.MethodHandleImpl
@@ -35,8 +35,8 @@ final class MemberName {
 		public static Factory INSTANCE = null;
 	}
 	/*[ENDIF]*/
-	
-	/*[IF Java11]*/
+
+	/*[IF JAVA_SPEC_VERSION >= 11]*/
 	private MethodHandle mh;
 
 	public MemberName() {
@@ -55,7 +55,7 @@ final class MemberName {
 	public boolean isStatic() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-	/*[ENDIF] Java11 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
 	public boolean isVarargs() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
@@ -80,8 +80,8 @@ final class MemberName {
 	public boolean isNative() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-	
-	/*[IF Java11]*/
+
+	/*[IF JAVA_SPEC_VERSION >= 11]*/
 	public MethodType getMethodType() {
 		if (method != null) {
 			return MethodType.methodType(method.getReturnType(), method.getParameterTypes());
@@ -107,7 +107,7 @@ final class MemberName {
 		/*[MSG "K0675", "Unexpected MethodHandle instance: {0} with {1}"]*/
 		throw new InternalError(com.ibm.oti.util.Msg.getString("K0675", mh, mh.getClass())); //$NON-NLS-1$
 	}
-	/*[ENDIF] Java11 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
 	/*[IF JAVA_SPEC_VERSION >= 15]*/
 	public byte getReferenceKind() {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -1,5 +1,4 @@
 /*[INCLUDE-IF Sidecar18-SE-OpenJ9 & !OPENJDK_METHODHANDLES]*/
-
 /*******************************************************************************
  * Copyright (c) 2017, 2020 IBM Corp. and others
  *
@@ -21,7 +20,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
 package java.lang.invoke;
 
 /*[IF Java11]*/
@@ -31,7 +29,6 @@ import java.lang.reflect.Method;
 /*
  * Stub class to compile OpenJDK j.l.i.MethodHandleImpl
  */
-
 final class MemberName {
 	/*[IF Sidecar18-SE-OpenJ9&!Sidecar19-SE-OpenJ9]*/
 	static final class Factory {
@@ -111,10 +108,10 @@ final class MemberName {
 		throw new InternalError(com.ibm.oti.util.Msg.getString("K0675", mh, mh.getClass())); //$NON-NLS-1$
 	}
 	/*[ENDIF] Java11 */
-	
-	/*[IF Java15]*/
+
+	/*[IF JAVA_SPEC_VERSION >= 15]*/
 	public byte getReferenceKind() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-	/*[ENDIF] Java15 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1102,7 +1102,7 @@ public abstract class MethodHandle
 		return "KIND_#"+kind; //$NON-NLS-1$
 	}
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	/**
 	 * Append to a list the child MethodHandle(s) which form "this" (parent MethodHandle).
 	 * 
@@ -1111,7 +1111,7 @@ public abstract class MethodHandle
 	 * @return true if MethodHandles are added to the list, and false otherwise.
 	 */
 	abstract boolean addRelatedMHs(List<MethodHandle> relatedMHs);
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 /*[IF OPENJDK_METHODHANDLES]*/
 	byte customizationCount;
@@ -1760,4 +1760,3 @@ final class StructuralComparator extends Comparator {
 }
 
 // }}} Comparator support
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -26,14 +26,14 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import java.lang.constant.ClassDesc;
 import java.lang.constant.Constable;
 import java.lang.constant.DirectMethodHandleDesc;
 import java.lang.constant.DirectMethodHandleDesc.Kind;
 import java.lang.constant.MethodHandleDesc;
 import java.lang.constant.MethodTypeDesc;
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Modifier;
 import java.security.AccessController;
@@ -43,20 +43,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 import java.util.Objects;
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import java.util.NoSuchElementException;
 import java.util.Optional;
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 // {{{ JIT support
 import java.util.concurrent.ConcurrentHashMap;
 
 /*[IF Sidecar19-SE]
 import jdk.internal.misc.Unsafe;
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import jdk.internal.access.SharedSecrets;
-/*[ELSE]
+/*[ELSE] JAVA_SPEC_VERSION >= 12
 import jdk.internal.misc.SharedSecrets;
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 import jdk.internal.reflect.ConstantPool;
 /*[ELSE]*/
 import sun.misc.Unsafe;
@@ -93,10 +93,10 @@ import com.ibm.oti.vm.VMLangAccess;
  * @since 1.7
  */
 @VMCONSTANTPOOL_CLASS
-public abstract class MethodHandle 
-/*[IF Java12]*/
+public abstract class MethodHandle
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	implements Constable
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 {
 	/* Ensure that these stay in sync with the MethodHandleInfo constants and VM constants in VM_MethodHandleKinds.h */
 	/* Order matters here - static and special are direct pointers */
@@ -135,9 +135,9 @@ public abstract class MethodHandle
 	/*[IF Panama]*/
 	static final byte KIND_NATIVE = 32;
 	/*[ENDIF]*/
-	/*[IF Java12]*/
+	/*[IF JAVA_SPEC_VERSION >= 12]*/
 	static final byte KIND_FILTERARGUMENTS_WITHCOMBINER = 33;
-	/*[ENDIF] Java12 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 /*[IF Sidecar18-SE-OpenJ9]
 	MethodHandle asTypeCache = null;
@@ -720,8 +720,8 @@ public abstract class MethodHandle
 	public MethodHandle asFixedArity() {
 		return this;
 	}
-	
-/*[IF Java12]*/
+
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * Returns the nominal descriptor of this MethodHandle instance, or an empty Optional 
 	 * if construction is not possible.
@@ -994,8 +994,8 @@ public abstract class MethodHandle
 	private MethodHandle returnFilterPlaceHolder() {
 		return this;
 	}
-	
-	/*[IF Java12]*/
+
+	/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/*[IF ]*/
 	/*
 	 * Used to preserve the MH on the stack when avoiding the call-in for
@@ -1008,7 +1008,7 @@ public abstract class MethodHandle
 	private MethodHandle filterArgumentsWithCombinerPlaceHolder() {
 		return this;
 	}
-	/*[ENDIF] Java12 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 	/*[IF ]*/
 	/*

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1165,14 +1165,14 @@ public abstract class MethodHandle
 	}
 	
 	MemberName internalMemberName() {
-		/*[IF Java11]*/
+		/*[IF JAVA_SPEC_VERSION >= 11]*/
 		/* Note: so far this method is only invoked by java.lang.invoke.ConstantBootstraps.getStaticFinal() 
 		 * to return a MemberName object, and only MemberName.isFinal() is invoked.
 		 */
 		return new MemberName(this);
-		/*[ELSE]
+		/*[ELSE] JAVA_SPEC_VERSION >= 11
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-		/*[ENDIF] Java11 */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 	}
 	
 	BoundMethodHandle rebind() {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -47,7 +47,7 @@ class MethodHandleNatives {
 		return linkageErr;
 	}
 
-	/*[IF Java14]*/
+	/*[IF JAVA_SPEC_VERSION >= 14]*/
 	static long objectFieldOffset(MemberName memberName) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
@@ -59,8 +59,8 @@ class MethodHandleNatives {
 	static Object staticFieldBase(MemberName memberName) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-	/*[ENDIF] Java14 */
-	
+	/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
+
 	/*[IF JAVA_SPEC_VERSION >= 15]*/
 	static boolean refKindIsMethod(byte kind) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -24,10 +24,10 @@
 /*[IF Java11]*/
 package java.lang.invoke;
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 class MethodHandleNatives {
 	static LinkageError mapLookupExceptionToError(ReflectiveOperationException roe) {
@@ -61,7 +61,7 @@ class MethodHandleNatives {
 	}
 	/*[ENDIF] Java14 */
 	
-	/*[IF Java15]*/
+	/*[IF JAVA_SPEC_VERSION >= 15]*/
 	static boolean refKindIsMethod(byte kind) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
@@ -88,6 +88,6 @@ class MethodHandleNatives {
 	}
 
 	native static void checkClassBytes(byte[] bytes);
-	/*[ENDIF] Java15 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 }
 /*[ENDIF] Java11 */

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -1,5 +1,4 @@
 /*[INCLUDE-IF Sidecar18-SE-OpenJ9 & !OPENJDK_METHODHANDLES]*/
-
 /*******************************************************************************
  * Copyright (c) 2017, 2020 IBM Corp. and others
  *
@@ -21,7 +20,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 package java.lang.invoke;
 
 /*[IF JAVA_SPEC_VERSION >= 15]*/
@@ -90,4 +89,4 @@ class MethodHandleNatives {
 	native static void checkClassBytes(byte[] bytes);
 	/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 }
-/*[ENDIF] Java11 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleResolver.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleResolver.java
@@ -88,8 +88,8 @@ final class MethodHandleResolver {
 	 * @throws  IllegalArgumentException if <i>index</i> has wrong constant pool type
 	 */
 	private static final native String getCPClassNameAt(Class<?> clazz, int index);
-	
-/*[IF Java11]*/
+
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 	/*
 	 * sun.reflect.ConstantPool doesn't have a getConstantDynamicAt method.  This is the 
 	 * equivalent for ConstantDynamic.
@@ -169,7 +169,7 @@ final class MethodHandleResolver {
 		
 		return result;
 	}
-/*[ENDIF] Java11*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
 
 	/*[IF ]*/
 	/*
@@ -272,9 +272,9 @@ final class MethodHandleResolver {
 		MethodHandle result = null;
 		MethodType type = null;
 
-/*[IF !Java11]*/
+/*[IF JAVA_SPEC_VERSION < 11]*/
 		try {
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION < 11 */
 			VMLangAccess access = VM.getVMLangAccess();
 			Object internalRamClass = access.createInternalRamClass(j9class);
 			Class<?> classObject = getClassFromJ9Class(j9class);
@@ -308,14 +308,14 @@ final class MethodHandleResolver {
 				staticArgs[BSM_OPTIONAL_ARGUMENTS_START_INDEX + i] = getAdditionalBsmArg(access, internalRamClass, classObject, bsm, bsmArgs, bsmTypeArgCount, i);
 			}
 
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 		/* JVMS JDK11 5.4.3.6 Dynamically-Computed Constant and Call Site Resolution
 		 * requires that exceptions from BSM invocation be wrapped in a BootstrapMethodError
 		 * unless the exception thrown is a sub-class of Error.
 		 * Exceptions thrown before invocation should be passed through unwrapped.
 		 */
 		try {
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 			CallSite cs = (CallSite)invokeBsm(bsm, staticArgs);
 			if (cs != null) {
 				MethodType callsiteType = cs.type();
@@ -323,14 +323,14 @@ final class MethodHandleResolver {
 					throw WrongMethodTypeException.newWrongMethodTypeException(type, callsiteType);
 				}
 				result = cs.dynamicInvoker();
-			} 
-			/*[IF Java11]*/
+			}
+			/*[IF JAVA_SPEC_VERSION >= 11]*/
 			else {
 				/* The result of the resolution of a dynamically-computed call site must not be null. */
 				/*[MSG "K0A02", "Bootstrap method returned null."]*/
 				throw new ClassCastException(Msg.getString("K0A02")); //$NON-NLS-1$
 			}
-			/*[ENDIF]*/
+			/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 		} catch(Throwable e) {
 
 			/*[IF Sidecar19-SE]*/
@@ -579,11 +579,11 @@ final class MethodHandleResolver {
 		case 14:
 			cpEntry = getCPMethodHandleAt(internalRamClass, index);
 			break;
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 		case 17:
 			cpEntry = getCPConstantDynamicAt(internalRamClass, index);
 			break;
-/*[ENDIF] Java11*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 		default:
 			// Do nothing. The null check below will throw the appropriate exception.
 		}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -185,15 +185,15 @@ public class MethodHandles {
 		
 		/* single cached value of public Lookup object */
 		static final int mhMask = 
-		/*[IF Java11]*/
+		/*[IF JAVA_SPEC_VERSION >= 11]*/
 		/*[IF JAVA_SPEC_VERSION >= 14]*/
 		Lookup.UNCONDITIONAL;
 		/*[ELSE] JAVA_SPEC_VERSION >= 14*/
 		Lookup.PUBLIC | Lookup.UNCONDITIONAL;
 		/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
-		/*[ELSE] Java11*/
+		/*[ELSE] JAVA_SPEC_VERSION >= 11 */
 		Lookup.PUBLIC;
-		/*[ENDIF] Java11*/
+		/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 		static Lookup PUBLIC_LOOKUP = new Lookup(Object.class, mhMask);
 		
 		/* single cached internal privileged lookup */
@@ -498,9 +498,9 @@ public class MethodHandles {
 				return;
 			} else if (Modifier.isPrivate(memberModifiers)) {
 				if (Modifier.isPrivate(accessMode) && ((definingClass == accessClass)
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 						|| definingClass.isNestmateOf(accessClass)
-/*[ENDIF] Java11*/	
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 				)) {
 					return;
 				}
@@ -1086,12 +1086,12 @@ public class MethodHandles {
 				}
 				handle = handle.cloneWithNewType(handle.type.changeParameterType(0, clazz));
 			} else if (!Modifier.isPublic(handle.getModifiers())) {
-				/*[IF Java11]*/
+				/*[IF JAVA_SPEC_VERSION >= 11]*/
 				handle = new DirectHandle(handleClass, methodName, type, MethodHandle.KIND_SPECIAL, handleClass, true);
 				handle = handle.cloneWithNewType(handle.type.changeParameterType(0, clazz));
-				/*[ELSE] Java11
+				/*[ELSE] JAVA_SPEC_VERSION >= 11
 				throw new IllegalAccessException();	
-				/*[ENDIF] Java11*/
+				/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 			} else {
 				handle = new InterfaceHandle(clazz, methodName, type);
 			}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -186,11 +186,11 @@ public class MethodHandles {
 		/* single cached value of public Lookup object */
 		static final int mhMask = 
 		/*[IF Java11]*/
-		/*[IF Java14]*/
+		/*[IF JAVA_SPEC_VERSION >= 14]*/
 		Lookup.UNCONDITIONAL;
-		/*[ELSE] Java14*/
+		/*[ELSE] JAVA_SPEC_VERSION >= 14*/
 		Lookup.PUBLIC | Lookup.UNCONDITIONAL;
-		/*[ENDIF] Java14*/
+		/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
 		/*[ELSE] Java11*/
 		Lookup.PUBLIC;
 		/*[ENDIF] Java11*/
@@ -475,17 +475,17 @@ public class MethodHandles {
 				Module accessModule = accessClass.getModule();
 
 				try {
-					/*[IF Java14]*/
+					/*[IF JAVA_SPEC_VERSION >= 14]*/
 					checkClassModuleVisibility(accessMode, accessClass, prevAccessClass, type.returnType());
 					for (Class<?> c: type.ptypes()) {
 						checkClassModuleVisibility(accessMode, accessClass, prevAccessClass, c);
 					}
-					/*[ELSE]*/
+					/*[ELSE] JAVA_SPEC_VERSION >= 14 */
 					checkClassModuleVisibility(accessMode, accessModule, type.returnType());
 					for (Class<?> c: type.ptypes()) {
 						checkClassModuleVisibility(accessMode, accessModule, c);
 					}
-					/*[ENDIF] Java14*/
+					/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
 				} catch (IllegalAccessException exc) {
 					IllegalAccessError err = new IllegalAccessError(exc.getMessage());
 					err.initCause(exc);
@@ -506,9 +506,9 @@ public class MethodHandles {
 				}
 			} else if (Modifier.isProtected(memberModifiers)) {
 				/* Ensure that the accessMode is not restricted (public-only) */
-				/*[IF !Java14]*/
+				/*[IF JAVA_SPEC_VERSION < 14]*/
 				if (accessMode != PUBLIC)
-				/*[ELSE]*/
+				/*[ELSE] JAVA_SPEC_VERSION < 14 */
 				/* Note: the lookup with the PUBLIC plus MODULE or UNCONDITIONAL mode 
 				 * can access public types in all modules, which means the access to 
 				 * non-public types should be rejected if the PUBLIC plus MODULE 
@@ -517,7 +517,7 @@ public class MethodHandles {
 				if ((accessMode != PUBLIC) 
 					&& (accessMode != (PUBLIC | MODULE))
 					&& (accessMode != UNCONDITIONAL))
-				/*[ENDIF] Java14 */
+				/*[ENDIF] JAVA_SPEC_VERSION < 14 */
 				{
 					if (definingClass.isArray()) {
 						/* The only methods array classes have are defined on Object and thus accessible */
@@ -599,11 +599,11 @@ public class MethodHandles {
 		 */
 		private void checkClassAccess(Class<?> targetClass) throws IllegalAccessException {
 			/*[IF Sidecar19-SE]*/
-			/*[IF Java14]*/
+			/*[IF JAVA_SPEC_VERSION >= 14]*/
 			checkClassModuleVisibility(accessMode, accessClass, prevAccessClass, targetClass);
-			/*[ELSE]*/
+			/*[ELSE] JAVA_SPEC_VERSION >= 14 */
 			checkClassModuleVisibility(accessMode, accessClass.getModule(), targetClass);
-			/*[ENDIF] Java14*/
+			/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
 			/*[ENDIF]*/
 			
 			if (NO_ACCESS != accessMode) {
@@ -613,8 +613,8 @@ public class MethodHandles {
 				 */
 				int targetClassModifiers = targetClass.getModifiers();
 				final boolean targetClassIsPublic = (Modifier.isPublic(targetClassModifiers) || Modifier.isProtected(targetClassModifiers));
-				 
-				/*[IF Java14]*/
+
+				/*[IF JAVA_SPEC_VERSION >= 14]*/
 				Module accessModule = accessClass.getModule();
 				Module targetModule = targetClass.getModule();
 				String targetClassPackageName = targetClass.getPackageName();
@@ -643,7 +643,7 @@ public class MethodHandles {
 						return;
 					}
 				} else if ((PUBLIC & accessMode) == PUBLIC) {
-				/*[ENDIF] Java14*/
+				/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
 					/* target class should always be accessible to the lookup class when they are the same class */
 					if (accessClass == targetClass) {
 						return;
@@ -657,9 +657,9 @@ public class MethodHandles {
 							return;
 						}
 					}
-				/*[IF Java14]*/
+				/*[IF JAVA_SPEC_VERSION >= 14]*/
 				}
-				/*[ENDIF] Java14*/
+				/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
 			}
 
 			/*[MSG "K0680", "Class '{0}' no access to: class '{1}'"]*/
@@ -873,7 +873,7 @@ public class MethodHandles {
 			return moduleName;
 		}
 		
-		/*[IF Java14]*/
+		/*[IF JAVA_SPEC_VERSION >= 14]*/
 		/**
 		 * Check if targetClass is in a package visible from the accessModule 
 		 * whether the previous lookup class is present or not
@@ -941,7 +941,7 @@ public class MethodHandles {
 				}
 			}
 		}
-		/*[ENDIF] Java14*/
+		/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 
 		/**
 		 * Check if targetClass is in a package visible from the accessModule
@@ -1275,7 +1275,7 @@ public class MethodHandles {
 			return handle;
 		}
 		
-		/*[IF Java14]*/
+		/*[IF JAVA_SPEC_VERSION >= 14]*/
 		/**
 		 * Create a lookup on the request class.  The resulting lookup will have no more 
 		 * access privileges than the original.
@@ -1286,7 +1286,7 @@ public class MethodHandles {
 		 * @throws IllegalArgumentException - if the requested Class is a primitive type or an array class
 		 */
 		public MethodHandles.Lookup in(Class<?> lookupClass) throws NullPointerException, IllegalArgumentException {
-		/*[ELSE]*/
+		/*[ELSE] JAVA_SPEC_VERSION >= 14 */
 		/**
 		 * Create a lookup on the request class.  The resulting lookup will have no more 
 		 * access privileges than the original.
@@ -1295,16 +1295,16 @@ public class MethodHandles {
 		 * @return a new MethodHandles.Lookup object
 		 */
 		public MethodHandles.Lookup in(Class<?> lookupClass) {
-		/*[ENDIF] Java14 */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 			Objects.requireNonNull(lookupClass);
-			
-			/*[IF Java14]*/
+
+			/*[IF JAVA_SPEC_VERSION >= 14]*/
 			if (lookupClass.isPrimitive() || lookupClass.isArray()) {
 				/*[MSG "K065T", "The requested class: {0} must not be a void type, primitive type or an array class"]*/
 				throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K065T", lookupClass.getCanonicalName())); //$NON-NLS-1$
 			}
-			/*[ENDIF] Java14 */
-			
+			/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
+
 			// If it's the same class as ourselves, return this
 			if (lookupClass == accessClass) {
 				return this;
@@ -1317,11 +1317,11 @@ public class MethodHandles {
 			/*[IF !Sidecar19-SE-OpenJ9]
 			newAccessMode &= ~PROTECTED;
 			/*[ELSE]*/
-			/*[IF !Java14]*/
+			/*[IF JAVA_SPEC_VERSION < 14]*/
 			/* The UNCONDITIONAL bit is discarded if the new lookup class differs from the old one in Java 9 */
 			newAccessMode &= ~UNCONDITIONAL;
-			/*[ENDIF] Java14 */
-			
+			/*[ENDIF] JAVA_SPEC_VERSION < 14 */
+
 			/* There are 3 cases to be addressed for the new lookup class from a different module:
 			 * 1) There is no access if the package containing the new lookup class is not exported to 
 			 *    the package containing the old one.
@@ -1336,7 +1336,7 @@ public class MethodHandles {
 				if (!lookupClassModule.isExported(lookupClass.getPackageName(), accessClassModule)) {
 					newAccessMode = NO_ACCESS;
 				} else
-				/*[IF !Java14]*/
+				/*[IF JAVA_SPEC_VERSION < 14]*/
 				if (accessClassModule.isNamed()) {
 					/* If the old lookup class is in a named module different from the new lookup class,
 					 * we should keep the public access only when it is a public lookup.
@@ -1347,7 +1347,7 @@ public class MethodHandles {
 						newAccessMode = NO_ACCESS;
 					}
 				} else
-				/*[ENDIF] Java14 */
+				/*[ENDIF] JAVA_SPEC_VERSION < 14 */
 				{
 					newAccessMode &= ~MODULE;
 				}
@@ -1396,7 +1396,7 @@ public class MethodHandles {
 				}
 			}
 			
-			/*[IF Java14]*/
+			/*[IF JAVA_SPEC_VERSION >= 14]*/
 			/* If the new lookup class is not accessible to the old lookup class, 
 			 * then no members, not even public members, will be accessible.
 			 * Note: the invocation of accessClass() is explicitly required since JDK14
@@ -1447,9 +1447,9 @@ public class MethodHandles {
 			}
 			
 			return new Lookup(lookupClass, newPrevAccessClass, newAccessMode, true);
-			/*[ELSE]*/
+			/*[ELSE] JAVA_SPEC_VERSION >= 14 */
 			return new Lookup(lookupClass, newAccessMode);
-			/*[ENDIF] Java14*/
+			/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
 		}
 		
 		/*
@@ -1474,8 +1474,8 @@ public class MethodHandles {
 		public Class<?> lookupClass() {
 			return accessClass;
 		}
-		
-		/*[IF Java14]*/
+
+		/*[IF JAVA_SPEC_VERSION >= 14]*/
 		/**
 		 * The class previously being used for visibility checks and access permissions.
 		 * 
@@ -1499,8 +1499,8 @@ public class MethodHandles {
 			}
 			return true;
 		}
-		/*[ENDIF] Java14*/
-		
+		/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
+
 		/**
 		 * Make a MethodHandle to the Reflect method.  If the method is non-static, the receiver argument
 		 * is treated as the initial argument in the MethodType.  
@@ -1836,12 +1836,12 @@ public class MethodHandles {
 		@Override
 		public String toString() {
 			String toString = accessClass.getName();
-			/*[IF Java14]*/
+			/*[IF JAVA_SPEC_VERSION >= 14]*/
 			if (prevAccessClass != null) {
 				toString += "/" + prevAccessClass.getName(); //$NON-NLS-1$
 			}
-			/*[ENDIF] Java14*/
-			
+			/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
+
 			switch(accessMode) {
 			case NO_ACCESS:
 				toString += "/noaccess"; //$NON-NLS-1$
@@ -1850,7 +1850,7 @@ public class MethodHandles {
 				toString += "/public"; //$NON-NLS-1$
 				break;
 			/*[IF Sidecar19-SE-OpenJ9]
-			/*[IF Java14]*/
+			/*[IF JAVA_SPEC_VERSION >= 14]*/
 			case UNCONDITIONAL:
 				toString += "/publicLookup"; //$NON-NLS-1$
 				break;
@@ -1865,7 +1865,7 @@ public class MethodHandles {
 			case PUBLIC | PACKAGE | PRIVATE | MODULE:
 				toString += "/private"; //$NON-NLS-1$
 				break;
-			/*[ELSE]*/
+			/*[ELSE] JAVA_SPEC_VERSION >= 14 */
 			case PUBLIC | UNCONDITIONAL:
 				toString += "/publicLookup"; //$NON-NLS-1$
 				break;
@@ -1878,7 +1878,7 @@ public class MethodHandles {
 			case PUBLIC | PACKAGE | PRIVATE | MODULE:
 				toString += "/private"; //$NON-NLS-1$
 				break;
-			/*[ENDIF] Java14 */
+			/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 			/*[ELSE]*/
 			case PUBLIC | PACKAGE:
 				toString += "/package"; //$NON-NLS-1$
@@ -2123,9 +2123,9 @@ public class MethodHandles {
 			
 			SecurityManager secmgr = System.getSecurityManager();
 			if ((null != secmgr)
-				/*[IF Java14]*/
+				/*[IF JAVA_SPEC_VERSION >= 14]*/
 				&& !hasFullPrivilegeAccess()
-				/*[ENDIF] Java14*/
+				/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
 			) {
 				secmgr.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionDefineClass);
 			}
@@ -2195,14 +2195,14 @@ public class MethodHandles {
 				throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K065R", Integer.toHexString(dropMode), Integer.toHexString(fullAccessMode))); //$NON-NLS-1$
 			}
 
-			/*[IF Java14]*/
+			/*[IF JAVA_SPEC_VERSION >= 14]*/
 			/* The lookup object has to discard the protected access by default */
 			int newAccessMode = accessMode & ~PROTECTED;
-			/*[ELSE]*/
+			/*[ELSE] JAVA_SPEC_VERSION >= 14 */
 			/* The lookup object has to discard the protected and unconditional access by default */
 			int newAccessMode = accessMode & ~(PROTECTED | UNCONDITIONAL);
-			/*[ENDIF] Java14*/
-			
+			/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
+
 			/* The access mode to be dropped must exist in the current access mode;
 			 * otherwise, the new access mode remains unchanged.
 			 */
@@ -2217,9 +2217,9 @@ public class MethodHandles {
 				newAccessMode &= ~PRIVATE;
 				break;
 			case UNCONDITIONAL:
-				/*[IF Java14]*/
+				/*[IF JAVA_SPEC_VERSION >= 14]*/
 				newAccessMode = NO_ACCESS;
-				/*[ENDIF] Java14*/
+				/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
 				break;
 			default:
 				/* no change in the access mode */
@@ -2231,8 +2231,8 @@ public class MethodHandles {
 			if ((dropMode == MODULE) || ((dropMode & newAccessMode) == MODULE)) {
 				newAccessMode &= ~(MODULE | PACKAGE | PRIVATE);
 			}
-			
-			/*[IF Java14]*/
+
+			/*[IF JAVA_SPEC_VERSION >= 14]*/
 			/* There is no previous lookup class for the requested lookup class
 			 * if the MODULE or UNCONDITIONAL bit is set in the new access mode.
 			 */
@@ -2244,9 +2244,9 @@ public class MethodHandles {
 			}
 			
 			return new Lookup(accessClass, newPrevAccessClass, newAccessMode, true);
-			/*[ELSE]*/
+			/*[ELSE] JAVA_SPEC_VERSION >= 14 */
 			return new Lookup(accessClass, newAccessMode);
-			/*[ENDIF] Java14*/
+			/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
 		}
 		
 		/**
@@ -2254,23 +2254,23 @@ public class MethodHandles {
 		 * 
 		 * @return a boolean type indicating whether the lookup class has private access
 		 */
-		/*[IF Java14]*/
+		/*[IF JAVA_SPEC_VERSION >= 14]*/
 		@Deprecated(forRemoval=false, since="14")
-		/*[ENDIF] Java14 */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 		public boolean hasPrivateAccess() {
 			/* Full access for use by MH implementation */
 			if (INTERNAL_PRIVILEGED == accessMode) {
 				return true;
 			}
-			
-			/*[IF Java14]*/
+
+			/*[IF JAVA_SPEC_VERSION >= 14]*/
 			return (!isWeakenedLookup() && (MODULE == (accessMode & MODULE)));
-			/*[ELSE]*/
+			/*[ELSE] JAVA_SPEC_VERSION >= 14 */
 			return !isWeakenedLookup();
-			/*[ENDIF] Java14*/
+			/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
 		}
-		
-		/*[IF Java14]*/
+
+		/*[IF JAVA_SPEC_VERSION >= 14]*/
 		/**
 		 * Return true if the lookup class has full privilege access
 		 * 
@@ -2284,7 +2284,7 @@ public class MethodHandles {
 			
 			return (!isWeakenedLookup() && (MODULE == (accessMode & MODULE)));
 		}
-		/*[ENDIF] Java14*/
+		/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
 		/*[ENDIF] Sidecar19-SE */
 		
 		/*[IF JAVA_SPEC_VERSION >= 15]*/
@@ -2556,32 +2556,32 @@ public class MethodHandles {
 		}
 		
 		int callerLookupMode = callerLookup.lookupModes();
-		/*[IF Java14]*/
+		/*[IF JAVA_SPEC_VERSION >= 14]*/
 		if (!callerLookup.hasFullPrivilegeAccess()) {
 			/*[MSG "K065W1", "The access mode: 0x{0} of the caller lookup doesn't have the PRIVATE & MODULE mode : 0x{1}"]*/
 			throw new IllegalAccessException(com.ibm.oti.util.Msg.getString("K065W1", Integer.toHexString(callerLookupMode), Integer.toHexString(Lookup.PRIVATE | Lookup.MODULE))); //$NON-NLS-1$
 		}
-		/*[ELSE]*/
+		/*[ELSE] JAVA_SPEC_VERSION >= 14 */
 		if (Lookup.MODULE != (Lookup.MODULE & callerLookupMode)) {
 			/*[MSG "K065W2", "The access mode: 0x{0} of the caller lookup doesn't have the MODULE mode : 0x{1}"]*/
 			throw new IllegalAccessException(com.ibm.oti.util.Msg.getString("K065W2", Integer.toHexString(callerLookupMode), Integer.toHexString(Lookup.MODULE))); //$NON-NLS-1$
 		}
-		/*[ENDIF] Java14*/
-		
+		/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
+
 		SecurityManager secmgr = System.getSecurityManager();
 		if (null != secmgr) {
 			secmgr.checkPermission(com.ibm.oti.util.ReflectPermissions.permissionSuppressAccessChecks);
 		}
-		
-		/*[IF Java14]*/
+
+		/*[IF JAVA_SPEC_VERSION >= 14]*/
 		if (Objects.equals(targetClassModule, accessClassModule)) {
 			return new Lookup(targetClass, null, callerLookupMode, true);
 		} else {
 			return new Lookup(targetClass, callerLookup.lookupClass(), (callerLookupMode & ~Lookup.MODULE), true);
 		}
-		/*[ELSE]*/
+		/*[ELSE] JAVA_SPEC_VERSION >= 14 */
 		return new Lookup(targetClass);
-		/*[ENDIF] Java14*/
+		/*[ENDIF] JAVA_SPEC_VERSION >= 14*/
 	}
 	/*[ENDIF] Sidecar19-SE-OpenJ9*/
 	
@@ -3053,12 +3053,12 @@ public class MethodHandles {
 	 */
 	public static VarHandle byteArrayViewVarHandle(Class<?> viewArrayClass, ByteOrder byteOrder) throws IllegalArgumentException {
 		Objects.requireNonNull(byteOrder);
-		/*[IF Java14]*/
+		/*[IF JAVA_SPEC_VERSION >= 14]*/
 		return VarHandles.byteArrayViewHandle(viewArrayClass, (byteOrder == ByteOrder.BIG_ENDIAN));
-		/*[ELSE] Java14
+		/*[ELSE] JAVA_SPEC_VERSION >= 14
 		checkArrayClass(viewArrayClass);
 		return new ByteArrayViewVarHandle(viewArrayClass.getComponentType(), byteOrder);
-		/*[ENDIF] Java14 */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 	}
 	
 	/**
@@ -3072,12 +3072,12 @@ public class MethodHandles {
 	 */
 	public static VarHandle byteBufferViewVarHandle(Class<?> viewArrayClass, ByteOrder byteOrder) throws IllegalArgumentException {
 		Objects.requireNonNull(byteOrder);
-		/*[IF Java14]*/
+		/*[IF JAVA_SPEC_VERSION >= 14]*/
 		return VarHandles.makeByteBufferViewHandle(viewArrayClass, (byteOrder == ByteOrder.BIG_ENDIAN));
-		/*[ELSE] Java14
+		/*[ELSE] JAVA_SPEC_VERSION >= 14
 		checkArrayClass(viewArrayClass);
 		return new ByteBufferViewVarHandle(viewArrayClass.getComponentType(), byteOrder);
-		/*[ENDIF] Java14 */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 	}
 	
 	private static void checkArrayClass(Class<?> arrayClass) throws IllegalArgumentException {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -57,15 +57,15 @@ import jdk.internal.reflect.CallerSensitive;
 import java.lang.invoke.VarHandle.AccessMode;
 import java.lang.reflect.Array;
 /*[IF Sidecar19-SE-OpenJ9]*/
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.JavaLangAccess;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-/*[ELSE]
+/*[ELSE] JAVA_SPEC_VERSION >= 12
 import jdk.internal.misc.SharedSecrets;
 import jdk.internal.misc.JavaLangAccess;
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 import java.security.ProtectionDomain;
 import jdk.internal.org.objectweb.asm.ClassReader;
 import jdk.internal.org.objectweb.asm.Opcodes;
@@ -3387,7 +3387,7 @@ public class MethodHandles {
 		return result;
 	}
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * Modifies a MethodHandle by applying a preprocessor handle as a filter to one of the arguments.
 	 * The preprocessor's return type must be the same as the argument in <i>handle</i> at the <i>filterPosition</i>.
@@ -3496,7 +3496,7 @@ public class MethodHandles {
 	static MethodHandle foldArgumentsWithCombiner(MethodHandle handle, int foldPosition, MethodHandle preprocessor, int... argumentIndices) throws NullPointerException, IllegalArgumentException {
 		return foldArguments(handle, foldPosition, preprocessor, argumentIndices);
 	}
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 	/**
 	 * Produce a MethodHandle that preprocesses some of the arguments by calling the preprocessor handle.

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -77,10 +77,10 @@ import java.lang.reflect.Module;
 import sun.reflect.CallerSensitive;
 /*[ENDIF] Sidecar19-SE*/
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import jdk.internal.misc.Unsafe;
 import java.util.Collections;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 /**
  * Factory class for creating and adapting MethodHandles.
@@ -176,10 +176,10 @@ public class MethodHandles {
 		private static final String INVOKE_EXACT = "invokeExact"; //$NON-NLS-1$
 		private static final String INVOKE = "invoke"; //$NON-NLS-1$
 		
-		/*[IF Java15]*/
+		/*[IF JAVA_SPEC_VERSION >= 15]*/
 		private static final int CLASSOPTION_FLAG_NESTMATE = 1;
 		private static final int CLASSOPTION_FLAG_STRONG = 2;
-		/*[ENDIF] Java15*/
+		/*[ENDIF] JAVA_SPEC_VERSION >= 15*/
 
 		static final int VARARGS = 0x80;
 		
@@ -223,11 +223,11 @@ public class MethodHandles {
 		 * For earlier releases, these lookups are illegal
 		  */
 		private static boolean lookupJLIPackageCheckDefault() {
-			/*[IF Java15]
+			/*[IF JAVA_SPEC_VERSION >= 15]
 			return false;
-			/*[ELSE] Java15*/
+			/*[ELSE]*/
 			return true;
-			/*[ENDIF] Java15*/
+			/*[ENDIF] JAVA_SPEC_VERSION >= 15*/
 		}
 		
 		Lookup(Class<?> lookupClass, Class<?> prevLookupClass, int lookupMode) {
@@ -1770,9 +1770,9 @@ public class MethodHandles {
 			 */
 			if (Modifier.isFinal(modifiers) && 
 				(!field.isAccessible() || Modifier.isStatic(modifiers)
-			/*[IF Java15]
+			/*[IF JAVA_SPEC_VERSION >= 15]
 				|| declaringClass.isHidden()
-			/*[ENDIF] Java15 */
+			/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 				)
 			) {
 				/*[MSG "K05cf", "illegal setter on final field"]*/
@@ -2287,7 +2287,7 @@ public class MethodHandles {
 		/*[ENDIF] Java14*/
 		/*[ENDIF] Sidecar19-SE */
 		
-		/*[IF Java15]*/
+		/*[IF JAVA_SPEC_VERSION >= 15]*/
 		/**
 		 * The ClassOption used to define the hidden class.
 		 * NESTMATE adds the hidden class into the same nest of the lookup class as a nest member.
@@ -2459,7 +2459,7 @@ public class MethodHandles {
 			}
 			return cls;
 		}
-		/*[ENDIF] Java15 */		
+		/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 		
 		/*[IF OPENJDK_METHODHANDLES]*/
 		MemberName resolveOrFail(byte b, MemberName mn) throws ReflectiveOperationException {
@@ -5557,7 +5557,7 @@ public class MethodHandles {
 		}
 	}
 
-	/*[IF Java15]*/
+	/*[IF JAVA_SPEC_VERSION >= 15]*/
 	/**
 	 * Validates that the permute[] specifies a valid permutation from permuteType to handleType.
 	 * This method throws IllegalArgumentException on failure and returns true on success. This
@@ -5700,7 +5700,7 @@ public class MethodHandles {
 
 		return false;
 	}
-	/*[ENDIF] Java15 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	/*[IF Sidecar18-SE-OpenJ9]*/	
 	static MethodHandle basicInvoker(MethodType mt) {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -335,12 +335,12 @@ public final class MethodType implements Serializable
 	public static MethodType fromMethodDescriptorString(String methodDescriptor, ClassLoader loader) {
 		ClassLoader classLoader = loader; 
 		if (classLoader == null) {
-			/*[IF Java14]*/
+			/*[IF JAVA_SPEC_VERSION >= 14]*/
 			SecurityManager security = System.getSecurityManager();
 			if (security != null) {
 				security.checkPermission(sun.security.util.SecurityConstants.GET_CLASSLOADER_PERMISSION);
 			}
-			/*[ENDIF]*/
+			/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 			classLoader = ClassLoader.getSystemClassLoader();
 		}
 		
@@ -1112,4 +1112,3 @@ public final class MethodType implements Serializable
 	}
 /*[ENDIF]*/
 }
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -28,11 +28,11 @@ import java.io.ObjectOutputStream;
 import java.io.ObjectStreamException;
 import java.io.ObjectStreamField;
 import java.io.Serializable;
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import java.lang.constant.Constable;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
@@ -43,10 +43,10 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import java.util.NoSuchElementException;
 import java.util.Optional;
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 import java.util.Set;
 import java.util.WeakHashMap;
 
@@ -70,9 +70,9 @@ import java.lang.invoke.MethodTypeForm;
  */
 @VMCONSTANTPOOL_CLASS
 public final class MethodType implements Serializable 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	, Constable, TypeDescriptor.OfMethod<Class<?>, MethodType>
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 {
 	static final Class<?>[] EMTPY_PARAMS = new Class<?>[0];
 
@@ -1027,12 +1027,12 @@ public final class MethodType implements Serializable
 		}
 		return invoker;
 	}
-	
-/*[IF Java12]*/
+
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	static MethodType makeImpl(Class<?> rtype, Class<?>[] ptypes, boolean arg) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 /*[IF Sidecar18-SE-OpenJ9]*/	
 	MethodType basicType() {
@@ -1076,7 +1076,7 @@ public final class MethodType implements Serializable
 /*[ENDIF]*/
 /*[ENDIF]*/
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * Return field descriptor of MethodType instance.
 	 * 
@@ -1110,5 +1110,5 @@ public final class MethodType implements Serializable
 			return Optional.empty();
 		}
 	}
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -835,9 +835,9 @@ public final class MethodType implements Serializable
 	 * 		type.parameterType(type.parameterCount() - 1)
 	 * @return class of final parameter, or void.class if there are no parameters
 	 */
-	/*[IF Java10]*/
+	/*[IF JAVA_SPEC_VERSION >= 10]*/
 	public
-	/*[ENDIF]*/
+	/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 	Class<?> lastParameterType() {
 		Class<?> result = void.class;
 		if (arguments.length > 0) {
@@ -1060,7 +1060,7 @@ public final class MethodType implements Serializable
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 
-	/*[IF Java10]*/
+	/*[IF JAVA_SPEC_VERSION >= 10]*/
 	/**
 	 * Returns the number of stack slots used by the described args in the MethodType.
 	 * @return The number of stack slots
@@ -1068,7 +1068,7 @@ public final class MethodType implements Serializable
 	int parameterSlotCount() {
 		return argSlots;
 	}
-	/*[ENDIF]*/	
+	/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 /*[ELSE]*/
 	MethodType asCollectorType(Class<?> clz, int num1) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodTypeHelper.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodTypeHelper.java
@@ -166,13 +166,13 @@ final class MethodTypeHelper {
 			}
 		}
 		String name = c.getName().replace('.', '/');
-		/*[IF Java15]*/
+		/*[IF JAVA_SPEC_VERSION >= 15]*/
 		if (clazz.isHidden()) {
 			/* keep the last "." before romaddress for hidden classes */
 			int index = name.lastIndexOf('/');
 			name = name.substring(0, index) + '.' + name.substring(index + 1,name.length());
 		}
-		/*[ENDIF] Java15 */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 		if (c.isArray()) {
 			return name;

--- a/jcl/src/java.base/share/classes/java/lang/invoke/PassThroughHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/PassThroughHandle.java
@@ -22,9 +22,9 @@
  *******************************************************************************/
 package java.lang.invoke;
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 /*
  * Special handle that in the interpreter calls the equivalent's implementation.
@@ -62,13 +62,12 @@ abstract class PassThroughHandle extends MethodHandle {
 		this.equivalent = originalHandle.equivalent;
 	}
 	
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		relatedMHs.add(equivalent);
 		return true;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 }
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/PermuteHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/PermuteHandle.java
@@ -22,9 +22,9 @@
  *******************************************************************************/
 package java.lang.invoke;
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 final class PermuteHandle extends MethodHandle {
 	@VMCONSTANTPOOL_FIELD
@@ -67,13 +67,13 @@ final class PermuteHandle extends MethodHandle {
 		return new PermuteHandle(permuteType, next, combinedPermute);
 	}
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		relatedMHs.add(next);
 		return true;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	// {{{ JIT support
 
@@ -122,4 +122,3 @@ final class PermuteHandle extends MethodHandle {
  		c.compareChildHandle(left.next, this.next);
  	}
 }
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/PrimitiveHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/PrimitiveHandle.java
@@ -30,9 +30,9 @@ import java.lang.reflect.Modifier;
 import com.ibm.oti.vm.VM;
 import com.ibm.jit.JITHelpers;
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 import static java.lang.invoke.MethodHandleResolver.UNSAFE;
 import static java.lang.invoke.MethodHandleResolver.JITHELPERS;
@@ -207,11 +207,11 @@ abstract class PrimitiveHandle extends MethodHandle {
 			throw new IllegalAccessException(e.getMessage());
 		}
 	}
-	
-/*[IF Java15]*/
+
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		return false;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ReceiverBoundHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ReceiverBoundHandle.java
@@ -24,14 +24,14 @@ package java.lang.invoke;
 
 import java.lang.reflect.Modifier;
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import com.ibm.oti.vm.VMLangAccess;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 /* ReceiverBoundHandle is a DirectHandle subclass used to call methods 
  * that have an exact known address and a bound first parameter.
@@ -110,7 +110,7 @@ final class ReceiverBoundHandle extends DirectHandle {
 		return result;
 	}
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		VMLangAccess vma = Lookup.getVMLangAccess();
@@ -149,7 +149,7 @@ final class ReceiverBoundHandle extends DirectHandle {
 		
 		return false;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	// {{{ JIT support
 	private static final ThunkTable _thunkTable = new ThunkTable();
@@ -245,4 +245,3 @@ final class ReceiverBoundHandle extends DirectHandle {
 		super.compareWithDirect(left, c);
 	}
 }
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/SimpleMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/SimpleMethodHandle.java
@@ -1,5 +1,4 @@
 /*[INCLUDE-IF Sidecar18-SE-OpenJ9 & !OPENJDK_METHODHANDLES]*/
-
 /*******************************************************************************
  * Copyright (c) 2017, 2020 IBM Corp. and others
  *
@@ -23,14 +22,13 @@
  *******************************************************************************/
 package java.lang.invoke;
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 /*
  * Stub class to compile OpenJDK j.l.i.MethodHandleImpl
  */
-
 final class SimpleMethodHandle extends BoundMethodHandle {
 	
 	private SimpleMethodHandle(MethodType type, LambdaForm form) {
@@ -50,10 +48,10 @@ final class SimpleMethodHandle extends BoundMethodHandle {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		return false;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/SpreadHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/SpreadHandle.java
@@ -22,9 +22,9 @@
  *******************************************************************************/
 package java.lang.invoke;
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 import com.ibm.oti.util.Msg;
 
@@ -113,13 +113,13 @@ final class SpreadHandle extends MethodHandle {
 			);
 	}
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		relatedMHs.add(next);
 		return true;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	// }}} JIT support
 
@@ -144,4 +144,3 @@ final class SpreadHandle extends MethodHandle {
 	}
 
 }
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/SpreadHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/SpreadHandle.java
@@ -84,11 +84,11 @@ final class SpreadHandle extends MethodHandle {
 		if (spreadArg == null) {
 			if (spreadCount != 0) {
 				/*[MSG "K05d1", "cannot have null spread argument unless spreadCount is 0"]*/
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 				throw new NullPointerException(Msg.getString("K05d1")); //$NON-NLS-1$
-/*[ELSE]*/
+/*[ELSE] JAVA_SPEC_VERSION >= 11 */
 				throw new IllegalArgumentException(Msg.getString("K05d1")); //$NON-NLS-1$
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 			}
 		} else if (spreadCount != java.lang.reflect.Array.getLength(spreadArg)) {
 			/*[MSG "K05d2", "expected '{0}' sized array; encountered '{1}' sized array"]*/

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -29,15 +29,15 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.ArrayList;
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import java.util.Optional;
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 /*[IF Sidecar19-SE]
 import jdk.internal.misc.Unsafe;
 /*[ELSE]*/
 import sun.misc.Unsafe;
 /*[ENDIF]*/
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import java.lang.constant.ClassDesc;
 import java.lang.constant.Constable;
 import java.lang.constant.ConstantDesc;
@@ -45,7 +45,7 @@ import java.lang.constant.ConstantDescs;
 import java.lang.constant.DirectMethodHandleDesc;
 import java.lang.constant.DynamicConstantDesc;
 import java.util.Objects;
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 import java.util.Map;
 import java.util.HashMap;
@@ -64,9 +64,9 @@ import java.lang.reflect.Method;
  * 
  */
 public abstract class VarHandle extends VarHandleInternal 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	implements Constable
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 {
 	/**
 	 * Access mode identifiers for VarHandle operations.
@@ -360,9 +360,9 @@ public abstract class VarHandle extends VarHandleInternal
 	final Class<?> fieldType;
 	final Class<?>[] coordinateTypes;
 	final int modifiers;
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	private int hashCode = 0;
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 /*[IF JAVA_SPEC_VERSION >= 16]*/
 	final boolean exact;
@@ -687,7 +687,7 @@ public abstract class VarHandle extends VarHandleInternal
 		return Collections.unmodifiableList(Arrays.<Class<?>>asList(coordinateTypes));
 	}
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * Returns the nominal descriptor of this VarHandle instance, or an empty Optional 
 	 * if construction is not possible.
@@ -777,8 +777,8 @@ public abstract class VarHandle extends VarHandleInternal
 		String coordList = Arrays.toString(coordinateTypes);
 		return String.format(structure, this.fieldType.getName(), coordList);
 	}
-/*[ENDIF]*/
-	
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
+
 	/**
 	 * Each {@link AccessMode}, e.g. get and set, requires different parameters
 	 * in addition to the {@link VarHandle#coordinateTypes() coordinateTypes()}. 
@@ -1447,7 +1447,7 @@ public abstract class VarHandle extends VarHandleInternal
 		return handleTable[operation];
 	}
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/* nominal descriptor of a VarHandle constant */
 	public static final class VarHandleDesc extends DynamicConstantDesc<VarHandle> implements ConstantDesc {
 		private Kind type = null;
@@ -1678,7 +1678,7 @@ public abstract class VarHandle extends VarHandleInternal
 			return (ClassDesc)args[0];
 		}		
 	}
-/*[ENDIF] Java12 */ 
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 /*[IF JAVA_SPEC_VERSION >= 15]*/
 	/**

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -351,11 +351,11 @@ public abstract class VarHandle extends VarHandleInternal
 	VarForm vform = null;
 /*[ENDIF] Java14 */
 	
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	MethodHandle[] handleTable;
 /*[ELSE]*/
 	private final MethodHandle[] handleTable;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	final Class<?> fieldType;
 	final Class<?>[] coordinateTypes;
@@ -563,7 +563,7 @@ public abstract class VarHandle extends VarHandleInternal
 	}
 /*[ENDIF] Java14 */
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	/**
 	 * Generate a MethodHandle which translates:
 	 *     FROM {VarHandle, Receiver, Intermediate ..., Value}ReturnType
@@ -642,7 +642,7 @@ public abstract class VarHandle extends VarHandleInternal
 
 		return operationMHs;
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	Class<?> getDefiningClass() {
 		/*[MSG "K0627", "Expected override of this method."]*/
@@ -663,11 +663,11 @@ public abstract class VarHandle extends VarHandleInternal
 	 * 
 	 * @return The field type
 	 */
-	/*[IF Java15]*/
+	/*[IF JAVA_SPEC_VERSION >= 15]*/
 	public Class<?> varType() {
 	/*[ELSE]*/
 	public final Class<?> varType() {
-	/*[ENDIF] Java15 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 		return this.fieldType;
 	}
 	
@@ -679,11 +679,11 @@ public abstract class VarHandle extends VarHandleInternal
 	 * 
 	 * @return The parameters required to access the field.
 	 */
-	/*[IF Java15]*/
+	/*[IF JAVA_SPEC_VERSION >= 15]*/
 	public List<Class<?>> coordinateTypes() {
 	/*[ELSE]*/
 	public final List<Class<?>> coordinateTypes() {
-	/*[ENDIF] Java15 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 		return Collections.unmodifiableList(Arrays.<Class<?>>asList(coordinateTypes));
 	}
 
@@ -884,11 +884,11 @@ public abstract class VarHandle extends VarHandleInternal
 	 * @return A {@link MethodHandle} for the specified {@link AccessMode}, bound to
 	 * 			this {@link VarHandle} instance.
 	 */
-	/*[IF Java15]*/
+	/*[IF JAVA_SPEC_VERSION >= 15]*/
 	public MethodHandle toMethodHandle(AccessMode accessMode) {
 	/*[ELSE]*/
 	public final MethodHandle toMethodHandle(AccessMode accessMode) {
-	/*[ENDIF] Java15 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 		MethodHandle mh = handleTable[accessMode.ordinal()];
 
 		if (mh != null) {
@@ -1680,7 +1680,7 @@ public abstract class VarHandle extends VarHandleInternal
 	}
 /*[ENDIF] Java12 */ 
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	/**
 	 * Return the target VarHandle. For a direct VarHandle, the target
 	 * VarHandle is null. An indirect VarHandle will override this method to
@@ -1724,9 +1724,9 @@ public abstract class VarHandle extends VarHandleInternal
 	private static VarHandle asDirect(VarHandle varHandle) {
 		return varHandle.asDirect();
 	}
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
-/*[IF Java15 | OPENJDK_METHODHANDLES]*/
+/*[IF (JAVA_SPEC_VERSION >= 15) | OPENJDK_METHODHANDLES]*/
 	/**
 	 * Return the MethodHandle corresponding to the integer-value of the AccessMode.
 	 * 
@@ -1737,7 +1737,7 @@ public abstract class VarHandle extends VarHandleInternal
 	MethodHandle getMethodHandle(int i) {
 		return handleTable[i];
 	}
-/*[ENDIF] Java15 | OPENJDK_METHODHANDLES */
+/*[ENDIF] (JAVA_SPEC_VERSION >= 15) | OPENJDK_METHODHANDLES */
 
 	MethodType accessModeTypeUncached(
 		/*[IF JAVA_SPEC_VERSION >= 16]*/

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -342,11 +342,11 @@ public abstract class VarHandle extends VarHandleInternal
 
 /*[IF Java14]*/
 	static final BiFunction<String,
-				/*[IF Java16]*/
+				/*[IF JAVA_SPEC_VERSION >= 16]*/
 				List<Number>,
 				/*[ELSE]*/
 				List<Integer>,
-				/*[ENDIF] Java16 */
+				/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 				ArrayIndexOutOfBoundsException> AIOOBE_SUPPLIER = null;
 	VarForm vform = null;
 /*[ENDIF] Java14 */
@@ -364,9 +364,9 @@ public abstract class VarHandle extends VarHandleInternal
 	private int hashCode = 0;
 /*[ENDIF] Java12 */
 
-/*[IF Java16]*/
+/*[IF JAVA_SPEC_VERSION >= 16]*/
 	final boolean exact;
-/*[ENDIF] Java16 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 
 	/**
 	 * Constructs a generic VarHandle instance. 
@@ -381,9 +381,9 @@ public abstract class VarHandle extends VarHandleInternal
 		this.coordinateTypes = coordinateTypes;
 		this.handleTable = handleTable;
 		this.modifiers = modifiers;
-/*[IF Java16]*/
+/*[IF JAVA_SPEC_VERSION >= 16]*/
 		this.exact = false;
-/*[ENDIF] Java16 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 	}
 
 /*[IF Java14]*/
@@ -393,7 +393,7 @@ public abstract class VarHandle extends VarHandleInternal
 	 * @param varForm an instance of VarForm.
 	 */
 	VarHandle(VarForm varForm) {
-/*[IF Java16]*/
+/*[IF JAVA_SPEC_VERSION >= 16]*/
 		this(varForm, false);
 	}
 
@@ -405,7 +405,7 @@ public abstract class VarHandle extends VarHandleInternal
 	 */
 	VarHandle(VarForm varForm, boolean exact) {
 		this.exact = exact;
-/*[ENDIF] Java16 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 		if (varForm.memberName_table == null) {
 			/* Indirect VarHandle. */
 			MethodType getter = varForm.methodType_table[VarHandle.AccessType.GET.ordinal()];
@@ -421,11 +421,11 @@ public abstract class VarHandle extends VarHandleInternal
 	
 			/* The first argument in AccessType.GET MethodType is the receiver class. */
 			Class<?> receiverActual = accessModeTypeUncached(
-					/*[IF Java16]*/
+					/*[IF JAVA_SPEC_VERSION >= 16]*/
 					AccessMode.GET.at
 					/*[ELSE]*/
 					AccessMode.GET
-					/*[ENDIF] Java16 */
+					/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 				).parameterType(0);
 
 			Class<?> receiverVarForm = varForm.methodType_table[AccessType.GET.ordinal()].parameterType(0);
@@ -793,11 +793,11 @@ public abstract class VarHandle extends VarHandleInternal
 		MethodHandle internalHandle = handleTable[accessMode.ordinal()];
 		if (internalHandle == null) {
 			modifiedType = accessModeTypeUncached(
-					/*[IF Java16]*/
+					/*[IF JAVA_SPEC_VERSION >= 16]*/
 					accessMode.at
 					/*[ELSE]*/
 					accessMode
-					/*[ENDIF] Java16 */
+					/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 				);
 		} else {
 			MethodType internalType = internalHandle.type();
@@ -903,11 +903,11 @@ public abstract class VarHandle extends VarHandleInternal
 			} else {
 
 				mt = accessModeTypeUncached(
-						/*[IF Java16]*/
+						/*[IF JAVA_SPEC_VERSION >= 16]*/
 						accessMode.at
 						/*[ELSE]*/
 						accessMode
-						/*[ENDIF] Java16 */
+						/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 					);
 
 				/* accessModeTypeUncached does not return null. It throws InternalError if the method type
@@ -1740,16 +1740,16 @@ public abstract class VarHandle extends VarHandleInternal
 /*[ENDIF] Java15 | OPENJDK_METHODHANDLES */
 
 	MethodType accessModeTypeUncached(
-		/*[IF Java16]*/
+		/*[IF JAVA_SPEC_VERSION >= 16]*/
 		AccessType type
 		/*[ELSE]*/
 		AccessMode accessMode
-		/*[ENDIF] Java16 */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 	) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 
-/*[IF Java16]*/
+/*[IF JAVA_SPEC_VERSION >= 16]*/
 	final MethodType accessModeTypeUncached(int index) {
 		return accessModeTypeUncached(AccessType.values()[index]);
 	}
@@ -1765,6 +1765,6 @@ public abstract class VarHandle extends VarHandleInternal
 	public boolean hasInvokeExactBehavior() {
 		return exact;
 	}
-/*[ENDIF] Java16 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -50,10 +50,10 @@ import java.util.Objects;
 import java.util.Map;
 import java.util.HashMap;
 
-/*[IF Java14]*/
+/*[IF JAVA_SPEC_VERSION >= 14]*/
 import java.util.function.BiFunction;
 import java.lang.reflect.Method;
-/*[ENDIF] Java14 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 
 /**
  * Dynamically typed reference to a field, allowing read and write operations, 
@@ -340,7 +340,7 @@ public abstract class VarHandle extends VarHandleInternal
 	static final Unsafe _unsafe = Unsafe.getUnsafe();
 	static final Lookup _lookup = Lookup.IMPL_LOOKUP;
 
-/*[IF Java14]*/
+/*[IF JAVA_SPEC_VERSION >= 14]*/
 	static final BiFunction<String,
 				/*[IF JAVA_SPEC_VERSION >= 16]*/
 				List<Number>,
@@ -349,7 +349,7 @@ public abstract class VarHandle extends VarHandleInternal
 				/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 				ArrayIndexOutOfBoundsException> AIOOBE_SUPPLIER = null;
 	VarForm vform = null;
-/*[ENDIF] Java14 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 	
 /*[IF JAVA_SPEC_VERSION >= 15]*/
 	MethodHandle[] handleTable;
@@ -386,7 +386,7 @@ public abstract class VarHandle extends VarHandleInternal
 /*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 	}
 
-/*[IF Java14]*/
+/*[IF JAVA_SPEC_VERSION >= 14]*/
 	/**
 	 * Constructs a generic VarHandle instance.
 	 *
@@ -561,7 +561,7 @@ public abstract class VarHandle extends VarHandleInternal
 
 		return MethodHandles.permuteArguments(methodHandle, permuteMethodType, reorder);
 	}
-/*[ENDIF] Java14 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 
 /*[IF JAVA_SPEC_VERSION >= 15]*/
 	/**
@@ -817,12 +817,12 @@ public abstract class VarHandle extends VarHandleInternal
 	 * @return A boolean value indicating whether the {@link AccessMode} is supported.
 	 */
 	boolean isAccessModeSupportedHelper(AccessMode accessMode) {
-/*[IF Java14]*/
+/*[IF JAVA_SPEC_VERSION >= 14]*/
 		if (vform != null) {
 			return (handleTable[accessMode.ordinal()] != null);
 		}
-/*[ENDIF] Java14 */
-		
+/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
+
 		switch (accessMode) {
 		case GET:
 		case GET_VOLATILE:

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandleByteArrayBase.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandleByteArrayBase.java
@@ -1,5 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE & !Java14 & !OPENJDK_METHODHANDLES]*/
-
+/*[INCLUDE-IF Sidecar19-SE & (JAVA_SPEC_VERSION < 14) & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
  * Copyright (c) 2017, 2020 IBM Corp. and others
  *

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -1,5 +1,4 @@
-/*[INCLUDE-IF Java11 & !Java14 & !OPENJDK_METHODHANDLES]*/
-
+/*[INCLUDE-IF Java11 & (JAVA_SPEC_VERSION < 14) & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
  * Copyright (c) 2017, 2020 IBM Corp. and others
  *
@@ -21,4 +20,3 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Java11 & (JAVA_SPEC_VERSION < 14) & !OPENJDK_METHODHANDLES]*/
+/*[INCLUDE-IF (11 <= JAVA_SPEC_VERSION) & (JAVA_SPEC_VERSION < 14) & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
  * Copyright (c) 2017, 2020 IBM Corp. and others
  *

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarargsCollectorHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarargsCollectorHandle.java
@@ -29,9 +29,9 @@ import java.util.Arrays;
 import java.util.Objects;
 /*[ENDIF]*/
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 import com.ibm.oti.util.Msg;
 
@@ -227,15 +227,15 @@ final class VarargsCollectorHandle extends MethodHandle {
 	boolean canRevealDirect() {
 		return isPrimitiveVarargs;
 	}
-	
-/*[IF Java15]*/
+
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 	@Override
 	boolean addRelatedMHs(List<MethodHandle> relatedMHs) {
 		relatedMHs.add(next);
 		return true;
 	}
-/*[ENDIF] Java15 */
-	
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
+
 	// {{{ JIT support
 
 	private static final ThunkTable _thunkTable = new ThunkTable();
@@ -272,4 +272,3 @@ final class VarargsCollectorHandle extends MethodHandle {
 		c.compareChildHandle(left.next, this.next);
 	}
 }
-

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarargsCollectorHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarargsCollectorHandle.java
@@ -23,11 +23,11 @@
 package java.lang.invoke;
 
 import java.lang.invoke.MethodHandles.Lookup;
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Objects;
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
 /*[IF JAVA_SPEC_VERSION >= 15]*/
 import java.util.List;
@@ -113,7 +113,7 @@ final class VarargsCollectorHandle extends MethodHandle {
 		if (args != null) {
 			argsLength = args.length;
 		}
-		/*[IF Java11]*/
+		/*[IF JAVA_SPEC_VERSION >= 11]*/
 		/*
 		 * If argument count exceeds the parameter count of the MethodHandle, special handling is required to
 		 * store the additional arguments in the trailing array.
@@ -140,7 +140,7 @@ final class VarargsCollectorHandle extends MethodHandle {
 
 			return this.asFixedArity().invokeWithArguments(newArgs);
 		} else
-		/*[ENDIF]*/
+		/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 		{
 			if (argsLength < 253) {
 				MethodHandle mh = IWAContainer.getMH(argsLength);

--- a/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -27,10 +27,10 @@ import java.security.PrivilegedAction;
 
 import com.ibm.oti.vm.VM;
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import jdk.internal.access.JavaLangRefAccess;
 import jdk.internal.access.SharedSecrets;
-/*[ELSE]
+/*[ELSE] JAVA_SPEC_VERSION >= 12
 /*[IF Sidecar19-SE]
 import jdk.internal.misc.JavaLangRefAccess;
 import jdk.internal.misc.SharedSecrets;
@@ -40,7 +40,7 @@ import sun.misc.JavaLangRefAccess;
 import sun.misc.SharedSecrets;
 /*[ENDIF]*/
 /*[ENDIF]*/
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 /**
  * Abstract class which describes behavior common to all reference objects.

--- a/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -73,11 +73,11 @@ public abstract class Reference<T> extends Object {
 				return waitForReferenceProcessingImpl();
 			}
 
-			/*[IF Java11]*/
+			/*[IF JAVA_SPEC_VERSION >= 11]*/
 			public void runFinalization() {
 				Finalizer.runFinalization();
 			}
-			/*[ENDIF]*/
+			/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 		});
 	}
 	
@@ -253,7 +253,7 @@ public static void reachabilityFence(java.lang.Object ref) {
 }
 /*[ENDIF]*/
 
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 /**
  * This method will always throw CloneNotSupportedException. A clone of this instance will not be returned 
  * since a Reference cannot be cloned. Workaround is to create a new Reference.
@@ -267,7 +267,7 @@ protected Object clone() throws CloneNotSupportedException {
 	/*[MSG "K0900", "Create a new Reference, since a Reference cannot be cloned."]*/
 	throw new CloneNotSupportedException(com.ibm.oti.util.Msg.getString("K0900")); //$NON-NLS-1$
 }
-/*[ENDIF] Java11 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
 /*[IF JAVA_SPEC_VERSION >= 16]*/
 /**

--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -935,8 +935,8 @@ public final class Unsafe {
 	 * @throws IllegalArgumentException if field is static
 	 */
 	private native long objectFieldOffset0(Field field);
-	
-/*[IF Java10]*/
+
+/*[IF JAVA_SPEC_VERSION >= 10]*/
 	/*
 	 * Returns byte offset to field.
 	 * 
@@ -947,7 +947,7 @@ public final class Unsafe {
 	 * @throws IllegalArgumentException if field is static
 	 */
 	private native long objectFieldOffset1(Class<?> c, String fieldName);
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 
 	/* 
 	 * Returns byte offset to start of static class or interface.
@@ -1477,8 +1477,8 @@ public final class Unsafe {
 		Objects.requireNonNull(field);
 		return objectFieldOffset0(field);
 	}
-	
-/*[IF Java10]*/
+
+/*[IF JAVA_SPEC_VERSION >= 10]*/
 	/**
 	 * Returns byte offset to field.
 	 * 
@@ -1494,7 +1494,7 @@ public final class Unsafe {
 		Objects.requireNonNull(fieldName);
 		return objectFieldOffset1(c, fieldName);
 	}
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 
 	/**
 	 * Returns byte offset to start of static class or interface.

--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1042,7 +1042,7 @@ public final class Unsafe {
 	/* @return true if machine is big endian, false otherwise */
 	private native boolean isBigEndian0();
 
-/*[IF Java14]*/
+/*[IF JAVA_SPEC_VERSION >= 14]*/
 	/**
 	 * Make sure that the virtual memory at address "addr" for length "len" has
 	 * been written back from the cache to physical memory.
@@ -1061,8 +1061,8 @@ public final class Unsafe {
 	 * @return true if cache writeback is possible, else false
 	 */
 	public static native boolean isWritebackEnabled();
-/*[ENDIF] Java14 */
-	
+/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
+
 	/**
 	 * Getter for unsafe instance.
 	 * 

--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -28,11 +28,11 @@ import com.ibm.oti.vm.VMLangAccess;
 import java.lang.reflect.Field;
 import java.security.ProtectionDomain;
 import java.util.Objects;
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 import java.nio.ByteBuffer;
 import sun.nio.ch.DirectBuffer;
 import jdk.internal.ref.Cleaner;
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 public final class Unsafe {
 
@@ -407,7 +407,7 @@ public final class Unsafe {
 	 */
 	public native void putObject(Object obj, long offset, Object value);
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * Gets the value of the Object in the obj parameter referenced by offset.
 	 * This is a non-volatile operation.
@@ -427,8 +427,8 @@ public final class Unsafe {
 	 * @param value Object to store in obj
 	 */
 	public native void putReference(Object obj, long offset, Object value);
-/*[ENDIF] Java12 */
-	
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
+
 	/**
 	 * Gets the value of the Object in memory referenced by address.
 	 * This is a non-volatile operation.
@@ -599,7 +599,7 @@ public final class Unsafe {
 	public final native Object compareAndExchangeObject(Object obj, long offset, Object compareValue,
 			Object exchangeValue);
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * Atomically sets the parameter value at offset in obj if the compare value 
 	 * matches the existing value in the object.
@@ -628,7 +628,7 @@ public final class Unsafe {
 	 */
 	public final native Object compareAndExchangeReference(Object obj, long offset, Object compareValue,
 			Object exchangeValue);
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 	/**
 	 * Atomically gets the value of the byte in the obj parameter referenced by offset.
@@ -792,7 +792,7 @@ public final class Unsafe {
 	 */
 	public native void putObjectVolatile(Object obj, long offset, Object value);
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * Atomically gets the value of the Object in the obj parameter referenced by offset.
 	 * 
@@ -810,7 +810,7 @@ public final class Unsafe {
 	 * @param value Object to store in obj
 	 */
 	public native void putReferenceVolatile(Object obj, long offset, Object value);
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 	/**
 	 * Makes permit available for thread parameter.
@@ -2804,7 +2804,7 @@ public final class Unsafe {
 		return compareAndSetObject(obj, offset, compareValue, setValue);
 	}
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * Atomically sets the parameter value at offset in obj if the compare value 
 	 * matches the existing value in the object.
@@ -2902,7 +2902,7 @@ public final class Unsafe {
 	public final boolean weakCompareAndSetReference(Object obj, long offset, Object compareValue, Object setValue) {
 		return compareAndSetReference(obj, offset, compareValue, setValue);
 	}
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 	/**
 	 * Gets the value of the byte in the obj parameter referenced by offset using acquire semantics.
@@ -3012,7 +3012,7 @@ public final class Unsafe {
 		return getObjectVolatile(obj, offset);
 	}
 
-	/*[IF Java12]*/
+	/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * Gets the value of the Object in the obj parameter referenced by offset using acquire semantics.
 	 * Preceding loads will not be reordered with subsequent loads/stores.
@@ -3024,7 +3024,7 @@ public final class Unsafe {
 	public final Object getReferenceAcquire(Object obj, long offset) {
 		return getReferenceVolatile(obj, offset);
 	}
-	/*[ENDIF] Java12 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 	/**
 	 * Sets the value of the byte in the obj parameter at memory offset using acquire semantics.
@@ -3134,7 +3134,7 @@ public final class Unsafe {
 		putObjectVolatile(obj, offset, value);
 	}
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * Sets the value of the Object in the obj parameter at memory offset using acquire semantics.
 	 * Preceding stores will not be reordered with subsequent loads/stores.
@@ -3146,8 +3146,8 @@ public final class Unsafe {
 	public final void putReferenceRelease(Object obj, long offset, Object value) {
 		putReferenceVolatile(obj, offset, value);
 	}
-/*[ENDIF] Java12 */
-	
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
+
 	/**
 	 * Gets the value of the byte in the obj parameter referenced by offset.
 	 * The operation is in program order, but does enforce ordering with respect to other threads.
@@ -3256,7 +3256,7 @@ public final class Unsafe {
 		return getObjectVolatile(obj, offset);
 	}
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * Gets the value of the Object in the obj parameter referenced by offset.
 	 * The operation is in program order, but does enforce ordering with respect to other threads.
@@ -3268,7 +3268,7 @@ public final class Unsafe {
 	public final Object getReferenceOpaque(Object obj, long offset) {
 		return getReferenceVolatile(obj, offset);
 	}
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 	/**
 	 * Sets the value of the byte in the obj parameter at memory offset.
@@ -3378,7 +3378,7 @@ public final class Unsafe {
 		putObjectVolatile(obj, offset, value);
 	}
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * Sets the value of the Object in the obj parameter at memory offset.
 	 * The operation is in program order, but does enforce ordering with respect to other threads.
@@ -3390,7 +3390,7 @@ public final class Unsafe {
 	public final void putReferenceOpaque(Object obj, long offset, Object value) {
 		putReferenceVolatile(obj, offset, value);
 	}
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 	/**
 	 * Get the load average in the system.
@@ -4348,7 +4348,7 @@ public final class Unsafe {
 		}
 	}
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * Atomically sets value at offset in obj
 	 * and returns the value of the field prior to the update.
@@ -4408,7 +4408,7 @@ public final class Unsafe {
 			}
 		}
 	}
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 	/**
 	 * Atomically OR's the given value to the current value of the 
@@ -5854,7 +5854,7 @@ public final class Unsafe {
 		putCharUnaligned(obj, offset, endianValue);
 	}
 
-/*[IF Java12]*/
+/*[IF JAVA_SPEC_VERSION >= 12]*/
 	/**
 	 * If incoming ByteBuffer is an instance of sun.nio.ch.DirectBuffer,
 	 * and it is direct, and not a slice or duplicate,
@@ -5886,7 +5886,7 @@ public final class Unsafe {
 			throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K0704")); //$NON-NLS-1$
 		}
 	}
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 	/* 
 	 * Private methods 

--- a/jcl/src/java.base/share/classes/openj9/management/internal/ThreadInfoBase.java
+++ b/jcl/src/java.base/share/classes/openj9/management/internal/ThreadInfoBase.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -170,13 +170,13 @@ public class ThreadInfoBase {
 		String ls = System.lineSeparator();
 		if (cachedToStringResult == null) {
 			StringBuilder result = new StringBuilder();
-/*[IF Java11]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 			result.append(String.format("\"%s\" prio=%d Id=%d %s", //$NON-NLS-1$
 					threadName, Integer.valueOf(priority), Long.valueOf(threadId), threadState));
-/*[ELSE]*/
+/*[ELSE] JAVA_SPEC_VERSION >= 11 */
 			result.append(String.format("\"%s\" Id=%d %s", //$NON-NLS-1$
 					threadName, Long.valueOf(threadId), threadState));
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 			if (State.BLOCKED == threadState) {
 				result.append(String.format(" on %s owned by \"%s\" Id=%d", //$NON-NLS-1$
 						lockName, lockOwnerName, Long.valueOf(lockOwnerId)));

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/BufferPoolMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/BufferPoolMXBeanImpl.java
@@ -32,10 +32,10 @@ import javax.management.ObjectName;
 import jdk.internal.misc.VM.BufferPool;
 import jdk.internal.access.SharedSecrets;
 /*[ELSE]
-/*[IF Java12]
+/*[IF JAVA_SPEC_VERSION >= 12]
 import jdk.internal.access.JavaNioAccess.BufferPool;
 import jdk.internal.access.SharedSecrets;
-/*[ELSE]
+/*[ELSE] JAVA_SPEC_VERSION >= 12
 /*[IF Sidecar19-SE]
 import jdk.internal.misc.JavaNioAccess.BufferPool;
 import jdk.internal.misc.SharedSecrets;
@@ -43,7 +43,7 @@ import jdk.internal.misc.SharedSecrets;
 import sun.misc.JavaNioAccess.BufferPool;
 import sun.misc.SharedSecrets;
 /*[ENDIF] Sidecar19-SE */
-/*[ENDIF] Java12 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 /*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 /**

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/BufferPoolMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/BufferPoolMXBeanImpl.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 import javax.management.ObjectName;
 
-/*[IF Java15]*/
+/*[IF JAVA_SPEC_VERSION >= 15]*/
 import jdk.internal.misc.VM.BufferPool;
 import jdk.internal.access.SharedSecrets;
 /*[ELSE]
@@ -44,7 +44,7 @@ import sun.misc.JavaNioAccess.BufferPool;
 import sun.misc.SharedSecrets;
 /*[ENDIF] Sidecar19-SE */
 /*[ENDIF] Java12 */
-/*[ENDIF] Java15 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 /**
  * The implementation MXBean for {@link java.lang.management.BufferPoolMXBean}.

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryMXBeanImpl.java
@@ -788,11 +788,11 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 	/**
 	 * {@inheritDoc}
 	 */
-	/*[IF Java11]*/
+	/*[IF JAVA_SPEC_VERSION >= 11]*/
 	@Deprecated(forRemoval=true, since="15")
-	/*[ELSE] Java11 */
+	/*[ELSE] JAVA_SPEC_VERSION >= 11 */
 	@Deprecated
-	/*[ENDIF] Java11 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 	public long getGCMasterThreadCpuUsed() {
 		return getGCMainThreadCpuUsedImpl();
 	}
@@ -817,11 +817,11 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 	/**
 	 * {@inheritDoc}
 	 */
-	/*[IF Java11]*/
+	/*[IF JAVA_SPEC_VERSION >= 11]*/
 	@Deprecated(forRemoval=true, since="15")
-	/*[ELSE] Java11 */
+	/*[ELSE] JAVA_SPEC_VERSION >= 11 */
 	@Deprecated
-	/*[ENDIF] Java11 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 	public long getGCSlaveThreadsCpuUsed() {
 		return getGCWorkerThreadsCpuUsedImpl();
 	}

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryMXBeanImpl.java
@@ -784,7 +784,7 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 	 */
 	private native long getGCMainThreadCpuUsedImpl();
 
-/*[IF !Java16]*/
+/*[IF JAVA_SPEC_VERSION < 16]*/
 	/**
 	 * {@inheritDoc}
 	 */
@@ -796,7 +796,7 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 	public long getGCMasterThreadCpuUsed() {
 		return getGCMainThreadCpuUsedImpl();
 	}
-/*[ENDIF] !Java16 */
+/*[ENDIF] JAVA_SPEC_VERSION < 16 */
 
 	/**
 	 * {@inheritDoc}
@@ -813,7 +813,7 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 	 */
 	private native long getGCWorkerThreadsCpuUsedImpl();
 
-/*[IF !Java16]*/
+/*[IF JAVA_SPEC_VERSION < 16]*/
 	/**
 	 * {@inheritDoc}
 	 */
@@ -825,7 +825,7 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 	public long getGCSlaveThreadsCpuUsed() {
 		return getGCWorkerThreadsCpuUsedImpl();
 	}
-/*[ENDIF] !Java16 */
+/*[ENDIF] JAVA_SPEC_VERSION < 16 */
 
 	/**
 	 * {@inheritDoc}

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ThreadMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ThreadMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2019 IBM Corp. and others
+ * Copyright (c) 2007, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -306,7 +306,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 		return getThreadInfoCommon(ids, lockedMonitors, lockedSynchronizers, Integer.MAX_VALUE);
 	}
 
-	/*[IF Java10]*/
+	/*[IF JAVA_SPEC_VERSION >= 10]*/
 	@Override
 	public ThreadInfo[] getThreadInfo(long[] ids, boolean lockedMonitors,
 			boolean lockedSynchronizers, int maxDepth) {
@@ -316,7 +316,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 		}
 		return getThreadInfoCommon(ids, lockedMonitors, lockedSynchronizers, maxDepth);
 	}
-	/*[ENDIF]*/ // Java10
+	/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 
 	private ThreadInfo[] getThreadInfoCommon(long[] ids, boolean lockedMonitors,
 			boolean lockedSynchronizers, int maxDepth) {
@@ -680,7 +680,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 		return makeThreadInfos(threadInfoBaseArray);
 	}
 
-	/*[IF Java10]*/
+	/*[IF JAVA_SPEC_VERSION >= 10]*/
 	/**
 	 * {@inheritDoc}
 	 */
@@ -693,7 +693,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 		}
 		return dumpAllThreadsCommon(lockedMonitors, lockedSynchronizers, maxDepth);
 	}
-	/*[ENDIF]*/ // Java10
+	/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 
 	/**
 	 * @param lockedMonitors

--- a/jcl/src/java.management/share/classes/java/lang/management/RuntimeMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/RuntimeMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -131,7 +131,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 */
 	public String getName();
 
-	/*[IF Java10]*/
+	/*[IF JAVA_SPEC_VERSION >= 10]*/
 	/**
 	 * Returns the process ID (PID) of the current running Java virtual machine.
 	 * 
@@ -147,7 +147,7 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 			}
 		});
 	}
-	/*[ENDIF]*/
+	/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 
 	/**
 	 * Returns the name of the Java virtual machine specification followed by

--- a/jcl/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -633,7 +633,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	public ThreadInfo[] dumpAllThreads(boolean lockedMonitors,
 			boolean lockedSynchronizers);
 
-	/*[IF Java10]*/
+	/*[IF JAVA_SPEC_VERSION >= 10]*/
 	/**
 	 * Returns an array of {@link ThreadInfo} objects holding information on all
 	 * threads that were alive when the call was invoked.
@@ -663,13 +663,11 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 *	</ul>
 	 * @since 10
 	 */
-
 	public default ThreadInfo[] dumpAllThreads(
 		boolean lockedMonitors, boolean lockedSynchronizers, int maxDepth
 	) {
 		throw new UnsupportedOperationException();
 	}
-
 
 	/**
 	 * Returns an array of {@link ThreadInfo} objects; one for each of the
@@ -735,5 +733,5 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	) {
 		throw new UnsupportedOperationException();
 	}
-	/*[ENDIF] Java10*/
+	/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 }

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/MemoryMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/MemoryMXBean.java
@@ -256,11 +256,11 @@ public interface MemoryMXBean extends java.lang.management.MemoryMXBean {
      * 
      * @deprecated renamed to getGCMainThreadCpuUsed
      */
-    /*[IF Java11]*/
+    /*[IF JAVA_SPEC_VERSION >= 11]*/
     @Deprecated(forRemoval=true, since="15")
-    /*[ELSE] Java11 */
+    /*[ELSE] JAVA_SPEC_VERSION >= 11 */
     @Deprecated
-    /*[ENDIF] Java11 */
+    /*[ENDIF] JAVA_SPEC_VERSION >= 11 */
     public long getGCMasterThreadCpuUsed();
 /*[ENDIF] JAVA_SPEC_VERSION < 16 */
 
@@ -281,11 +281,11 @@ public interface MemoryMXBean extends java.lang.management.MemoryMXBean {
      * 
      * @deprecated renamed to getGCWorkerThreadsCpuUsed
      */
-    /*[IF Java11]*/
+    /*[IF JAVA_SPEC_VERSION >= 11]*/
     @Deprecated(forRemoval=true, since="15")
-    /*[ELSE] Java11 */
+    /*[ELSE] JAVA_SPEC_VERSION >= 11 */
     @Deprecated
-    /*[ENDIF] Java11 */
+    /*[ENDIF] JAVA_SPEC_VERSION >= 11 */
     public long getGCSlaveThreadsCpuUsed();
 /*[ENDIF] JAVA_SPEC_VERSION < 16 */
 

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/MemoryMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/MemoryMXBean.java
@@ -247,7 +247,7 @@ public interface MemoryMXBean extends java.lang.management.MemoryMXBean {
      */
     public String getGCMode();
 
-/*[IF !Java16]*/
+/*[IF JAVA_SPEC_VERSION < 16]*/
     /**
      * Returns the amount of CPU time spent in the GC by the master thread, in
      * milliseconds.
@@ -262,7 +262,7 @@ public interface MemoryMXBean extends java.lang.management.MemoryMXBean {
     @Deprecated
     /*[ENDIF] Java11 */
     public long getGCMasterThreadCpuUsed();
-/*[ENDIF] !Java16 */
+/*[ENDIF] JAVA_SPEC_VERSION < 16 */
 
     /**
      * Returns the amount of CPU time spent in the GC by the main thread, in
@@ -272,7 +272,7 @@ public interface MemoryMXBean extends java.lang.management.MemoryMXBean {
      */
     public long getGCMainThreadCpuUsed();
 
-/*[IF !Java16]*/
+/*[IF JAVA_SPEC_VERSION < 16]*/
     /**
      * Returns the total amount of CPU time spent in the GC by all slave threads, in
      * milliseconds.
@@ -287,7 +287,7 @@ public interface MemoryMXBean extends java.lang.management.MemoryMXBean {
     @Deprecated
     /*[ENDIF] Java11 */
     public long getGCSlaveThreadsCpuUsed();
-/*[ENDIF] !Java16 */
+/*[ENDIF] JAVA_SPEC_VERSION < 16 */
 
     /**
      * Returns the total amount of CPU time spent in the GC by all worker threads,

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/RuntimeMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/RuntimeMXBean.java
@@ -92,15 +92,15 @@ public interface RuntimeMXBean extends java.lang.management.RuntimeMXBean {
 	 * 
 	 * @return A long representing the process ID (pid) on the underlying 
 	 * operating system.
-	/*[IF Java10]
+	/*[IF JAVA_SPEC_VERSION >= 10]
 	 * 
 	 * @deprecated As of Java 10. Use 
 	 * {@link java.lang.management.RuntimeMXBean#getPid() getPid()} instead.
 	 */
 	@Deprecated(forRemoval=true, since="10")
-	/*[ELSE]
+	/*[ELSE] JAVA_SPEC_VERSION >= 10
 	 */
-	/*[ENDIF]*/
+	/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 	public long getProcessID();
 
 	/**

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedOperatingSystemMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedOperatingSystemMXBeanImpl.java
@@ -170,7 +170,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 	 */
 	private native long getFreePhysicalMemorySizeImpl();
 
-/*[IF Java14]*/
+/*[IF JAVA_SPEC_VERSION >= 14]*/
 	/**
 	 * {@inheritDoc}
 	 */
@@ -194,7 +194,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 	public long getFreeMemorySize() {
 		return getFreePhysicalMemorySizeImpl();
 	}
-/*[ENDIF] Java14 */
+/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 
 	/**
 	 * {@inheritDoc}

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/plugins/impl/ClassScanner.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/plugins/impl/ClassScanner.java
@@ -44,7 +44,7 @@ public class ClassScanner extends ClassVisitor {
 	private final Set<ClassListener> listeners;
 
 	public ClassScanner(URL url, Set<ClassListener> listeners) {
-		/*[IF Java15]*/
+		/*[IF JAVA_SPEC_VERSION >= 15]*/
 		super(Opcodes.ASM8, null);
 		/*[ELSE]*/
 		/*[IF Java14]*/
@@ -56,7 +56,7 @@ public class ClassScanner extends ClassVisitor {
 		super(Opcodes.ASM5, null);
 		/*[ENDIF] Java11 */
 		/*[ENDIF] Java14 */
-		/*[ENDIF] Java15 */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 		this.url = url;
 		this.listeners = listeners;
 	}

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/plugins/impl/ClassScanner.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/plugins/impl/ClassScanner.java
@@ -47,7 +47,7 @@ public class ClassScanner extends ClassVisitor {
 		/*[IF JAVA_SPEC_VERSION >= 15]*/
 		super(Opcodes.ASM8, null);
 		/*[ELSE]*/
-		/*[IF Java14]*/
+		/*[IF JAVA_SPEC_VERSION >= 14]*/
 		super(Opcodes.ASM7, null);
 		/*[ELSE]*/
 		/*[IF Java11]*/
@@ -55,7 +55,7 @@ public class ClassScanner extends ClassVisitor {
 		/*[ELSE]*/
 		super(Opcodes.ASM5, null);
 		/*[ENDIF] Java11 */
-		/*[ENDIF] Java14 */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 		/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 		this.url = url;
 		this.listeners = listeners;

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/plugins/impl/ClassScanner.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/plugins/impl/ClassScanner.java
@@ -50,11 +50,11 @@ public class ClassScanner extends ClassVisitor {
 		/*[IF JAVA_SPEC_VERSION >= 14]*/
 		super(Opcodes.ASM7, null);
 		/*[ELSE]*/
-		/*[IF Java11]*/
+		/*[IF JAVA_SPEC_VERSION >= 11]*/
 		super(Opcodes.ASM6, null);
 		/*[ELSE]*/
 		super(Opcodes.ASM5, null);
-		/*[ENDIF] Java11 */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 		/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 		/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 		this.url = url;

--- a/jcl/src/openj9.gpu/share/classes/com/ibm/gpu/Maths.java
+++ b/jcl/src/openj9.gpu/share/classes/com/ibm/gpu/Maths.java
@@ -30,15 +30,15 @@ import java.util.Objects;
  * on any connected CUDA GPU. A successful sort operation
  * results in the array being sorted in ascending order.
  */
-/*[IF Java16]*/
+/*[IF JAVA_SPEC_VERSION >= 16]*/
 public final class Maths {
 
 	private Maths() {
 		super();
 	}
-/*[ELSE] Java16
+/*[ELSE] JAVA_SPEC_VERSION >= 16
 public class Maths {
-/*[ENDIF] Java16*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 16*/
 
 	private static int getDefaultDevice() {
 		return CUDAManager.instanceInternal().getDefaultDevice();

--- a/jcl/src/openj9.gpu/share/classes/com/ibm/gpu/Version.java
+++ b/jcl/src/openj9.gpu/share/classes/com/ibm/gpu/Version.java
@@ -27,15 +27,15 @@ package com.ibm.gpu;
  * The main method can be launched from the command line, which will print
  * the current level to stdout.
  */
-/*[IF Java16]*/
+/*[IF JAVA_SPEC_VERSION >= 16]*/
 public final class Version {
 
 	private Version() {
 		super();
 	}
-/*[ELSE] Java16
+/*[ELSE] JAVA_SPEC_VERSION >= 16
 public class Version {
-/*[ENDIF] Java16*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 16*/
 
 	/**
 	 * The current build level of this package.

--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassCacheInfo.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassCacheInfo.java
@@ -1,8 +1,6 @@
 /*[INCLUDE-IF SharedClasses]*/
-package com.ibm.oti.shared;
-
 /*******************************************************************************
- * Copyright (c) 2010, 2019 IBM Corp. and others
+ * Copyright (c) 2010, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +20,7 @@ package com.ibm.oti.shared;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package com.ibm.oti.shared;
 
 /**
  * SharedClassCacheInfo stores information about a shared class cache and
@@ -163,9 +162,9 @@ public class SharedClassCacheInfo {
 	
 	/**
 	 * Gets the JVM level for the shared class cache.  
-	/*[IF Java10] 
+	/*[IF JAVA_SPEC_VERSION >= 10]
 	 * Starting from Java 10, the JVM LEVEL equals to the java version number on which the share class cache is created.
-	/*[ENDIF]
+	/*[ENDIF] JAVA_SPEC_VERSION >= 10
 	 *
 	 * @return		A JVMLEVEL constant.
 	 */					


### PR DESCRIPTION
* remove `Java10` and replace with `JAVA_SPEC_VERSION >= 10`
* remove `Java11` and replace with `JAVA_SPEC_VERSION >= 11`
* remove `Java12` and replace with `JAVA_SPEC_VERSION >= 12`
* remove `Java13` and replace with `JAVA_SPEC_VERSION >= 13`
* remove `Java14` and replace with `JAVA_SPEC_VERSION >= 14`
* remove `Java15` and replace with `JAVA_SPEC_VERSION >= 15`
* remove `Java16` and replace with `JAVA_SPEC_VERSION >= 16`
* remove unused flag `Open-Module-Support`