### PR TITLE
Update ROMClass walk implementation to support ROMClass serialization in JITServer

### DIFF
--- a/runtime/oti/dbg.h
+++ b/runtime/oti/dbg.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -190,8 +190,11 @@ typedef struct J9LineNumber {
 } J9LineNumber;
 
 typedef struct J9VariableInfoValues {
+    J9SRP* nameSrp;
     struct J9UTF8* name;
+    J9SRP* signatureSrp;
     struct J9UTF8* signature;
+    J9SRP* genericSignatureSrp;
     struct J9UTF8* genericSignature;
     U_32 startVisibility;
     U_32 visibilityLength;

--- a/runtime/util/optinfo.c
+++ b/runtime/util/optinfo.c
@@ -580,15 +580,19 @@ variableInfoNextDo(J9VariableInfoWalkState *state)
 		return NULL;
 	}
 
+	state->values.nameSrp = (J9SRP *)state->variableTablePtr;
 	state->values.name = READ_SRP(state->variableTablePtr, J9UTF8*);
 	state->variableTablePtr += sizeof(J9SRP);
+	state->values.signatureSrp = (J9SRP *)state->variableTablePtr;
 	state->values.signature = READ_SRP(state->variableTablePtr, J9UTF8*);
 	state->variableTablePtr += sizeof(J9SRP);
 
 	if (state->values.visibilityLength & J9_ROMCLASS_OPTINFO_VARIABLE_TABLE_HAS_GENERIC) {
+		state->values.genericSignatureSrp = (J9SRP *)state->variableTablePtr;
 		state->values.genericSignature = READ_SRP(state->variableTablePtr, J9UTF8*);
 		state->variableTablePtr += sizeof(J9SRP);
 	} else {
+		state->values.genericSignatureSrp = 0;
 		state->values.genericSignature = NULL;
 	}
 

