### PR TITLE
Rename OpenJ9 MethodType fields to match OpenJDK MethodType

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2262,7 +2262,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          int32_t collectArraySize = fe->getInt32Field(methodHandle, "collectArraySize");
          uintptr_t arguments = fe->getReferenceField(
                   fe->getReferenceField(methodHandle, "type", "Ljava/lang/invoke/MethodType;"),
-                  "arguments", "[Ljava/lang/Class;");
+                  "ptypes", "[Ljava/lang/Class;");
          int32_t numArguments = (int32_t)fe->getArrayLengthInElements(arguments);
          int32_t collectionStart = 0;
          if (getPos)
@@ -2277,7 +2277,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          uintptr_t methodHandle = *std::get<0>(recv);
          uintptr_t guardArgs = fe->getReferenceField(fe->methodHandle_type(fe->getReferenceField(methodHandle,
             "guard", "Ljava/lang/invoke/MethodHandle;")),
-            "arguments", "[Ljava/lang/Class;");
+            "ptypes", "[Ljava/lang/Class;");
          int32_t numGuardArgs = (int32_t)fe->getArrayLengthInElements(guardArgs);
          client->write(response, numGuardArgs);
          }
@@ -2308,14 +2308,14 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             methodHandle,
             "next",             "Ljava/lang/invoke/MethodHandle;"),
             "type",             "Ljava/lang/invoke/MethodType;"),
-            "arguments",        "[Ljava/lang/Class;");
+            "ptypes",           "[Ljava/lang/Class;");
          TR_OpaqueClassBlock *targetParmClass = (TR_OpaqueClassBlock*)(intptr_t)fe->getInt64Field(fe->getReferenceElement(targetArguments, argIndex),
                                                                           "vmRef" /* should use fej9->getOffsetOfClassFromJavaLangClassField() */);
          // Load callsite type and check if two types are compatible
          uintptr_t sourceArguments = fe->getReferenceField(fe->getReferenceField(
             methodHandle,
             "type",             "Ljava/lang/invoke/MethodType;"),
-            "arguments",        "[Ljava/lang/Class;");
+            "ptypes",           "[Ljava/lang/Class;");
          TR_OpaqueClassBlock *sourceParmClass = (TR_OpaqueClassBlock*)(intptr_t)fe->getInt64Field(fe->getReferenceElement(sourceArguments, argIndex),
                                                                           "vmRef" /* should use fej9->getOffsetOfClassFromJavaLangClassField() */);
          client->write(response, sourceParmClass, targetParmClass);
@@ -2377,10 +2377,10 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          TR::VMAccessCriticalSection invokeSpreadHandle(fe);
          uintptr_t methodHandle = *std::get<0>(recv);
          bool getSpreadPosition = std::get<1>(recv);
-         uintptr_t arguments = fe->getReferenceField(fe->methodHandle_type(methodHandle), "arguments", "[Ljava/lang/Class;");
+         uintptr_t arguments = fe->getReferenceField(fe->methodHandle_type(methodHandle), "ptypes", "[Ljava/lang/Class;");
          int32_t numArguments = (int32_t)fe->getArrayLengthInElements(arguments);
          uintptr_t next = fe->getReferenceField(methodHandle, "next", "Ljava/lang/invoke/MethodHandle;");
-         uintptr_t nextArguments = fe->getReferenceField(fe->methodHandle_type(next), "arguments", "[Ljava/lang/Class;");
+         uintptr_t nextArguments = fe->getReferenceField(fe->methodHandle_type(next), "ptypes", "[Ljava/lang/Class;");
          int32_t numNextArguments = (int32_t)fe->getArrayLengthInElements(nextArguments);
          int32_t spreadStart = 0;
          // Guard to protect old code
@@ -2396,7 +2396,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          uintptr_t methodHandle = *std::get<0>(recv);
          int32_t insertionIndex = fe->getInt32Field(methodHandle, "insertionIndex");
          uintptr_t arguments = fe->getReferenceField(fe->getReferenceField(methodHandle, "type",
-                  "Ljava/lang/invoke/MethodType;"), "arguments", "[Ljava/lang/Class;");
+                  "Ljava/lang/invoke/MethodType;"), "ptypes", "[Ljava/lang/Class;");
          int32_t numArguments = (int32_t)fe->getArrayLengthInElements(arguments);
          uintptr_t values = fe->getReferenceField(methodHandle, "values", "[Ljava/lang/Object;");
          int32_t numValues = (int32_t)fe->getArrayLengthInElements(values);
@@ -2424,7 +2424,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          else
             {
             uintptr_t combiner         = fe->getReferenceField(methodHandle, "combiner", "Ljava/lang/invoke/MethodHandle;");
-            uintptr_t combinerArguments = fe->getReferenceField(fe->methodHandle_type(combiner), "arguments", "[Ljava/lang/Class;");
+            uintptr_t combinerArguments = fe->getReferenceField(fe->methodHandle_type(combiner), "ptypes", "[Ljava/lang/Class;");
             numArgs = (int32_t)fe->getArrayLengthInElements(combinerArguments);
             }
          client->write(response, indices, foldPosition, numArgs);
@@ -2470,7 +2470,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          uintptr_t methodHandle = *std::get<0>(recv);
          uintptr_t finallyTarget = fe->getReferenceField(methodHandle, "finallyTarget", "Ljava/lang/invoke/MethodHandle;");
          uintptr_t finallyType = fe->getReferenceField(finallyTarget, "type", "Ljava/lang/invoke/MethodType;");
