### PR TITLE
Adjust signature of JVM_LookupLambdaProxyClassFromArchive for jdk16

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -1753,7 +1753,11 @@ JVM_RegisterLambdaProxyClassForArchiving(JNIEnv *env, jclass arg1, jstring arg2,
 }
 
 JNIEXPORT jclass JNICALL
-JVM_LookupLambdaProxyClassFromArchive(JNIEnv *env, jclass arg1, jstring arg2, jobject arg3, jobject arg4, jobject arg5, jobject arg6, jboolean arg7)
+JVM_LookupLambdaProxyClassFromArchive(JNIEnv *env, jclass arg1, jstring arg2, jobject arg3, jobject arg4, jobject arg5, jobject arg6
+#if JAVA_SPEC_VERSION == 15
+		, jboolean arg7
+#endif /* JAVA_SPEC_VERSION == 15 */
+		)
 {
 	assert(!"JVM_LookupLambdaProxyClassFromArchive unimplemented");
 	return NULL;

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -331,8 +331,10 @@ _IF([JAVA_SPEC_VERSION >= 16],
 	[_X(JVM_GetRandomSeedForDumping, JNICALL, false, jlong)])
 _IF([JAVA_SPEC_VERSION >= 15],
 	[_X(JVM_RegisterLambdaProxyClassForArchiving, JNICALL, false, void, JNIEnv *env, jclass arg1, jstring arg2, jobject arg3, jobject arg4, jobject arg5, jobject arg6, jclass arg7)])
-_IF([JAVA_SPEC_VERSION >= 15],
+_IF([JAVA_SPEC_VERSION == 15],
 	[_X(JVM_LookupLambdaProxyClassFromArchive, JNICALL, false, jclass, JNIEnv *env, jclass arg1, jstring arg2, jobject arg3, jobject arg4, jobject arg5, jobject arg6, jboolean arg7)])
+_IF([JAVA_SPEC_VERSION >= 16],
+	[_X(JVM_LookupLambdaProxyClassFromArchive, JNICALL, false, jclass, JNIEnv *env, jclass arg1, jstring arg2, jobject arg3, jobject arg4, jobject arg5, jobject arg6)])
 _IF([JAVA_SPEC_VERSION >= 15],
 	[_X(JVM_IsCDSDumpingEnabled, JNICALL, false, jboolean, JNIEnv *env)])
 _IF([JAVA_SPEC_VERSION == 15],


### PR DESCRIPTION
The final parameter is removed by
* 8257241: CDS should not handle disableEagerInitialization for archived lambda proxy classes