### PR TITLE
Make ROMClass walkers in DDR and VM consistent

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/walkers/LocalVariableTable.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/walkers/LocalVariableTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,28 +21,36 @@
  *******************************************************************************/
 package com.ibm.j9ddr.vm29.j9.walkers;
 
+import com.ibm.j9ddr.vm29.pointer.SelfRelativePointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9UTF8Pointer;
 import com.ibm.j9ddr.vm29.types.U32;
 
 public class LocalVariableTable {
-	public LocalVariableTable(U32 slotNumber, U32 startVisibility,
-			U32 visibilityLength,
-			J9UTF8Pointer genericSignature, J9UTF8Pointer name, J9UTF8Pointer signature) {
+	public LocalVariableTable(U32 slotNumber, U32 startVisibility, U32 visibilityLength,
+			SelfRelativePointer genericSignatureSrp, J9UTF8Pointer genericSignature,
+			SelfRelativePointer nameSrp, J9UTF8Pointer name,
+			SelfRelativePointer signatureSrp, J9UTF8Pointer signature) {
 		this.slotNumber = slotNumber;
 		this.startVisibility = startVisibility;
 		this.visibilityLength = visibilityLength;
+		this.genericSignatureSrp = genericSignatureSrp;
 		this.genericSignature = genericSignature;
+		this.nameSrp = nameSrp;
 		this.name = name;
+		this.signatureSrp = signatureSrp;
 		this.signature = signature;
 	}
 
 	private U32 slotNumber;
 	private U32 startVisibility;
 	private U32 visibilityLength;
+	private SelfRelativePointer genericSignatureSrp;
 	private J9UTF8Pointer genericSignature;
+	private SelfRelativePointer nameSrp;
 	private J9UTF8Pointer name;
+	private SelfRelativePointer signatureSrp;
 	private J9UTF8Pointer signature;
-	
+
 	public U32 getSlotNumber() {
 		return slotNumber;
 	}
@@ -52,11 +60,20 @@ public class LocalVariableTable {
 	public U32 getVisibilityLength() {
 		return visibilityLength;
 	}
+	public SelfRelativePointer getGenericSignatureSrp() {
+		return genericSignatureSrp;
+	}
 	public J9UTF8Pointer getGenericSignature() {
 		return genericSignature;
 	}
+	public SelfRelativePointer getNameSrp() {
+		return nameSrp;
+	}
 	public J9UTF8Pointer getName() {
 		return name;
+	}
+	public SelfRelativePointer getSignatureSrp() {
+		return signatureSrp;
 	}
 	public J9UTF8Pointer getSignature() {
 		return signature;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/RomClassWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/RomClassWalker.java
@@ -980,6 +980,7 @@ public class RomClassWalker extends ClassWalker {
 		classWalkerCallback.addSection(clazz, annotation, increment * U32.SIZEOF, annotationSectionName, true);
 		return increment;
 	}
+
 	long allSlotsInMethodDebugInfoDo(U32Pointer cursor) throws CorruptDataException
 	{
 		J9MethodDebugInfoPointer methodDebugInfo;
@@ -1036,7 +1037,7 @@ public class RomClassWalker extends ClassWalker {
 			if (methodDebugInfo.lineNumberCount().allBitsIn(1)) {
 				classWalkerCallback.addSlot(clazz, SlotType.J9_U32, U32Pointer.cast(methodDebugInfo.add(1)), "compressed line number size");
 			}
-			
+
 			currentLineNumberPtr = J9MethodDebugInfoHelper.getCompressedLineNumberTableForROMClassV1(methodDebugInfo);
 			if (currentLineNumberPtr.notNull()) {
 				for (int j = 0; j < J9MethodDebugInfoHelper.getLineNumberCompressedSize(methodDebugInfo).intValue(); j++) {
@@ -1054,10 +1055,10 @@ public class RomClassWalker extends ClassWalker {
 				LocalVariableTable values = variableInfoValuesIterator.next();
 
 				// Need to walk the name and signature to add them to the UTF8 section
-				classWalkerCallback.addSlot(clazz, SlotType.J9_UTF8, values.getName(), "name");
-				classWalkerCallback.addSlot(clazz, SlotType.J9_UTF8, values.getSignature(), "getSignature");
+				classWalkerCallback.addSlot(clazz, SlotType.J9_ROM_UTF8, values.getNameSrp(), "name");
+				classWalkerCallback.addSlot(clazz, SlotType.J9_ROM_UTF8, values.getSignatureSrp(), "signature");
 				if (values.getGenericSignature().notNull()) {
-					classWalkerCallback.addSlot(clazz, SlotType.J9_UTF8, values.getGenericSignature(), "getGenericSignature");
+					classWalkerCallback.addSlot(clazz, SlotType.J9_ROM_UTF8, values.getGenericSignatureSrp(), "genericSignature");
 				}
 			}
 			U8Pointer end = variableInfoValuesIterator.getLocalVariableTablePtr();
@@ -1073,6 +1074,7 @@ public class RomClassWalker extends ClassWalker {
 		classWalkerCallback.addSection(clazz, methodDebugInfo, sectionSizeBytes, "methodDebugInfo" + (inlineDebugExtension?" Inline":""), inlineDebugExtension);
 		return inlineSize;
 	}
+
 	void allSlotsInEnclosingObjectDo(J9EnclosingObjectPointer enclosingObject) throws CorruptDataException
 	{
 		if (enclosingObject.isNull()) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/RomClassWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/RomClassWalker.java
@@ -297,7 +297,7 @@ public class RomClassWalker extends ClassWalker {
 
 		return J9ROMMethodPointer.cast(cursor);
 	}
-	
+
 	private long allSlotsInMethodParametersDataDo(U32Pointer cursor) throws CorruptDataException
 	{
 		J9MethodParametersDataPointer methodParametersData = J9MethodParametersDataPointer.cast(cursor);
@@ -305,30 +305,30 @@ public class RomClassWalker extends ClassWalker {
 		long methodParametersSize = ROMHelp.J9_METHOD_PARAMS_SIZE_FROM_NUMBER_OF_PARAMS(methodParametersData.parameterCount().longValue());
 		long padding = U32.SIZEOF - (methodParametersSize % U32.SIZEOF);
 		long size = 0;
-		
+
 		if (padding == U32.SIZEOF) {
 			padding = 0;
 		}
-		
+
 		size = methodParametersSize + padding;
-		
+
 		classWalkerCallback.addSlot(clazz, SlotType.J9_SRP, methodParametersData.parameterCountEA(), "parameterCount");
-		
+
 		for (int i = 0; i < methodParametersData.parameterCount().longValue(); i++) {
-			classWalkerCallback.addSlot(clazz, SlotType.J9_SRP, parameters.nameEA(), "methodParameterName");
-			classWalkerCallback.addSlot(clazz, SlotType.J9_U16, parameters.flagsEA(), "methodParameterFlag");			
+			classWalkerCallback.addSlot(clazz, SlotType.J9_ROM_UTF8, parameters.nameEA(), "methodParameterName");
+			classWalkerCallback.addSlot(clazz, SlotType.J9_U16, parameters.flagsEA(), "methodParameterFlag");
 		}
-		
+
 		cursor = cursor.addOffset(methodParametersSize);
 		for (; padding > 0; padding--) {
 			classWalkerCallback.addSlot(clazz, SlotType.J9_U8, cursor, "MethodParameters padding");
 			cursor.addOffset(1);
 		}
-		
+
 		classWalkerCallback.addSection(clazz, methodParametersData, size, "Method Parameters", true);
 		return size/U32.SIZEOF;
 	}
-	
+
 	private int allSlotsInROMFieldDo(J9ROMFieldShapePointer field) throws CorruptDataException {
 		int fieldLength = 0;
 		

--- a/runtime/ddr/overrides-vm
+++ b/runtime/ddr/overrides-vm
@@ -82,6 +82,8 @@ typeoverride.J9AnnotationInfoEntry.annotationType=J9SRP(J9UTF8)
 typeoverride.J9AnnotationInfoEntry.memberName=J9SRP(J9UTF8)
 typeoverride.J9AnnotationInfoEntry.memberSignature=J9SRP(J9UTF8)
 
+typeoverride.J9MethodParameter.name=J9SRP(J9UTF8)
+
 typeoverride.J9EnclosingObject.nameAndSignature=J9SRP(J9ROMNameAndSignature)
 
 typeoverride.J9ROMClass.className=J9SRP(J9UTF8)

--- a/runtime/ddr/vmddrstructs.properties
+++ b/runtime/ddr/vmddrstructs.properties
@@ -160,6 +160,8 @@ ddrblob.typeoverride.J9AnnotationInfoEntry.annotationType=J9SRP(struct J9UTF8)
 ddrblob.typeoverride.J9AnnotationInfoEntry.memberName=J9SRP(struct J9UTF8)
 ddrblob.typeoverride.J9AnnotationInfoEntry.memberSignature=J9SRP(struct J9UTF8)
 
+ddrblob.typeoverride.J9MethodParameter.name=J9SRP(struct J9UTF8)
+
 ddrblob.typeoverride.J9EnclosingObject.nameAndSignature=J9SRP(struct J9ROMNameAndSignature)
 
 ddrblob.typeoverride.J9ROMClass.className=J9SRP(struct J9UTF8)


### PR DESCRIPTION
This PR updates DDR ROMClass walker to match recent changes in the other ROMClass walker (the one used by VM code and cfdumper) in #11330:
- Method parameter names are handled as UTF8 strings rather than raw SRPs.
- Strings in method debug info are visited as SRPs rather than direct pointers to J9UTF8.

Note: this PR should be merged after #11330.