### PR TITLE
JDK16 Changes

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -431,11 +431,15 @@ final class Access implements JavaLangAccess {
 	}
 /*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
-	/*[IF JAVA_SPEC_VERSION >= 16]*/
+/*[IF JAVA_SPEC_VERSION >= 16]*/
 	public void bindToLoader(ModuleLayer ml, ClassLoader cl) {
 		ml.bindToLoader(cl);
 	}
-	/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
+
+	public void addExports(Module fromModule, String pkg) {
+		fromModule.implAddExports(pkg);
+	}
+/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 
 /*[ENDIF] Sidecar19-SE */
 }

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -113,6 +113,31 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 	}
 
+/*[IF JAVA_SPEC_VERSION >= 16]*/
+	/**
+	 * Copy bytes from value starting at srcIndex into the bytes array starting at
+	 * destIndex. No range checking is needed. Caller ensures bytes is in UTF16.
+	 * 
+	 * @param bytes copy destination
+	 * @param srcIndex index into value
+	 * @param destIndex index into bytes
+	 * @param coder LATIN1 or UTF16
+	 * @param length the number of elements to copy
+	 */
+	void getBytes(byte[] bytes, int srcIndex, int destIndex, byte coder, int length) {
+		// Check if the String is compressed
+		if (enableCompression && (null == compressionFlag || this.coder == LATIN1)) {
+			if (String.LATIN1 == coder) {
+				compressedArrayCopy(value, srcIndex, bytes, destIndex, length);
+			} else {
+				decompress(value, srcIndex, bytes, destIndex, length);
+			}
+		} else {
+			decompressedArrayCopy(value, srcIndex, bytes, destIndex, length);
+		}
+	}
+/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
+	
 	// no range checking, caller ensures bytes is in UTF16
 	// coder is one of LATIN1 or UTF16
 	void getBytes(byte[] bytes, int offset, byte coder) {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -162,14 +162,20 @@ public class MethodHandles {
 		 */
 		public static final int UNCONDITIONAL = 0x20;
 		/*[ENDIF] Sidecar19-SE*/
-		
-		static final int INTERNAL_PRIVILEGED = 0x40;
 
-		/*[IF Sidecar19-SE-OpenJ9]
+		static final int INTERNAL_PRIVILEGED = 0x80;
+
+		/*[IF JAVA_SPEC_VERSION >= 16]*/
+		public static final int ORIGINAL = 0x40;
+
+		private static final int FULL_ACCESS_MASK = PUBLIC | PRIVATE | PROTECTED | PACKAGE | MODULE | ORIGINAL;
+		/*[ELSE] JAVA_SPEC_VERSION >= 16*/
+		/*[IF Sidecar19-SE-OpenJ9]*/
 		private static final int FULL_ACCESS_MASK = PUBLIC | PRIVATE | PROTECTED | PACKAGE | MODULE;
 		/*[ELSE]*/
 		private static final int FULL_ACCESS_MASK = PUBLIC | PRIVATE | PROTECTED | PACKAGE;
 		/*[ENDIF] Sidecar19-SE-OpenJ9*/
+		/*[ENDIF] JAVA_SPEC_VERSION >= 16*/
 		
 		private static final int NO_ACCESS = 0;
 		
@@ -2358,6 +2364,41 @@ public class MethodHandles {
 			ClassDefiner definer = classDefiner(bytes, classOptions);
 			return new Lookup(definer.defineClass(initOption));
 		}
+		
+		/*[IF JAVA_SPEC_VERSION >= 16]*/
+		/**
+		 * Constructs a new hidden class from an array of class file bytes.
+		 * Equivalent to defineHiddenClass(bytes, true, classOptions).
+		 * 
+		 * @param bytes the class file bytes of the hidden class to be defined.
+		 * @param classData the classData to be stored in the hidden class.
+		 * @param initOption whether to initialize the hidden class.
+		 * @param classOptions the {@link ClassOption} to define the hidden class.
+		 * 
+		 * @return A Lookup object of the newly created hidden class.
+		 * @throws IllegalAccessException if this Lookup does not have full privilege access.
+		 */
+		public Lookup defineHiddenClassWithClassData(byte[] bytes, Object classData, boolean initOption, ClassOption... classOptions) throws IllegalAccessException {
+			ClassDefiner definer = classDefiner(bytes, classOptions);
+			return new Lookup(definer.defineClass(initOption, classData));
+		}
+		/*[ELSE] JAVA_SPEC_VERSION >= 16*/
+		/**
+		 * Constructs a new hidden class from an array of class file bytes.
+		 * Equivalent to defineHiddenClass(bytes, true, classOptions).
+		 * 
+		 * @param bytes the class file bytes of the hidden class to be defined.
+		 * @param classData the classData to be stored in the hidden class.
+		 * @param classOptions the {@link ClassOption} to define the hidden class.
+		 * 
+		 * @return A Lookup object of the newly created hidden class.
+		 * @throws IllegalAccessException if this Lookup does not have full privilege access.
+		 */
+		Lookup defineHiddenClassWithClassData(byte[] bytes, Object classData, ClassOption... classOptions) throws IllegalAccessException {
+			ClassDefiner definer = classDefiner(bytes, classOptions);
+			return new Lookup(definer.defineClass(true, classData));
+		}
+		/*[ENDIF] JAVA_SPEC_VERSION >= 16*/
 		
 		/**
 		 * Constructs a new hidden class from an array of class file bytes.


### PR DESCRIPTION
1. Add `String.getBytes` for JDK16.

2. Add `Lookup.ORIGINAL` and update `defineHiddenClassWithClassData` for JDK16.

3. Add implementation of `JavaLangAccess.addExports` for JDK16.

Closes: #11312

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>