### PR TITLE
Handle monitor enter/exit on value based instances (X86)

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -5426,10 +5426,11 @@ J9::CodeGenerator::getMonClass(TR::Node* monNode)
 TR_YesNoMaybe
 J9::CodeGenerator::isMonitorValueType(TR::Node* monNode)
    {
-   if (_monitorMapping.find(monNode->getGlobalIndex()) == _monitorMapping.end())
+   TR_OpaqueClassBlock *clazz = self()->getMonClass(monNode);
+
+   if (!clazz)
       return TR_maybe;
 
-   TR_OpaqueClassBlock *clazz = _monitorMapping[monNode->getGlobalIndex()];
    //java.lang.Object class is only set when monitor is java.lang.Object but not its subclass
    if (clazz == self()->comp()->getObjectClassPointer())
       return TR_no;
@@ -5438,6 +5439,27 @@ J9::CodeGenerator::isMonitorValueType(TR::Node* monNode)
       return TR_maybe;
 
    if (TR::Compiler->cls.isValueTypeClass(clazz))
+      return TR_yes;
+
+   return TR_no;
+   }
+
+TR_YesNoMaybe
+J9::CodeGenerator::isMonitorValueBasedOrValueType(TR::Node* monNode)
+   {
+   TR_OpaqueClassBlock *clazz = self()->getMonClass(monNode);
+
+   if (!clazz)
+      return TR_maybe;
+
+   //java.lang.Object class is only set when monitor is java.lang.Object but not its subclass
+   if (clazz == self()->comp()->getObjectClassPointer())
+      return TR_no;
+
+   if (!TR::Compiler->cls.isConcreteClass(self()->comp(), clazz))
+      return TR_maybe;
+
+   if (TR::Compiler->cls.isValueBasedOrValueTypeClass(clazz))
       return TR_yes;
 
    return TR_no;

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -332,6 +332,16 @@ public:
     *    TR_maybe It is unknown whether the monitor object is identity type or value type
     */
    TR_YesNoMaybe isMonitorValueType(TR::Node* monNode);
+   /*
+    * \brief
+    *    Whether a monitor object is of value based class type or value type
+    *
+    * \return
+    *    TR_yes The monitor object is definitely value based class type or value type
+    *    TR_no The monitor object is definitely not value based class type or value type
+    *    TR_maybe It is unknown whether the monitor object is value based class type or value type
+    */
+   TR_YesNoMaybe isMonitorValueBasedOrValueType(TR::Node* monNode);
 
 protected:
 

--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -826,6 +826,29 @@ J9::ClassEnv::isValueTypeClassFlattened(TR_OpaqueClassBlock *clazz)
    }
 
 bool
