### PR TITLE
Limit size of core files created by the OS, and reduce -Xmx

### DIFF
--- a/test/functional/cmdLineTests/sigabrtHandlingTest/sigabrtHandlingTest.xml
+++ b/test/functional/cmdLineTests/sigabrtHandlingTest/sigabrtHandlingTest.xml
@@ -26,73 +26,110 @@
 
 <suite id="SIGABRT Handling Tests" timeout="2400">
  <variable name="CP" value="-cp $Q$$RESJAR$$Q$ VMBench.GPTests.GPTest" />
- 
- <!-- 
+
+ <!--
    The system, JIT, snap and heap dumps are disabled to reduce the memory footprint of
    the tests. Only a Java dump will be generated when the JVM abort handler is invoked.
    This should be sufficient to test the -XX:[+|-]HandleSIGABRT option.
  -->
  <variable name="DUMP" value="-Xdump:system+heap+snap+jit:none" />
+ <variable name="LIMT_HEAPSIZE" value="-Xmx20m" />
+ <variable name="NON_WINDOWS_PLATFORMS" value="aix.*,linux.*,zos.*,osx.*" />
+ <variable name="WINDOWS_PLATFORMS" value="win.*" />
 
  <test id="Default">
-  <command>$EXE$ $DUMP$ $CP$ abort</command>
+  <command>$EXE$ $LIMT_HEAPSIZE$ $DUMP$ $CP$ abort</command>
   <output type="success" regex="no">Processing dump event "abort"</output>
   <output type="required" regex="no">Processed dump event "abort"</output>
  </test>
 
  <test id="-XX:+HandleSIGABRT">
-  <command>$EXE$ $DUMP$ -XX:+HandleSIGABRT $CP$ abort</command>
+  <command>$EXE$ $LIMT_HEAPSIZE$ $DUMP$ -XX:+HandleSIGABRT $CP$ abort</command>
   <output type="success" regex="no">Processing dump event "abort"</output>
   <output type="required" regex="no">Processed dump event "abort"</output>
  </test>
 
  <test id="-XX:-HandleSIGABRT -XX:+HandleSIGABRT">
-  <command>$EXE$ $DUMP$ -XX:-HandleSIGABRT -XX:+HandleSIGABRT $CP$ abort</command>
+  <command>$EXE$ $LIMT_HEAPSIZE$ $DUMP$ -XX:-HandleSIGABRT -XX:+HandleSIGABRT $CP$ abort</command>
   <output type="success" regex="no">Processing dump event "abort"</output>
   <output type="required" regex="no">Processed dump event "abort"</output>
  </test>
 
- <test id="-XX:-HandleSIGABRT">
-  <command>$EXE$ $DUMP$ -XX:-HandleSIGABRT $CP$ abort</command>
+ <test id="-XX:-HandleSIGABRT" platforms="$WINDOWS_PLATFORMS$">
+  <command>$EXE$ $LIMT_HEAPSIZE$ $DUMP$ -XX:-HandleSIGABRT $CP$ abort</command>
   <output type="success" regex="no">Invoking abort!</output>
   <output type="failure" regex="no">Processing dump event "abort"</output>
  </test>
 
- <test id="-XX:+HandleSIGABRT -XX:-HandleSIGABRT">
-  <command>$EXE$ $DUMP$ -XX:+HandleSIGABRT -XX:-HandleSIGABRT $CP$ abort</command>
+ <test id="-XX:-HandleSIGABRT" platforms="$NON_WINDOWS_PLATFORMS$">
+  <command>bash -c $Q$ulimit -c 0 ; $EXE$ $LIMT_HEAPSIZE$ $DUMP$ -XX:-HandleSIGABRT $CP$ abort$Q$</command>
+  <output type="success" regex="no">Invoking abort!</output>
+  <output type="failure" regex="no">Processing dump event "abort"</output>
+ </test>
+
+ <test id="-XX:+HandleSIGABRT -XX:-HandleSIGABRT" platforms="$WINDOWS_PLATFORMS$">
+  <command>$EXE$ $LIMT_HEAPSIZE$ $DUMP$ -XX:+HandleSIGABRT -XX:-HandleSIGABRT $CP$ abort</command>
+  <output type="success" regex="no">Invoking abort!</output>
+  <output type="failure" regex="no">Processing dump event "abort"</output>
+ </test>
+
+ <test id="-XX:+HandleSIGABRT -XX:-HandleSIGABRT" platforms="$NON_WINDOWS_PLATFORMS$">
+  <command>bash -c $Q$ulimit -c 0 ; $EXE$ $LIMT_HEAPSIZE$ $DUMP$ -XX:+HandleSIGABRT -XX:-HandleSIGABRT $CP$ abort$Q$</command>
   <output type="success" regex="no">Invoking abort!</output>
   <output type="failure" regex="no">Processing dump event "abort"</output>
  </test>
 
  <test id="-XX:+HandleSIGABRT -Xrs">
