### PR TITLE
Correct name of NestHost class for value type withfield test class

### DIFF
--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -2777,7 +2777,7 @@ public class ValueTypeTests {
 		 * }
 		 */
 		String fields[] = {"x:I", "y:I"};
-		Class valueClass = ValueTypeGenerator.generateValueClass("UnresolvedD", fields, "HostD");
+		Class valueClass = ValueTypeGenerator.generateValueClass("UnresolvedD", fields, "UsingUnresolvedD");
 		String fields2[] = {};
 		Class usingClass = ValueTypeGenerator.generateHostRefClass("UsingUnresolvedD", fields2, "UnresolvedD", fields);
 

--- a/test/functional/Valhalla/testng.xml
+++ b/test/functional/Valhalla/testng.xml
@@ -28,20 +28,12 @@
 	</listeners>
 	<test name="ValueTypeTests">
 		<classes>
-			<class name="org.openj9.test.lworld.ValueTypeTests">
-				<methods>
-					<exclude name="testUnresolvedWithFieldUse"/>
-				</methods>
-			</class>
+			<class name="org.openj9.test.lworld.ValueTypeTests"/>
 		</classes>
 	</test>
 	<test name="ValueTypeTestsJIT">
 		<classes>
-			<class name="org.openj9.test.lworld.ValueTypeTests">
-				<methods>
-					<exclude name="testUnresolvedWithFieldUse"/>
-				</methods>
-			</class>
+			<class name="org.openj9.test.lworld.ValueTypeTests"/>
 		</classes>
 	</test>
 </suite> <!-- Suite -->


### PR DESCRIPTION
The nest host specified for the value type class `UnresolvedD` is a nonexistent class, `HostD`.  Corrected the name of the nest host to be the actual nest host, `UsingUnresolvedD`.

Also, reenable `testUnresolvedWithFieldUse` test.