### PR TITLE
Perform cleanup in x86 and Z's multianewarrayEvaluator

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1411,6 +1411,7 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
 
    generateRegInstruction(DEC4Reg, node, firstDimLenReg, cg);
    generateLabelInstruction(JA4, node, loopLabel, cg);
+   generateLabelInstruction(JMP4, node, fallThru, cg);
 
    TR::RegisterDependencyConditions  *deps = generateRegisterDependencyConditions((uint8_t)0, 13, cg);
 

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1298,7 +1298,10 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
 
    generateRegMemInstruction(L4RegMem, node, secondDimLenReg,
                              generateX86MemoryReference(dimsPtrReg, 0, cg), cg);
-   generateRegMemInstruction(L4RegMem, node, firstDimLenReg,
+   // Load the 32-bit length value as a 64-bit value so that the top half of the register
+   // can be zeroed out. This will allow us to treat the value as 64-bit when performing
+   // calculations later on.
+   generateRegMemInstruction(MOVSXReg8Mem4, node, firstDimLenReg,
                              generateX86MemoryReference(dimsPtrReg, 4, cg), cg);
 
    generateRegImmInstruction(CMP4RegImm4, node, secondDimLenReg, 0, cg);
@@ -1357,8 +1360,8 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
       }
 
    // temp2Reg = firstDimLenReg * 16 (discontiguousArrayHeaderSizeInBytes)
-   generateRegRegInstruction(MOVRegReg(),  node, temp2Reg, firstDimLenReg, cg);
-   generateRegImmInstruction(SHLRegImm1(), node, temp2Reg, 4, cg);
+   TR_ASSERT_FATAL(zeroArraySize >= 0 && zeroArraySize <= 127, "discontiguousArrayHeaderSizeInBytes cannot be > 127 for IMulRegRegImms instruction");
+   generateRegRegImmInstruction(IMULRegRegImm4(), node, temp2Reg, firstDimLenReg, zeroArraySize, cg);
 
    // temp2Reg = temp2Reg + temp1Reg
    generateRegRegInstruction(ADDRegReg(), node, temp2Reg, temp1Reg, cg);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1252,6 +1252,7 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
 
    // 2-dimensional MultiANewArray
    TR::Compilation *comp = cg->comp();
+   TR_ASSERT_FATAL(comp->target().is64Bit(), "multianewArrayEvaluator is only supported on 64-bit JVMs!");
    TR_J9VMBase *fej9 = static_cast<TR_J9VMBase *>(comp->fe());
 
    TR::Register *dimsPtrReg       = NULL;

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -2973,7 +2973,7 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
 
    // In the mainline, first load the first and second dimensions' lengths into registers.
    TR::Register *firstDimLenReg = cg->allocateRegister();
-   generateRXInstruction(cg, TR::InstOpCode::L, node, firstDimLenReg, generateS390MemoryReference(dimsPtrReg, 4, cg));
+   generateRXInstruction(cg, TR::InstOpCode::LGF, node, firstDimLenReg, generateS390MemoryReference(dimsPtrReg, 4, cg));
 
    TR::Register *secondDimLenReg = cg->allocateRegister();
    generateRXInstruction(cg, TR::InstOpCode::L, node, secondDimLenReg, generateS390MemoryReference(dimsPtrReg, 0, cg));
@@ -3032,7 +3032,8 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
    TR::Register *temp2Reg = cg->allocateRegister();
    TR_ASSERT_FATAL(TR::Compiler->om.discontiguousArrayHeaderSizeInBytes() == 16, "multianewArrayEvaluator - Expecting discontiguousArrayHeaderSizeInBytes to be 16.");
    // temp2Reg = firstDimLenReg * 16 (discontiguousArrayHeaderSizeInBytes)
