### PR TITLE
AArch64: Enable implicit NULLCHK

### DIFF
--- a/runtime/compiler/env/ProcessorDetection.cpp
+++ b/runtime/compiler/env/ProcessorDetection.cpp
@@ -126,7 +126,7 @@ TR_J9VMBase::initializeSystemProperties()
    {
    initializeProcessorType();
 
-   #if defined(TR_TARGET_POWER) || defined(TR_TARGET_S390) || defined(TR_TARGET_X86)
+   #if defined(TR_TARGET_POWER) || defined(TR_TARGET_S390) || defined(TR_TARGET_X86) || defined(TR_TARGET_ARM64)
    initializeHasResumableTrapHandler();
    initializeHasFixedFrameC_CallingConvention();
    #endif

--- a/runtime/compiler/runtime/codertinit.cpp
+++ b/runtime/compiler/runtime/codertinit.cpp
@@ -90,6 +90,8 @@ extern "C" UDATA jitPPCHandler(J9VMThread* vmThread, U_32 sigType, void* sigInfo
 extern "C" UDATA jit390Handler(J9VMThread* vmThread, U_32 sigType, void* sigInfo);
 #elif defined(TR_HOST_X86) && defined(TR_TARGET_X86) && defined(TR_TARGET_64BIT)
 extern "C" UDATA jitAMD64Handler(J9VMThread* vmThread, U_32 sigType, void* sigInfo);
+#elif defined(TR_HOST_ARM64) && defined(TR_TARGET_ARM64)
+extern "C" UDATA jitARM64Handler(J9VMThread* vmThread, U_32 sigType, void* sigInfo);
 #endif
 #endif
 
@@ -499,6 +501,8 @@ void codert_init_helpers_and_targets(J9JITConfig * jitConfig, char isSMP)
    jitConfig->jitSignalHandler = jit390Handler;
 #elif defined(TR_HOST_X86) && defined(TR_TARGET_X86) && defined(TR_TARGET_64BIT)
    jitConfig->jitSignalHandler = jitAMD64Handler;
+#elif defined(TR_HOST_ARM64) && defined(TR_TARGET_ARM64)
+   jitConfig->jitSignalHandler = jitARM64Handler;
 #endif
 #endif
 


### PR DESCRIPTION
Install `jitARM64SignalHandler`.
Add `TR_TARGET_ARM64` to #ifdef guard of following function calls:
- `initializeHasResumableTrapHandler()`
- `initializeHasFixedFrameC_CallingConvention()`

Depends on:
- https://github.com/eclipse/omr/pull/5705
- https://github.com/eclipse/openj9/pull/11344
- https://github.com/eclipse/openj9/pull/11346

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>