### PR TITLE
Update CCData usage for changes made in master

### DIFF
--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -308,7 +308,7 @@ J9::CodeCacheManager::allocateCodeCacheWithDataSegmentRO(size_t segmentSize,
          {
          TR_ASSERT_FATAL(_codeCacheData == NULL, "A CCData instance already exists; this code currently doesn't support multiple codecache segments because we can only allocate one CCData instance. TODO: Fix this limitation.");
          uint8_t * const dataArea = ccDataSegment->baseAddress;
-         _codeCacheData = new OMR::CCData(dataArea, dataAreaSize);
+         _codeCacheData = new TR::CCData(dataArea, dataAreaSize);
          }
       mcc_printf("TR::CodeCache::allocated : codeCacheSegment is %p\n",codeCacheSegment);
       if (config.verboseCodeCache())
@@ -525,7 +525,7 @@ J9::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
          {
          TR_ASSERT_FATAL(_codeCacheData == NULL, "A CCData instance already exists; this code currently doesn't support multiple codecache segments because we can only allocate one CCData instance. TODO: Fix this limitation.");
          uint8_t * const dataArea = codeCacheSegment->baseAddress + codeCacheSizeToAllocate;
-         _codeCacheData = new OMR::CCData(dataArea, dataAreaSize);
+         _codeCacheData = new TR::CCData(dataArea, dataAreaSize);
          }
       mcc_printf("TR::CodeCache::allocated : codeCacheSegment is %p\n",codeCacheSegment);
       if (config.verboseCodeCache())

--- a/runtime/compiler/z/codegen/J9MemoryReference.cpp
+++ b/runtime/compiler/z/codegen/J9MemoryReference.cpp
@@ -397,9 +397,8 @@ J9::Z::MemoryReference::create(TR::CodeGenerator* cg, TR::Node* node)
 
       typedef J9::Z::UnresolvedDataReadOnlySnippet::CCUnresolvedData CCUnresolvedData;
 
-      OMR::CCData *codeCacheData = cg->getCodeCache()->manager()->getCodeCacheData();
-      OMR::CCData::index_t index;
-      if (!(codeCacheData->put(NULL, sizeof(CCUnresolvedData), alignof(CCUnresolvedData), NULL, index)))
+      TR::CCData *codeCacheData = cg->getCodeCache()->manager()->getCodeCacheData();
+      TR::CCData::index_t index;
          {
          comp->failCompilation<TR::CompilationException>("Could not allocate unresolved data metadata");
          }

--- a/runtime/compiler/z/codegen/J9MemoryReference.cpp
+++ b/runtime/compiler/z/codegen/J9MemoryReference.cpp
@@ -399,10 +399,11 @@ J9::Z::MemoryReference::create(TR::CodeGenerator* cg, TR::Node* node)
 
       TR::CCData *codeCacheData = cg->getCodeCache()->manager()->getCodeCacheData();
       TR::CCData::index_t index;
+      if (!(codeCacheData->reserve(sizeof(CCUnresolvedData), alignof(CCUnresolvedData), NULL, index)))
          {
          comp->failCompilation<TR::CompilationException>("Could not allocate unresolved data metadata");
          }
-      
+
       CCUnresolvedData* ccUnresolvedDataAddress = codeCacheData->get<CCUnresolvedData>(index);
 
       TR::SymbolReference *symRef = node->getSymbolReference();
@@ -458,7 +459,7 @@ J9::Z::MemoryReference::create(TR::CodeGenerator* cg, TR::Node* node)
       auto cursor = new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRCL, node, 0x8, snippet, NULL, cg);
       cursor->setNeedsGCMap(0xFFFFFFFF);
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionEnd, dependencies);
-      
+
       TR::MemoryReference *loadStoreDataMR = NULL;
       if (baseReg != NULL)
          {

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -1595,9 +1595,8 @@ J9::Z::PrivateLinkage::buildNoPatchingVirtualDispatchWithResolve(TR::Node *callN
       int32_t vtableOffset;
       };
    
-   OMR::CCData *codeCacheData = cg()->getCodeCache()->manager()->getCodeCacheData();
-   OMR::CCData::index_t index;
-   if (!(codeCacheData->put(NULL, sizeof(ccResolveVirtualData), alignof(ccResolveVirtualData), NULL, index)))
+   TR::CCData *codeCacheData = cg()->getCodeCache()->manager()->getCodeCacheData();
+   TR::CCData::index_t index;
       {
       comp()->failCompilation<TR::CompilationException>("Could not allocate resolve virtual dispatch metadata");
       }
@@ -1674,8 +1673,8 @@ J9::Z::PrivateLinkage::buildNoPatchingIPIC(TR::Node *callNode, TR::RegisterDepen
     * We can create a different data structure to hold the J9Class and method address
     * size of which can be fixed at compilation time and use that.
     */
-   OMR::CCData *codeCacheData = cg()->getCodeCache()->manager()->getCodeCacheData();
-   OMR::CCData::index_t index;
+   TR::CCData *codeCacheData = cg()->getCodeCache()->manager()->getCodeCacheData();
+   TR::CCData::index_t index;
 
    if (!(codeCacheData->put(NULL, sizeof(ccInterfaceData), 16, NULL, index)))
       {


### PR DESCRIPTION
These patches account for the CCData changes made in master and should be merged together with https://github.com/eclipse/openj9-omr/pull/91.