-         uintptr_t arguments        = fe->getReferenceField(finallyType, "arguments", "[Ljava/lang/Class;");
+         uintptr_t arguments        = fe->getReferenceField(finallyType, "ptypes", "[Ljava/lang/Class;");
          int32_t numArgsPassToFinallyTarget = (int32_t)fe->getArrayLengthInElements(arguments);
 
          uintptr_t methodDescriptorRef = fe->getReferenceField(finallyType, "methodDescriptor", "Ljava/lang/String;");
@@ -2485,7 +2485,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto recv = client->getRecvData<uintptr_t*>();
          TR::VMAccessCriticalSection invokeFilterArgumentsWithCombinerHandle(fe);
          uintptr_t methodHandle = *std::get<0>(recv);
-         uintptr_t arguments = fe->getReferenceField(fe->methodHandle_type(methodHandle), "arguments", "[Ljava/lang/Class;");
+         uintptr_t arguments = fe->getReferenceField(fe->methodHandle_type(methodHandle), "ptypes", "[Ljava/lang/Class;");
          int32_t numArguments = (int32_t)fe->getArrayLengthInElements(arguments);
          int32_t filterPos     = (int32_t)fe->getInt32Field(methodHandle, "filterPosition");
          client->write(response, numArguments, filterPos);
@@ -2541,7 +2541,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto recv = client->getRecvData<uintptr_t*>();
          TR::VMAccessCriticalSection invokeFilderArgumentsHandle(fe);
          uintptr_t methodHandle = *std::get<0>(recv);
-         uintptr_t arguments = fe->getReferenceField(fe->methodHandle_type(methodHandle), "arguments", "[Ljava/lang/Class;");
+         uintptr_t arguments = fe->getReferenceField(fe->methodHandle_type(methodHandle), "ptypes", "[Ljava/lang/Class;");
          int32_t numArguments = (int32_t)fe->getArrayLengthInElements(arguments);
          int32_t startPos     = (int32_t)fe->getInt32Field(methodHandle, "startPos");
          uintptr_t filters = fe->getReferenceField(methodHandle, "filters", "[Ljava/lang/invoke/MethodHandle;");
@@ -2558,7 +2558,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          uintptr_t catchArguments = fe->getReferenceField(fe->getReferenceField(
             catchTarget,
             "type", "Ljava/lang/invoke/MethodType;"),
-            "arguments", "[Ljava/lang/Class;");
+            "ptypes", "[Ljava/lang/Class;");
          int32_t numCatchArguments = (int32_t)fe->getArrayLengthInElements(catchArguments);
          client->write(response, numCatchArguments);
          }
@@ -2604,7 +2604,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          uintptr_t arguments = fe->getReferenceField(fe->getReferenceField(
             methodHandle,
             "type", "Ljava/lang/invoke/MethodType;"),
-            "arguments", "[Ljava/lang/Class;");
+            "ptypes", "[Ljava/lang/Class;");
          int32_t parameterCount = (int32_t)fe->getArrayLengthInElements(arguments);
          client->write(response, parameterCount);
          }
@@ -2649,7 +2649,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
                methodHandle,
                "next",             "Ljava/lang/invoke/MethodHandle;"),
                "type",             "Ljava/lang/invoke/MethodType;"),
-               "arguments",        "[Ljava/lang/Class;");
+               "ptypes",           "[Ljava/lang/Class;");
             componentClazz = fe->getComponentClassFromArrayClass(fe->getClassFromJavaLangClass(fe->getReferenceElement(arguments, collectPosition)));
             }
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -7710,7 +7710,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                   methodHandle,
                   "next",             "Ljava/lang/invoke/MethodHandle;"),
                   "type",             "Ljava/lang/invoke/MethodType;"),
-                  "arguments",        "[Ljava/lang/Class;");
+                  "ptypes",           "[Ljava/lang/Class;");
                componentClazz = fej9->getComponentClassFromArrayClass(fej9->getClassFromJavaLangClass(fej9->getReferenceElement(arguments, collectPosition)));
                }
 
@@ -7769,7 +7769,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             collectArraySize = fej9->getInt32Field(methodHandle, "collectArraySize");
             if (getCollectPosition)
                collectionStart = fej9->getInt32Field(methodHandle, "collectPosition");
-            arguments = fej9->getReferenceField(fej9->getReferenceField(methodHandle, "type", "Ljava/lang/invoke/MethodType;"), "arguments", "[Ljava/lang/Class;");
+            arguments = fej9->getReferenceField(fej9->getReferenceField(methodHandle, "type", "Ljava/lang/invoke/MethodType;"), "ptypes", "[Ljava/lang/Class;");
             numArguments = (int32_t)fej9->getArrayLengthInElements(arguments);
             }
 
@@ -7935,14 +7935,14 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                      methodHandle,
                      "next",             "Ljava/lang/invoke/MethodHandle;"),
                      "type",             "Ljava/lang/invoke/MethodType;"),
