### PR TITLE
Reset softmx after testing to avoid OOMs later

### DIFF
--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryMXBean.java
@@ -142,6 +142,10 @@ public class TestMemoryMXBean {
 
 	@AfterClass
 	protected void tearDown() throws Exception {
+		MemoryMXBean bean = (MemoryMXBean)ManagementFactory.getMemoryMXBean();
+		if (bean.isSetMaxHeapSizeSupported()) {
+			bean.setMaxHeapSize(bean.getMaxHeapSizeLimit());
+		}
 	}
 
 	static class ClassForTestMaxHeapSize implements Task {
@@ -809,6 +813,8 @@ public class TestMemoryMXBean {
 			try {
 				mb.setMaxHeapSize(newHeapSize);
 				AssertJUnit.assertEquals(newHeapSize, mb.getMaxHeapSize());
+				// reset to the limit
+				mb.setMaxHeapSize(mb.getMaxHeapSizeLimit());
 			} catch (IllegalArgumentException i) {
 
 			}


### PR DESCRIPTION
Fixes https://github.com/eclipse/openj9/issues/11282

Ran 15x grinders using the same JVM that failed https://ci.eclipse.org/openj9/view/Test/job/Grinder/1222

Compiles and passes on jdk8 as well https://ci.eclipse.org/openj9/view/Test/job/Grinder/1225