### PR TITLE
Fully serialize ROMClasses sent to JITServer

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1517,44 +1517,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, method->getUnresolvedFieldInCP(cpIndex));
          }
          break;
-      case MessageType::ResolvedMethod_getRemoteROMString:
-         {
-         auto recv = client->getRecvData<TR_ResolvedJ9Method *, size_t, std::string>();
-         TR_ResolvedJ9Method *method = std::get<0>(recv);
-         size_t offsetFromROMClass = std::get<1>(recv);
-         std::string offsetsStr = std::get<2>(recv);
-         size_t numOffsets = offsetsStr.size() / sizeof(size_t);
-         size_t *offsets = (size_t*) &offsetsStr[0];
-         uint8_t *ptr = (uint8_t*) method->romClassPtr() + offsetFromROMClass;
-         for (size_t i = 0; i < numOffsets; i++)
-            {
-            size_t offset = offsets[i];
-            ptr = ptr + offset + *(J9SRP*)(ptr + offset);
-            }
-         int32_t len;
-         char * data = utf8Data((J9UTF8*) ptr, len);
-         client->write(response, std::string(data, len));
-         }
-         break;
-      case MessageType::ClassInfo_getRemoteROMString:
-         {
-         auto recv = client->getRecvData<J9ROMClass *, size_t, std::string>();
-         J9ROMClass *romClass = std::get<0>(recv);
-         size_t offsetFromROMClass = std::get<1>(recv);
-         std::string offsetsStr = std::get<2>(recv);
-         size_t numOffsets = offsetsStr.size() / sizeof(size_t);
-         size_t *offsets = (size_t*) &offsetsStr[0];
-         uint8_t *ptr = (uint8_t*) romClass + offsetFromROMClass;
-         for (size_t i = 0; i < numOffsets; i++)
-            {
-            size_t offset = offsets[i];
-            ptr = ptr + offset + *(J9SRP*)(ptr + offset);
-            }
-         int32_t len;
-         char * data = utf8Data((J9UTF8*) ptr, len);
-         client->write(response, std::string(data, len));
-         }
-         break;
       case MessageType::ResolvedMethod_fieldOrStaticName:
          {
          auto recv = client->getRecvData<TR_ResolvedJ9Method *, int32_t>();

--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -25,10 +25,13 @@
 #include "control/CompilationRuntime.hpp"
 #include "control/JITServerCompilationThread.hpp"
 #include "control/MethodToBeCompiled.hpp"
+#include "env/StackMemoryRegion.hpp"
 #include "infra/CriticalSection.hpp"
 #include "infra/Statistics.hpp"
 #include "net/CommunicationStream.hpp"
 #include "OMR/Bytes.hpp"// for OMR::alignNoCheck()
+#include "romclasswalk.h"
+#include "util_api.h"// for allSlotsInROMClassDo()
 
 
 uint32_t     JITServerHelpers::serverMsgTypeCount[] = {};
@@ -44,84 +47,306 @@ TR::Monitor *JITServerHelpers::_clientStreamMonitor = NULL;
 static size_t
 getUTF8Size(const J9UTF8 *str)
    {
-   return OMR::alignNoCheck(str->length, sizeof(*str)) + sizeof(*str);
+   return OMR::alignNoCheck(J9UTF8_TOTAL_SIZE(str), sizeof(*str));
    }
 
+// Copies a UTF8 string and returns its total size including the padding.
+// src doesn't have to be padded, dst is padded.
 static size_t
-getPackedUTF8Size(const J9UTF8 *str, const J9ROMClass *romClass)
+copyUTF8(J9UTF8 *dst, const J9UTF8 *src)
    {
-   return JITServerHelpers::isAddressInROMClass(str, romClass) ? 0 : getUTF8Size(str);
+   size_t size = J9UTF8_TOTAL_SIZE(src);
+   memcpy(dst, src, size);
+   static_assert(sizeof(*src) == 2, "UTF8 header is not 2 bytes large");
+   // If the length is not aligned, pad the destination string with a zero
+   if (!OMR::alignedNoCheck(size, sizeof(*src)))
+      dst->data[src->length] = '\0';
+   return getUTF8Size(src);
    }
 
-// If the string points outside of the contiguous part of origRomClass, appends
-// it (with padding) at curPos and updates the SRP to the string in the packed
-// ROMClass. Returns the new value of curPos.
-static uint8_t *
-packUTF8(uint8_t *curPos, const J9UTF8 *origStr, const J9ROMClass *origRomClass, J9SRP &srp)
+// State maintained while iterating over UTF8 strings in a ROMClass
+struct ROMClassPackContext
    {
-   if (JITServerHelpers::isAddressInROMClass(origStr, origRomClass))
-      return curPos;
+   ROMClassPackContext(TR_Memory *trMemory, size_t origSize) :
+      _origSize(origSize), _callback(NULL), _stringsSize(0),
+      _utf8SectionStart((const uint8_t *)-1), _utf8SectionEnd(NULL), _utf8SectionSize(0),
+      _strToOffsetMap(decltype(_strToOffsetMap)::allocator_type(trMemory->currentStackRegion())),
+      _packedRomClass(NULL), _cursor(NULL) {}
 
-   size_t size = getUTF8Size(origStr);
-   memcpy(curPos, origStr, origStr->length + sizeof(*origStr));
-   static_assert(sizeof(*origStr) == 2, "UTF8 header is not 2 bytes large");
-   if (!OMR::alignedNoCheck(origStr->length, sizeof(*origStr)))
-      curPos[size - 1] = '\0';
-   NNSRP_SET(srp, curPos);
-   return curPos + size;
+   bool isInline(const void *address, const J9ROMClass *romClass)
+      {
+      return (address >= romClass) && (address < (uint8_t *)romClass + _origSize);
+      }
+
+   typedef void (*Callback)(const J9ROMClass *, const J9SRP *, ROMClassPackContext &);
+
+   const size_t _origSize;
+   Callback _callback;
+   size_t _stringsSize;
+   const uint8_t *_utf8SectionStart;
+   const uint8_t *_utf8SectionEnd;// only needed for assertions
+   size_t _utf8SectionSize;// only needed for assertions
+   // Maps original strings to their offsets from UTF8 section start in the packed ROMClass
+   // Offset value -1 signifies that the string is skipped
+   UnorderedMap<const J9UTF8 *, size_t> _strToOffsetMap;
+   J9ROMClass *_packedRomClass;
+   uint8_t *_cursor;
+   };
+
+// Updates size info and maps original string to its future location in the packed ROMClass
+static void
+sizeInfoCallback(const J9ROMClass *romClass, const J9SRP *origSrp, ROMClassPackContext &ctx)
+   {
+   // Skip SRPs stored outside of the ROMClass bounds such as the ones in out-of-line method debug info
+   bool skip = !ctx.isInline(origSrp, romClass);
+   auto str = NNSRP_PTR_GET(origSrp, const J9UTF8 *);
+   auto it = ctx._strToOffsetMap.find(str);
+   if (it != ctx._strToOffsetMap.end())// duplicate - already visited
+      {
+      if (!skip && (it->second == (size_t)-1))
+         {
+         // Previously visited SRPs to this string were skipped, but this one isn't
+         it->second = ctx._stringsSize;
+         ctx._stringsSize += getUTF8Size(str);
+         }
+      return;
+      }
+
+   ctx._strToOffsetMap.insert(it, { str, skip ? (size_t)-1 : ctx._stringsSize });
+   size_t size = getUTF8Size(str);
+   ctx._stringsSize += skip ? 0 : size;
+
+   if (ctx.isInline(str, romClass))
+      {
+      ctx._utf8SectionStart = std::min(ctx._utf8SectionStart, (const uint8_t *)str);
+      ctx._utf8SectionEnd = std::max(ctx._utf8SectionEnd, (const uint8_t *)str + size);
+      ctx._utf8SectionSize += size;
+      }
+   }
+
+// Copies original string into its location in the packed ROMClass and updates the SRP to it
+static void
+packCallback(const J9ROMClass *romClass, const J9SRP *origSrp, ROMClassPackContext &ctx)
+   {
+   // Skip SRPs stored outside of the ROMClass bounds such as the ones in out-of-line method debug info
+   if (!ctx.isInline(origSrp, romClass))
+      return;
+
+   auto str = NNSRP_PTR_GET(origSrp, const J9UTF8 *);
+   auto srp = (J9SRP *)((uint8_t *)ctx._packedRomClass + ((uint8_t *)origSrp - (uint8_t *)romClass));
+
+   auto it = ctx._strToOffsetMap.find(str);
+   TR_ASSERT(it != ctx._strToOffsetMap.end(), "UTF8 slot not visited in 1st pass");
+   auto dst = (uint8_t *)ctx._packedRomClass + (ctx._utf8SectionStart - (uint8_t *)romClass) + it->second;
+
+   NNSRP_PTR_SET(srp, dst);
+   if (dst == ctx._cursor)
+      ctx._cursor += copyUTF8((J9UTF8 *)dst, str);
+   else
+      TR_ASSERT((dst < ctx._cursor) && (memcmp(dst, str, J9UTF8_TOTAL_SIZE(str)) == 0), "Must be already copied");
+   }
+
+static void
+utf8SlotCallback(const J9ROMClass *romClass, const J9SRP *srp, void *userData)
+   {
+   auto &ctx = *(ROMClassPackContext *)userData;
+   if (*srp)
+      ctx._callback(romClass, srp, ctx);
+   }
+
+// Invoked for each slot in a ROMClass. Calls ctx._callback for all non-null SRPs to UTF8 strings.
+static void
+slotCallback(J9ROMClass *romClass, uint32_t slotType, void *slotPtr, const char *slotName, void *userData)
+   {
+   switch (slotType)
+      {
+      case J9ROM_UTF8:
+         utf8SlotCallback(romClass, (const J9SRP *)slotPtr, userData);
+         break;
+
+      case J9ROM_NAS:
+         if (auto nas = SRP_PTR_GET(slotPtr, const J9ROMNameAndSignature *))
+            {
+            utf8SlotCallback(romClass, &nas->name, userData);
+            utf8SlotCallback(romClass, &nas->signature, userData);
+            }
+         break;
+      }
+   }
+
+static bool
+isArrayROMClass(const J9ROMClass *romClass)
+   {
+   if (!J9ROMCLASS_IS_ARRAY(romClass))
+      return false;
+
+   auto name = J9ROMCLASS_CLASSNAME(romClass);
+   TR_ASSERT((name->length == 2) && (name->data[0] == '['),
+             "Unexpected array ROMClass name: %.*s", name->length, name->data);
+   return true;
+   }
+
+// Array ROMClasses have a different layout (see runtime/vm/romclasses.c):
+// they all share the same SRP array of interfaces, which breaks the generic
+// packing implementation. Instead, we manually pack all the data stored
+// outside of the ROMClass header: class name, superclass name, interfaces.
+// This function returns the total size of the packed array ROMClass.
+static size_t
+getArrayROMClassPackedSize(const J9ROMClass *romClass)
+   {
+   size_t totalSize = sizeof(*romClass);
+   totalSize += getUTF8Size(J9ROMCLASS_CLASSNAME(romClass));
+   totalSize += getUTF8Size(J9ROMCLASS_SUPERCLASSNAME(romClass));
+
+   totalSize += romClass->interfaceCount * sizeof(J9SRP);
+   for (size_t i = 0; i < romClass->interfaceCount; ++i)
+      {
+      auto name = NNSRP_GET(J9ROMCLASS_INTERFACES(romClass)[i], const J9UTF8 *);
+      totalSize += getUTF8Size(name);
+      }
+
+   return OMR::alignNoCheck(totalSize, sizeof(uint64_t));
+   }
+
+static void
+packUTF8(const J9UTF8 *str, J9SRP &srp, ROMClassPackContext &ctx)
+   {
+   NNSRP_SET(srp, ctx._cursor);
+   ctx._cursor += copyUTF8((J9UTF8 *)ctx._cursor, str);
+   }
+
+// Packs the data stored outside of the array ROMClass header
+static void
+packArrayROMClassData(const J9ROMClass *romClass, ROMClassPackContext &ctx)
+   {
+   NNSRP_SET(ctx._packedRomClass->interfaces, ctx._cursor);
+   ctx._cursor += ctx._packedRomClass->interfaceCount * sizeof(J9SRP);
+
+   packUTF8(J9ROMCLASS_CLASSNAME(romClass), ctx._packedRomClass->className, ctx);
+   packUTF8(J9ROMCLASS_SUPERCLASSNAME(romClass), ctx._packedRomClass->superclassName, ctx);
+
+   for (size_t i = 0; i < romClass->interfaceCount; ++i)
+      {
+      auto name = NNSRP_GET(J9ROMCLASS_INTERFACES(romClass)[i], const J9UTF8 *);
+      packUTF8(name, J9ROMCLASS_INTERFACES(ctx._packedRomClass)[i], ctx);
+      }
    }
 
 // Packs a ROMClass into a std::string to be transferred to the server.
-// Some of the name and signature strings are interned and stored outside
-// of the ROMClass body. Such strings are appended to the end of the cloned
-// ROMClass body and the self referential pointers to them are updated.
+// UTF8 strings that a ROMClass refers to can be interned and stored outside of
+// the ROMClass body. This function puts all the strings (including interned ones)
+// at the end of the cloned ROMClass in deterministic order and updates the SRPs
+// to them. It also removes some of the data that is not used by the JIT compiler.
+//
+// Note that the strings that were stored inside of the original ROMClass body
+// do not keep their offsets in the serialized ROMClass (in the general case).
+// The order in which the strings are serialized is determined by the ROMClass
+// walk, not by their original locations.
+//
+// Packing involves 2 passes over all the strings that a ROMClass refers to:
+// 1. Compute total size and map original strings to their locations in the packed ROMClass.
+// 2. Copy each original string to its location in the packed ROMClass.
+//
+// This implementation makes (and checks at runtime) the following assumptions:
+// - Intermediate class data is either stored at the end of the ROMClass, or points
+//   to the ROMClass itself, or is interned (i.e. points outside of the ROMClass).
+// - All non-interned strings are stored in a single contiguous range (the UTF8 section)
+//   located at the end of the ROMClass (can only be followed by intermediate class data).
+// - ROMClass walk visits all the strings that the ROMClass references.
+//
 static std::string
-packROMClass(J9ROMClass *origRomClass, TR_Memory *trMemory)
+packROMClass(J9ROMClass *romClass, TR_Memory *trMemory)
    {
-   size_t totalSize = origRomClass->romSize;
-   J9UTF8 *className = J9ROMCLASS_CLASSNAME(origRomClass);
-   totalSize += getPackedUTF8Size(className, origRomClass);
+   auto name = J9ROMCLASS_CLASSNAME(romClass);
+   // Primitive ROMClasses have different layout (see runtime/vm/romclasses.c): the last
+   // ROMClass includes all the others' UTF8 name strings in its romSize, which breaks the
+   // generic packing implementation. Pretend that its romSize only includes the header.
+   size_t origRomSize = J9ROMCLASS_IS_PRIMITIVE_TYPE(romClass) ? sizeof(*romClass) : romClass->romSize;
+   size_t totalSize = origRomSize;
 
-   J9ROMMethod *romMethod = J9ROMCLASS_ROMMETHODS(origRomClass);
-   for (size_t i = 0; i < origRomClass->romMethodCount; ++i)
+   // Remove intermediate class data (not used by JIT)
+   uint8_t *icData = J9ROMCLASS_INTERMEDIATECLASSDATA(romClass);
+   if (JITServerHelpers::isAddressInROMClass(icData, romClass) && (icData != (uint8_t *)romClass))
       {
-      totalSize += getPackedUTF8Size(J9ROMMETHOD_NAME(romMethod), origRomClass);
-      totalSize += getPackedUTF8Size(J9ROMMETHOD_SIGNATURE(romMethod), origRomClass);
-      romMethod = nextROMMethod(romMethod);
+      TR_ASSERT_FATAL(icData + romClass->intermediateClassDataLength == (uint8_t *)romClass + romClass->romSize,
+                      "Intermediate class data not stored at the end of ROMClass %.*s", name->length, name->data);
+      totalSize -= romClass->intermediateClassDataLength;
       }
 
-   // Check if the contiguous part of the ROMClass already contains all the strings visited above
-   if (totalSize == origRomClass->romSize)
-      return std::string((char *)origRomClass, origRomClass->romSize);
+   // All allocated memory is only used in this function
+   TR::StackMemoryRegion stackMemoryRegion(*trMemory);
+   ROMClassPackContext ctx(trMemory, origRomSize);
 
-   J9ROMClass *romClass = (J9ROMClass *)trMemory->allocateHeapMemory(totalSize);
-   if (!romClass)
+   size_t copySize = 0;
+   if (isArrayROMClass(romClass))
+      {
+      copySize = sizeof(*romClass);
+      totalSize = getArrayROMClassPackedSize(romClass);
+      }
+   else
+      {
+      // 1st pass: iterate all strings in the ROMClass to compute its total size (including
+      // interned strings) and map the strings to their locations in the packed ROMClass
+      ctx._callback = sizeInfoCallback;
+      allSlotsInROMClassDo(romClass, slotCallback, NULL, NULL, &ctx);
+      // Handle the case when all strings are interned
+      auto classEnd = (const uint8_t *)romClass + totalSize;
+      ctx._utf8SectionStart = std::min(ctx._utf8SectionStart, classEnd);
+
+      auto end = ctx._utf8SectionEnd ? ctx._utf8SectionEnd : classEnd;
+      TR_ASSERT_FATAL(ctx._utf8SectionSize == end - ctx._utf8SectionStart,
+                      "Missed strings in ROMClass %.*s UTF8 section: %zu != %zu",
+                      name->length, name->data, ctx._utf8SectionSize, end - ctx._utf8SectionStart);
+      end = (const uint8_t *)OMR::alignNoCheck((uintptr_t)end, sizeof(uint64_t));
+      TR_ASSERT_FATAL(end == classEnd, "UTF8 section not stored at the end of ROMClass %.*s: %p != %p",
+                      name->length, name->data, end, classEnd);
+
+      copySize = ctx._utf8SectionStart - (const uint8_t *)romClass;
+      totalSize = OMR::alignNoCheck(copySize + ctx._stringsSize, sizeof(uint64_t));
+      }
+
+   ctx._packedRomClass = (J9ROMClass *)trMemory->allocateStackMemory(totalSize);
+   if (!ctx._packedRomClass)
       throw std::bad_alloc();
-   memcpy(romClass, origRomClass, origRomClass->romSize);
-   // Update the size to include the strings that will be appended at the end
-   romClass->romSize = totalSize;
+   memcpy(ctx._packedRomClass, romClass, copySize);
+   ctx._packedRomClass->romSize = totalSize;
+   ctx._cursor = (uint8_t *)ctx._packedRomClass + copySize;
 
-   uint8_t *curPos = ((uint8_t *)romClass) + origRomClass->romSize;
-   curPos = packUTF8(curPos, className, origRomClass, romClass->className);
+   // Zero out SRP to intermediate class data
+   ctx._packedRomClass->intermediateClassData = 0;
+   ctx._packedRomClass->intermediateClassDataLength = 0;
 
-   romMethod = J9ROMCLASS_ROMMETHODS(romClass);
-   J9ROMMethod *origRomMethod = J9ROMCLASS_ROMMETHODS(origRomClass);
-   for (size_t i = 0; i < romClass->romMethodCount; ++i)
+   // Zero out SRPs to out-of-line method debug info
+   J9ROMMethod *romMethod = J9ROMCLASS_ROMMETHODS(ctx._packedRomClass);
+   for (size_t i = 0; i < ctx._packedRomClass->romMethodCount; ++i)
       {
-      curPos = packUTF8(curPos, J9ROMMETHOD_NAME(origRomMethod), origRomClass,
-                        romMethod->nameAndSignature.name);
-      curPos = packUTF8(curPos, J9ROMMETHOD_SIGNATURE(origRomMethod), origRomClass,
-                        romMethod->nameAndSignature.signature);
+      if (J9ROMMETHOD_HAS_DEBUG_INFO(romMethod))
+         {
+         auto debugInfo = methodDebugInfoFromROMMethod(romMethod);
+         if (!(debugInfo->srpToVarInfo & 1))
+            debugInfo->srpToVarInfo = 0;
+         }
       romMethod = nextROMMethod(romMethod);
-      origRomMethod = nextROMMethod(origRomMethod);
       }
 
-   TR_ASSERT(curPos == (uint8_t *)romClass + romClass->romSize, "Cursor offset mismatch: %zu != %zu",
-             curPos - (uint8_t *)romClass, romClass->romSize);
+   if (isArrayROMClass(romClass))
+      {
+      packArrayROMClassData(romClass, ctx);
+      }
+   else
+      {
+      // 2nd pass: copy all strings to their locations in the packed ROMClass
+      ctx._callback = packCallback;
+      allSlotsInROMClassDo(romClass, slotCallback, NULL, NULL, &ctx);
+      }
 
-   std::string romClassStr((char *) romClass, totalSize);
-   trMemory->freeMemory(romClass, heapAlloc);
-   return romClassStr;
+   // Pad to required alignment
+   auto end = (uint8_t *)OMR::alignNoCheck((uintptr_t)ctx._cursor, sizeof(uint64_t));
+   TR_ASSERT(end == (uint8_t *)ctx._packedRomClass + totalSize, "Invalid final cursor position: %p != %p",
+             end, (uint8_t *)ctx._packedRomClass + totalSize);
+   memset(ctx._cursor, 0, end - ctx._cursor);
+
+   return std::string((char *)ctx._packedRomClass, totalSize);
    }
 
 // insertIntoOOSequenceEntryList needs to be executed with sequencingMonitor in hand.

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -257,7 +257,6 @@ private:
    TR_IPMethodHashTableEntry *_iProfilerMethodEntry;
 
    char* getROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
-   char* getRemoteROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
    virtual char * fieldOrStaticName(I_32 cpIndex, int32_t & len, TR_Memory * trMemory, TR_AllocationKind kind = heapAlloc) override;
    void unpackMethodInfo(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, uint32_t vTableSlot, TR::CompilationInfoPerThread *threadCompInfo, const TR_ResolvedJ9JITServerMethodInfo &methodInfo);
    };

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -109,7 +109,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 18;
+   static const uint16_t MINOR_NUMBER = 19;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,7 +64,6 @@ enum MessageType : uint16_t
    ResolvedMethod_isSubjectToPhaseChange,
    ResolvedMethod_getUnresolvedSpecialMethodInCP,
    ResolvedMethod_getUnresolvedFieldInCP,
