### PR TITLE
For z/OS, set attach.enable=yes running testJpsSanity

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJps.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJps.java
@@ -53,7 +53,8 @@ public class TestJps extends AttachApiTest {
 	public void testJpsSanity() throws IOException {
 		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null);
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
-		List<String> jpsOutput = runCommand();
+		// Allow jps to be attached on z/OS, like other platforms
+		List<String> jpsOutput = runCommand(Collections.singletonList("-J-Dcom.ibm.tools.attach.enable=yes"));
 		assertTrue(TEST_PROCESS_ID_MISSING, StringUtilities.searchSubstring(vmId, jpsOutput).isPresent());
 		assertTrue("jps is missing", StringUtilities.searchSubstring(JPS_Class, jpsOutput).isPresent()); //$NON-NLS-1$
 		assertTrue(CHILD_IS_MISSING, StringUtilities.searchSubstring(tgtMgr.targetId, jpsOutput).isPresent());


### PR DESCRIPTION
Allow jps utility to be visible to itself on zOS, like other platforms.

On z/OS running `jps` doesn't show itself running since attach API is
disabled by default, while running
`jps -J-Dcom.ibm.tools.attach.enable=yes` works like other platforms and
shows output like `83886940 Jps`. testJpsSanity expects to find jps in
the output.

Test still passes https://ci.eclipse.org/openj9/view/Test/job/Grinder/1229

and on zOS now view/Test_grinder/job/Grinder/12290
