### PR TITLE
Improve the mechanism of accepting new request at JITServer

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1036,7 +1036,10 @@ public:
    TR::Monitor *getclassesCachedAtServerMonitor() const { return _classesCachedAtServerMonitor; }
    TR::Monitor *getSequencingMonitor() const { return _sequencingMonitor; }
    uint32_t getCompReqSeqNo() const { return _compReqSeqNo; }
-   uint32_t incCompReqSeqNo() { return ++_compReqSeqNo; }
+   uint32_t incCompReqSeqNo() { return _compReqSeqNo++; }
+   uint32_t getLastCriticalSeqNo() const { return _lastCriticalCompReqSeqNo; }
+   void setLastCriticalSeqNo(uint32_t seqNo) { _lastCriticalCompReqSeqNo = seqNo; }
+
    void markCHTableUpdateDone(uint8_t threadId) { _chTableUpdateFlags |= (1 << threadId); }
    void resetCHTableUpdateDone(uint8_t threadId) { _chTableUpdateFlags &= ~(1 << threadId); }
    uint8_t getCHTableUpdateDone() const { return _chTableUpdateFlags; }
@@ -1262,6 +1265,7 @@ private:
    PersistentVector<TR_OpaqueClassBlock*> *_illegalFinalFieldModificationList; // JITServer list of classes that have J9ClassHasIllegalFinalFieldModifications is set
    TR::Monitor                   *_sequencingMonitor; // Used for ordering outgoing messages at the client
    uint32_t                      _compReqSeqNo; // seqNo for outgoing messages at the client
+   uint32_t                      _lastCriticalCompReqSeqNo; // seqNo for last request that carried information that needs to be processed in order
    PersistentUnorderedMap<TR_OpaqueClassBlock*, uint8_t> *_newlyExtendedClasses; // JITServer table of newly extended classes
    uint8_t                       _chTableUpdateFlags;
    uint32_t                      _localGCCounter; // Number of local gc cycles done

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2196,6 +2196,7 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
                   }
             case compilationStreamMessageTypeMismatch:
             case compilationStreamVersionIncompatible:
+            case compilationStreamLostMessage:
 #endif
             case compilationInterrupted:
             case compilationCodeReservationFailure:

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -145,7 +145,38 @@ TR::CompilationInfoPerThreadRemote::CompilationInfoPerThreadRemote(TR::Compilati
    {}
 
 /**
- * @brief Method executed by JITServer to update the expecting sequence number.
+ * @brief Method executed by JITServer to dequeue and notify all waiting threads 
+ *        that the condition they were waiting for has been fulfilled. 
+ *        Needs to be executed with clientSession->getSequencingMonitor() in hand.
+ */
+void
+TR::CompilationInfoPerThreadRemote::notifyAndDetachWaitingRequests(ClientSessionData *clientSession)
+   {
+   TR_MethodToBeCompiled *nextEntry = clientSession->getOOSequenceEntryList();
+   // I need to keep notifying until the first request that is blocked 
+   // because the request it depends on hasn't been processed yet.
+   while (nextEntry)
+      {
+      uint32_t nextWaitingSeqNo = ((CompilationInfoPerThreadRemote*)(nextEntry->_compInfoPT))->getSeqNo();
+      uint32_t expectedSeqNo = ((CompilationInfoPerThreadRemote*)(nextEntry->_compInfoPT))->getExpectedSeqNo();
+      if (expectedSeqNo <= clientSession->getLastProcessedCriticalSeqNo())
+         {
+         clientSession->notifyAndDetachFirstWaitingThread();
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d notifying out-of-sequence thread %d for clientUID=%llu seqNo=%u (entry=%p)",
+               getCompThreadId(), nextEntry->_compInfoPT->getCompThreadId(), (unsigned long long)clientSession->getClientUID(), nextWaitingSeqNo, nextEntry);
+         nextEntry = clientSession->getOOSequenceEntryList();
+         }
+      else // The request I depend on hasn't been processed yet, so stop here
+         {
+         break;
+         }
+      }
+   }
+
+/**
+ * @brief Method executed by a compilation thread at JITServer to wait for all
+ *        previous compilation requests it depends on to be processed.
  *        Needs to be executed with sequencingMonitor in hand.
  */
 void