-   ResolvedMethod_getRemoteROMString,
    ResolvedMethod_fieldOrStaticName,
    ResolvedMethod_getRemoteROMClassAndMethods,
    ResolvedMethod_getResolvedHandleMethod,
@@ -98,13 +97,13 @@ enum MessageType : uint16_t
    ResolvedMethod_getResolvedImplementorMethods,
    ResolvedMethod_isFieldFlattened,
 
-   ResolvedRelocatableMethod_createResolvedRelocatableJ9Method, // 67
+   ResolvedRelocatableMethod_createResolvedRelocatableJ9Method, // 66
    ResolvedRelocatableMethod_fieldAttributes,
    ResolvedRelocatableMethod_staticAttributes,
    ResolvedRelocatableMethod_getFieldType,
 
    // For TR_J9ServerVM methods
-   VM_isClassLibraryClass, // 71
+   VM_isClassLibraryClass, // 70
    VM_isClassLibraryMethod,
    VM_getSuperClass,
    VM_isInstanceOf,
@@ -208,7 +207,7 @@ enum MessageType : uint16_t
    VM_getFields,
 
    // For static TR::CompilationInfo methods
-   CompInfo_isCompiled, // 173
+   CompInfo_isCompiled, // 172
    CompInfo_getPCIfCompiled,
    CompInfo_getInvocationCount,
    CompInfo_setInvocationCount,
