### PR TITLE
Remove invalid shrc asserts during shutdown

### DIFF
--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -3710,20 +3710,9 @@ SH_CompositeCacheImpl::runExitCode(J9VMThread *currentThread)
 	 * If not unprotected here, subsequent JVMs will not be able to write to readwrite area.
 	 */
 	unprotectHeaderReadWriteArea(currentThread, true);
-	if (0 != (*_runtimeFlags & J9SHR_RUNTIMEFLAG_ENABLE_MPROTECT_ALL)) {
-		/* If mprotect=all is set, above call to unprotectHeaderReadWriteArea() will set _readWriteProtectCntr to 1. */
-		Trc_SHR_Assert_Equals(_readWriteProtectCntr, 1);
-	} else {
-		Trc_SHR_Assert_Equals(_readWriteProtectCntr, 0);
-	}
 #else
 	unprotectHeaderReadWriteArea(currentThread, false);
-	Trc_SHR_Assert_Equals(_readWriteProtectCntr, 0);
 #endif
-	/* If mprotect=all is not set, then final value of _headerProtectCntr should be same is its initial value (= 1).
-	 * If mprotect=all is set, then above call to unprotectHeaderReadWriteArea() will set it to 1.
-	 */
-	Trc_SHR_Assert_Equals(_headerProtectCntr, 1);
 
 	if (_commonCCInfo->hasRWMutexThreadMprotectAll == currentThread) {
 		Trc_SHR_Assert_Equals(currentThread, _commonCCInfo->hasReadWriteMutexThread);


### PR DESCRIPTION
The asserts are accessing _readWriteProtectCntr without holding the
appropriate mutex, the value can be modified by other threads. The value
can be greater than zero (or 1 in the z/OS case) if another thread has
unprotected the read write area. Checking for equality with a particular
value is invalid.

Removing the assert for _headerProtectCntr at the same time since it's
not providing much value.

Testing shows _readWriteProtectCntr had a value of 1 before
`unprotectHeaderReadWriteArea(currentThread, false)` was called, and
reverts to zero after a delay.

The asserts occur during VM shutdown, which for the shared classes
component happens after the trace engine is shut down. The normal
assertion behavior does not occur. If an assert fails the VM exits with
return code 255 (-1) instead of zero.

Fixes https://github.com/eclipse/openj9/issues/6361

The following grinder with the assert removed shows the cmdline tester is no longer failing the test due to a non-zero return code. It also shows the assert would have failed since_readWriteProtectCntr had a value of 1 before `unprotectHeaderReadWriteArea(currentThread, false)` was called, and later a value of zero after `sleep(1)`, indicating another thread changed the value.
```
	orgCntr = _readWriteProtectCntr;
	unprotectHeaderReadWriteArea(currentThread, false);
	if (_readWriteProtectCntr != 0) {
		j9tty_printf(PORTLIB, "Assert _readWriteProtectCntr 0, org %zx _runtimeFlags %llx mprotect all %llx\n", orgCntr, *_runtimeFlags, *_runtimeFlags & J9SHR_RUNTIMEFLAG_ENABLE_MPROTECT_ALL);
		sleep(1);
		j9tty_printf(PORTLIB, "_readWriteProtectCntr %zx\n", _readWriteProtectCntr);
	}
```
```
10:30:19  Assert _readWriteProtectCntr 0, org 1 _runtimeFlags 80102001eca6229b mprotect all 0
10:30:21  _readWriteProtectCntr 0
```
https://ci.eclipse.org/openj9/view/Test/job/Grinder/1221