-                     "arguments",        "[Ljava/lang/Class;");
+                     "ptypes",           "[Ljava/lang/Class;");
                   targetParmClass = (TR_OpaqueClassBlock*)(intptr_t)fej9->getInt64Field(fej9->getReferenceElement(targetArguments, argIndex),
                                                                                    "vmRef" /* should use fej9->getOffsetOfClassFromJavaLangClassField() */);
                   // Load callsite type and check if two types are compatible
                   sourceArguments = fej9->getReferenceField(fej9->getReferenceField(
                      methodHandle,
                      "type",             "Ljava/lang/invoke/MethodType;"),
-                     "arguments",        "[Ljava/lang/Class;");
+                     "ptypes",           "[Ljava/lang/Class;");
                   sourceParmClass = (TR_OpaqueClassBlock*)(intptr_t)fej9->getInt64Field(fej9->getReferenceElement(sourceArguments, argIndex),
                                                                                    "vmRef" /* should use fej9->getOffsetOfClassFromJavaLangClassField() */);
                   }
@@ -8377,7 +8377,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             methodHandle = *thunkDetails->getHandleRef();
             guardArgs = fej9->getReferenceField(fej9->methodHandle_type(fej9->getReferenceField(methodHandle,
                "guard", "Ljava/lang/invoke/MethodHandle;")),
-               "arguments", "[Ljava/lang/Class;");
+               "ptypes", "[Ljava/lang/Class;");
             numGuardArgs = (int32_t)fej9->getArrayLengthInElements(guardArgs);
             }
 
@@ -8415,7 +8415,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             TR::VMAccessCriticalSection invokeInsertHandle(fej9);
             methodHandle = *thunkDetails->getHandleRef();
             insertionIndex = fej9->getInt32Field(methodHandle, "insertionIndex");
-            arguments = fej9->getReferenceField(fej9->getReferenceField(methodHandle, "type", "Ljava/lang/invoke/MethodType;"), "arguments", "[Ljava/lang/Class;");
+            arguments = fej9->getReferenceField(fej9->getReferenceField(methodHandle, "type", "Ljava/lang/invoke/MethodType;"), "ptypes", "[Ljava/lang/Class;");
             numArguments = (int32_t)fej9->getArrayLengthInElements(arguments);
             values = fej9->getReferenceField(methodHandle, "values", "[Ljava/lang/Object;");
             numValues = (int32_t)fej9->getArrayLengthInElements(values);
@@ -8731,10 +8731,10 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             {
             TR::VMAccessCriticalSection invokeSpreadHandle(fej9);
             methodHandle = *thunkDetails->getHandleRef();
-            arguments = fej9->getReferenceField(fej9->methodHandle_type(methodHandle), "arguments", "[Ljava/lang/Class;");
+            arguments = fej9->getReferenceField(fej9->methodHandle_type(methodHandle), "ptypes", "[Ljava/lang/Class;");
             numArguments = (int32_t)fej9->getArrayLengthInElements(arguments);
             next         = fej9->getReferenceField(methodHandle, "next", "Ljava/lang/invoke/MethodHandle;");
-            nextArguments = fej9->getReferenceField(fej9->methodHandle_type(next), "arguments", "[Ljava/lang/Class;");
+            nextArguments = fej9->getReferenceField(fej9->methodHandle_type(next), "ptypes", "[Ljava/lang/Class;");
             numNextArguments = (int32_t)fej9->getArrayLengthInElements(nextArguments);
             // Guard to protect old code
             if (symRef->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod() == TR::java_lang_invoke_SpreadHandle_spreadStart ||
@@ -8830,7 +8830,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             else
                {
                uintptr_t combiner         = fej9->getReferenceField(methodHandle, "combiner", "Ljava/lang/invoke/MethodHandle;");
-               uintptr_t combinerArguments = fej9->getReferenceField(fej9->methodHandle_type(combiner), "arguments", "[Ljava/lang/Class;");
+               uintptr_t combinerArguments = fej9->getReferenceField(fej9->methodHandle_type(combiner), "ptypes", "[Ljava/lang/Class;");
                int32_t numArgs = (int32_t)fej9->getArrayLengthInElements(combinerArguments);
                // Push the indices in reverse order
                for (int i=foldPosition+numArgs-1; i>=foldPosition; i--)
@@ -9004,7 +9004,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             uintptr_t methodHandle = *thunkDetails->getHandleRef();
             uintptr_t finallyTarget = fej9->getReferenceField(methodHandle, "finallyTarget", "Ljava/lang/invoke/MethodHandle;");
             uintptr_t finallyType = fej9->getReferenceField(finallyTarget, "type", "Ljava/lang/invoke/MethodType;");
-            uintptr_t arguments        = fej9->getReferenceField(finallyType, "arguments", "[Ljava/lang/Class;");
+            uintptr_t arguments        = fej9->getReferenceField(finallyType, "ptypes", "[Ljava/lang/Class;");
             numArgsPassToFinallyTarget = (int32_t)fej9->getArrayLengthInElements(arguments);
 
             uintptr_t methodDescriptorRef = fej9->getReferenceField(finallyType, "methodDescriptor", "Ljava/lang/String;");
@@ -9049,7 +9049,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             {
             TR::VMAccessCriticalSection invokeFilterArgumentsWithCombinerHandle(fej9);
             methodHandle = *thunkDetails->getHandleRef();
-            arguments = fej9->getReferenceField(fej9->methodHandle_type(methodHandle), "arguments", "[Ljava/lang/Class;");
+            arguments = fej9->getReferenceField(fej9->methodHandle_type(methodHandle), "ptypes", "[Ljava/lang/Class;");
             numArguments = (int32_t)fej9->getArrayLengthInElements(arguments);
             filterPos     = (int32_t)fej9->getInt32Field(methodHandle, "filterPosition");
             }
@@ -9089,7 +9089,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             {
             TR::VMAccessCriticalSection invokeFilterArgumentsHandle2(fej9);
             methodHandle = *thunkDetails->getHandleRef();
-            arguments = fej9->getReferenceField(fej9->methodHandle_type(methodHandle), "arguments", "[Ljava/lang/Class;");
+            arguments = fej9->getReferenceField(fej9->methodHandle_type(methodHandle), "ptypes", "[Ljava/lang/Class;");
             numArguments = (int32_t)fej9->getArrayLengthInElements(arguments);
             startPos     = (int32_t)fej9->getInt32Field(methodHandle, "startPos");
             filters = fej9->getReferenceField(methodHandle, "filters", "[Ljava/lang/invoke/MethodHandle;");
@@ -9303,7 +9303,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             uintptr_t catchArguments = fej9->getReferenceField(fej9->getReferenceField(
                catchTarget,
                "type", "Ljava/lang/invoke/MethodType;"),
-               "arguments", "[Ljava/lang/Class;");
+               "ptypes", "[Ljava/lang/Class;");
             numCatchArguments = (int32_t)fej9->getArrayLengthInElements(catchArguments);
             }
 
@@ -9336,7 +9336,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             uintptr_t arguments        = fej9->getReferenceField(fej9->getReferenceField(
                methodHandle,
                "type", "Ljava/lang/invoke/MethodType;"),
-               "arguments", "[Ljava/lang/Class;");
+               "ptypes", "[Ljava/lang/Class;");
             parameterCount = (int32_t)fej9->getArrayLengthInElements(arguments);
             }
 