@@ -222,7 +221,7 @@ enum MessageType : uint16_t
    CompInfo_getJ9MethodStartPC,
 
    // For J9::ClassEnv Methods
-   ClassEnv_classFlagsValue, // 185
+   ClassEnv_classFlagsValue, // 184
    ClassEnv_classDepthOf,
    ClassEnv_classInstanceSize,
    ClassEnv_superClassesOf,
@@ -236,13 +235,13 @@ enum MessageType : uint16_t
    ClassEnv_enumerateFields,
 
    // For TR_J9SharedCache
-   SharedCache_getClassChainOffsetInSharedCache, // 198
+   SharedCache_getClassChainOffsetInSharedCache, // 196
    SharedCache_rememberClass,
    SharedCache_addHint,
    SharedCache_storeSharedData,
 
    // For runFEMacro
-   runFEMacro_invokeCollectHandleNumArgsToCollect, // 202
+   runFEMacro_invokeCollectHandleNumArgsToCollect, // 200
    runFEMacro_invokeExplicitCastHandleConvertArgs,
    runFEMacro_targetTypeL,
    runFEMacro_invokeILGenMacrosInvokeExactAndFixup,
@@ -268,24 +267,22 @@ enum MessageType : uint16_t
    runFEMacro_invokeCollectHandleAllocateArray,
 
    // for JITServerPersistentCHTable