@@ -154,6 +185,7 @@ TR::CompilationInfoPerThreadRemote::waitForMyTurn(ClientSessionData *clientSessi
    TR_ASSERT(getMethodBeingCompiled() == &entry, "Must have stored the entry to be compiled into compInfoPT");
    TR_ASSERT(entry._compInfoPT == this, "Must have stored compInfoPT into the entry to be compiled");
    uint32_t seqNo = getSeqNo();
+   uint32_t criticalSeqNo = getExpectedSeqNo(); // This is the seqNo that I must wait for
 
    // Insert this thread into the list of out of sequence entries
    JITServerHelpers::insertIntoOOSequenceEntryList(clientSession, &entry);
@@ -168,12 +200,12 @@ TR::CompilationInfoPerThreadRemote::waitForMyTurn(ClientSessionData *clientSessi
       clientSession->getSequencingMonitor()->exit(); // release monitor before waiting
       const int64_t waitTimeMillis = 1000; // TODO: create an option for this
       if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d (entry=%p) doing a timed wait for %d ms",
-         getCompThreadId(), &entry, (int32_t)waitTimeMillis);
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d (entry=%p) doing a timed wait for %d ms (waiting for seqNo=%u)",
+         getCompThreadId(), &entry, (int32_t)waitTimeMillis, criticalSeqNo);
 
       Trc_JITServerTimedWait(getCompilationThread(), getCompThreadId(), clientSession,
             (unsigned long long)clientSession->getClientUID(), &entry,
-            seqNo, clientSession->getExpectedSeqNo(), clientSession->getNumActiveThreads(), (int32_t)waitTimeMillis);
+            seqNo, criticalSeqNo, clientSession->getNumActiveThreads(), (int32_t)waitTimeMillis);
 
       intptr_t monitorStatus = entry.getMonitor()->wait_timed(waitTimeMillis, 0); // 0 or J9THREAD_TIMED_OUT
       if (monitorStatus == 0) // Thread was notified
@@ -188,19 +220,19 @@ TR::CompilationInfoPerThreadRemote::waitForMyTurn(ClientSessionData *clientSessi
 
          Trc_JITServerParkThread(getCompilationThread(), getCompThreadId(), clientSession,
                (unsigned long long)clientSession->getClientUID(), &entry,
-               seqNo, clientSession->getExpectedSeqNo(), clientSession->getNumActiveThreads(), seqNo);
+               seqNo, criticalSeqNo, clientSession->getNumActiveThreads(), seqNo);
          }
-      else
+      else // Timeout
          {
          entry.getMonitor()->exit();
          TR_ASSERT(monitorStatus == J9THREAD_TIMED_OUT, "Unexpected monitor state");
          if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCompFailure, TR_VerboseJITServer, TR_VerbosePerformance))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d (entry=%p) timed-out while waiting for seqNo=%d ",
-               getCompThreadId(), &entry, clientSession->getExpectedSeqNo());
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d (entry=%p) timed-out while waiting for seqNo=%u ",
+               getCompThreadId(), &entry, criticalSeqNo);
 
          Trc_JITServerTimedOut(getCompilationThread(), getCompThreadId(), clientSession,
                (unsigned long long)clientSession->getClientUID(), &entry,
-               seqNo, clientSession->getExpectedSeqNo(), clientSession->getNumActiveThreads(), clientSession->getExpectedSeqNo());
+               seqNo, criticalSeqNo, clientSession->getNumActiveThreads(), criticalSeqNo);
 
          // The simplest thing is to delete the cached data for the session and start fresh
          // However, we must wait for any active threads to drain out
@@ -208,7 +240,7 @@ TR::CompilationInfoPerThreadRemote::waitForMyTurn(ClientSessionData *clientSessi
 
          // This thread could have been waiting, then timed-out and then waited
          // to acquire the sequencing monitor. Check whether it can proceed.
-         if (seqNo == clientSession->getExpectedSeqNo())
+         if (criticalSeqNo <= clientSession->getLastProcessedCriticalSeqNo())
             {
             // The entry cannot be in the list
             TR_MethodToBeCompiled *headEntry = clientSession->getOOSequenceEntryList();
@@ -226,25 +258,28 @@ TR::CompilationInfoPerThreadRemote::waitForMyTurn(ClientSessionData *clientSessi
             !getWaitToBeNotified()) // Avoid a cohort of threads clearing the caches
             {
             clientSession->clearCaches();
-            TR_MethodToBeCompiled *detachedEntry = clientSession->notifyAndDetachFirstWaitingThread();
+
+            if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+               TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+                  "compThreadID=%d has cleared the session caches for clientUID=%llu criticalSeqNo=%u seqNo=%u firstEntry=%p",
+                  getCompThreadId(), clientSession->getClientUID(), criticalSeqNo, seqNo, &entry);
 
             Trc_JITServerClearedSessionCaches(getCompilationThread(), getCompThreadId(), clientSession,
                   (unsigned long long)clientSession->getClientUID(),
-                  seqNo, clientSession->getExpectedSeqNo(), clientSession->getNumActiveThreads(), detachedEntry,
-                  clientSession->getExpectedSeqNo(), seqNo);
+                  seqNo, criticalSeqNo, clientSession->getNumActiveThreads(), &entry,
+                  clientSession->getLastProcessedCriticalSeqNo(), seqNo);
 
-            clientSession->setExpectedSeqNo(seqNo);// Allow myself to go through
+            clientSession->setLastProcessedCriticalSeqNo(criticalSeqNo);// Allow myself to go through
+            notifyAndDetachWaitingRequests(clientSession);
             // Mark the next request that it should not try to clear the caches,
-            // but rather to sleep again waiting for my notification.
+            // but rather to sleep again waiting for my notification. 
+            // We only need to do this for the head entry in the waiting list
+            // due to the check `&entry == clientSession->getOOSequenceEntryList()` above
             TR_MethodToBeCompiled *nextWaitingEntry = clientSession->getOOSequenceEntryList();
             if (nextWaitingEntry)
                {
                ((TR::CompilationInfoPerThreadRemote*)(nextWaitingEntry->_compInfoPT))->setWaitToBeNotified(true);
                }
-            if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-               TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
-                  "compThreadID=%d has cleared the session caches for clientUID=%llu expectedSeqNo=%u detachedEntry=%p",
-                  getCompThreadId(), clientSession->getClientUID(), clientSession->getExpectedSeqNo(), detachedEntry);
             }
          else
             {
@@ -257,43 +292,12 @@ TR::CompilationInfoPerThreadRemote::waitForMyTurn(ClientSessionData *clientSessi
 
             Trc_JITServerThreadGoSleep(getCompilationThread(), getCompThreadId(), clientSession,
                   (unsigned long long)clientSession->getClientUID(),
-                  seqNo, clientSession->getExpectedSeqNo(), clientSession->getNumActiveThreads(), getWaitToBeNotified());
+                  seqNo, criticalSeqNo, clientSession->getNumActiveThreads(), getWaitToBeNotified());
             }
          }
