### PR TITLE
OpenJDK MethodType arg slots not needed to support OpenJDK MethodHandle

### DIFF
--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -368,10 +368,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="java/lang/invoke/MemberName" name="type" signature="Ljava/lang/Object;" flags="opt_openjdkMethodhandle"/>
 	<fieldref class="java/lang/invoke/MemberName" name="flags" signature="I" flags="opt_openjdkMethodhandle"/>
 	<fieldref class="java/lang/invoke/MemberName" name="resolution" signature="Ljava/lang/Object;" flags="opt_openjdkMethodhandle"/>
-	<fieldref class="java/lang/invoke/MethodType" name="form" signature="Ljava/lang/invoke/MethodTypeForm;" flags="opt_openjdkMethodhandle"/>
-	<fieldref class="java/lang/invoke/MethodTypeForm" name="parameterSlotCount" signature="S" versions="14-" flags="opt_openjdkMethodhandle">
-		<fieldalias name="argCounts" signature="J" versions="8-11"  flags="opt_openjdkMethodhandle"/>
-	</fieldref>
 	<fieldref class="java/lang/invoke/LambdaForm" name="vmentry" signature="Ljava/lang/invoke/MemberName;" flags="opt_openjdkMethodhandle"/>
 	<fieldref class="java/lang/invoke/MethodHandle" name="form" signature="Ljava/lang/invoke/LambdaForm;" flags="opt_openjdkMethodhandle"/>
 


### PR DESCRIPTION
`MethodType` `arg slots` are only needed to support OpenJDK `MethodType` with
OpenJ9 `MethodHandle`. Recently, it was decided that we won't be pushing
the changes to support OpenJDK `MethodType` with OpenJ9 `MethodHandle`.

So, the `vmconstantpool` refs to retrieve the `arg slots` from OpenJDK
`MethodType` are being removed.

Co-authored-by: Jack Lu <Jack.S.Lu@ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>