-   CHTable_getAllClassInfo, // 226
+   CHTable_getAllClassInfo, // 224
    CHTable_getClassInfoUpdates,
    CHTable_commit,
    CHTable_clearReservable,
 
    // for JITServerIProfiler
-   IProfiler_profilingSample, // 230
+   IProfiler_profilingSample, // 228
    IProfiler_searchForMethodSample,
    IProfiler_getMaxCallCount,
    IProfiler_setCallCount,
 
-   Recompilation_getExistingMethodInfo, // 234
+   Recompilation_getExistingMethodInfo, // 232
    Recompilation_getJittedBodyInfoFromPC,
 
-   ClassInfo_getRemoteROMString,
-
    // for KnownObjectTable
-   KnownObjectTable_getOrCreateIndex, // 237
+   KnownObjectTable_getOrCreateIndex, // 234
    KnownObjectTable_getOrCreateIndexAt,
    KnownObjectTable_getPointer,
    KnownObjectTable_getExistingIndexAt,
@@ -299,7 +296,8 @@ enum MessageType : uint16_t
    KnownObjectTable_invokeDirectHandleDirectCall,
    KnownObjectTable_getKnownObjectTableDumpInfo,
 
-   ClassEnv_isClassRefValueType, // 249
+   ClassEnv_isClassRefValueType, // 246
+
    MessageType_MAXTYPE
    };
 