-      } while (seqNo > clientSession->getExpectedSeqNo());
+      } while (criticalSeqNo > clientSession->getLastProcessedCriticalSeqNo());
    }
 
-/**
- * @brief Method executed by JITServer to update the expecting sequence number.
- *        Needs to be executed with clientSession->getSequencingMonitor() in hand.
- */
-void
-TR::CompilationInfoPerThreadRemote::updateSeqNo(ClientSessionData *clientSession)
-   {
-   uint32_t newSeqNo = clientSession->getExpectedSeqNo() + 1;
-   Trc_JITServerUpdateSeqNo(getCompilationThread(), getCompThreadId(), clientSession,
-      (unsigned long long)clientSession->getClientUID(),
-      getSeqNo(), clientSession->getExpectedSeqNo(), clientSession->getNumActiveThreads(),
-      clientSession->getExpectedSeqNo(), newSeqNo);
-
-   clientSession->setExpectedSeqNo(newSeqNo);
-
-   // Notify a possible waiting thread that arrived out of sequence
-   // and take that entry out of the OOSequenceEntryList
-   TR_MethodToBeCompiled *nextEntry = clientSession->getOOSequenceEntryList();
-   if (nextEntry)
-      {
-      uint32_t nextWaitingSeqNo = ((CompilationInfoPerThreadRemote*)(nextEntry->_compInfoPT))->getSeqNo();
-      if (nextWaitingSeqNo == newSeqNo)
-         {
-         clientSession->notifyAndDetachFirstWaitingThread();
-
-         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d notifying out-of-sequence thread %d for clientUID=%llu seqNo=%u (entry=%p)",
-               getCompThreadId(), nextEntry->_compInfoPT->getCompThreadId(), (unsigned long long)clientSession->getClientUID(), nextWaitingSeqNo, nextEntry);
-         }
-      }
-   }
 
 /**
  * @brief Method executed by JITServer to process the compilation request.
@@ -324,6 +328,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
    bool useAotCompilation = false;
    uint32_t seqNo = 0;
    ClientSessionData *clientSession = NULL;
+   bool isCriticalRequest = false;
    // numActiveThreads is incremented after it waits for its turn to execute
    // and before the thread processes unloaded classes and CHTable init and update.
    // A stream exception could be thrown at any time such as reading the compilation
@@ -335,27 +340,30 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
    bool hasIncNumActiveThreads = false;
    try
       {
-      auto req = stream->readCompileRequest<uint64_t, uint32_t, uint32_t, J9Method *, J9Class*, TR_OptimizationPlan,
-         std::string, J9::IlGeneratorMethodDetailsType,
-         std::vector<TR_OpaqueClassBlock*>, std::vector<TR_OpaqueClassBlock*>,
+      auto req = stream->readCompileRequest<uint64_t, uint32_t, uint32_t, uint32_t, J9Method *, J9Class*,
+         TR_OptimizationPlan, std::string, J9::IlGeneratorMethodDetailsType,
+         std::vector<TR_OpaqueClassBlock*>, std::vector<TR_OpaqueClassBlock*>, 
          JITServerHelpers::ClassInfoTuple, std::string, std::string, std::string, std::string, bool>();
 
       clientId                           = std::get<0>(req);
       seqNo                              = std::get<1>(req); // Sequence number at the client
-      uint32_t romMethodOffset           = std::get<2>(req);
-      J9Method *ramMethod                = std::get<3>(req);
-      J9Class *clazz                     = std::get<4>(req);
-      TR_OptimizationPlan clientOptPlan  = std::get<5>(req);
-      std::string detailsStr             = std::get<6>(req);
-      auto detailsType                   = std::get<7>(req);
-      auto &unloadedClasses              = std::get<8>(req);
-      auto &illegalModificationList      = std::get<9>(req);
-      auto &classInfoTuple               = std::get<10>(req);
-      std::string clientOptStr           = std::get<11>(req);
-      std::string recompInfoStr          = std::get<12>(req);
-      const std::string &chtableUnloads  = std::get<13>(req);
-      const std::string &chtableMods     = std::get<14>(req);
-      useAotCompilation                  = std::get<15>(req);
+      uint32_t criticalSeqNo             = std::get<2>(req); // Sequence number of the request this request depends upon
+      uint32_t romMethodOffset           = std::get<3>(req);
+      J9Method *ramMethod                = std::get<4>(req);
+      J9Class *clazz                     = std::get<5>(req);
+      TR_OptimizationPlan clientOptPlan  = std::get<6>(req);
+      std::string detailsStr             = std::get<7>(req);
+      auto detailsType                   = std::get<8>(req);
+      auto &unloadedClasses              = std::get<9>(req);
+      auto &illegalModificationList      = std::get<10>(req);
+      auto &classInfoTuple               = std::get<11>(req);
+      std::string clientOptStr           = std::get<12>(req);
+      std::string recompInfoStr          = std::get<13>(req);
+      const std::string &chtableUnloads  = std::get<14>(req);
+      const std::string &chtableMods     = std::get<15>(req);
+      useAotCompilation                  = std::get<16>(req);
+
+      isCriticalRequest = !chtableMods.empty() || !chtableUnloads.empty() || !illegalModificationList.empty() || !unloadedClasses.empty();
 
       if (useAotCompilation)
          {
@@ -372,11 +380,12 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          // This behaviour is consistent with non-JITServer
          ((TR_J9JITServerSharedCache *) _vm->sharedCache())->setStream(stream);
 
-      //if (seqNo == 100)
+      //if (seqNo == 501)
       //   throw JITServer::StreamFailure(); // stress testing
 
       stream->setClientId(clientId);
       setSeqNo(seqNo); // Memorize the sequence number of this request
+      setExpectedSeqNo(criticalSeqNo); // Memorize the message I have to wait for
 
       bool sessionDataWasEmpty = false;
       {
@@ -388,58 +397,71 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          throw std::bad_alloc();
 
       setClientData(clientSession); // Cache the session data into CompilationInfoPerThreadRemote object
-      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d %s clientSessionData=%p for clientUID=%llu seqNo=%u",
-            getCompThreadId(), sessionDataWasEmpty ? "created" : "found", clientSession, (unsigned long long)clientId, seqNo);
       } // End critical section
 
+     if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d %s clientSessionData=%p for clientUID=%llu seqNo=%u (isCritical=%d) (criticalSeqNo=%u lastProcessedCriticalReq=%u)",
+            getCompThreadId(), sessionDataWasEmpty ? "created" : "found", clientSession, (unsigned long long)clientId, seqNo, 
+            isCriticalRequest, criticalSeqNo, clientSession->getLastProcessedCriticalSeqNo());
 
-      Trc_JITServerClientSessionData(compThread, getCompThreadId(), sessionDataWasEmpty ? "created" : "found",
-            clientSession, (unsigned long long)clientId, seqNo);
+      Trc_JITServerClientSessionData1(compThread, getCompThreadId(), sessionDataWasEmpty ? "created" : "found",
+         clientSession, (unsigned long long)clientId, seqNo, isCriticalRequest, criticalSeqNo, clientSession->getLastProcessedCriticalSeqNo());
       // We must process unloaded classes lists in the same order they were generated at the client
       // Use a sequencing scheme to re-order compilation requests
       //
       clientSession->getSequencingMonitor()->enter();
-      clientSession->updateMaxReceivedSeqNo(seqNo);
-      if (seqNo > clientSession->getExpectedSeqNo()) // Out of order messages
+      clientSession->updateMaxReceivedSeqNo(seqNo); // TODO: why do I need this?
+      // This request can go through as long as criticalSeqNo has been processed
+      if (criticalSeqNo > clientSession->getLastProcessedCriticalSeqNo())
          {
-         // Park this request until the missing ones arrive
+         // Park this request until `criticalSeqNo` arrives and is processed
          if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d out-of-sequence msg detected for clientUID=%llu seqNo=%u > expectedSeqNo=%u. Parking this thread (entry=%p)",
-            getCompThreadId(), (unsigned long long)clientId, seqNo, clientSession->getExpectedSeqNo(), &entry);
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d out-of-sequence msg=%u detected for clientUID=%llu criticalSeqNo=%u > lastCriticalSeqNo=%u. Parking this thread (entry=%p)",
+            getCompThreadId(), seqNo, (unsigned long long)clientId, criticalSeqNo, clientSession->getLastProcessedCriticalSeqNo(), &entry);
 
-         Trc_JITServerOutOfSequenceMessage(compThread, getCompThreadId(), clientSession,
-               (unsigned long long)clientId, &entry, seqNo, clientSession->getExpectedSeqNo(), clientSession->getNumActiveThreads());
+         Trc_JITServerOutOfSequenceMsg1(compThread, getCompThreadId(), clientSession, (unsigned long long)clientId, &entry, seqNo, 
+            clientSession->getLastProcessedCriticalSeqNo(), clientSession->getNumActiveThreads(), clientSession->getLastProcessedCriticalSeqNo());
 
          waitForMyTurn(clientSession, entry);
          }
-      else if (seqNo < clientSession->getExpectedSeqNo())
+
+      TR_ASSERT_FATAL(criticalSeqNo <= clientSession->getLastProcessedCriticalSeqNo(), 
+         "Critical requests must be processed in order: compThreadID=%d seqNo=%u criticalSeqNo=%u > lastProcessedCriticalSeqNo=%u clientUID=%llu",
+         getCompThreadId(), seqNo, criticalSeqNo, clientSession->getLastProcessedCriticalSeqNo(), (unsigned long long)clientId);
+
+      if (criticalSeqNo < clientSession->getLastProcessedCriticalSeqNo())
          {
-         // Note that it is possible for seqNo to be smaller than expectedSeqNo.
-         // This could happen for instance for the very first message that arrives late.
-         // In that case, the second message would have created the client session and
-         // written its own seqNo into expectedSeqNo. We should avoid processing stale updates
-         if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCompFailure, TR_VerboseJITServer, TR_VerbosePerformance))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d discarding older msg for clientUID=%llu seqNo=%u < expectedSeqNo=%u",
-                  getCompThreadId(), (unsigned long long)clientId, seqNo, clientSession->getExpectedSeqNo());
+         // It's possible that a critical request is delayed so much that we clear the caches, start over,
+         // and then the missing request arrives. At this point we should ignore it, so we throw StreamOOO.
+         // Another possibility is when request 1 arrives before request 0 and creates the session, setting
+         // lastProcessedCriticalSeqNo to 1. As request 0 is "critical" by definition, we throw StreamOOO.
+         // Request 0 will be aborted (retried at te client) while request 1 will ask about entire CHTable
+         // because CHTable is empty at the server
+         if (isCriticalRequest)
+            {      
+            if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCompFailure, TR_VerboseJITServer, TR_VerbosePerformance))
+               TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, 
+                  "compThreadID=%d discarding older msg for clientUID=%llu seqNo=%u criticalSeqNo=%u < lastProcessedCriticalSeqNo=%u",
+                  getCompThreadId(), (unsigned long long)clientId, seqNo, criticalSeqNo, clientSession->getLastProcessedCriticalSeqNo());
 
-         Trc_JITServerDiscardMessage(compThread, getCompThreadId(), clientSession,
-               (unsigned long long)clientId, seqNo, clientSession->getExpectedSeqNo(), clientSession->getNumActiveThreads());
+            Trc_JITServerDiscardMessage(compThread, getCompThreadId(), clientSession,
+               (unsigned long long)clientId, seqNo, criticalSeqNo, clientSession->getNumActiveThreads());
 
-         clientSession->getSequencingMonitor()->exit();
-         throw JITServer::StreamOOO();
+            clientSession->getSequencingMonitor()->exit();
+            throw JITServer::StreamOOO();
+            }
          }
 
       // Increment the number of active threads before issuing the read for ramClass
       clientSession->incNumActiveThreads();
       hasIncNumActiveThreads = true;
 
-      // We can release the sequencing monitor now because nobody with a
-      // larger sequence number can pass until I increment expectedSeqNo
+      // We can release the sequencing monitor now because no critical request with a
+      // larger sequence number can pass until I increment lastProcessedCriticalSeqNo
       clientSession->getSequencingMonitor()->exit();
 
       // At this point I know that all preceeding requests have been processed
-      // and only one thread can ever be present in this section
+      // and only one thread with critical information can ever be present in this section
       if (!clientSession->cachesAreCleared())
          {
          // Free data for all classes that were unloaded for this sequence number
@@ -457,17 +479,19 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
 
          // Process the CHTable updates in order
          // Note that applying the updates will acquire the CHTable monitor and VMAccess
-         auto chTable = (JITServerPersistentCHTable*)compInfo->getPersistentInfo()->getPersistentCHTable();
-         TR_ASSERT_FATAL(chTable->isInitialized() || (chtableUnloads.empty() && chtableMods.empty()),
-                         "CHTable must have been initialized for clientUID=%llu", (unsigned long long)clientId);
          if (!chtableUnloads.empty() || !chtableMods.empty())
+            {
+            auto chTable = (JITServerPersistentCHTable*)clientSession->getCHTable(); // Will create CHTable if it doesn't exist
+            TR_ASSERT_FATAL(chTable->isInitialized(), "CHTable must have been initialized for clientUID=%llu", (unsigned long long)clientId);
             chTable->doUpdate(_vm, chtableUnloads, chtableMods);
+            }
          }
       else // Internal caches are empty
          {
          if (TR::Options::getVerboseOption(TR_VerboseJITServer))
             TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d will ask for address ranges of unloaded classes and CHTable for clientUID %llu",
                getCompThreadId(), (unsigned long long)clientId);
+
          stream->write(JITServer::MessageType::getUnloadedClassRangesAndCHTable, JITServer::Void());
          auto response = stream->read<std::vector<TR_AddressRange>, int32_t, std::string>();
          // TODO: we could send JVM info that is global and does not change together with CHTable
@@ -484,7 +508,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
             clientSession->processUnloadedClasses(unloadedClasses, false);
             }
 
-         auto chTable = static_cast<JITServerPersistentCHTable *>(compInfo->getPersistentInfo()->getPersistentCHTable());
+         auto chTable = static_cast<JITServerPersistentCHTable *>(clientSession->getCHTable());
          // Need CHTable mutex
          TR_ASSERT_FATAL(!chTable->isInitialized(), "CHTable must be empty for clientUID=%llu", (unsigned long long)clientId);
          if (TR::Options::getVerboseOption(TR_VerboseJITServer))
@@ -494,27 +518,32 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          clientSession->setCachesAreCleared(false);
          }
 
-      clientSession->getSequencingMonitor()->enter();
-
-      if (seqNo != clientSession->getExpectedSeqNo())
+      // Critical requests must update lastProcessedCriticalSeqNo and notify any waiting threads. 
+      // Dependent threads will pass through once we've released the sequencing monitor.
+      if (isCriticalRequest)
          {
-         Trc_JITServerUnexpectedSeqNo(compThread, getCompThreadId(), clientSession,
-               (unsigned long long)clientId, seqNo, clientSession->getExpectedSeqNo(), clientSession->getNumActiveThreads());
+         clientSession->getSequencingMonitor()->enter();
+         TR_ASSERT_FATAL(criticalSeqNo <= clientSession->getLastProcessedCriticalSeqNo(),
+            "compThreadID=%d clientSessionData=%p clientUID=%llu seqNo=%u, criticalSeqNo=%u != lastProcessedCriticalSeqNo=%u, numActiveThreads=%d",
+            getCompThreadId(), clientSession, (unsigned long long)clientId, seqNo, criticalSeqNo,
+            clientSession->getLastProcessedCriticalSeqNo(), clientSession->getNumActiveThreads());
+      
+         clientSession->setLastProcessedCriticalSeqNo(seqNo);
+         Trc_JITServerUpdateSeqNo(getCompilationThread(), getCompThreadId(), clientSession,
+                                 (unsigned long long)clientSession->getClientUID(),
+                                 getSeqNo(), criticalSeqNo, clientSession->getNumActiveThreads(),
+                                 clientSession->getLastProcessedCriticalSeqNo(), seqNo);
 
-         TR_ASSERT(false, "compThreadID=%d clientSessionData=%p clientUID=%llu (seqNo=%u, expectedSeqNo=%u, numActiveThreads=%d) unexpected seqNo",
-               getCompThreadId(), clientSession, (unsigned long long)clientId,
-               seqNo, clientSession->getExpectedSeqNo(), clientSession->getNumActiveThreads());
+         // Notify waiting threads. I need to keep notifying until the first request that
+         // is blocked because the request it depends on hasn't been processed yet.
+         notifyAndDetachWaitingRequests(clientSession);
 
-         clientSession->setExpectedSeqNo(seqNo);
+         // Finally, release the sequencing monitor so that other threads
+         // can process their lists of unloaded classes
+         clientSession->getSequencingMonitor()->exit();
          }
 
-      // Update the expecting sequence number. This will allow subsequent
-      // threads to pass through once we've released the sequencing monitor.
-      updateSeqNo(clientSession);
-
-      // Finally, release the sequencing monitor so that other threads
-      // can process their lists of unloaded classes
-      clientSession->getSequencingMonitor()->exit();
+   
 
       // Copy the option strings
       size_t clientOptSize = clientOptStr.size();
@@ -584,6 +613,9 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       }
    catch (const JITServer::StreamFailure &e)
       {
+      // This could happen because the client disconnected on purpose, in which case there is no harm done, 
+      // or if there was a network problem. In the latter case, if the request was critical, the server
+      // will observe a missing seqNo and after a timeout, it will clear the caches and start over
       if (TR::Options::getVerboseOption(TR_VerboseJITServer))
          TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d stream failed while reading the compilation request: %s",
             getCompThreadId(), e.what());
@@ -671,28 +703,26 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       // If the client aborted this compilation it could have happened only while asking for entire
       // CHTable and unloaded class address ranges and at that point the seqNo was not updated.
       // We must update seqNo now to allow for blocking threads to pass through.
-      clientSession->getSequencingMonitor()->enter();
-
-      if (seqNo != clientSession->getExpectedSeqNo())
+      // Since the caches are already cleared there is no harm in discarding this message.
+      if (isCriticalRequest)
          {
-         Trc_JITServerUnexpectedSeqNo(compThread, getCompThreadId(), clientSession,
-               (unsigned long long)clientId, seqNo, clientSession->getExpectedSeqNo(), clientSession->getNumActiveThreads());
+         clientSession->getSequencingMonitor()->enter();
+         if (seqNo > clientSession->getLastProcessedCriticalSeqNo())
+            {
+            Trc_JITServerUpdateSeqNo(getCompilationThread(), getCompThreadId(), clientSession,
+               (unsigned long long)clientSession->getClientUID(),
+               seqNo, getExpectedSeqNo(), clientSession->getNumActiveThreads(),
+               clientSession->getLastProcessedCriticalSeqNo(), seqNo);
 
-         TR_ASSERT(false, "compThreadID=%d clientSessionData=%p clientUID=%llu (seqNo=%u, expectedSeqNo=%u, numActiveThreads=%d) unexpected seqNo",
-               getCompThreadId(), clientSession, (unsigned long long)clientId,
-               seqNo, clientSession->getExpectedSeqNo(), clientSession->getNumActiveThreads());
-
-         clientSession->setExpectedSeqNo(seqNo);
-         }
-
-      updateSeqNo(clientSession);
-      // Release the sequencing monitor so that other threads can process their lists of unloaded classes
-      clientSession->getSequencingMonitor()->exit();
+            clientSession->setLastProcessedCriticalSeqNo(seqNo);
+            notifyAndDetachWaitingRequests(clientSession);
+            }
+         clientSession->getSequencingMonitor()->exit();
+         }      
       }
    catch (const JITServer::StreamOOO &e)
       {
       // Error message was printed when the exception was thrown
-      // TODO: the client should handle this error code
       stream->writeError(compilationStreamLostMessage); // the client should recognize this code and retry
       abortCompilation = true;
       }

--- a/runtime/compiler/control/JITServerCompilationThread.hpp
+++ b/runtime/compiler/control/JITServerCompilationThread.hpp
@@ -51,8 +51,10 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
 
    uint32_t getSeqNo() const { return _seqNo; }; // For ordering requests at the server
    void setSeqNo(uint32_t seqNo) { _seqNo = seqNo; }
-   void updateSeqNo(ClientSessionData *clientSession);
+   uint32_t getExpectedSeqNo() const { return _expectedSeqNo; }
+   void setExpectedSeqNo(uint32_t seqNo) { _expectedSeqNo = seqNo; }
 
+   void notifyAndDetachWaitingRequests(ClientSessionData *clientSession);
    void waitForMyTurn(ClientSessionData *clientSession, TR_MethodToBeCompiled &entry); // Return false if timeout
    bool getWaitToBeNotified() const { return _waitToBeNotified; }
    void setWaitToBeNotified(bool b) { _waitToBeNotified = b; }
@@ -138,6 +140,7 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
 
    TR_PersistentMethodInfo *_recompilationMethodInfo;
    uint32_t _seqNo;
+   uint32_t _expectedSeqNo; // this request is allowed to go if _expectedSeqNo is processed
    bool _waitToBeNotified; // accessed with clientSession->_sequencingMonitor in hand
    IPTableHeap_t *_methodIPDataPerComp;
    TR_ResolvedMethodInfoCache *_resolvedMethodInfoMap;

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -206,13 +206,13 @@ char *compilationErrorNames[]={
    "compilationAOTRelocationRecordGenerationFailure", //54
    "compilationAotPatchedCPConstant", //55
 #if defined(J9VM_OPT_JITSERVER)
-   "compilationStreamFailure", //55
-   "compilationStreamLostMessage", // 56
-   "compilationStreamMessageTypeMismatch", // 57
-   "compilationStreamVersionIncompatible", // 58
-   "compilationStreamInterrupted", // 59
+   "compilationStreamFailure", //56
+   "compilationStreamLostMessage", // 57
+   "compilationStreamMessageTypeMismatch", // 58
+   "compilationStreamVersionIncompatible", // 59
+   "compilationStreamInterrupted", // 60
 #endif /* defined(J9VM_OPT_JITSERVER) */
