### PR TITLE
Update to use the new LoadStoreHandler API on Power

### DIFF
--- a/runtime/compiler/build/files/target/p.mk
+++ b/runtime/compiler/build/files/target/p.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2020 IBM Corp. and others
+# Copyright (c) 2000, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/build/files/target/p.mk
+++ b/runtime/compiler/build/files/target/p.mk
@@ -28,6 +28,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/p/codegen/OMRInstOpCode.cpp \
     omr/compiler/p/codegen/OMRInstruction.cpp \
     omr/compiler/p/codegen/OMRLinkage.cpp \
+    omr/compiler/p/codegen/OMRLoadStoreHandler.cpp \
     omr/compiler/p/codegen/OMRMachine.cpp \
     omr/compiler/p/codegen/OMRMemoryReference.cpp \
     omr/compiler/p/codegen/OMRPeephole.cpp \

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -403,7 +403,7 @@ J9::Power::CodeGenerator::insertPrefetchIfNecessary(TR::Node *node, TR::Register
    static bool disableStringObjPrefetch = (feGetEnv("TR_DisableStringObjPrefetch") != NULL);
    bool optDisabled = false;
 
-   if (node->getOpCodeValue() == TR::aloadi ||
+   if ((node->getOpCodeValue() == TR::aloadi && !comp->target().is64Bit()) ||
         (comp->target().is64Bit() &&
          comp->useCompressedPointers() &&
          node->getOpCodeValue() == TR::l2a &&
@@ -631,7 +631,7 @@ J9::Power::CodeGenerator::insertPrefetchIfNecessary(TR::Node *node, TR::Register
          }
       }
 
-   if (node->getOpCodeValue() == TR::aloadi ||
+   if ((node->getOpCodeValue() == TR::aloadi && !comp->target().is64Bit()) ||
          (comp->target().is64Bit() &&
           comp->useCompressedPointers() &&
           (node->getOpCodeValue() == TR::iloadi || node->getOpCodeValue() == TR::irdbari) &&

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -7095,7 +7095,6 @@ static bool simpleReadMonitor(TR::Node *node, TR::CodeGenerator *cg, TR::Node *o
       tempMR = TR::LoadStoreHandler::generateSimpleLoadMemoryReference(cg, nextTopNode, 4);
       loadOpCode = TR::InstOpCode::lwz;
       }
-   TR_ASSERT_FATAL_WITH_NODE(nextTopNode, !tempMR.getMemoryReference()->getIndexRegister(), "Simple read monitors do not currently support indexed loads");
    // end of code derived from the iaload and iiload evaluators
 
    TR::addDependency(conditions, loadResultReg, TR::RealRegister::NoReg, TR_GPR, cg);


### PR DESCRIPTION
Recently, OMR has decided to simplify the way that node-based loads and stores are generated on Power due to a large number of issues regarding missing barriers for volatile loads and a great deal of OpenJ9-specific code surrounding volatile and unresolved that has leaked into OMR (eclipse/omr#5630). The current plan is for the old API for directly generating memory references from nodes to be deprecated after the new API is implemented, so OpenJ9 must be updated to use this new API.

This PR should be merged simultaneously with the corresponding OMR PR to implement the new API (eclipse/omr#5652).