@@ -341,7 +339,6 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "ResolvedMethod_isSubjectToPhaseChange",
    "ResolvedMethod_getUnresolvedSpecialMethodInCP",
    "ResolvedMethod_getUnresolvedFieldInCP",
-   "ResolvedMethod_getRemoteROMString",
    "ResolvedMethod_fieldOrStaticName",
    "ResolvedMethod_getRemoteROMClassAndMethods",
    "ResolvedMethod_getResolvedHandleMethod",
@@ -374,11 +371,11 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "ResolvedMethod_definingClassFromCPFieldRef",
    "ResolvedMethod_getResolvedImplementorMethods",
    "ResolvedMethod_isFieldFlattened",
-   "ResolvedRelocatableMethod_createResolvedRelocatableJ9Method", // 67
+   "ResolvedRelocatableMethod_createResolvedRelocatableJ9Method", // 66
    "ResolvedRelocatableMethod_fieldAttributes",
    "ResolvedRelocatableMethod_staticAttributes",
    "ResolvedRelocatableMethod_getFieldType",
-   "VM_isClassLibraryClass", // 71
+   "VM_isClassLibraryClass", // 70
    "VM_isClassLibraryMethod",
    "VM_getSuperClass",
    "VM_isInstanceOf",
@@ -480,7 +477,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "VM_getObjectSizeClass",
    "VM_stackWalkerMaySkipFramesSVM",
    "VM_getFields",