-   "compilationAotHasInvokeSpecialInterface", //60
+   "compilationAotHasInvokeSpecialInterface", //61
    "compilationMaxError",
 };
 

--- a/runtime/compiler/env/j9jit.tdf
+++ b/runtime/compiler/env/j9jit.tdf
@@ -129,3 +129,7 @@ TraceEvent=Trc_JITServerStreamClientSessionTerminate Overhead=1 Level=1 Test Tem
 TraceEvent=Trc_JITServerStreamInterrupted            Overhead=1 Level=1 Test Template="JITServer: compThreadID=%d (%s) stream interrupted by JITClient (compiling %s @ %s): %s"
 
 TraceEvent=Trc_JIT_portableSharedCache_enabled_or_disabled Overhead=1 Level=3 Test Template="PortableSharedCache is %d"
+
+TraceEvent=Trc_JITServerClientSessionData1   Overhead=1 Level=1 Test Template="JITServer: compThreadID=%d %s clientSessionData=%p for clientUID=%llu seqNo=%u (isCritical=%d) (expectedSeqNo=%u lastProcessedCriticalSeqNo=%u)"
+TraceEvent=Trc_JITServerOutOfSequenceMsg1    Overhead=1 Level=1 Test Template="JITServer: compThreadID=%d clientSessionData=%p clientUID=%llu (entry=%p) (seqNo=%u, expectedSeqNo=%u, numActiveThreads=%d) out-of-sequence msg detected (lastProcessedCriticalSeqNo=%u). Parking this thread"
+

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -33,9 +33,9 @@
 #include "runtime/SymbolValidationManager.hpp"
 
 
