### PR TITLE
AArch64: Add a method for setting up implicit exception point to InstructionDelegate

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9InstructionDelegate.cpp
+++ b/runtime/compiler/aarch64/codegen/J9InstructionDelegate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,10 +21,78 @@
 
 #include "codegen/ARM64Instruction.hpp"
 #include "codegen/CallSnippet.hpp"
+#include "codegen/CodeGenerator.hpp"
 #include "codegen/InstructionDelegate.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
 
 void
 J9::ARM64::InstructionDelegate::encodeBranchToLabel(TR::CodeGenerator *cg, TR::ARM64ImmSymInstruction *ins, uint8_t *cursor)
    {
    ((TR::ARM64CallSnippet *)ins->getCallSnippet())->setCallRA(cursor + ARM64_INSTRUCTION_LENGTH);
+   }
+
+static void
+setupImplicitNullPointerExceptionImpl(TR::CodeGenerator *cg, TR::Instruction *instr, TR::Node *node, TR::MemoryReference *mr)
+   {
+   TR::Compilation *comp = cg->comp();
+   if(cg->getHasResumableTrapHandler())
+      {
+      // If the treetop node is BNDCHK node combined with NULLCHK, the previous treetop node is NULLCHK.
+      auto treeTopNode = cg->getCurrentEvaluationTreeTop()->getNode();
+      if (treeTopNode->chkFoldedImplicitNULLCHK())
+         {
+         treeTopNode = cg->getCurrentEvaluationTreeTop()->getPrevTreeTop()->getNode();
+         }
+      // this instruction throws an implicit null check if:
+      // 1. The treetop node is a NULLCHK node
+      // 2. The memory reference of this instruction can cause a null pointer exception
+      // 3. The null check reference node must be a child of this node
+      // 4. This memory reference uses the same register as the null check reference
+      // 5. This is the first instruction in the evaluation of this null check node to have met all the conditions
+
+      // Test conditions 1, 2, and 5
+      if(node != NULL & mr != NULL &&
+         mr->getCausesImplicitNullPointerException() &&
+         treeTopNode->getOpCode().isNullCheck() &&
+         cg->getImplicitExceptionPoint() == NULL)
+         {
+         // determine what the NULLcheck reference node is
+         TR::Node * nullCheckReference;
+         TR::Node * firstChild = treeTopNode->getFirstChild();
+         if (comp->useCompressedPointers() &&
+               firstChild->getOpCodeValue() == TR::l2a)
+            {
+            TR::ILOpCodes loadOp = comp->il.opCodeForIndirectLoad(TR::Int32);
+            TR::ILOpCodes rdbarOp = comp->il.opCodeForIndirectReadBarrier(TR::Int32);
+            while (firstChild->getOpCodeValue() != loadOp && firstChild->getOpCodeValue() != rdbarOp)
+               firstChild = firstChild->getFirstChild();
+            nullCheckReference = firstChild->getFirstChild();
+            }
+         else
+            nullCheckReference = treeTopNode->getNullCheckReference();
+
+         TR::Register *nullCheckReg = nullCheckReference->getRegister();
+         // Test conditions 3 and 4
+         if ((node->getOpCode().hasSymbolReference() &&
+               node->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef()) ||
+             (node->hasChild(nullCheckReference) && (nullCheckReg != NULL) && mr->refsRegister(nullCheckReg)))
+            {
+            traceMsg(comp,"Instruction %p throws an implicit NPE, node: %p NPE node: %p\n", instr, node, nullCheckReference);
+            cg->setImplicitExceptionPoint(instr);
+            }
+         }
+      }
+   }
+
+void
+J9::ARM64::InstructionDelegate::setupImplicitNullPointerException(TR::CodeGenerator *cg, TR::ARM64Trg1MemInstruction *instr)
+   {
+   setupImplicitNullPointerExceptionImpl(cg, instr, instr->getNode(), instr->getMemoryReference());
+   }
+
+void
+J9::ARM64::InstructionDelegate::setupImplicitNullPointerException(TR::CodeGenerator *cg, TR::ARM64MemInstruction *instr)
+   {
+   setupImplicitNullPointerExceptionImpl(cg, instr, instr->getNode(), instr->getMemoryReference());
    }

--- a/runtime/compiler/aarch64/codegen/J9InstructionDelegate.hpp
+++ b/runtime/compiler/aarch64/codegen/J9InstructionDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,9 +33,12 @@ namespace J9 { typedef J9::ARM64::InstructionDelegate InstructionDelegateConnect
 #error J9::ARM64::InstructionDelegate expected to be a primary connector, but a J9 connector is already defined
 #endif
 
-#include "codegen/ARM64Instruction.hpp"
 #include "compiler/codegen/J9InstructionDelegate.hpp"
 #include "infra/Annotations.hpp"
+
+namespace TR { class ARM64ImmSymInstruction; }
+namespace TR { class ARM64Trg1MemInstruction; }
+namespace TR { class ARM64MemInstruction; }
 
 namespace J9
 {
@@ -58,6 +61,20 @@ public:
     * @param[in] cursor : instruction cursor
     */
    static void encodeBranchToLabel(TR::CodeGenerator *cg, TR::ARM64ImmSymInstruction *ins, uint8_t *cursor);
+
+   /**
+    * @brief Determines if this instruction will throw an implicit null pointer exception and sets appropriate flags
+    * @param[in] cg    : CodeGenerator
+    * @param[in] instr : instruction with memory reference
+    */
+   static void setupImplicitNullPointerException(TR::CodeGenerator *cg, TR::ARM64Trg1MemInstruction *instr);
+
+   /**
+    * @brief Determines if this instruction will throw an implicit null pointer exception and sets appropriate flags
+    * @param[in] cg    : CodeGenerator
+    * @param[in] instr : instruction with memory reference
+    */
+   static void setupImplicitNullPointerException(TR::CodeGenerator *cg, TR::ARM64MemInstruction *instr);
 
    };
 


### PR DESCRIPTION
Add implementation of `setupImplicitNullPointerException` method to `J9::ARM64::InstructionDelegate`.

Depends on:
- https://github.com/eclipse/omr/pull/5706
- https://github.com/eclipse/openj9/pull/11343

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>