-   "CompInfo_isCompiled", // 173
+   "CompInfo_isCompiled", // 172
    "CompInfo_getPCIfCompiled",
    "CompInfo_getInvocationCount",
    "CompInfo_setInvocationCount",
@@ -492,7 +489,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "CompInfo_setInvocationCountAtomic",
    "CompInfo_isClassSpecial",
    "CompInfo_getJ9MethodStartPC",
-   "ClassEnv_classFlagsValue", // 185
+   "ClassEnv_classFlagsValue", // 184
    "ClassEnv_classDepthOf",
    "ClassEnv_classInstanceSize",
    "ClassEnv_superClassesOf",
@@ -504,11 +501,11 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "ClassEnv_classHasIllegalStaticFinalFieldModification",
    "ClassEnv_getROMClassRefName",
    "ClassEnv_enumerateFields",
-   "SharedCache_getClassChainOffsetInSharedCache", // 198
+   "SharedCache_getClassChainOffsetInSharedCache", // 196
    "SharedCache_rememberClass",
    "SharedCache_addHint",
    "SharedCache_storeSharedData",
-   "runFEMacro_invokeCollectHandleNumArgsToCollect", // 202
+   "runFEMacro_invokeCollectHandleNumArgsToCollect", // 200
    "runFEMacro_invokeExplicitCastHandleConvertArgs",
    "runFEMacro_targetTypeL",
    "runFEMacro_invokeILGenMacrosInvokeExactAndFixup",