+J9::ClassEnv::isValueBasedOrValueTypeClass(TR_OpaqueClassBlock *clazz)
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      uintptr_t classFlags = 0;
+      JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, TR::compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_CLASS_FLAGS, (void *)&classFlags);
+#ifdef DEBUG
+      stream->write(JITServer::MessageType::ClassEnv_classFlagsValue, clazz);
+      uintptr_t classFlagsRemote = std::get<0>(stream->read<uintptr_t>());
+      // Check that class flags from remote call is equal to the cached ones
+      classFlags = classFlags & J9_CLASS_DISALLOWS_LOCKING_FLAGS;
+      classFlagsRemote = classFlagsRemote & J9_CLASS_DISALLOWS_LOCKING_FLAGS;
+      TR_ASSERT_FATAL(classFlags == classFlagsRemote, "remote call class flags is not equal to cached class flags");
+#endif
+      return J9_ARE_ANY_BITS_SET(classFlags, J9_CLASS_DISALLOWS_LOCKING_FLAGS);
+      }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+   J9Class *j9class = reinterpret_cast<J9Class*>(clazz);
+   return J9_ARE_ANY_BITS_SET(j9class->classFlags, J9_CLASS_DISALLOWS_LOCKING_FLAGS);
+   }
+
+bool
 J9::ClassEnv::isZeroInitializable(TR_OpaqueClassBlock *clazz)
    {
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -93,6 +93,7 @@ public:
    bool isConcreteClass(TR::Compilation *comp, TR_OpaqueClassBlock * clazzPointer);
    bool isValueTypeClass(TR_OpaqueClassBlock *);
    bool isValueTypeClassFlattened(TR_OpaqueClassBlock *clazz);
+   bool isValueBasedOrValueTypeClass(TR_OpaqueClassBlock *);
 
    /**
     * \brief

--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -116,6 +116,22 @@ J9::ObjectModel::areValueTypesEnabled()
    }
 
 
+bool
+J9::ObjectModel::areValueBasedMonitorChecksEnabled()
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+	   return J9_ARE_ANY_BITS_SET(vmInfo->_extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_VALUE_BASED_EXCEPTION | J9_EXTENDED_RUNTIME2_VALUE_BASED_WARNING);
+      }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+   J9JavaVM * javaVM = TR::Compiler->javaVM;
+   return javaVM->internalVMFunctions->areValueBasedMonitorChecksEnabled(javaVM);
+   }
+
+
 int32_t
 J9::ObjectModel::sizeofReferenceField()
    {

--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -62,6 +62,10 @@ public:
    bool mayRequireSpineChecks();
 
    bool areValueTypesEnabled();
+   /**
+   * @brief Whether the check is enabled on monitor object being value based class type
+   */
+   bool areValueBasedMonitorChecksEnabled();
 
    int32_t sizeofReferenceField();
    bool isHotReferenceFieldRequired();

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
@@ -93,7 +93,8 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
 
    /*
    * \brief
-   *     Generates the sequence to handle cases where the monitor object is value type
+   *     Generates the sequence to handle cases where the monitor object
+   *     is value type or value based class type
    *
    * \param node
    *     the monitor enter/exit node
@@ -102,14 +103,16 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    *     the label for OOL code calling VM monitor enter/exit helpers
    *
    * \details
-   *     Call the VM helper if it's detected at runtime that the monitor object is value type.
-   *     The VM helper throws appropriate IllegalMonitorStateException.
+   *     Call the VM helper if it's detected at runtime that the monitor object
+   *     is value type or value based class type.
+   *     The VM helper throws appropriate IllegalMonitorStateException for value type
+   *     and VirtualMachineError for value based class type.
    *
    * \note
    *     This method only handles the cases where, at compile time, it's unknown whether the
-   *     object is reference type or value type.
+   *     object is reference type or value type or value based class type.
    */
-   static void generateCheckForValueTypeMonitorEnterOrExit(TR::Node *node, TR::LabelSymbol *snippetLabel, TR::CodeGenerator *cg);
+   static void generateCheckForValueMonitorEnterOrExit(TR::Node *node, int32_t classFlag, TR::LabelSymbol *snippetLabel, TR::CodeGenerator *cg);
    static void transactionalMemoryJITMonitorEntry(TR::Node *node, TR::CodeGenerator *cg, TR::LabelSymbol *startLabel, TR::LabelSymbol *snippetLabel, TR::LabelSymbol *JITMonitorEnterSnippetLabel, TR::Register *objectReg, int lwoffset);
    static void generateValueTracingCode(TR::Node *node, TR::Register *vmThreadReg, TR::Register *scratchReg, TR::Register *valueRegHigh, TR::Register *valueRegLow, TR::CodeGenerator *cg);
    static void generateValueTracingCode(TR::Node *node, TR::Register *vmThreadReg, TR::Register *scratchReg, TR::Register *valueReg, TR::CodeGenerator *cg);


### PR DESCRIPTION
Add `areValueBasedMonitorChecksEnabled` which calls VM to check if value based class monitor check is enabled. 

Add `isValueBasedClass` and `isMonitorValueBased` to determine if a monitor object is a value based class instance.

If the monitor object type is value based class, VM will either issue a warning or throw an exception
based on `-XX:ValueBasedClassCheck `option.

If the monitor object type is unkonwn, insert a runtime memory check in monitor enter/exit on the class flag `J9ClassIsValueBased`.

If the monitor object type is not value based class, proceed as how it is handled today.

Related to JEP390 #10620