--- a/runtime/compiler/il/J9Symbol.cpp
+++ b/runtime/compiler/il/J9Symbol.cpp
@@ -142,7 +142,7 @@
        {r(TR::Symbol::Java_lang_invoke_MutableCallSiteDynamicInvokerHandle_mutableSite,"java/lang/invoke/MutableCallSiteDynamicInvokerHandle", "mutableSite", "Ljava/lang/invoke/MutableCallSite;")},
        {r(TR::Symbol::Java_lang_invoke_MethodHandle_thunks,           "java/lang/invoke/MethodHandle", "thunks", "Ljava/lang/invoke/ThunkTuple;")},
        {r(TR::Symbol::Java_lang_invoke_MethodHandle_type,             "java/lang/invoke/MethodHandle", "type", "Ljava/lang/invoke/MethodType;")},
-       {r(TR::Symbol::Java_lang_invoke_MethodType_arguments,          "java/lang/invoke/MethodType", "arguments", "[Ljava/lang/Class;")},
+       {r(TR::Symbol::Java_lang_invoke_MethodType_ptypes,             "java/lang/invoke/MethodType", "ptypes", "[Ljava/lang/Class;")},
        {r(TR::Symbol::Java_lang_invoke_PrimitiveHandle_rawModifiers,  "java/lang/invoke/PrimitiveHandle", "rawModifiers", "I")},
        {r(TR::Symbol::Java_lang_invoke_PrimitiveHandle_defc,          "java/lang/invoke/PrimitiveHandle", "defc", "Ljava/lang/Class;")},
        {r(TR::Symbol::Java_lang_invoke_ThunkTuple_invokeExactThunk,   "java/lang/invoke/ThunkTuple", "invokeExactThunk", "J")},

--- a/runtime/compiler/il/J9Symbol.hpp
+++ b/runtime/compiler/il/J9Symbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -152,7 +152,7 @@ public:
       Java_lang_invoke_MutableCallSiteDynamicInvokerHandle_mutableSite,
       Java_lang_invoke_MethodHandle_thunks,
       Java_lang_invoke_MethodHandle_type,