@@ -532,18 +529,17 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "runFEMacro_invokeFilterArgumentsWithCombinerHandleFilterPosition",
    "runFEMacro_invokeFilterArgumentsWithCombinerHandleArgumentIndices",
    "runFEMacro_invokeCollectHandleAllocateArray",
-   "CHTable_getAllClassInfo", // 226
+   "CHTable_getAllClassInfo", // 224
    "CHTable_getClassInfoUpdates",
    "CHTable_commit",
    "CHTable_clearReservable",
-   "IProfiler_profilingSample", // 230
+   "IProfiler_profilingSample", // 228
    "IProfiler_searchForMethodSample",
    "IProfiler_getMaxCallCount",
    "IProfiler_setCallCount",
-   "Recompilation_getExistingMethodInfo", // 234
+   "Recompilation_getExistingMethodInfo", // 232
    "Recompilation_getJittedBodyInfoFromPC",
-   "ClassInfo_getRemoteROMString",
-   "KnownObjectTable_getOrCreateIndex", // 236
+   "KnownObjectTable_getOrCreateIndex", // 234
    "KnownObjectTable_getOrCreateIndexAt",
    "KnownObjectTable_getPointer",
    "KnownObjectTable_getExistingIndexAt",
@@ -555,7 +551,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "KnownObjectTable_getReferenceField",
    "KnownObjectTable_invokeDirectHandleDirectCall",
    "KnownObjectTable_getKnownObjectTableDumpInfo",
