### PR TITLE
Add more info to assert message in SymRefTab

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -865,11 +865,27 @@ J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * ow
       containingClass =
          owningMethod->definingClassFromCPFieldRef(comp(), cpIndex, isStatic);
 
-      TR_ASSERT_FATAL(
-         containingClass != NULL,
-         "failed to get defining class of field ref cpIndex=%d in owning method J9Method=%p",
-         cpIndex,
-         owningMethod->getNonPersistentIdentifier());
+      if (comp()->compileRelocatableCode())
+         {
+         TR_ASSERT_FATAL(
+            containingClass != NULL,
+            "failed to get defining class of field ref cpIndex=%d in owning method J9Method=%p\n"
+            "\tTR_ResolvedJ9Method::definingClassFromCPFieldRef=%p, TR_ResolvedRelocatableJ9Method::definingClassFromCPFieldRef=%p\n"
+            "\tTR_UseSymbolValidationManager=%d",
+            cpIndex,
+            owningMethod->getNonPersistentIdentifier(),
+            owningMethod->TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp(), owningMethod->cp(), cpIndex, isStatic),
+            static_cast<TR_ResolvedRelocatableJ9Method *>(owningMethod)->definingClassFromCPFieldRef(comp(), cpIndex, isStatic),
+            comp()->getOption(TR_UseSymbolValidationManager));
+         }
+      else
+         {
+         TR_ASSERT_FATAL(
+            containingClass != NULL,
+            "failed to get defining class of field ref cpIndex=%d in owning method J9Method=%p",
+            cpIndex,
+            owningMethod->getNonPersistentIdentifier());
+         }
 
       ResolvedFieldShadowKey key(containingClass, offset, type);
       TR::SymbolReference *symRef =


### PR DESCRIPTION
In order to debug #9416, it would be helpful to know what values are
returned by `TR_ResolvedJ9Method::definingClassFromCPFieldRef` and
`TR_ResolvedRelocatableJ9Method::definingClassFromCPFieldRef`. As such,
this commit adds the result of those to calls to the message of the
assert being triggered. It doesn't make sense to call
`TR_ResolvedRelocatableJ9Method::definingClassFromCPFieldRef` for
regular compilations so the extra information is only added for AOT
compilations.

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>