-   generateRSInstruction(cg, TR::InstOpCode::getShiftLeftLogicalSingleOpCode(), node, temp2Reg, firstDimLenReg, 4);
+   generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, temp2Reg, firstDimLenReg);
+   generateRILInstruction(cg, TR::InstOpCode::MSGFI, node, temp2Reg, zeroArraySize);
 
    generateRRInstruction(cg, TR::InstOpCode::getAddRegOpCode(), node, temp2Reg, temp1Reg);
 

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -2987,16 +2987,16 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
    // First dimension zero, so only allocate 1 zero-length object array
    int32_t zeroArraySize = TR::Compiler->om.discontiguousArrayHeaderSizeInBytes();
    TR::Register *vmThreadReg = cg->getMethodMetaDataRealRegister();
-   generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, targetReg, generateS390MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg));
+   generateRXInstruction(cg, TR::InstOpCode::LG, node, targetReg, generateS390MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg));
 
    // Branch to OOL if there's not enough space for an array of size 0.
    TR::Register *temp1Reg = cg->allocateRegister();
-   generateRIEInstruction(cg, TR::InstOpCode::getAddHalfWordImmDistinctOperandOpCode(), node, temp1Reg, targetReg, zeroArraySize);
-   generateRXInstruction(cg, TR::InstOpCode::getCmpLogicalOpCode(), node, temp1Reg, generateS390MemoryReference(vmThreadReg, offsetof(J9VMThread, heapTop), cg));
+   generateRIEInstruction(cg, TR::InstOpCode::AGHIK, node, temp1Reg, targetReg, zeroArraySize);
+   generateRXInstruction(cg, TR::InstOpCode::CLG, node, temp1Reg, generateS390MemoryReference(vmThreadReg, offsetof(J9VMThread, heapTop), cg));
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BH, node, oolJumpLabel);
 
    // If there's enough space, then we can continue to allocate.
-   generateRXInstruction(cg, TR::InstOpCode::getStoreOpCode(), node, temp1Reg, generateS390MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg));
+   generateRXInstruction(cg, TR::InstOpCode::STG, node, temp1Reg, generateS390MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg));
    
    bool use64BitClasses = comp->target().is64Bit() && !TR::Compiler->om.generateCompressedObjectHeaders();
 
@@ -3008,7 +3008,7 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, nonZeroFirstDimLabel);
 
    TR::Register *componentClassReg = cg->allocateRegister();
-   generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, componentClassReg, generateS390MemoryReference(classReg, offsetof(J9ArrayClass, componentType), cg));
+   generateRXInstruction(cg, TR::InstOpCode::LG, node, componentClassReg, generateS390MemoryReference(classReg, offsetof(J9ArrayClass, componentType), cg));
 
    // Calculate maximum allowable object size in elements and jump to OOL if it's higher than firstDimLenReg.
    int32_t elementSize = TR::Compiler->om.sizeofReferenceField();
@@ -3032,38 +3032,28 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
    TR::Register *temp2Reg = cg->allocateRegister();
    TR_ASSERT_FATAL(TR::Compiler->om.discontiguousArrayHeaderSizeInBytes() == 16, "multianewArrayEvaluator - Expecting discontiguousArrayHeaderSizeInBytes to be 16.");
    // temp2Reg = firstDimLenReg * 16 (discontiguousArrayHeaderSizeInBytes)
-   generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, temp2Reg, firstDimLenReg);
+   generateRRInstruction(cg, TR::InstOpCode::LGR, node, temp2Reg, firstDimLenReg);
    generateRILInstruction(cg, TR::InstOpCode::MSGFI, node, temp2Reg, zeroArraySize);
 
-   generateRRInstruction(cg, TR::InstOpCode::getAddRegOpCode(), node, temp2Reg, temp1Reg);
+   generateRRInstruction(cg, TR::InstOpCode::AGR, node, temp2Reg, temp1Reg);
 