-   "ClassEnv_isClassRefValueType", // 249
+   "ClassEnv_isClassRefValueType", // 246
    };
    }; // namespace JITServer
 #endif // MESSAGE_TYPES_HPP

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -142,16 +142,6 @@ struct ClassLoaderStringPair
       }
    };
 
-struct TR_RemoteROMStringKey
-   {
-   void *_basePtr;
-   uint32_t _offsets;
-   bool operator==(const TR_RemoteROMStringKey &other) const
-      {
-      return (_basePtr == other._basePtr) && (_offsets == other._offsets);
-      }
-   };
-
 
 // custom specializations of std::hash injected in std namespace
 namespace std
@@ -171,16 +161,6 @@ namespace std
       std::size_t operator()(const std::pair<T, Q> &key) const noexcept
          {
          return std::hash<T>()(key.first) ^ std::hash<Q>()(key.second);
-         }
-      };
-
-   template <> struct hash<TR_RemoteROMStringKey>
-      {
-      std::size_t operator()(const TR_RemoteROMStringKey &k) const noexcept
-         {
-         // Compute a hash for the table of ROM strings by hashing basePtr and offsets 
-         // separately and then XORing them
-         return (std::hash<void *>()(k._basePtr)) ^ (std::hash<uint32_t>()(k._offsets));
          }
       };
    }
@@ -256,7 +236,6 @@ class ClientSessionData
       J9ConstantPool *_constantPool;
       uintptr_t _classFlags;
       uintptr_t _classChainOffsetOfIdentifyingLoaderForClazz;
-      PersistentUnorderedMap<TR_RemoteROMStringKey, std::string> _remoteROMStringsCache; // cached strings from the client
       PersistentUnorderedMap<int32_t, std::string> _fieldOrStaticNameCache;
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _classOfStaticCache;
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _constantClassPoolCache;
@@ -273,7 +252,6 @@ class ClientSessionData
       PersistentUnorderedSet<J9ClassLoader *> _referencingClassLoaders;
 
       char* getROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
-      char* getRemoteROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
       }; // struct ClassInfo
 
 


### PR DESCRIPTION
Packed ROMClasses that JIT client sends to the server do not always include UTF8 strings due to interning. In the current implementation, JITServer requests missing strings from the client and caches them in the client session. To avoid these requests, in this PR the ROMClass is fully serialized with all the required strings that it refers to.

All the strings are written at the end of the serialized ROMClass in a fixed order that is determined by the ROMClass walk implementation, regardless of whether they are stored within the bounds of the original ROMClass or interned.

The following data is not used by JITServer and is excluded from the resulting packed ROMClass, with their SRPs set to 0:
- Intermediate class data.
- Strings that are part of inline method debug info. (The rest of method debug info data is stored in ROMMethod, and removing it would require shifting everything after it and updating SRPs, which is not easy to implement.)
Other strings that are guaranteed not to be used by JITServer can also be excluded in the future.

Note: this PR depends on #11330

Closes: #11329