-  <command>$EXE$ $DUMP$ -XX:+HandleSIGABRT -Xrs $CP$ abort</command>
+  <command>$EXE$ $LIMT_HEAPSIZE$ $DUMP$ -XX:+HandleSIGABRT -Xrs $CP$ abort</command>
   <output type="success" regex="no">-XX:+HandleSIGABRT is not supported with -Xrs</output>
   <output type="failure" regex="no">Invoking abort!</output>
   <output type="failure" regex="no">Processing dump event "abort"</output>
  </test>
 
  <test id="-XX:+HandleSIGABRT -Xrs:sync">
-  <command>$EXE$ $DUMP$ -XX:+HandleSIGABRT -Xrs:sync $CP$ abort</command>
+  <command>$EXE$ $LIMT_HEAPSIZE$ $DUMP$ -XX:+HandleSIGABRT -Xrs:sync $CP$ abort</command>
   <output type="success" regex="no">-XX:+HandleSIGABRT is not supported with -Xrs</output>
   <output type="failure" regex="no">Invoking abort!</output>
   <output type="failure" regex="no">Processing dump event "abort"</output>
  </test>
 
- <test id="-Xrs">
-  <command>$EXE$ $DUMP$ -Xrs $CP$ abort</command>
+ <test id="-Xrs" platforms="$WINDOWS_PLATFORMS$">
+  <command>$EXE$ $LIMT_HEAPSIZE$ $DUMP$ -Xrs $CP$ abort</command>
   <output type="success" regex="no">Invoking abort!</output>
   <output type="failure" regex="no">Processing dump event "abort"</output>
  </test>
- 
- <test id="-XX:-HandleSIGABRT -Xrs">
-  <command>$EXE$ $DUMP$ -XX:-HandleSIGABRT -Xrs $CP$ abort</command>
+
+ <test id="-Xrs" platforms="$NON_WINDOWS_PLATFORMS$">
+  <command>bash -c $Q$ulimit -c 0 ; $EXE$ $LIMT_HEAPSIZE$ $DUMP$ -Xrs $CP$ abort$Q$</command>
   <output type="success" regex="no">Invoking abort!</output>
   <output type="failure" regex="no">Processing dump event "abort"</output>
  </test>
- 
- <test id="-XX:-HandleSIGABRT -Xrs:sync">
-  <command>$EXE$ $DUMP$ -XX:-HandleSIGABRT -Xrs:sync $CP$ abort</command>
+
+ <test id="-XX:-HandleSIGABRT -Xrs" platforms="$WINDOWS_PLATFORMS$">
+  <command>$EXE$ $LIMT_HEAPSIZE$ $DUMP$ -XX:-HandleSIGABRT -Xrs $CP$ abort</command>
   <output type="success" regex="no">Invoking abort!</output>
   <output type="failure" regex="no">Processing dump event "abort"</output>
  </test>
+
+ <test id="-XX:-HandleSIGABRT -Xrs" platforms="$NON_WINDOWS_PLATFORMS$">
+  <command>bash -c $Q$ulimit -c 0 ; $EXE$ $LIMT_HEAPSIZE$ $DUMP$ -XX:-HandleSIGABRT -Xrs $CP$ abort$Q$</command>
+  <output type="success" regex="no">Invoking abort!</output>
+  <output type="failure" regex="no">Processing dump event "abort"</output>
+ </test>
+
+ <test id="-XX:-HandleSIGABRT -Xrs:sync" platforms="$WINDOWS_PLATFORMS$">
+  <command>$EXE$ $LIMT_HEAPSIZE$ $DUMP$ -XX:-HandleSIGABRT -Xrs:sync $CP$ abort</command>
+  <output type="success" regex="no">Invoking abort!</output>
+  <output type="failure" regex="no">Processing dump event "abort"</output>
+ </test>
+
+ <test id="-XX:-HandleSIGABRT -Xrs:sync" platforms="$NON_WINDOWS_PLATFORMS$">
+  <command>bash -c $Q$ulimit -c 0 ; $EXE$ $LIMT_HEAPSIZE$ $DUMP$ -XX:-HandleSIGABRT -Xrs:sync $CP$ abort$Q$</command>
+  <output type="success" regex="no">Invoking abort!</output>
+  <output type="failure" regex="no">Processing dump event "abort"</output>
+ </test>
+
+ <!-- Remove any core file created by the OS -->
+ <exec command="bash -c $Q$rm core.*$Q$" />
+
 </suite>


### PR DESCRIPTION
On some OSes, such as AIX, a core file is produced by the tests which
disable the abort handler. Use ulimit to avoid creating any core files.
Limit the size of the object heap by running the tests with a reduced
-Xmx. Delete any remaining core files afterwards.

Closes https://github.com/eclipse/openj9/issues/11335

[ci skip]

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>