### PR TITLE
Adjust max stack for some generated test methods

### DIFF
--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -336,7 +336,7 @@ public class ValueTypeGenerator extends ClassLoader {
 		mv.visitLdcInsn(Long.valueOf(123L));
 		mv.visitFieldInsn(WITHFIELD, className, "longField", "J");
 		mv.visitInsn(ARETURN);
-		mv.visitMaxs(1, 2);
+		mv.visitMaxs(3, 2);
 		mv.visitEnd();
 	}
 	
@@ -351,7 +351,7 @@ public class ValueTypeGenerator extends ClassLoader {
 		mv.visitLdcInsn(Long.valueOf(123L));
 		mv.visitFieldInsn(WITHFIELD, className, "longField", "J");
 		mv.visitInsn(ARETURN);
-		mv.visitMaxs(1, 2);
+		mv.visitMaxs(3, 2);
 		mv.visitEnd();
 	}
 	
@@ -368,7 +368,7 @@ public class ValueTypeGenerator extends ClassLoader {
 		mv.visitLdcInsn(Long.valueOf(123L));
 		mv.visitFieldInsn(WITHFIELD, "NonExistentClass", "longField", "J");
 		mv.visitInsn(ARETURN);
-		mv.visitMaxs(1, 2);
+		mv.visitMaxs(3, 2);
 		mv.visitEnd();
 	}
 


### PR DESCRIPTION
Three generated test methods for `withfield` operations have maximum stack depths of one specified.  However, all three methods have at one point an address and a long value on the stack, so they should have maximum stack depths of three.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>