--- a/runtime/util/romclasswalk.c
+++ b/runtime/util/romclasswalk.c
@@ -1245,18 +1245,18 @@ allSlotsInMethodDebugInfoDo(J9ROMClass* romClass, U_32* cursor, J9ROMClassWalkCa
 
 		while (NULL != values) {
 			/* Need to walk the name and signature to add them to the UTF8 section */
-			rangeValid = callbacks->validateRangeCallback(romClass, values->name, sizeof(J9UTF8), userData);
+			rangeValid = callbacks->validateRangeCallback(romClass, values->nameSrp, sizeof(J9SRP), userData);
 			if (rangeValid) {
-				callbacks->slotCallback(romClass, J9ROM_UTF8_NOSRP, values->name, "name", userData);
+				callbacks->slotCallback(romClass, J9ROM_UTF8, values->nameSrp, "name", userData);
 			}
-			rangeValid = callbacks->validateRangeCallback(romClass, values->signature, sizeof(J9UTF8), userData);
+			rangeValid = callbacks->validateRangeCallback(romClass, values->signatureSrp, sizeof(J9SRP), userData);
 			if (rangeValid) {
-				callbacks->slotCallback(romClass, J9ROM_UTF8_NOSRP, values->signature, "signature", userData);
+				callbacks->slotCallback(romClass, J9ROM_UTF8, values->signatureSrp, "signature", userData);
 			}
 			if (NULL != values->genericSignature) {
-				rangeValid = callbacks->validateRangeCallback(romClass, values->genericSignature, sizeof(J9UTF8), userData);
+				rangeValid = callbacks->validateRangeCallback(romClass, values->genericSignatureSrp, sizeof(J9SRP), userData);
 				if (rangeValid) {
-					callbacks->slotCallback(romClass, J9ROM_UTF8_NOSRP, values->genericSignature, "genericSignature", userData);
+					callbacks->slotCallback(romClass, J9ROM_UTF8, values->genericSignatureSrp, "genericSignature", userData);
 				}
 			}
 

--- a/runtime/util/romclasswalk.c
+++ b/runtime/util/romclasswalk.c
@@ -1247,16 +1247,16 @@ allSlotsInMethodDebugInfoDo(J9ROMClass* romClass, U_32* cursor, J9ROMClassWalkCa
 			/* Need to walk the name and signature to add them to the UTF8 section */
 			rangeValid = callbacks->validateRangeCallback(romClass, values->nameSrp, sizeof(J9SRP), userData);
 			if (rangeValid) {
-				callbacks->slotCallback(romClass, J9ROM_UTF8, values->nameSrp, "name", userData);
+				callbacks->slotCallback(romClass, J9ROM_UTF8, values->nameSrp, "variableName", userData);
 			}
 			rangeValid = callbacks->validateRangeCallback(romClass, values->signatureSrp, sizeof(J9SRP), userData);
 			if (rangeValid) {
-				callbacks->slotCallback(romClass, J9ROM_UTF8, values->signatureSrp, "signature", userData);
+				callbacks->slotCallback(romClass, J9ROM_UTF8, values->signatureSrp, "variableSignature", userData);
 			}
 			if (NULL != values->genericSignature) {
 				rangeValid = callbacks->validateRangeCallback(romClass, values->genericSignatureSrp, sizeof(J9SRP), userData);
 				if (rangeValid) {
-					callbacks->slotCallback(romClass, J9ROM_UTF8, values->genericSignatureSrp, "genericSignature", userData);
+					callbacks->slotCallback(romClass, J9ROM_UTF8, values->genericSignatureSrp, "variableGenericSignature", userData);
 				}
 			}
 

--- a/runtime/util/romclasswalk.c
+++ b/runtime/util/romclasswalk.c
@@ -113,7 +113,7 @@ void allSlotsInROMClassDo(J9ROMClass* romClass,
 	SLOT_CALLBACK(romClass, J9ROM_UTF8, romClass, className);
 	SLOT_CALLBACK(romClass, J9ROM_UTF8, romClass, superclassName);
 	SLOT_CALLBACK(romClass, J9ROM_U32,  romClass, modifiers);
-	SLOT_CALLBACK(romClass, J9ROM_U32,  romClass, extraModifiers);	
+	SLOT_CALLBACK(romClass, J9ROM_U32,  romClass, extraModifiers);
 	SLOT_CALLBACK(romClass, J9ROM_U32,  romClass, interfaceCount);
 	SLOT_CALLBACK(romClass, J9ROM_SRP,  romClass, interfaces);
 	SLOT_CALLBACK(romClass, J9ROM_U32,  romClass, romMethodCount);
@@ -137,7 +137,7 @@ void allSlotsInROMClassDo(J9ROMClass* romClass,
 	SLOT_CALLBACK(romClass, J9ROM_U32,  romClass, innerClassCount);
 	SLOT_CALLBACK(romClass, J9ROM_SRP,  romClass, innerClasses);
 #if JAVA_SPEC_VERSION >= 11
-	SLOT_CALLBACK(romClass, J9ROM_SRP,  romClass, nestHost);
+	SLOT_CALLBACK(romClass, J9ROM_UTF8, romClass, nestHost);
 	SLOT_CALLBACK(romClass, J9ROM_U16,  romClass, nestMemberCount);
 	SLOT_CALLBACK(romClass, J9ROM_U16,  romClass, unused);
 	SLOT_CALLBACK(romClass, J9ROM_SRP,  romClass, nestMembers);
@@ -1071,7 +1071,7 @@ static void allSlotsInStackMapDo(J9ROMClass* romClass, U_8 *stackMap, J9ROMClass
 }
 
 
-static UDATA 
+static UDATA
 allSlotsInMethodParametersDataDo(J9ROMClass* romClass, U_8 * cursor, J9ROMClassWalkCallbacks* callbacks, void* userData)
 {
 	J9MethodParametersData* methodParametersData = (J9MethodParametersData* )cursor;
@@ -1093,7 +1093,7 @@ allSlotsInMethodParametersDataDo(J9ROMClass* romClass, U_8 * cursor, J9ROMClassW
 		SLOT_CALLBACK(romClass, J9ROM_U8, methodParametersData, parameterCount);
 
 		for (; i < methodParametersData->parameterCount; i++) {
-			callbacks->slotCallback(romClass, J9ROM_SRP, &parameters[i].name, "methodParameterName", userData);
+			callbacks->slotCallback(romClass, J9ROM_UTF8, &parameters[i].name, "methodParameterName", userData);
 			callbacks->slotCallback(romClass, J9ROM_U16, &parameters[i].flags, "methodParameterFlag", userData);
 		}
 	}


### PR DESCRIPTION
JITServer will use ROMClass walk (`allSlotsInROMClassDo()` from `romclasswalk.c`) to fully serialize a ROMClass (including possibly interned UTF8 strings that it refers to) when it's sent from the client to the server. This PR updates the walk implementation such that it properly visits all SRPs to UTF8 strings in the ROMClass:
- Some `J9ROM_SRP` slots are changed to `J9ROM_UTF8` since they actually point to UTF8 strings.
- `J9ROM_UTF8` is used instead of `J9ROM_UTF8_NOSRP` for strings in method debug info.
- Out-of-line method debug info is walked unless skipped by the `validateRangeCallback`. (This shouldn't affect any existing code that uses ROMClass walk.)