### PR TITLE
Disable FieldVarHandle native methods for OpenJDK MH

### DIFF
--- a/runtime/jcl/common/java_lang_invoke_VarHandle.c
+++ b/runtime/jcl/common/java_lang_invoke_VarHandle.c
@@ -39,6 +39,7 @@
 #include "j9vmconstantpool.h"
 #include "j9jclnls.h"
 
+#if defined(J9VM_OPT_METHOD_HANDLE)
 static BOOLEAN
 accessCheckFieldType(J9VMThread *currentThread, J9Class* lookupClass, J9Class* type, J9UTF8 *lookupSig)
 {
@@ -162,6 +163,7 @@ Java_java_lang_invoke_FieldVarHandle_unreflectField(JNIEnv *env, jobject handle,
 	vmFuncs->internalExitVMToJNI(vmThread);
 	return fieldOffset;
 }
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 jobject JNICALL
 Java_java_lang_invoke_VarHandle_get(JNIEnv *env, jobject handle, jobject args)

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -522,11 +522,16 @@ endif()
 
 # java 9+
 if(NOT JAVA_SPEC_VERSION LESS 9)
+	if(J9VM_OPT_METHOD_HANDLE)
+		omr_add_exports(jclse
+			Java_java_lang_invoke_FieldVarHandle_lookupField
+			Java_java_lang_invoke_FieldVarHandle_unreflectField
+		)
+	endif()
+
 	omr_add_exports(jclse
 		Java_java_lang_StackWalker_getImpl
 		Java_java_lang_StackWalker_walkWrapperImpl
-		Java_java_lang_invoke_FieldVarHandle_lookupField
-		Java_java_lang_invoke_FieldVarHandle_unreflectField
 		Java_java_lang_invoke_VarHandle_addAndGet
 		Java_java_lang_invoke_VarHandle_compareAndExchange
 		Java_java_lang_invoke_VarHandle_compareAndExchangeAcquire

--- a/runtime/jcl/uma/se9_exports.xml
+++ b/runtime/jcl/uma/se9_exports.xml
@@ -1,5 +1,5 @@
 <!-- 
-	Copyright (c) 2016, 2018 IBM Corp. and others
+	Copyright (c) 2016, 2020 IBM Corp. and others
 	
 	This program and the accompanying materials are made available under
 	the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,8 +20,12 @@
 	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <exports group="se9">
-	<export name="Java_java_lang_invoke_FieldVarHandle_lookupField" />
-	<export name="Java_java_lang_invoke_FieldVarHandle_unreflectField" />
+	<export name="Java_java_lang_invoke_FieldVarHandle_lookupField">
+		<include-if condition="spec.flags.opt_methodHandle" />
+	</export>
+	<export name="Java_java_lang_invoke_FieldVarHandle_unreflectField">
+		<include-if condition="spec.flags.opt_methodHandle" />
+	</export>
 	<export name="Java_java_lang_invoke_VarHandle_get" />
 	<export name="Java_java_lang_invoke_VarHandle_set" />
 	<export name="Java_java_lang_invoke_VarHandle_getVolatile" />

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -944,8 +944,10 @@ Java_java_lang_invoke_MethodHandleNatives_checkClassBytes(JNIEnv *env, jclass jl
 #endif /* JAVA_SPEC_VERSION >= 15 */
 
 /* java_lang_invoke_VarHandle.c */
+#if defined(J9VM_OPT_METHOD_HANDLE)
 jlong JNICALL Java_java_lang_invoke_FieldVarHandle_lookupField(JNIEnv *env, jobject handle, jclass lookupClass, jstring name, jstring signature, jclass type, jboolean isStatic, jclass accessClass);
 jlong JNICALL Java_java_lang_invoke_FieldVarHandle_unreflectField(JNIEnv *env, jobject handle, jobject reflectField, jboolean isStatic);
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 jobject JNICALL Java_java_lang_invoke_VarHandle_get(JNIEnv *env, jobject handle, jobject args);
 void JNICALL Java_java_lang_invoke_VarHandle_set(JNIEnv *env, jobject handle, jobject args);
 jobject JNICALL Java_java_lang_invoke_VarHandle_getVolatile(JNIEnv *env, jobject handle, jobject args);


### PR DESCRIPTION
`FieldVarHandle` native methods are only used by OpenJ9 `VarHandles`.

Related: https://github.com/eclipse/openj9/issues/7352

Co-authored-by: Jack Lu <Jack.S.Lu@ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>