### PR TITLE
Support for OpenJDK MethodHandles

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF Sidecar18-SE & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
  * Copyright (c) 2009, 2020 IBM Corp. and others
  *

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodTypeForm.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodTypeForm.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9 & !OPENJDK_METHODHANDLES]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -2401,7 +2401,11 @@ swapClassesForFastHCR(J9Class *originalClass, J9Class *obsoleteClass)
 	/* Force invokedynamics to be re-resolved as we can't map from the old callsite index to the new one */
 	SWAP_MEMBER(callSites, j9object_t*, originalClass, obsoleteClass);
 	/* Force methodTypes to be re-resolved as indexes are assigned in CP order, no mapping from old to new. */
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	SWAP_MEMBER(invokeCache, j9object_t*, originalClass, obsoleteClass);
+#else /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	SWAP_MEMBER(methodTypes, j9object_t*, originalClass, obsoleteClass);
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 	J9CLASS_EXTENDED_FLAGS_SET(obsoleteClass, J9ClassReusedStatics);
 	Assert_hshelp_true(0 == (J9CLASS_EXTENDED_FLAGS(originalClass) & J9ClassReusedStatics));


### PR DESCRIPTION
1. Disable OpenJ9 `MethodType` and `MethodTypeForm` for OpenJDK `MethodHandles`. 

2. `J9Class->methodTypes` renamed to `J9Class->invokeCache` for OpenJDK `MethodHandles`
as part of https://github.com/eclipse/openj9/pull/10893.

Co-authored-by: Jack Lu <Jack.S.Lu@ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>