-      Java_lang_invoke_MethodType_arguments,
+      Java_lang_invoke_MethodType_ptypes,
       Java_lang_invoke_PrimitiveHandle_rawModifiers,
       Java_lang_invoke_PrimitiveHandle_defc,
       Java_lang_invoke_ThunkTuple_invokeExactThunk,

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -196,7 +196,7 @@ static bool isArrayWithConstantElements(TR::SymbolReference *symRef, TR::Compila
       switch (symbol->getRecognizedField())
          {
          case TR::Symbol::Java_lang_invoke_BruteArgumentMoverHandle_extra:
-         case TR::Symbol::Java_lang_invoke_MethodType_arguments:
+         case TR::Symbol::Java_lang_invoke_MethodType_ptypes:
          case TR::Symbol::Java_lang_invoke_VarHandle_handleTable:
          case TR::Symbol::Java_lang_String_value:
             return true;

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -347,7 +347,7 @@ accessCheckFieldSignature(J9VMThread *currentThread, J9Class* lookupClass, UDATA
 	
 		if ('L' == lookupSigData[sigOffset]) {
 			BOOLEAN isVirtual = (0 == (((J9ROMFieldShape*)romField)->modifiers & J9AccStatic));
-			j9object_t argsArray = J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(currentThread, methodType);
+			j9object_t argsArray = J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(currentThread, methodType);
 			U_32 numParameters = J9INDEXABLEOBJECT_SIZE(currentThread, argsArray);
 			j9object_t clazz = NULL;
 			J9Class *ramClass = NULL;
@@ -358,7 +358,7 @@ accessCheckFieldSignature(J9VMThread *currentThread, J9Class* lookupClass, UDATA
 
 			/* '()X' or '(Receiver)X' are both getters.  All others are setters */
 			if (((0 == numParameters) && !isVirtual) || ((1 == numParameters) && isVirtual)) {
-				clazz = J9VMJAVALANGINVOKEMETHODTYPE_RETURNTYPE(currentThread, methodType);
+				clazz = J9VMJAVALANGINVOKEMETHODTYPE_RTYPE(currentThread, methodType);
 			} else {
 				U_32 argumentIndex = 0;
 
@@ -396,7 +396,7 @@ accessCheckMethodSignature(J9VMThread *currentThread, J9Method *method, j9object
 	if (NULL != verifyData) {
 		U_8 *lookupSigData = J9UTF8_DATA(lookupSig);
 		/* Grab the args array and length from MethodType.arguments */
-		j9object_t argsArray = J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(currentThread, methodType);
+		j9object_t argsArray = J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(currentThread, methodType);
 		j9object_t clazz = NULL;
 		J9Class *methodRamClass = J9_CLASS_FROM_METHOD(method);
 		J9ClassLoader *targetClassloader = methodRamClass->classLoader;
@@ -465,7 +465,7 @@ accessCheckMethodSignature(J9VMThread *currentThread, J9Method *method, j9object
 		if('L' == lookupSigData[index]) {
 			J9Class *returnRamClass = NULL;
 			/* Grab the MethodType returnType */
-			clazz = J9VMJAVALANGINVOKEMETHODTYPE_RETURNTYPE(currentThread, methodType);
+			clazz = J9VMJAVALANGINVOKEMETHODTYPE_RTYPE(currentThread, methodType);
 			returnRamClass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, clazz);
 
 			/* Check if we really need to check this classloader constraint */

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1484,12 +1484,12 @@ done:
 	doMethodTypesMatchIgnoringLastArgument(J9VMThread *currentThread, j9object_t shorterMT, j9object_t longerMT)
 	{
 		bool matched = false;
-		j9object_t shorterMTReturnType = J9VMJAVALANGINVOKEMETHODTYPE_RETURNTYPE(currentThread, shorterMT);
-		j9object_t longerMTReturnType = J9VMJAVALANGINVOKEMETHODTYPE_RETURNTYPE(currentThread, longerMT);
+		j9object_t shorterMTReturnType = J9VMJAVALANGINVOKEMETHODTYPE_RTYPE(currentThread, shorterMT);
+		j9object_t longerMTReturnType = J9VMJAVALANGINVOKEMETHODTYPE_RTYPE(currentThread, longerMT);
 
 		if (shorterMTReturnType == longerMTReturnType) {
-			j9object_t shorterMTArguments = J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(currentThread, shorterMT);
-			j9object_t longerMTArguments = J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(currentThread, longerMT);
+			j9object_t shorterMTArguments = J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(currentThread, shorterMT);
+			j9object_t longerMTArguments = J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(currentThread, longerMT);
 			I_32 longerMTArgumentsLength = (I_32)J9INDEXABLEOBJECT_SIZE(currentThread, longerMTArguments);
 
 			if ((longerMTArgumentsLength - 1) == (I_32)J9INDEXABLEOBJECT_SIZE(currentThread, shorterMTArguments)) {

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -315,8 +315,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="java/lang/invoke/SpreadHandle" name="arrayClass" signature="Ljava/lang/Class;" flags="opt_methodHandle"/>
 	<fieldref class="java/lang/invoke/SpreadHandle" name="spreadCount" signature="I" flags="opt_methodHandle"/>
 	<fieldref class="java/lang/invoke/SpreadHandle" name="spreadPosition" signature="I" flags="opt_methodHandle"/>
-	<fieldref class="java/lang/invoke/MethodType" name="arguments" signature="[Ljava/lang/Class;" flags="opt_methodHandle"/>
-	<fieldref class="java/lang/invoke/MethodType" name="returnType" signature="Ljava/lang/Class;" flags="opt_methodHandle"/>
 	<fieldref class="java/lang/invoke/MethodType" name="argSlots" signature="I" flags="opt_methodHandle"/>
 	<fieldref class="java/lang/invoke/MethodType" name="stackDescriptionBits" signature="[I" flags="opt_methodHandle"/>
 	<fieldref class="java/lang/invoke/DynamicInvokerHandle" name="site" signature="Ljava/lang/invoke/CallSite;" flags="opt_methodHandle"/>
@@ -362,6 +360,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<!-- Common field references shared between OpenJ9 and OpenJDK MethodHandles. -->
 	<fieldref class="java/lang/invoke/MethodType" name="methodDescriptor" signature="Ljava/lang/String;" flags="opt_methodHandleCommon"/>
 	<fieldref class="java/lang/invoke/MethodHandle" name="type" signature="Ljava/lang/invoke/MethodType;" flags="opt_methodHandleCommon"/>
+	<fieldref class="java/lang/invoke/MethodType" name="ptypes" signature="[Ljava/lang/Class;" flags="opt_methodHandleCommon"/>
+	<fieldref class="java/lang/invoke/MethodType" name="rtype" signature="Ljava/lang/Class;" flags="opt_methodHandleCommon"/>
 	
 	<!-- Field references needed to support OpenJDK MethodHandles. -->
 	<fieldref class="java/lang/invoke/MemberName" name="clazz" signature="Ljava/lang/Class;" flags="opt_openjdkMethodhandle"/>
@@ -369,8 +369,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="java/lang/invoke/MemberName" name="type" signature="Ljava/lang/Object;" flags="opt_openjdkMethodhandle"/>
 	<fieldref class="java/lang/invoke/MemberName" name="flags" signature="I" flags="opt_openjdkMethodhandle"/>
 	<fieldref class="java/lang/invoke/MemberName" name="resolution" signature="Ljava/lang/Object;" flags="opt_openjdkMethodhandle"/>
-	<fieldref class="java/lang/invoke/MethodType" name="ptypes" signature="[Ljava/lang/Class;" flags="opt_openjdkMethodhandle"/>
-	<fieldref class="java/lang/invoke/MethodType" name="rtype" signature="Ljava/lang/Class;" flags="opt_openjdkMethodhandle"/>
 	<fieldref class="java/lang/invoke/MethodType" name="form" signature="Ljava/lang/invoke/MethodTypeForm;" flags="opt_openjdkMethodhandle"/>
 	<fieldref class="java/lang/invoke/MethodTypeForm" name="parameterSlotCount" signature="S" versions="14-" flags="opt_openjdkMethodhandle">
 		<fieldalias name="argCounts" signature="J" versions="8-11"  flags="opt_openjdkMethodhandle"/>

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -942,7 +942,7 @@ obj:
 		static U_8 const bcReturnFromJ2I[] = { JBinvokestatic, 0, 0, JBreturnFromJ2I };
 		void* const jitReturnAddress = VM_JITInterface::fetchJITReturnAddress(_currentThread, _sp);
 		j9object_t methodType = J9VMJAVALANGINVOKEMETHODHANDLE_TYPE(_currentThread, methodHandle);
-		j9object_t returnType = J9VMJAVALANGINVOKEMETHODTYPE_RETURNTYPE(_currentThread, methodType);
+		j9object_t returnType = J9VMJAVALANGINVOKEMETHODTYPE_RTYPE(_currentThread, methodType);
 		void* const exitPoint = j2iReturnPoint(J9VM_J9CLASS_FROM_HEAPCLASS(_currentThread, returnType));
 		/* Get the argument count from the MethodHandle */
 		UDATA argCount = J9VMJAVALANGINVOKEMETHODTYPE_ARGSLOTS(_currentThread, methodType) + 1; /* argSlots does not include the receiver of the invokeExact */

--- a/runtime/vm/MHInterpreter.hpp
+++ b/runtime/vm/MHInterpreter.hpp
@@ -207,7 +207,7 @@ private:
 	{
 		return J9VM_J9CLASS_FROM_HEAPCLASS(
 				_currentThread,
-				J9VMJAVALANGINVOKEMETHODTYPE_RETURNTYPE(_currentThread, methodType));
+				J9VMJAVALANGINVOKEMETHODTYPE_RTYPE(_currentThread, methodType));
 	}
 
 	/**
@@ -218,7 +218,7 @@ private:
 	VMINLINE j9object_t
 	getMethodTypeArguments(j9object_t methodType) const
 	{
-		return J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(_currentThread, methodType);
+		return J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(_currentThread, methodType);
 	}
 
 	/**

--- a/runtime/vm/MHInterpreter.inc
+++ b/runtime/vm/MHInterpreter.inc
@@ -348,7 +348,7 @@ VM_MHInterpreter::dispatchLoop(j9object_t methodHandle)
 			insertFourArgumentPlaceHolderFrame(0, parentHandle, 0, 0, 0, J9VMJAVALANGINVOKEMETHODHANDLE_FILTERARGUMENTSPLACEHOLDER_METHOD(_vm));
 
 			/* Accessing FAH.type.arguments[] and its attributes for future operations */
-			j9object_t parentTypeArguments = J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(_currentThread, parentType);
+			j9object_t parentTypeArguments = J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(_currentThread, parentType);
 			UDATA *parentPtr = UNTAGGED_A0(frameNext);  /* Store pointer to parent */
 
 			/* Copy identical args between parent and next */
@@ -687,7 +687,7 @@ VM_MHInterpreter::impdep1()
 		/* Get the filterHandle.type.arguments[0] to determine the kind of value on the stack */
 		j9object_t filterHandle = *(j9object_t*)_currentThread->arg0EA;
 		j9object_t filterType = J9VMJAVALANGINVOKEMETHODHANDLE_TYPE(_currentThread, filterHandle);
-		j9object_t argTypes = J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(_currentThread, filterType);
+		j9object_t argTypes = J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(_currentThread, filterType);
 		UDATA returnSlots = J9INDEXABLEOBJECT_SIZE(_currentThread, argTypes);
 		/* Determine how many slots to pop off the stack */
 		UDATA returnValue0 = 0;
@@ -758,7 +758,7 @@ VM_MHInterpreter::impdep1()
 		/* [... FAH[1] args MTFrame FAH.next UpdatedArgs MTFrame FAH[2] index parentOffset nextOffset PlaceHolderFrame filterReturnValue] */
 		j9object_t parentHandle = *(j9object_t *)_currentThread->arg0EA;
 		j9object_t parentType = J9VMJAVALANGINVOKEMETHODHANDLE_TYPE(_currentThread, parentHandle);
-		j9object_t parentTypeArguments = J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(_currentThread, parentType);
+		j9object_t parentTypeArguments = J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(_currentThread, parentType);
 
 		j9object_t filters = J9VMJAVALANGINVOKEFILTERARGUMENTSHANDLE_FILTERS(_currentThread, parentHandle);
 		U_32 filtersLength = J9INDEXABLEOBJECT_SIZE(_currentThread, filters);
@@ -767,7 +767,7 @@ VM_MHInterpreter::impdep1()
 		j9object_t nextHandle = J9VMJAVALANGINVOKEFILTERARGUMENTSHANDLE_NEXT(_currentThread, parentHandle);
 		j9object_t nextType = J9VMJAVALANGINVOKEMETHODHANDLE_TYPE(_currentThread, nextHandle);
 		U_32 nextArgSlots = (U_32)J9VMJAVALANGINVOKEMETHODTYPE_ARGSLOTS(_currentThread, nextType);
-		j9object_t nextTypeArguments = J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(_currentThread, nextType);
+		j9object_t nextTypeArguments = J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(_currentThread, nextType);
 
 		U_32 *index = (U_32 *)(_currentThread->arg0EA - 1);
 		U_32 *parentOffset = (U_32 *)(_currentThread->arg0EA - 2);
@@ -1438,7 +1438,7 @@ VM_MHInterpreter::replaceReturnValueForFilterArgumentsWithCombiner()
 	/* Locally store the return value from the combinerHandle and determine stackslots required by the return value */
 	j9object_t combinerHandle = getCombinerHandleForFilter(filterHandle);
 	j9object_t combinerType = getMethodHandleMethodType(combinerHandle);
-	j9object_t combinerReturnType = J9VMJAVALANGINVOKEMETHODTYPE_RETURNTYPE(_currentThread, combinerType);
+	j9object_t combinerReturnType = J9VMJAVALANGINVOKEMETHODTYPE_RTYPE(_currentThread, combinerType);
 	J9Class *combinerReturnTypeClass = J9VM_J9CLASS_FROM_HEAPCLASS(_currentThread, combinerReturnType);
 	U_32 combinerReturnSlots = 1;
 	UDATA combinerReturnValue0 = _currentThread->sp[0];
@@ -1611,7 +1611,7 @@ VM_MHInterpreter::insertReturnValueForFoldArguments()
 	/* Locally store the return value from the combinerHandle and determine stackslots required by the return value */
 	j9object_t combinerHandle = getCombinerHandleForFold(foldHandle);
 	j9object_t combinerType = getMethodHandleMethodType(combinerHandle);
-	j9object_t combinerReturnType = J9VMJAVALANGINVOKEMETHODTYPE_RETURNTYPE(_currentThread, combinerType);
+	j9object_t combinerReturnType = J9VMJAVALANGINVOKEMETHODTYPE_RTYPE(_currentThread, combinerType);
 	J9Class *argTypeClass = J9VM_J9CLASS_FROM_HEAPCLASS(_currentThread, combinerReturnType);
 	UDATA combinerReturnSlots = 0;
 	UDATA combinerReturnValue0 = 0;
@@ -1663,7 +1663,7 @@ j9object_t
 VM_MHInterpreter::permuteForPermuteHandle(j9object_t methodHandle)
 {
 	j9object_t currentType = J9VMJAVALANGINVOKEMETHODHANDLE_TYPE(_currentThread, methodHandle);
-	j9object_t currentTypeArguments = J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(_currentThread, currentType);
+	j9object_t currentTypeArguments = J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(_currentThread, currentType);
 	U_32 currentTypeArgumentsLength = J9INDEXABLEOBJECT_SIZE(_currentThread, currentTypeArguments);
 	U_32 currentArgSlots = (U_32)J9VMJAVALANGINVOKEMETHODTYPE_ARGSLOTS(_currentThread, currentType);
 	j9object_t nextHandle = J9VMJAVALANGINVOKEPERMUTEHANDLE_NEXT(_currentThread, methodHandle);
@@ -1763,7 +1763,7 @@ VM_MHInterpreter::insertArgumentsForInsertHandle(j9object_t methodHandle)
 {
 	j9object_t currentType = J9VMJAVALANGINVOKEMETHODHANDLE_TYPE(_currentThread, methodHandle);
 	U_32 currentArgSlots = (U_32)J9VMJAVALANGINVOKEMETHODTYPE_ARGSLOTS(_currentThread, currentType);
-	j9object_t currentTypeArguments = J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(_currentThread, currentType);
+	j9object_t currentTypeArguments = J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(_currentThread, currentType);
     U_32 currentTypeArgumentsLength = J9INDEXABLEOBJECT_SIZE(_currentThread, currentTypeArguments);
 	j9object_t nextHandle = J9VMJAVALANGINVOKEINSERTHANDLE_NEXT(_currentThread, methodHandle);
 	j9object_t nextType = J9VMJAVALANGINVOKEMETHODHANDLE_TYPE(_currentThread, nextHandle);
@@ -1958,7 +1958,7 @@ VM_MHInterpreter::primitiveArrayCollect(j9object_t collectedArgsArrayRef, U_32 c
 ExceptionType
 VM_MHInterpreter::convertArguments(UDATA * currentArgs, j9object_t *currentType, UDATA * nextArgs, j9object_t *nextType, UDATA explicitCast, ClassCastExceptionData *exceptionData)
 {
-	U_32 argCount = (U_32)J9INDEXABLEOBJECT_SIZE(_currentThread, J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(_currentThread, *currentType));
+	U_32 argCount = (U_32)J9INDEXABLEOBJECT_SIZE(_currentThread, J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(_currentThread, *currentType));
 	U_32 i;
 	J9JavaVM * vm = _currentThread->javaVM;
 	J9Class * booleanReflectClass = vm->booleanReflectClass;
@@ -1984,8 +1984,8 @@ VM_MHInterpreter::convertArguments(UDATA * currentArgs, j9object_t *currentType,
 	ExceptionType rc = NO_EXCEPTION;
 
 	for (i = 0; i < argCount; ++i) {
-		J9Class * currentClass = J9VM_J9CLASS_FROM_HEAPCLASS(_currentThread, J9JAVAARRAYOFOBJECT_LOAD(_currentThread, J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(_currentThread, *currentType), i));
-		J9Class * nextClass = J9VM_J9CLASS_FROM_HEAPCLASS(_currentThread, J9JAVAARRAYOFOBJECT_LOAD(_currentThread, J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(_currentThread, *nextType), i));
+		J9Class * currentClass = J9VM_J9CLASS_FROM_HEAPCLASS(_currentThread, J9JAVAARRAYOFOBJECT_LOAD(_currentThread, J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(_currentThread, *currentType), i));
+		J9Class * nextClass = J9VM_J9CLASS_FROM_HEAPCLASS(_currentThread, J9JAVAARRAYOFOBJECT_LOAD(_currentThread, J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(_currentThread, *nextType), i));
 
 		if (currentClass == nextClass) {
 			/* Trivial case - types are identical */
@@ -2280,7 +2280,7 @@ VM_MHInterpreter::mhStackValidator(j9object_t methodhandle)
 
 	j9object_t currentType = J9VMJAVALANGINVOKEMETHODHANDLE_TYPE(_currentThread, methodhandle);
 	U_32 argSlots = (U_32)J9VMJAVALANGINVOKEMETHODTYPE_ARGSLOTS(_currentThread, currentType);
-	j9object_t arguments = J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(_currentThread, currentType);
+	j9object_t arguments = J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(_currentThread, currentType);
 	U_32 argCount = (U_32)J9INDEXABLEOBJECT_SIZE(_currentThread, arguments);
 
 	U_32 i;

--- a/runtime/vm/OutOfLineINL_java_lang_invoke_NativeMethodHandle.cpp
+++ b/runtime/vm/OutOfLineINL_java_lang_invoke_NativeMethodHandle.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,8 +48,8 @@ OutOfLineINL_java_lang_invoke_NativeMethodHandle_initJ9NativeCalloutDataRef(J9VM
 	Assert_VM_Null(J9VMJAVALANGINVOKENATIVEMETHODHANDLE_J9NATIVECALLOUTDATAREF(currentThread, methodHandle));
 
 	j9object_t methodType = J9VMJAVALANGINVOKEMETHODHANDLE_TYPE(currentThread, methodHandle);
-	J9Class *returnTypeClass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, J9VMJAVALANGINVOKEMETHODTYPE_RETURNTYPE(currentThread, methodType));
-	j9object_t argTypesObject = J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(currentThread, methodType);
+	J9Class *returnTypeClass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, J9VMJAVALANGINVOKEMETHODTYPE_RTYPE(currentThread, methodType));
+	j9object_t argTypesObject = J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(currentThread, methodType);
 
 	FFITypeHelpers FFIHelpers = FFITypeHelpers(currentThread);
 	j9object_t argLayoutStringsObject = *(j9object_t*)currentThread->sp;
@@ -165,7 +165,7 @@ OutOfLineINL_java_lang_invoke_NativeMethodHandle_freeJ9NativeCalloutDataRef(J9VM
 	j9object_t methodHandle = *(j9object_t*)currentThread->sp;
 
 	j9object_t methodType = J9VMJAVALANGINVOKEMETHODHANDLE_TYPE(currentThread, methodHandle);
-	j9object_t argTypesObject = J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(currentThread, methodType);
+	j9object_t argTypesObject = J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(currentThread, methodType);
 	U_32 argumentCount = J9INDEXABLEOBJECT_SIZE(currentThread, argTypesObject) + 1;
 	J9NativeCalloutData *nativeCalloutData = J9VMJAVALANGINVOKENATIVEMETHODHANDLE_J9NATIVECALLOUTDATAREF(currentThread, methodHandle);
 

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -1827,7 +1827,7 @@ resolveMethodTypeRefInto(J9VMThread *vmThread, J9ConstantPool *ramCP, UDATA cpIn
 	if (NULL != methodType) {
 		/* check returnType */
 		J9Class *senderClass = ramCP->ramClass;
-		J9Class *returnTypeClass = J9VM_J9CLASS_FROM_HEAPCLASS(vmThread, J9VMJAVALANGINVOKEMETHODTYPE_RETURNTYPE(vmThread, methodType));
+		J9Class *returnTypeClass = J9VM_J9CLASS_FROM_HEAPCLASS(vmThread, J9VMJAVALANGINVOKEMETHODTYPE_RTYPE(vmThread, methodType));
 		J9Class *illegalClass = NULL;
 		IDATA visibilityReturnCode = 0;
 
@@ -1844,7 +1844,7 @@ resolveMethodTypeRefInto(J9VMThread *vmThread, J9ConstantPool *ramCP, UDATA cpIn
 			illegalClass = returnTypeClass;
 		} else {
 			/* check paramTypes */
-			j9object_t argTypesObject = J9VMJAVALANGINVOKEMETHODTYPE_ARGUMENTS(vmThread, methodType);
+			j9object_t argTypesObject = J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(vmThread, methodType);
 			U_32 typeCount = J9INDEXABLEOBJECT_SIZE(vmThread, argTypesObject);
 
 			for (UDATA i = 0; i < typeCount; i++) {


### PR DESCRIPTION
1. "arguments" renamed to "ptypes".
2. "returnType" renamed to "rtype".

Related: #7352

Co-authored-by: Jack Lu <Jack.S.Lu@ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>