### PR TITLE
Improve error message on duplicate class definition

### DIFF
--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2597,7 +2597,7 @@ retry:
 	if (vmFuncs->hashClassTableAt(classLoader, utf8Name, utf8Length) != NULL) {
 		/* Bad, we have already defined this class - fail */
 		threadEnv->monitor_exit(vm->classTableMutex);
-		vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGLINKAGEERROR, (UDATA *)*(j9object_t*)className);
+		vmFuncs->setCurrentExceptionNLSWithArgs(currentThread, J9NLS_JCL_DUPLICATE_CLASS_DEFINITION, J9VMCONSTANTPOOL_JAVALANGLINKAGEERROR, utf8Length, utf8Name);
 		goto done;
 	}
 

--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -24,8 +24,7 @@
 #include "j9consts.h"
 #include "jclprots.h"
 #include "j9protos.h"
-
-
+#include "j9jclnls.h"
 
 jclass 
 defineClassCommon(JNIEnv *env, jobject classLoaderObject,
@@ -144,7 +143,7 @@ retry:
 			/* Bad, we have already defined this class - fail */
 			omrthread_monitor_exit(vm->classTableMutex);
 			if (J9_ARE_NO_BITS_SET(*options, J9_FINDCLASS_FLAG_NAME_IS_INVALID)) {
-				vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGLINKAGEERROR, (UDATA *)*(j9object_t*)className);
+				vmFuncs->setCurrentExceptionNLSWithArgs(currentThread, J9NLS_JCL_DUPLICATE_CLASS_DEFINITION, J9VMCONSTANTPOOL_JAVALANGLINKAGEERROR, utf8Length, utf8Name);
 			}
 			goto done;
 		}

--- a/runtime/nls/j9cl/j9jcl.nls
+++ b/runtime/nls/j9cl/j9jcl.nls
@@ -436,3 +436,11 @@ J9NLS_JCL_NEST_MEMBER_CLAIMS_DIFFERENT_NEST_HOST.system_action=The JVM will thro
 J9NLS_JCL_NEST_MEMBER_CLAIMS_DIFFERENT_NEST_HOST.user_response=Contact the provider of the classfile for a corrected version.
 # END NON-TRANSLATABLE
 
+J9NLS_JCL_DUPLICATE_CLASS_DEFINITION=A duplicate class definition for %2$.*1$s is found
+# START NON-TRANSLATABLE
+J9NLS_JCL_DUPLICATE_CLASS_DEFINITION.sample_input_1=3
+J9NLS_JCL_DUPLICATE_CLASS_DEFINITION.sample_input_2=Foo
+J9NLS_JCL_DUPLICATE_CLASS_DEFINITION.explanation=A duplicated class definition is found.
+J9NLS_JCL_DUPLICATE_CLASS_DEFINITION.system_action=The JVM will throw a LinkageError.
+J9NLS_JCL_DUPLICATE_CLASS_DEFINITION.user_response=Ensure there is no duplicate definition for the class in the message and try again.
+# END NON-TRANSLATABLE

--- a/runtime/vm/exceptionsupport.c
+++ b/runtime/vm/exceptionsupport.c
@@ -135,7 +135,7 @@ setCurrentExceptionNLSWithArgs(J9VMThread * vmThread, U_32 nlsModule, U_32 nlsID
 	nlsMsgFormat = omrnls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
 			nlsModule,
 			nlsID,
-			"");
+			NULL);
 
 	va_start(stringArgList, exceptionIndex);
 	msgCharLength = j9str_vprintf(NULL, 0, nlsMsgFormat, stringArgList);


### PR DESCRIPTION
1. Add an error message on LinkageError when a duplicate class 
definition is found.
2. Change setCurrentExceptionNLSWithArgs() to pass in NULL rather 
than an empty string as the default message.
j9nls_lookup_message() directly returns the default message when it 
is not NULL and the locale is English, making the message in
setCurrentExceptionNLSWithArgs() always to be the default empty string.

Fixes #11243

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>