### PR TITLE
Reset runtimeAssumptionList field in metadata on restore

### DIFF
--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -666,7 +666,6 @@ TR_RuntimeAssumptionTable::serialize(J9JITConfig *jitConfig)
                atlas->_numAssumptionsPerKind[k]._count++;
                atlas->_numAssumptionsPerKind[k]._size += size;
 
-               owningMetadata->runtimeAssumptionList = NULL;
                buffer += size;
 
                cursor = cursor->getNext();

--- a/runtime/compiler/runtime/codertinit.cpp
+++ b/runtime/compiler/runtime/codertinit.cpp
@@ -176,6 +176,7 @@ static void restoreJitArtifacts(J9JavaVM *vm)
       {
       for (J9JITExceptionTable *metadata = currentClassLoader->jitMetaDataList; metadata != NULL; metadata = J9JITEXCEPTIONTABLE_NEXTMETHOD_GET(metadata))
          {
+         metadata->runtimeAssumptionList = NULL;
          jit_artifact_insert(vm, translationArtifacts, metadata);
          }
 
@@ -191,6 +192,7 @@ static void restoreJitArtifacts(J9JavaVM *vm)
       {
       for (J9JITExceptionTable *metadata = clazz->jitMetaDataList; metadata != NULL; metadata = J9JITEXCEPTIONTABLE_NEXTMETHOD_GET(metadata))
          {
+         metadata->runtimeAssumptionList = NULL;
          jit_artifact_insert(vm, translationArtifacts, metadata);
          }
       clazz = vmFuncs->allClassesNextDo(&classWalkState);


### PR DESCRIPTION
In the past, the snapshot would only occur at shutdown. Now that it can
occur during runtime, the runtimeAssumptionList field in the metadata
for a JIT'd body should not be set to NULL. The reason is because if,
after the snapshot point, the JVM continues to run and the body is
reclaimed (because of recompilation or any other read), the assumptions
associated with that body will not be deleted.  This is problematic
because the assumptions are registered against specific instruction
addresses. If, after the a JIT'd body is removed and another is placed
in the location it used to reside in, some event occurs that results
in the assumptions firing, it will patch code in the new body.

Therefore, this commit does not set the runtimeAssumptionList field to
NULL while serialzing the assumptions, and instead sets it to NULL on
restore.

Signed-off-by: Irwin D'Souza <dsouzai.gh@gmail.com>