-ClientSessionData::ClientSessionData(uint64_t clientUID, uint32_t seqNo) :
-   _clientUID(clientUID), _expectedSeqNo(seqNo), _maxReceivedSeqNo(seqNo), _OOSequenceEntryList(NULL),
-   _chTable(NULL),
+ClientSessionData::ClientSessionData(uint64_t clientUID, uint32_t seqNo) : 
+   _clientUID(clientUID), _expectedSeqNo(seqNo), _maxReceivedSeqNo(seqNo), _lastProcessedCriticalSeqNo(seqNo), 
+   _OOSequenceEntryList(NULL), _chTable(NULL),
    _romClassMap(decltype(_romClassMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _J9MethodMap(decltype(_J9MethodMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _classBySignatureMap(decltype(_classBySignatureMap)::allocator_type(TR::Compiler->persistentAllocator())),

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -403,6 +403,8 @@ class ClientSessionData
    TR_MethodToBeCompiled *notifyAndDetachFirstWaitingThread();
    uint32_t getExpectedSeqNo() const { return _expectedSeqNo; }
    void setExpectedSeqNo(uint32_t seqNo) { _expectedSeqNo = seqNo; }
+   uint32_t getLastProcessedCriticalSeqNo() const { return _lastProcessedCriticalSeqNo; }
+   void setLastProcessedCriticalSeqNo(uint32_t seqNo) { _lastProcessedCriticalSeqNo = seqNo; }
    uint32_t getMaxReceivedSeqNo() const { return _maxReceivedSeqNo; }
    // updateMaxReceivedSeqNo needs to be executed with sequencingMonitor in hand
    void updateMaxReceivedSeqNo(uint32_t seqNo)
@@ -481,6 +483,9 @@ class ClientSessionData
    TR_MethodToBeCompiled *_OOSequenceEntryList;
    uint32_t _expectedSeqNo; // used for ordering compilation requests from the same client
    uint32_t _maxReceivedSeqNo; // the largest seqNo received from this client
+
+   uint32_t _lastProcessedCriticalSeqNo; // highest seqNo processed request carrying info that needs to be applied in order
+
    int8_t  _inUse;  // Number of concurrent compilations from the same client
                     // Accessed with compilation monitor in hand
    int8_t _numActiveThreads; // Number of threads working on compilations for this client


### PR DESCRIPTION
To reduce network communication overhead, the JITServer keeps a cache for
the CHTable (segregated by client UID), which is kept up-to-date with
incremental updates sent by the client. The client keeps track of all the
"new" changes to the CHTable since the last update was sent. When it needs
to send a new compilation request, the client packs all these updates into
a std::string and sends them together with the compilation request.
At the same time, the set of "new" CHTable changes is reset and built anew.

For this mechanism to work, the set of updates needs to be applied at the
server in the same order it was computed at the client. The proper ordering
is accomplished with a sequencing number scheme: when the client computes the
set of CHTable changes to be sent, it will acquire a "ticket" which is nothing
more than a sequenceNumber that is sent together with the updates.
The JITServer receives the updates and must ensure that they are applied in
the order dictated by the sequenceNumber. If an update arrives out-of-order,
the client will "park" the corresponding compilation thread (make it sleep on
a monitor) until its turn comes. The waiting on the monitor has a timeout to
avoid scenarios where a sequenceNumber is completely lost. In that situation,
the JITServer must clear its cache because some important updates may be missing.
Starting with a clear CHTable cache, the JITServer will ask the client for the
entire CHTable, after which the incremental CHTable updates mechanism may start
again.

The mechanism described above is already implemented, but has a shortcoming:
the incoming requests are processed strictly in the order dictated by the client
even though they may not cary any information related to CHTable updates.
This PR relaxes this requirement.

We can distinguish two types of compilation requests: the ones that carry class
load/unload information (critical requests) and the ones that do not.
We must process critical requests strictly in the order in which they were encountered
at the client based on their sequence number. Non-critical requests may be executed
in any order, however, we will impose the following rules:
1) A non-critical request can be executed after a critical request with a higher seqNo.
The reason is that the non-critical request will have more up-to-date information.
2) The opposite is not allowed: a non-critical request with a higher seqNo than a
critical request must wait for the critical request to be processed first.

Implementation
The client will send not only the SeqNo of the current request, but also the SeqNo
of the last critical request. The server receives request seqNo_N and the last critical
request seqNo_M. It then checks whether seqNo_M has been processed and if it did,
then this request can go as well. If not, this request will be parked (put to sleep
into a waiting queue). When a request has been processed, it may need to notify
other requests that are waiting in the queue. It needs to notify all waiting
requests up to and including the next critical request (if there is any).
Only critical requests need to activate threads because a comp request can only
be waiting for a critical request. When activating, we must check that the request
that is being activated does not depend on a critical request that hasn't arrived yet.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>