-   generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, targetReg, generateS390MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg));
-   generateRRInstruction(cg, TR::InstOpCode::getAddRegOpCode(), node, temp2Reg, targetReg);
-   generateRXInstruction(cg, TR::InstOpCode::getCmpLogicalOpCode(), node, temp2Reg, generateS390MemoryReference(vmThreadReg, offsetof(J9VMThread, heapTop), cg));
+   generateRXInstruction(cg, TR::InstOpCode::LG, node, targetReg, generateS390MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg));
+   generateRRInstruction(cg, TR::InstOpCode::AGR, node, temp2Reg, targetReg);
+   generateRXInstruction(cg, TR::InstOpCode::CLG, node, temp2Reg, generateS390MemoryReference(vmThreadReg, offsetof(J9VMThread, heapTop), cg));
 
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BH, node, oolJumpLabel);
 
    // We have enough space, so proceed with the allocation.
-   generateRXInstruction(cg, TR::InstOpCode::getStoreOpCode(), node, temp2Reg, generateS390MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg));
+   generateRXInstruction(cg, TR::InstOpCode::STG, node, temp2Reg, generateS390MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg));
 
    // Init 1st dim array class and size fields.
    generateRXInstruction(cg, use64BitClasses ? TR::InstOpCode::STG : TR::InstOpCode::ST, node, classReg, generateS390MemoryReference(targetReg, TR::Compiler->om.offsetOfObjectVftField(), cg));
    generateRXInstruction(cg, TR::InstOpCode::ST, node, firstDimLenReg, generateS390MemoryReference(targetReg, fej9->getOffsetOfContiguousArraySizeField(), cg));
 
    // temp2 point to end of 1st dim array i.e. start of 2nd dim
-   generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, temp2Reg, targetReg);
-   generateRRInstruction(cg, TR::InstOpCode::getAddRegOpCode(), node, temp2Reg, temp1Reg);
-   generateRIEInstruction(cg, TR::InstOpCode::getAddHalfWordImmDistinctOperandOpCode(), node, temp1Reg, targetReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
-
-   uintptr_t heapBase = TR::Compiler->vm.heapBaseAddress();
-   bool useRegForHeapBase = comp->target().is64Bit() && comp->useCompressedPointers() &&
-                           (heapBase != 0) && (!IS_32BIT_SIGNED(heapBase) || TR::Compiler->om.nativeAddressesCanChangeSize());
-   if (useRegForHeapBase)
-      {
-      uint32_t high32 = heapBase >> 32;
-      generateRILInstruction(cg, TR::InstOpCode::LLIHF, node, secondDimLenReg, high32);
-      generateRILInstruction(cg, TR::InstOpCode::IILF, node, secondDimLenReg, static_cast<uint32_t>(heapBase));
-      }
+   generateRRInstruction(cg, TR::InstOpCode::LGR, node, temp2Reg, targetReg);
+   generateRRInstruction(cg, TR::InstOpCode::AGR, node, temp2Reg, temp1Reg);
+   generateRIEInstruction(cg, TR::InstOpCode::AGHIK, node, temp1Reg, targetReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
 
    // Loop start
    TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
@@ -3077,33 +3067,21 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
    if (comp->target().is64Bit() && comp->useCompressedPointers())
       {
       int32_t shiftAmount = TR::Compiler->om.compressedReferenceShift();
-      generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, temp3Reg, temp2Reg);
-
-      if (heapBase != 0)
-         {
-         if (useRegForHeapBase)
-            {
-            generateRRInstruction(cg, TR::InstOpCode::getSubstractRegOpCode(), node, temp3Reg, secondDimLenReg);
-            }
-         else
-            {
-            generateRILInstruction(cg, TR::InstOpCode::getSubtractLogicalImmOpCode(), node, temp3Reg, static_cast<int32_t>(heapBase));
-            }
-         }
+      generateRRInstruction(cg, TR::InstOpCode::LGR, node, temp3Reg, temp2Reg);
       if (shiftAmount != 0)
          {
-         generateRSInstruction(cg, comp->target().is64Bit() ? TR::InstOpCode::SRAG : TR::InstOpCode::SRAK, node, temp3Reg, temp3Reg, shiftAmount);
+         generateRSInstruction(cg, TR::InstOpCode::SRAG, node, temp3Reg, temp3Reg, shiftAmount);
          }
       generateRXInstruction(cg, TR::InstOpCode::ST, node, temp3Reg, generateS390MemoryReference(temp1Reg, 0, cg));
       }
    else
       {
-      generateRXInstruction(cg, TR::InstOpCode::getStoreOpCode(), node, temp2Reg, generateS390MemoryReference(temp1Reg, 0, cg));
+      generateRXInstruction(cg, TR::InstOpCode::STG, node, temp2Reg, generateS390MemoryReference(temp1Reg, 0, cg));
       }
 
    // Advance cursors temp1 and temp2. Then branch back or fall through if done.
-   generateRIInstruction(cg, TR::InstOpCode::getAddHalfWordImmOpCode(), node, temp2Reg, TR::Compiler->om.discontiguousArrayHeaderSizeInBytes());
-   generateRIInstruction(cg, TR::InstOpCode::getAddHalfWordImmOpCode(), node, temp1Reg, elementSize);
+   generateRIInstruction(cg, TR::InstOpCode::AGHI, node, temp2Reg, TR::Compiler->om.discontiguousArrayHeaderSizeInBytes());
+   generateRIInstruction(cg, TR::InstOpCode::AGHI, node, temp1Reg, elementSize);
 
    generateRILInstruction(cg, TR::InstOpCode::SLFI, node, firstDimLenReg, 1);
    generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::CL, node, firstDimLenReg, 0, TR::InstOpCode::COND_BNE, loopLabel, false);
@@ -3127,7 +3105,7 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionEnd, dependencies);
 
    TR::Register *targetRegisterFinal = cg->allocateCollectedReferenceRegister();
-   generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, targetRegisterFinal, targetReg);
+   generateRRInstruction(cg, TR::InstOpCode::LGR, node, targetRegisterFinal, targetReg);
 
    // Generate the OOL code before final bookkeeping.
    TR_S390OutOfLineCodeSection *outlinedSlowPath = new (cg->trHeapMemory()) TR_S390OutOfLineCodeSection(oolFailLabel, cFlowRegionEnd, cg);
@@ -3140,7 +3118,7 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
    TR::Register *targetReg2 = TR::TreeEvaluator::performCall(node, false, cg);
    TR::Node::recreate(node, opCode);
 
-   generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, targetReg, targetReg2);
+   generateRRInstruction(cg, TR::InstOpCode::LGR, node, targetReg, targetReg2);
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, cFlowRegionEnd);
    outlinedSlowPath->swapInstructionListsWithCompilation();
 

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -2945,6 +2945,7 @@ TR::Register *
 J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    TR::Compilation *comp = cg->comp();
+   TR_ASSERT_FATAL(comp->target().is64Bit(), "multianewArrayEvaluator is only supported on 64-bit JVMs!");
    TR_J9VMBase *fej9 = static_cast<TR_J9VMBase *>(comp->fe());
    TR::Register *targetReg = cg->allocateRegister();
 
@@ -3030,7 +3031,6 @@ J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator
       }
 
    TR::Register *temp2Reg = cg->allocateRegister();
-   TR_ASSERT_FATAL(TR::Compiler->om.discontiguousArrayHeaderSizeInBytes() == 16, "multianewArrayEvaluator - Expecting discontiguousArrayHeaderSizeInBytes to be 16.");
    // temp2Reg = firstDimLenReg * 16 (discontiguousArrayHeaderSizeInBytes)
    generateRRInstruction(cg, TR::InstOpCode::LGR, node, temp2Reg, firstDimLenReg);
    generateRILInstruction(cg, TR::InstOpCode::MSGFI, node, temp2Reg, zeroArraySize);


### PR DESCRIPTION
This commit does the following in the above evaluator:
- Remove unreachable code
- Uses the OMR::align API to calculate alignment compensation
- Fix an RA bug where multiple jump instructions to OOL code are
  created. This is incorrect as the RA will only account for the
  last jump point to the OOL code when doing assignment.
- Add C++ casts
- Simplify calculation of elementSize
- Simplify instructions comparing firstDimLenReg and
  maxObjectSizeInElements

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>