### PR TITLE
Use portable formats from omrformatconsts.h

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -44,6 +44,7 @@
 #include "env/annotations/GPUAnnotation.hpp"
 #include "optimizer/Dominators.hpp"
 #include "optimizer/Structure.hpp"
+#include "omrformatconsts.h"
 
 #define OPT_DETAILS "O^O CODE GENERATION: "
 
@@ -576,7 +577,7 @@ static void getParmName(int32_t slot, char * s, bool addr = true)
    {
    int32_t len = 0;
 
-   len = snprintf(s, MAX_NAME, "%%p%d%s", slot,  addr ? ".addr" : "");
+   len = snprintf(s, MAX_NAME, "%%p%" OMR_PRId32 "%s", slot,  addr ? ".addr" : "");
 
    TR_ASSERT(len < MAX_NAME, "Auto's or parm's name is too long\n");
    }
@@ -588,9 +589,9 @@ static void getAutoOrParmName(TR::Symbol *sym, char * s, bool addr = true)
    TR_ASSERT(sym->isAutoOrParm(), "expecting auto or parm");
 
    if (sym->isParm())
-      len = snprintf(s, MAX_NAME, "%%p%d%s", sym->castToParmSymbol()->getSlot(),  addr ? ".addr" : "");
+      len = snprintf(s, MAX_NAME, "%%p%" OMR_PRId32 "%s", sym->castToParmSymbol()->getSlot(),  addr ? ".addr" : "");
    else
-      len = snprintf(s, MAX_NAME, "%%a%d%s", sym->castToAutoSymbol()->getLiveLocalIndex(), addr ? ".addr" : "");
+      len = snprintf(s, MAX_NAME, "%%a%" OMR_PRId32 "%s", sym->castToAutoSymbol()->getLiveLocalIndex(), addr ? ".addr" : "");
 
    TR_ASSERT(len < MAX_NAME, "Auto's or parm's name is too long\n");
    }
@@ -661,24 +662,24 @@ static void getNodeName(TR::Node* node, char * s, TR::Compilation *comp)
          {
          case TR::Int8:
             if(isUnsigned)
-               len = snprintf(s, MAX_NAME, "%u", node->getUnsignedByte());
+               len = snprintf(s, MAX_NAME, "%" OMR_PRIu8, node->getUnsignedByte());
             else
-               len = snprintf(s, MAX_NAME, "%d", node->getByte());
+               len = snprintf(s, MAX_NAME, "%" OMR_PRId8, node->getByte());
             break;
          case TR::Int16:
-            len = snprintf(s, MAX_NAME, "%d", node->getConst<uint16_t>());
+            len = snprintf(s, MAX_NAME, "%" OMR_PRIu16, node->getConst<uint16_t>());
             break;
          case TR::Int32:
             if(isUnsigned)
-               len = snprintf(s, MAX_NAME, "%u", node->getUnsignedInt());
+               len = snprintf(s, MAX_NAME, "%" OMR_PRIu32, node->getUnsignedInt());
             else
-               len = snprintf(s, MAX_NAME, "%d", node->getInt());
+               len = snprintf(s, MAX_NAME, "%" OMR_PRId32, node->getInt());
             break;
          case TR::Int64:
             if(isUnsigned)
-               len = snprintf(s, MAX_NAME, UINT64_PRINTF_FORMAT, node->getUnsignedLongInt());
+               len = snprintf(s, MAX_NAME, "%" OMR_PRIu64, node->getUnsignedLongInt());
             else
-               len = snprintf(s, MAX_NAME, INT64_PRINTF_FORMAT, node->getLongInt());
+               len = snprintf(s, MAX_NAME, "%" OMR_PRId64, node->getLongInt());
             break;
          case TR::Float:
             union
@@ -687,10 +688,10 @@ static void getNodeName(TR::Node* node, char * s, TR::Compilation *comp)
                int64_t                 doubleBits;
                };
             doubleValue = node->getFloat();
-            len = snprintf(s, MAX_NAME, "0x%0.16llx", doubleBits);
+            len = snprintf(s, MAX_NAME, "0x%016" OMR_PRIx64, doubleBits);
             break;
          case TR::Double:
-            len = snprintf(s, MAX_NAME, "0x%0.16llx", node->getDoubleBits());
+            len = snprintf(s, MAX_NAME, "0x%016" OMR_PRIx64, node->getDoubleBits());
             break;
          case TR::Address:
             if (node->getAddress() == 0)
@@ -704,7 +705,7 @@ static void getNodeName(TR::Node* node, char * s, TR::Compilation *comp)
       }
    else
       {
-      len = snprintf(s, MAX_NAME, "%%%d", node->getLocalIndex());
+      len = snprintf(s, MAX_NAME, "%%%" OMR_PRIu32, node->getLocalIndex());
       }
 
    TR_ASSERT(len < MAX_NAME, "Node's name is too long\n");
@@ -1332,7 +1333,7 @@ J9::CodeGenerator::printNVVMIR(
          }
       else
          {
-         int32_t len = snprintf(name0, MAX_NAME, "%d", smsize);
+         int32_t len = snprintf(name0, MAX_NAME, "%" OMR_PRId32, smsize);
          TR_ASSERT(len < MAX_NAME, "Node's name is too long\n");
          }
 
@@ -2861,4 +2862,3 @@ J9::CodeGenerator::objectHeaderInvariant()
    {
    return self()->objectLengthOffset() + 4 /*length*/ ;
    }
-

--- a/runtime/compiler/env/annotations/TestAnnotation.cpp
+++ b/runtime/compiler/env/annotations/TestAnnotation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,6 +29,7 @@
 #include "il/Symbol.hpp"
 #include "il/SymbolReference.hpp"
 #include "compile/ResolvedMethod.hpp"
+#include "omrformatconsts.h"
 
 // only purpose of this class is to test that annotations are working.  Will
 // expect specific values
@@ -55,7 +56,7 @@ TR_TestAnnotation::TR_TestAnnotation(TR::Compilation *comp,TR::SymbolReference *
   J9SRP *strPtr;
   if(getValue(symRef,"intField",kInt,&intptr))
      {
-     printf("Found int value %d\n",*intptr);
+     printf("Found int value %" OMR_PRId32 "\n", *intptr);
      }
    if(getValue(symRef,"floatField",kFloat,&fltptr))
      {
@@ -63,7 +64,7 @@ TR_TestAnnotation::TR_TestAnnotation(TR::Compilation *comp,TR::SymbolReference *
      }
    if(getValue(symRef,"booleanField",kBool,&intptr))
      {
-     printf("Found boolean value %d\n",*intptr);
+     printf("Found boolean value %" OMR_PRId32 "\n", *intptr);
      }
    if(getValue(symRef,"doubleField",kDouble,&dblptr))
      {
@@ -71,19 +72,19 @@ TR_TestAnnotation::TR_TestAnnotation(TR::Compilation *comp,TR::SymbolReference *
      }
    if(getValue(symRef,"charField",kChar,&intptr))
      {
-     printf("Found char value %d\n",*intptr);
+     printf("Found char value %" OMR_PRId32 "\n", *intptr);
      }
    if(getValue(symRef,"shortField",kShort,&intptr))
      {
-     printf("Found short value %d\n",*intptr);
+     printf("Found short value %" OMR_PRId32 "\n", *intptr);
      }
    if(getValue(symRef,"byteField",kByte,&intptr))
      {
-     printf("Found byte value %d\n",*intptr);
+     printf("Found byte value %" OMR_PRId32 "\n", *intptr);
      }
    if(getValue(symRef,"longField",kLong,&longptr))
      {
-     printf("Found byte value %lld\n",*longptr);
+     printf("Found long value %" OMR_PRId64 "\n", *longptr);
      }
    char *enumerationName=NULL, *enumerationValue=NULL;
    int32_t nameLen,valueLen;
@@ -110,5 +111,3 @@ TR_TestAnnotation::TR_TestAnnotation(TR::Compilation *comp,TR::SymbolReference *
 
   _isValid=true;
 }
-
-

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -69,6 +69,7 @@
 #include "optimizer/TransformUtil.hpp"
 #include "optimizer/UseDefInfo.hpp"
 #include "ras/Debug.hpp"
+#include "omrformatconsts.h"
 
 #define OPT_DETAILS "O^O NEWLOOPREDUCER: "
 #define VERBOSE 0
@@ -5207,11 +5208,11 @@ TR_CISCTransformer::extractMatchingRegion()
                   isEmbed = false;
                   if (showMesssagesStdout())
                      {
-                     printf("!!!!!!!!!!!!!! Predecessor of tID %d is different from that of idiom.\n",tID);
+                     printf("!!!!!!!!!!!!!! Predecessor of tID %" OMR_PRIu32 " is different from that of idiom.\n", tID);
                      }
                   if (trace())
                      {
-                     traceMsg(comp(), "Predecessor of tID %d is different from that of idiom.\n",tID);
+                     traceMsg(comp(), "Predecessor of tID %" OMR_PRIu32 " is different from that of idiom.\n", tID);
                      }
                   }
             }
@@ -7616,13 +7617,13 @@ TR_CISCTransformer::computeTopologicalEmbedding(TR_CISCGraph *P, TR_CISCGraph *T
       bool inlined = getBCIndexMinMax(_candidateRegion, &minIndex, &maxIndex, &minLN, &maxLN, true);
       if (minIndex <= maxIndex)
          {
-         sprintf(tmpbuf, ", bcindex %d - %d linenumber %d - %d%s.", minIndex, maxIndex, minLN, maxLN, inlined ? " (inlined)" : "");
+         sprintf(tmpbuf, ", bcindex %" OMR_PRIu32 " - %" OMR_PRIu32 " linenumber %" OMR_PRIu32 " - %" OMR_PRIu32 "%s.", minIndex, maxIndex, minLN, maxLN, inlined ? " (inlined)" : "");
          bcinfo = tmpbuf;
          }
 #endif
 #if SHOW_STATISTICS
       if (showMesssagesStdout())
-         printf("!! Hash=0x%llx %s %s\n", getHashValue(_candidateRegion), P->getTitle(), T->getTitle());
+         printf("!! Hash=0x%" OMR_PRIx64 " %s %s\n", getHashValue(_candidateRegion), P->getTitle(), T->getTitle());
 #endif
 
       if (trace()) traceMsg(comp(), "***** Transformed *****, %s, %s, %s, loop:%d%s\n",
@@ -7837,7 +7838,7 @@ TR_CISCTransformer::insertBitsKeepAliveCalls(TR::Block * block)
          {
          TR::TreeTop * prev = info->_prevTreeTop;
          TR::Block * keepAliveBlock = info->_block;
-         traceMsg(comp(), "\t\tInserting KeepAlive call clone node: %p from block %d [%p] node: %p into block :%d %p\n",callNode, keepAliveBlock->getNumber(), keepAliveBlock, tt->getNode(), block->getNumber(), block);
+         traceMsg(comp(), "\t\tInserting KeepAlive call clone node: %p from block %d [%p] node: %p into block: %d %p\n", callNode, keepAliveBlock->getNumber(), keepAliveBlock, tt->getNode(), block->getNumber(), block);
          }
       }
    }
@@ -7861,4 +7862,3 @@ TR_CISCTransformer::restoreBitsKeepAliveCalls()
       prev->insertAfter(tt);
       }
    }
-

--- a/runtime/compiler/ras/kca_offsets_generator.cpp
+++ b/runtime/compiler/ras/kca_offsets_generator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,6 +43,7 @@
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "env/PersistentInfo.hpp"
+#include "omrformatconsts.h"
 #include <stdio.h>
 
 
@@ -71,11 +72,11 @@ J9::Options::kcaOffsets(char *option, void *, TR::OptionTable *entry)
       fprintf( file, "/*Automatically Generated Header*/\n\n" );
       fprintf( file, "/*File name: %s*/\n\n", szFileName );
 
-      fprintf( file, "#define J9METHOD_BYTECODES         (%d)\n", offsetof(J9Method,bytecodes) );
-      fprintf( file, "#define J9METHOD_CONSTANTPOOL      (%d)\n", offsetof(J9Method,constantPool) );
-      fprintf( file, "#define J9METHOD_EXTRA             (%d)\n", offsetof(J9Method,extra) );
+      fprintf( file, "#define J9METHOD_BYTECODES         (%" OMR_PRIuSIZE ")\n", offsetof(J9Method,bytecodes) );
+      fprintf( file, "#define J9METHOD_CONSTANTPOOL      (%" OMR_PRIuSIZE ")\n", offsetof(J9Method,constantPool) );
+      fprintf( file, "#define J9METHOD_EXTRA             (%" OMR_PRIuSIZE ")\n", offsetof(J9Method,extra) );
 
-      fprintf( file, "#define J9CLASSLOADER_OBJ          (%d)\n", offsetof(J9ClassLoader,classLoaderObject) );
+      fprintf( file, "#define J9CLASSLOADER_OBJ          (%" OMR_PRIuSIZE ")\n", offsetof(J9ClassLoader,classLoaderObject) );
 
       // There should be a better way to do this???
       #if EsVersionMajor == 2 && EsVersionMinor <= 30
@@ -85,142 +86,141 @@ J9::Options::kcaOffsets(char *option, void *, TR::OptionTable *entry)
       #endif
 
 
-      fprintf( file, "#define J9OBJECT_J9CLASS           (%d)\n", offsetof(J9IndexableObjectContiguous,clazz) );
+      fprintf( file, "#define J9OBJECT_J9CLASS           (%" OMR_PRIuSIZE ")\n", offsetof(J9IndexableObjectContiguous,clazz) );
       #if !defined(J9VM_INTERP_FLAGS_IN_CLASS_SLOT)
-      fprintf( file, "#define J9OBJECT_FLAGS             (%d)\n", offsetof(J9IndexableObjectContiguous,flags) );
+      fprintf( file, "#define J9OBJECT_FLAGS             (%" OMR_PRIuSIZE ")\n", offsetof(J9IndexableObjectContiguous,flags) );
       #else
 	  fprintf( file, "#define J9OBJECT_FLAGS             (0) // Does not exist!\n" );
       #endif
       fprintf( file, "#define J9OBJECT_MONITOR           (0) // Does not exist!\n" );
-      fprintf( file, "#define J9OBJECT_ARRAY_SIZE        (%d)\n", offsetof(J9IndexableObjectContiguous,size) );
+      fprintf( file, "#define J9OBJECT_ARRAY_SIZE        (%" OMR_PRIuSIZE ")\n", offsetof(J9IndexableObjectContiguous,size) );
 
-      fprintf( file, "#define METADATA_CLASSNAME         (%d)\n", offsetof(J9JITExceptionTable,className) );
-      fprintf( file, "#define METADATA_METHODNAME        (%d)\n", offsetof(J9JITExceptionTable,methodName) );
-      fprintf( file, "#define METADATA_SIGNATURE         (%d)\n", offsetof(J9JITExceptionTable,methodSignature) );
-      fprintf( file, "#define METADATA_CONSTANTPOOL      (%d)\n", offsetof(J9JITExceptionTable,constantPool) );
-      fprintf( file, "#define METADATA_J9METHOD          (%d)\n", offsetof(J9JITExceptionTable,ramMethod) );
-      fprintf( file, "#define METADATA_STARTPC           (%d)\n", offsetof(J9JITExceptionTable,startPC) );
-      fprintf( file, "#define METADATA_ENDWARMPC         (%d)\n", offsetof(J9JITExceptionTable,endWarmPC) );
-      fprintf( file, "#define METADATA_COLDSTART         (%d)\n", offsetof(J9JITExceptionTable,startColdPC) );
-      fprintf( file, "#define METADATA_COLDEND           (%d)\n", offsetof(J9JITExceptionTable,endPC) );
-      fprintf( file, "#define METADATA_FRAMESIZE         (%d)\n", offsetof(J9JITExceptionTable,totalFrameSize) );
-      fprintf( file, "#define METADATA_NUM_EXC_RANGES    (%d)\n", offsetof(J9JITExceptionTable,numExcptionRanges) );
-      fprintf( file, "#define METADATA_INLINEDCALLS      (%d)\n", offsetof(J9JITExceptionTable,inlinedCalls) );
-      fprintf( file, "#define METADATA_BODYINFO          (%d)\n", offsetof(J9JITExceptionTable,bodyInfo) );
-      fprintf( file, "#define METADATA_SIZE              (%d)\n", sizeof(J9JITExceptionTable) );
+      fprintf( file, "#define METADATA_CLASSNAME         (%" OMR_PRIuSIZE ")\n", offsetof(J9JITExceptionTable,className) );
+      fprintf( file, "#define METADATA_METHODNAME        (%" OMR_PRIuSIZE ")\n", offsetof(J9JITExceptionTable,methodName) );
+      fprintf( file, "#define METADATA_SIGNATURE         (%" OMR_PRIuSIZE ")\n", offsetof(J9JITExceptionTable,methodSignature) );
+      fprintf( file, "#define METADATA_CONSTANTPOOL      (%" OMR_PRIuSIZE ")\n", offsetof(J9JITExceptionTable,constantPool) );
+      fprintf( file, "#define METADATA_J9METHOD          (%" OMR_PRIuSIZE ")\n", offsetof(J9JITExceptionTable,ramMethod) );
+      fprintf( file, "#define METADATA_STARTPC           (%" OMR_PRIuSIZE ")\n", offsetof(J9JITExceptionTable,startPC) );
+      fprintf( file, "#define METADATA_ENDWARMPC         (%" OMR_PRIuSIZE ")\n", offsetof(J9JITExceptionTable,endWarmPC) );
+      fprintf( file, "#define METADATA_COLDSTART         (%" OMR_PRIuSIZE ")\n", offsetof(J9JITExceptionTable,startColdPC) );
+      fprintf( file, "#define METADATA_COLDEND           (%" OMR_PRIuSIZE ")\n", offsetof(J9JITExceptionTable,endPC) );
+      fprintf( file, "#define METADATA_FRAMESIZE         (%" OMR_PRIuSIZE ")\n", offsetof(J9JITExceptionTable,totalFrameSize) );
+      fprintf( file, "#define METADATA_NUM_EXC_RANGES    (%" OMR_PRIuSIZE ")\n", offsetof(J9JITExceptionTable,numExcptionRanges) );
+      fprintf( file, "#define METADATA_INLINEDCALLS      (%" OMR_PRIuSIZE ")\n", offsetof(J9JITExceptionTable,inlinedCalls) );
+      fprintf( file, "#define METADATA_BODYINFO          (%" OMR_PRIuSIZE ")\n", offsetof(J9JITExceptionTable,bodyInfo) );
+      fprintf( file, "#define METADATA_SIZE              (%" OMR_PRIuSIZE ")\n", sizeof(J9JITExceptionTable) );
 
-      fprintf( file, "#define J9CLASS_J9ROMCLASS         (%d)\n", offsetof(J9Class,romClass) );
-      fprintf( file, "#define J9CLASS_SUPERCLASSES       (%d)\n", offsetof(J9Class,superclasses) );
-      fprintf( file, "#define J9CLASS_CLASSDEPTHANDFLAGS (%d)\n", offsetof(J9Class,classDepthAndFlags) );
-      fprintf( file, "#define J9CLASS_CLASSLOADER        (%d)\n", offsetof(J9Class,classLoader) );
+      fprintf( file, "#define J9CLASS_J9ROMCLASS         (%" OMR_PRIuSIZE ")\n", offsetof(J9Class,romClass) );
+      fprintf( file, "#define J9CLASS_SUPERCLASSES       (%" OMR_PRIuSIZE ")\n", offsetof(J9Class,superclasses) );
+      fprintf( file, "#define J9CLASS_CLASSDEPTHANDFLAGS (%" OMR_PRIuSIZE ")\n", offsetof(J9Class,classDepthAndFlags) );
+      fprintf( file, "#define J9CLASS_CLASSLOADER        (%" OMR_PRIuSIZE ")\n", offsetof(J9Class,classLoader) );
       #if EsVersionMajor == 2 && EsVersionMinor <= 30
       fprintf( file, "#define J9CLASS_CLASSOBJECT        (0)\n" ); // Not used by KCA for 22/23
       #else
-      fprintf( file, "#define J9CLASS_CLASSOBJECT        (%d)\n", offsetof(J9Class,classObject) );
+      fprintf( file, "#define J9CLASS_CLASSOBJECT        (%" OMR_PRIuSIZE ")\n", offsetof(J9Class,classObject) );
       #endif
-      fprintf( file, "#define J9CLASS_J9METHODS          (%d)\n", offsetof(J9Class,ramMethods) );
-      fprintf( file, "#define J9CLASS_INSTANCESIZE       (%d)\n", offsetof(J9Class,totalInstanceSize) );
-      fprintf( file, "#define J9CLASS_SUBCLASSLINK       (%d)\n", offsetof(J9Class,subclassTraversalLink) );
-      fprintf( file, "#define J9CLASS_ITABLE             (%d)\n", offsetof(J9Class,iTable) );
-      fprintf( file, "#define J9CLASS_VFT                (%d)\n", sizeof(J9Class) );
-      fprintf( file, "#define J9CLASS_LOCKOFFSET         (%d)\n", offsetof(J9Class,lockOffset) );
+      fprintf( file, "#define J9CLASS_J9METHODS          (%" OMR_PRIuSIZE ")\n", offsetof(J9Class,ramMethods) );
+      fprintf( file, "#define J9CLASS_INSTANCESIZE       (%" OMR_PRIuSIZE ")\n", offsetof(J9Class,totalInstanceSize) );
+      fprintf( file, "#define J9CLASS_SUBCLASSLINK       (%" OMR_PRIuSIZE ")\n", offsetof(J9Class,subclassTraversalLink) );
+      fprintf( file, "#define J9CLASS_ITABLE             (%" OMR_PRIuSIZE ")\n", offsetof(J9Class,iTable) );
+      fprintf( file, "#define J9CLASS_VFT                (%" OMR_PRIuSIZE ")\n", sizeof(J9Class) );
+      fprintf( file, "#define J9CLASS_LOCKOFFSET         (%" OMR_PRIuSIZE ")\n", offsetof(J9Class,lockOffset) );
 
-      fprintf( file, "#define J9ARRAYCLASS_ARRAYTYPE     (%d)\n", offsetof(J9ArrayClass,arrayClass) );
-      fprintf( file, "#define J9ARRAYCLASS_COMPTYPE      (%d)\n", offsetof(J9ArrayClass,componentType) );
+      fprintf( file, "#define J9ARRAYCLASS_ARRAYTYPE     (%" OMR_PRIuSIZE ")\n", offsetof(J9ArrayClass,arrayClass) );
+      fprintf( file, "#define J9ARRAYCLASS_COMPTYPE      (%" OMR_PRIuSIZE ")\n", offsetof(J9ArrayClass,componentType) );
 
-      fprintf( file, "#define J9ROMCLASS_CLASSNAME       (%d)\n", offsetof(J9ROMClass,className) );
-      fprintf( file, "#define J9ROMCLASS_SUPERCLASSNAME  (%d)\n", offsetof(J9ROMClass,superclassName) );
-      fprintf( file, "#define J9ROMCLASS_MODIFIERS       (%d)\n", offsetof(J9ROMClass,modifiers) );
-      fprintf( file, "#define J9ROMCLASS_ROMMETHODCOUNT  (%d)\n", offsetof(J9ROMClass,romMethodCount) );
-      fprintf( file, "#define J9ROMCLASS_ROMMETHODS      (%d)\n", offsetof(J9ROMClass,romMethods) );
-      fprintf( file, "#define J9ROMCLASS_ROMFIELDCOUNT   (%d)\n", offsetof(J9ROMClass,romFieldCount) );
-      fprintf( file, "#define J9ROMCLASS_ROMFIELDS       (%d)\n", offsetof(J9ROMClass,romFields) );
-      fprintf( file, "#define J9ROMCLASS_RAMCPCOUNT      (%d)\n", offsetof(J9ROMClass,ramConstantPoolCount) );
-      fprintf( file, "#define J9ROMCLASS_ROMCPCOUNT      (%d)\n", offsetof(J9ROMClass,romConstantPoolCount) );
+      fprintf( file, "#define J9ROMCLASS_CLASSNAME       (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMClass,className) );
+      fprintf( file, "#define J9ROMCLASS_SUPERCLASSNAME  (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMClass,superclassName) );
+      fprintf( file, "#define J9ROMCLASS_MODIFIERS       (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMClass,modifiers) );
+      fprintf( file, "#define J9ROMCLASS_ROMMETHODCOUNT  (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMClass,romMethodCount) );
+      fprintf( file, "#define J9ROMCLASS_ROMMETHODS      (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMClass,romMethods) );
+      fprintf( file, "#define J9ROMCLASS_ROMFIELDCOUNT   (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMClass,romFieldCount) );
+      fprintf( file, "#define J9ROMCLASS_ROMFIELDS       (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMClass,romFields) );
+      fprintf( file, "#define J9ROMCLASS_RAMCPCOUNT      (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMClass,ramConstantPoolCount) );
+      fprintf( file, "#define J9ROMCLASS_ROMCPCOUNT      (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMClass,romConstantPoolCount) );
 
-      fprintf( file, "#define J9ROMMETHOD_NAME           (%d)\n", offsetof(J9ROMMethod,nameAndSignature) + offsetof(J9ROMNameAndSignature,name) );
-      fprintf( file, "#define J9ROMMETHOD_SIGNATURE      (%d)\n", offsetof(J9ROMMethod,nameAndSignature) + offsetof(J9ROMNameAndSignature,signature) );
-      fprintf( file, "#define J9ROMMETHOD_MODIFIERS      (%d)\n", offsetof(J9ROMMethod,modifiers) );
+      fprintf( file, "#define J9ROMMETHOD_NAME           (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMMethod,nameAndSignature) + offsetof(J9ROMNameAndSignature,name) );
+      fprintf( file, "#define J9ROMMETHOD_SIGNATURE      (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMMethod,nameAndSignature) + offsetof(J9ROMNameAndSignature,signature) );
+      fprintf( file, "#define J9ROMMETHOD_MODIFIERS      (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMMethod,modifiers) );
       #if EsVersionMajor == 2 && EsVersionMinor <= 30
-      fprintf( file, "#define J9ROMMETHOD_BC_SIZELOW     (%d)\n", offsetof(J9ROMMethod,bytecodeSlots) );
-      fprintf( file, "#define J9ROMMETHOD_BC_SIZEHIGH    (%d)\n", offsetof(J9ROMMethod,bytecodeSlotsHigh) );
+      fprintf( file, "#define J9ROMMETHOD_BC_SIZELOW     (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMMethod,bytecodeSlots) );
+      fprintf( file, "#define J9ROMMETHOD_BC_SIZEHIGH    (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMMethod,bytecodeSlotsHigh) );
       #else
-      fprintf( file, "#define J9ROMMETHOD_BC_SIZELOW     (%d)\n", offsetof(J9ROMMethod,bytecodeSizeLow) );
-      fprintf( file, "#define J9ROMMETHOD_BC_SIZEHIGH    (%d)\n", offsetof(J9ROMMethod,bytecodeSizeHigh) );
+      fprintf( file, "#define J9ROMMETHOD_BC_SIZELOW     (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMMethod,bytecodeSizeLow) );
+      fprintf( file, "#define J9ROMMETHOD_BC_SIZEHIGH    (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMMethod,bytecodeSizeHigh) );
       #endif
-      fprintf( file, "#define J9ROMMETHOD_MAXSTACK       (%d)\n", offsetof(J9ROMMethod,maxStack) );
-      fprintf( file, "#define J9ROMMETHOD_ARGCOUNT       (%d)\n", offsetof(J9ROMMethod,argCount) );
+      fprintf( file, "#define J9ROMMETHOD_MAXSTACK       (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMMethod,maxStack) );
+      fprintf( file, "#define J9ROMMETHOD_ARGCOUNT       (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMMethod,argCount) );
 
-      fprintf( file, "#define J9ROMFIELDSHAPE_NAME       (%d)\n", offsetof(J9ROMFieldShape,nameAndSignature) + offsetof(J9ROMNameAndSignature,name) );
-      fprintf( file, "#define J9ROMFIELDSHAPE_SIGNATURE  (%d)\n", offsetof(J9ROMFieldShape,nameAndSignature) + offsetof(J9ROMNameAndSignature,signature) );
-      fprintf( file, "#define J9ROMFIELDSHAPE_MODIFIERS  (%d)\n", offsetof(J9ROMFieldShape,modifiers) );
-      fprintf( file, "#define J9ROMFIELDSHAPE_VALUE      (%d)\n", sizeof(J9ROMFieldShape) );
+      fprintf( file, "#define J9ROMFIELDSHAPE_NAME       (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMFieldShape,nameAndSignature) + offsetof(J9ROMNameAndSignature,name) );
+      fprintf( file, "#define J9ROMFIELDSHAPE_SIGNATURE  (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMFieldShape,nameAndSignature) + offsetof(J9ROMNameAndSignature,signature) );
+      fprintf( file, "#define J9ROMFIELDSHAPE_MODIFIERS  (%" OMR_PRIuSIZE ")\n", offsetof(J9ROMFieldShape,modifiers) );
+      fprintf( file, "#define J9ROMFIELDSHAPE_VALUE      (%" OMR_PRIuSIZE ")\n", sizeof(J9ROMFieldShape) );
 
-      fprintf( file, "#define J9METHOD_SIZE              (%d)\n", sizeof(J9Method) );
-      fprintf( file, "#define BYTECODES_J9ROMMETHOD      (%d)\n", -(int)sizeof(J9ROMMethod));
+      fprintf( file, "#define J9METHOD_SIZE              (%" OMR_PRIuSIZE ")\n", sizeof(J9Method) );
+      fprintf( file, "#define BYTECODES_J9ROMMETHOD      (-%" OMR_PRIdSIZE ")\n", sizeof(J9ROMMethod) );
 
-      fprintf( file, "#define J9VMRAS_VM                 (%d)\n", offsetof(J9RAS,vm) );
-      fprintf( file, "#define J9VMRAS_CRASHINFO          (%d)\n", offsetof(J9RAS,crashInfo) );
+      fprintf( file, "#define J9VMRAS_VM                 (%" OMR_PRIuSIZE ")\n", offsetof(J9RAS,vm) );
+      fprintf( file, "#define J9VMRAS_CRASHINFO          (%" OMR_PRIuSIZE ")\n", offsetof(J9RAS,crashInfo) );
 
-      fprintf( file, "#define CRASHINFO_FAILINGTHREAD    (%d)\n", offsetof(J9RASCrashInfo,failingThread) );
-      fprintf( file, "#define CRASHINFO_GPINFO           (%d)\n", offsetof(J9RASCrashInfo,gpInfo) );
+      fprintf( file, "#define CRASHINFO_FAILINGTHREAD    (%" OMR_PRIuSIZE ")\n", offsetof(J9RASCrashInfo,failingThread) );
+      fprintf( file, "#define CRASHINFO_GPINFO           (%" OMR_PRIuSIZE ")\n", offsetof(J9RASCrashInfo,gpInfo) );
 
-      fprintf( file, "#define VM_MAIN_THREAD             (%d)\n", offsetof(J9JavaVM,mainThread) );
-      fprintf( file, "#define VM_JITCONFIG               (%d)\n", offsetof(J9JavaVM,jitConfig) );
-      fprintf( file, "#define VM_BOOLARRAYCLASS          (%d)\n", offsetof(J9JavaVM,booleanArrayClass) );
-      fprintf( file, "#define VM_CMPRSS_DISPLACEMENT     (%d)\n", 0 );
+      fprintf( file, "#define VM_MAIN_THREAD             (%" OMR_PRIuSIZE ")\n", offsetof(J9JavaVM,mainThread) );
+      fprintf( file, "#define VM_JITCONFIG               (%" OMR_PRIuSIZE ")\n", offsetof(J9JavaVM,jitConfig) );
+      fprintf( file, "#define VM_BOOLARRAYCLASS          (%" OMR_PRIuSIZE ")\n", offsetof(J9JavaVM,booleanArrayClass) );
+      fprintf( file, "#define VM_CMPRSS_DISPLACEMENT     (%" OMR_PRIuSIZE ")\n", (size_t)0 );
       #if defined(OMR_GC_COMPRESSED_POINTERS)
-      fprintf( file, "#define VM_CMPRSS_SHIFT            (%d)\n", offsetof(J9JavaVM,compressedPointersShift) );
+      fprintf( file, "#define VM_CMPRSS_SHIFT            (%" OMR_PRIuSIZE ")\n", offsetof(J9JavaVM,compressedPointersShift) );
       #else
-      fprintf( file, "#define VM_CMPRSS_SHIFT            (%d)\n", 0 );
+      fprintf( file, "#define VM_CMPRSS_SHIFT            (%" OMR_PRIuSIZE ")\n", (size_t)0 );
       #endif
 
-      fprintf( file, "#define JITCONFIG_JITARTIFACTS     (%d)\n", offsetof(J9JITConfig,translationArtifacts) );
-      fprintf( file, "#define JITCONFIG_COMPILING        (%d)\n", 0 );
-      fprintf( file, "#define JITCONFIG_PSEUDOTOC        (%d)\n", offsetof(J9JITConfig,pseudoTOC) );
+      fprintf( file, "#define JITCONFIG_JITARTIFACTS     (%" OMR_PRIuSIZE ")\n", offsetof(J9JITConfig,translationArtifacts) );
+      fprintf( file, "#define JITCONFIG_COMPILING        (%" OMR_PRIuSIZE ")\n", (size_t)0 );
+      fprintf( file, "#define JITCONFIG_PSEUDOTOC        (%" OMR_PRIuSIZE ")\n", offsetof(J9JITConfig,pseudoTOC) );
 
-      fprintf( file, "#define J9AVLTREE_ROOTNODE         (%d)\n", offsetof(J9AVLTree,rootNode) );
+      fprintf( file, "#define J9AVLTREE_ROOTNODE         (%" OMR_PRIuSIZE ")\n", offsetof(J9AVLTree,rootNode) );
 
-      fprintf( file, "#define J9VMTHREAD_COMPILING       (%d)\n", offsetof(J9VMThread,jitMethodToBeCompiled) );
-      fprintf( file, "#define J9VMTHREAD_VM              (%d)\n", offsetof(J9VMThread,javaVM) );
-      fprintf( file, "#define J9VMTHREAD_ARG0EA          (%d)\n", offsetof(J9VMThread,arg0EA) );
-      fprintf( file, "#define J9VMTHREAD_BYTECODES       (%d)\n", offsetof(J9VMThread,bytecodes) );
-      fprintf( file, "#define J9VMTHREAD_SP              (%d)\n", offsetof(J9VMThread,sp) );
-      fprintf( file, "#define J9VMTHREAD_PC              (%d)\n", offsetof(J9VMThread,pc) );
-      fprintf( file, "#define J9VMTHREAD_LITERALS        (%d)\n", offsetof(J9VMThread,literals) );
-      fprintf( file, "#define J9VMTHREAD_SOF_MARK        (%d)\n", offsetof(J9VMThread,stackOverflowMark) );
+      fprintf( file, "#define J9VMTHREAD_COMPILING       (%" OMR_PRIuSIZE ")\n", offsetof(J9VMThread,jitMethodToBeCompiled) );
+      fprintf( file, "#define J9VMTHREAD_VM              (%" OMR_PRIuSIZE ")\n", offsetof(J9VMThread,javaVM) );
+      fprintf( file, "#define J9VMTHREAD_ARG0EA          (%" OMR_PRIuSIZE ")\n", offsetof(J9VMThread,arg0EA) );
+      fprintf( file, "#define J9VMTHREAD_BYTECODES       (%" OMR_PRIuSIZE ")\n", offsetof(J9VMThread,bytecodes) );
+      fprintf( file, "#define J9VMTHREAD_SP              (%" OMR_PRIuSIZE ")\n", offsetof(J9VMThread,sp) );
+      fprintf( file, "#define J9VMTHREAD_PC              (%" OMR_PRIuSIZE ")\n", offsetof(J9VMThread,pc) );
+      fprintf( file, "#define J9VMTHREAD_LITERALS        (%" OMR_PRIuSIZE ")\n", offsetof(J9VMThread,literals) );
+      fprintf( file, "#define J9VMTHREAD_SOF_MARK        (%" OMR_PRIuSIZE ")\n", offsetof(J9VMThread,stackOverflowMark) );
       #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
-      fprintf( file, "#define J9VMTHREAD_HEAP_ALLOC      (%d)\n", offsetof(J9VMThread,heapAlloc) );
+      fprintf( file, "#define J9VMTHREAD_HEAP_ALLOC      (%" OMR_PRIuSIZE ")\n", offsetof(J9VMThread,heapAlloc) );
       #else
-      fprintf( file, "#define J9VMTHREAD_HEAP_ALLOC      (%d)\n", 0 ); // The RealTime JVM does not have this field
+      fprintf( file, "#define J9VMTHREAD_HEAP_ALLOC      (%" OMR_PRIuSIZE ")\n", (size_t)0 ); // The RealTime JVM does not have this field
       #endif
-      fprintf( file, "#define J9VMTHREAD_THREADOBJ       (%d)\n", offsetof(J9VMThread,threadObject) );
-      fprintf( file, "#define J9VMTHREAD_STACKOBJ        (%d)\n", offsetof(J9VMThread,stackObject) );
-      fprintf( file, "#define J9VMTHREAD_OSTHREAD        (%d)\n", offsetof(J9VMThread,osThread) );
-      fprintf( file, "#define J9VMTHREAD_CUR_EXCEPTION   (%d)\n", offsetof(J9VMThread,currentException) );
-      fprintf( file, "#define J9VMTHREAD_NEXT_THREAD     (%d)\n", offsetof(J9VMThread,linkNext) );
-      fprintf( file, "#define J9VMTHREAD_ELS             (%d)\n", offsetof(J9VMThread,entryLocalStorage) );
+      fprintf( file, "#define J9VMTHREAD_THREADOBJ       (%" OMR_PRIuSIZE ")\n", offsetof(J9VMThread,threadObject) );
+      fprintf( file, "#define J9VMTHREAD_STACKOBJ        (%" OMR_PRIuSIZE ")\n", offsetof(J9VMThread,stackObject) );
+      fprintf( file, "#define J9VMTHREAD_OSTHREAD        (%" OMR_PRIuSIZE ")\n", offsetof(J9VMThread,osThread) );
+      fprintf( file, "#define J9VMTHREAD_CUR_EXCEPTION   (%" OMR_PRIuSIZE ")\n", offsetof(J9VMThread,currentException) );
+      fprintf( file, "#define J9VMTHREAD_NEXT_THREAD     (%" OMR_PRIuSIZE ")\n", offsetof(J9VMThread,linkNext) );
+      fprintf( file, "#define J9VMTHREAD_ELS             (%" OMR_PRIuSIZE ")\n", offsetof(J9VMThread,entryLocalStorage) );
 
-      fprintf( file, "#define OSTHREAD_TID               (%d)\n", offsetof(J9AbstractThread,tid) );
+      fprintf( file, "#define OSTHREAD_TID               (%" OMR_PRIuSIZE ")\n", offsetof(J9AbstractThread,tid) );
 
-      fprintf( file, "#define J9JITSTACKATLAS_MAPBYTES   (%d)\n", offsetof(J9JITStackAtlas,numberOfMapBytes) );
-      fprintf( file, "#define BODYINFO_HOTNESS           (%d)\n", offsetof(TR_PersistentJittedBodyInfo,_hotness) );
-      fprintf( file, "#define PERSISTENTINFO_CHTABLE     (%d)\n", offsetof(TR::PersistentInfo,_persistentCHTable) );
-      fprintf( file, "#define PERSISTENTCLASS_VISITED    (%d)\n", offsetof(TR_PersistentClassInfo,_visitedStatus) );
+      fprintf( file, "#define J9JITSTACKATLAS_MAPBYTES   (%" OMR_PRIuSIZE ")\n", offsetof(J9JITStackAtlas,numberOfMapBytes) );
+      fprintf( file, "#define BODYINFO_HOTNESS           (%" OMR_PRIuSIZE ")\n", offsetof(TR_PersistentJittedBodyInfo,_hotness) );
+      fprintf( file, "#define PERSISTENTINFO_CHTABLE     (%" OMR_PRIuSIZE ")\n", offsetof(TR::PersistentInfo,_persistentCHTable) );
+      fprintf( file, "#define PERSISTENTCLASS_VISITED    (%" OMR_PRIuSIZE ")\n", offsetof(TR_PersistentClassInfo,_visitedStatus) );
 
-      fprintf( file, "#define ELS_OLDELS                 (%d)\n", offsetof(J9VMEntryLocalStorage,oldEntryLocalStorage) );
-      fprintf( file, "#define ELS_I2JSTATE               (%d)\n", offsetof(J9VMEntryLocalStorage,i2jState) );
+      fprintf( file, "#define ELS_OLDELS                 (%" OMR_PRIuSIZE ")\n", offsetof(J9VMEntryLocalStorage,oldEntryLocalStorage) );
+      fprintf( file, "#define ELS_I2JSTATE               (%" OMR_PRIuSIZE ")\n", offsetof(J9VMEntryLocalStorage,i2jState) );
 
-      fprintf( file, "#define I2JSTATE_RETURNSP          (%d)\n", offsetof(J9I2JState,returnSP) );
-      fprintf( file, "#define I2JSTATE_A0                (%d)\n", offsetof(J9I2JState,a0) );
-      fprintf( file, "#define I2JSTATE_J9METHOD          (%d)\n", offsetof(J9I2JState,literals) );
-      fprintf( file, "#define I2JSTATE_RETURNPC          (%d)\n", offsetof(J9I2JState,pc) );
+      fprintf( file, "#define I2JSTATE_RETURNSP          (%" OMR_PRIuSIZE ")\n", offsetof(J9I2JState,returnSP) );
+      fprintf( file, "#define I2JSTATE_A0                (%" OMR_PRIuSIZE ")\n", offsetof(J9I2JState,a0) );
+      fprintf( file, "#define I2JSTATE_J9METHOD          (%" OMR_PRIuSIZE ")\n", offsetof(J9I2JState,literals) );
+      fprintf( file, "#define I2JSTATE_RETURNPC          (%" OMR_PRIuSIZE ")\n", offsetof(J9I2JState,pc) );
 
-      fprintf( file, "#define J9SFJ2IFRAME_RETURNADDR    (%d)\n", offsetof(J9SFJ2IFrame,returnAddress) );
-      fprintf( file, "#define J9SFJ2IFRAME_RETURNSP      (%d)\n", offsetof(J9SFJ2IFrame,taggedReturnSP) );
+      fprintf( file, "#define J9SFJ2IFRAME_RETURNADDR    (%" OMR_PRIuSIZE ")\n", offsetof(J9SFJ2IFrame,returnAddress) );
+      fprintf( file, "#define J9SFJ2IFRAME_RETURNSP      (%" OMR_PRIuSIZE ")\n", offsetof(J9SFJ2IFrame,taggedReturnSP) );
 
       fclose(file);
       }
    return option;
    }
-

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -38,6 +38,7 @@
 #include "control/CompilationThread.hpp"
 #include "runtime/JITClientSession.hpp"
 #endif
+#include "omrformatconsts.h"
 
 extern TR::Monitor *assumptionTableMutex;
 
@@ -322,7 +323,7 @@ void TR_RuntimeAssumptionTable::purgeAssumptionListHead(OMR::RuntimeAssumption *
    assumptionList->compensate(fe, 0, 0);
 
    OMR::RuntimeAssumption *next = assumptionList->getNextEvenIfDead();
-   printf("Freeing Assumption 0x%x and next assumption is 0x%x \n", assumptionList, next);
+   printf("Freeing Assumption 0x%" OMR_PRIxPTR " and next assumption is 0x%" OMR_PRIxPTR "\n", (uintptr_t)assumptionList, (uintptr_t)next);
 
    assumptionList->dequeueFromListOfAssumptionsForJittedBody();
    incReclaimedAssumptionCount(assumptionList->getAssumptionKind());
@@ -1521,7 +1522,7 @@ void TR_AddressSet::add(uintptr_t start, uintptr_t end)
          {
          fprintf(stderr, "UAR:    ");
          for (int j = 0; (j < 4) && (i+j < _numAddressRanges); j++)
-            fprintf(stderr, " %4d [%p - %p]", i+j, _addressRanges[i+j].getStart(), _addressRanges[i+j].getEnd());
+            fprintf(stderr, " %4d [%#" OMR_PRIxPTR " - %#" OMR_PRIxPTR "]", i+j, _addressRanges[i+j].getStart(), _addressRanges[i+j].getEnd());
          fprintf(stderr, "\n");
          }
       }
@@ -1578,5 +1579,3 @@ int32_t TR_AddressSet::firstHigherAddressRangeIndex(uintptr_t address)
 
    return result;
    }
-
-

--- a/runtime/compiler/runtime/HWProfiler.cpp
+++ b/runtime/compiler/runtime/HWProfiler.cpp
@@ -44,6 +44,7 @@
 #include "env/VMJ9.h"
 #include "env/j9method.h"
 #include "env/VerboseLog.hpp"
+#include "omrformatconsts.h"
 
 
 uint32_t TR_HWProfiler::_STATS_TotalBuffersProcessed = 0;
@@ -866,22 +867,22 @@ TR_HWProfiler::createRecords(TR::Compilation *comp)
 void
 TR_HWProfiler::printStats()
    {
-   printf("Number of recompilations induced = %llu\n",                   _numRecompilationsInduced);
-   printf("Number of reduced warm recompilations induced = %llu\n",      _numReducedWarmRecompilationsInduced);
-   printf("Number of reduced warm recompilations upgraded = %llu\n",     _numReducedWarmRecompilationsUpgraded);
-   printf("Number of recompilations induced due to jitSampling = %d\n",   TR::Recompilation::jitRecompilationsInduced);
-   printf("TR::Recompilation::jitGlobalSampleCount = %d\n",               TR::Recompilation::jitGlobalSampleCount);
-   printf("TR::Recompilation::hwpGlobalSampleCount = %d\n",               TR::Recompilation::hwpGlobalSampleCount);
-   printf("Number of buffers completely filled = %llu\n",                _numBuffersCompletelyFilled);
-   printf("Average buffer filled percentage = %f\n",                     _bufferSizeSum ? (((float)_bufferFilledSum) / ((float)_bufferSizeSum) * 100) : 0);
-   printf("Number of requests = %llu\n",                                 _numRequests);
-   printf("Number of requests skipped = %llu\n",                         _numRequestsSkipped);
-   printf("Memory used by metadata bytecodePC to IA mapping = %llu B\n", _totalMemoryUsedByMetadataMapping);
-   printf("Total buffers processed = %llu\n",                            _STATS_TotalBuffersProcessed);
-   printf("Total buffers processed by App Thread= %llu\n",               _STATS_BuffersProcessedByAppThread);
-   printf("Total event records: %llu\n",                                 _STATS_TotalEntriesProcessed);
-   printf("Total instructions tracked: %u\n",                            _STATS_TotalInstructionsTracked);
-   printf("Total downgrades due to RI: %u\n",                            _STATS_NumCompDowngradesDueToRI);
-   printf("Total upgrades due to RI: %u\n",                              _STATS_NumUpgradesDueToRI);
+   printf("Number of recompilations induced = %" OMR_PRIu64 "\n",                   _numRecompilationsInduced);
+   printf("Number of reduced warm recompilations induced = %" OMR_PRIu64 "\n",      _numReducedWarmRecompilationsInduced);
+   printf("Number of reduced warm recompilations upgraded = %" OMR_PRIu64 "\n",     _numReducedWarmRecompilationsUpgraded);
+   printf("Number of recompilations induced due to jitSampling = %d\n",             TR::Recompilation::jitRecompilationsInduced);
+   printf("TR::Recompilation::jitGlobalSampleCount = %d\n",                         TR::Recompilation::jitGlobalSampleCount);
+   printf("TR::Recompilation::hwpGlobalSampleCount = %d\n",                         TR::Recompilation::hwpGlobalSampleCount);
+   printf("Number of buffers completely filled = %" OMR_PRIu32 "\n",                _numBuffersCompletelyFilled);
+   printf("Average buffer filled percentage = %f\n",                               _bufferSizeSum ? (((float)_bufferFilledSum) / ((float)_bufferSizeSum) * 100) : 0);
+   printf("Number of requests = %" OMR_PRIu64 "\n",                                 _numRequests);
+   printf("Number of requests skipped = %" OMR_PRIu64 "\n",                         _numRequestsSkipped);
+   printf("Memory used by metadata bytecodePC to IA mapping = %" OMR_PRIu64 " B\n", _totalMemoryUsedByMetadataMapping);
+   printf("Total buffers processed = %" OMR_PRIu32 "\n",                            _STATS_TotalBuffersProcessed);
+   printf("Total buffers processed by App Thread= %" OMR_PRIu32 "\n",               _STATS_BuffersProcessedByAppThread);
+   printf("Total event records: %" OMR_PRIu64 "\n",                                 _STATS_TotalEntriesProcessed);
+   printf("Total instructions tracked: %u\n",                                      _STATS_TotalInstructionsTracked);
+   printf("Total downgrades due to RI: %u\n",                                      _STATS_NumCompDowngradesDueToRI);
+   printf("Total upgrades due to RI: %u\n",                                        _STATS_NumUpgradesDueToRI);
    printf("\n");
    }

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -71,6 +71,7 @@
 #include "ilgen/J9ByteCodeIterator.hpp"
 #include "runtime/IProfiler.hpp"
 #include "runtime/J9Profiler.hpp"
+#include "omrformatconsts.h"
 
 #define BC_HASH_TABLE_SIZE  34501 // 131071// 34501
 #undef  IPROFILER_CONTENDED_LOCKING
@@ -422,7 +423,7 @@ TR_IProfiler::persistIprofileInfo(TR::ResolvedMethodSymbol *resolvedMethodSymbol
                {
                char methodSig[3000];
                fej9->printTruncatedSignature(methodSig, 3000, method);
-               fprintf(stdout, "Persist: %s count %d  Compiling %s\n", methodSig, comp->signature() );
+               fprintf(stdout, "Persist: %s count %" OMR_PRId32 " Compiling %s\n", methodSig, count, comp->signature());
                }
 
             vcount_t visitCount = comp->incVisitCount();
@@ -2568,11 +2569,11 @@ TR_IProfiler::outputStats()
    TR::Options *options = TR::Options::getCmdLineOptions();
    if (options && !options->getOption(TR_DisableIProfilerThread))
       {
-      fprintf(stderr, "IProfiler: Number of buffers to be processed           =%llu\n", _numRequests);
-      fprintf(stderr, "IProfiler: Number of buffers discarded                 =%llu\n", _numRequestsSkipped);
-      fprintf(stderr, "IProfiler: Number of buffers handed to iprofiler thread=%llu\n", _numRequestsHandedToIProfilerThread);
+      fprintf(stderr, "IProfiler: Number of buffers to be processed           =%" OMR_PRIu64 "\n", _numRequests);
+      fprintf(stderr, "IProfiler: Number of buffers discarded                 =%" OMR_PRIu64 "\n", _numRequestsSkipped);
+      fprintf(stderr, "IProfiler: Number of buffers handed to iprofiler thread=%" OMR_PRIu64 "\n", _numRequestsHandedToIProfilerThread);
       }
-   fprintf(stderr, "IProfiler: Number of records processed=%llu\n", _iprofilerNumRecords);
+   fprintf(stderr, "IProfiler: Number of records processed=%" OMR_PRIu64 "\n", _iprofilerNumRecords);
    fprintf(stderr, "IProfiler: Number of hashtable entries=%u\n", countEntries());
    checkMethodHashTable();
    }
@@ -2814,7 +2815,7 @@ TR_IPBCDataCallGraph::getSumCount(TR::Compilation *comp, bool)
          {
          int32_t len;
          const char * s = _csInfo.getClazz(i) ? comp->fej9()->getClassNameChars((TR_OpaqueClassBlock*)_csInfo.getClazz(i), len) : "0";
-         fprintf(stderr,"[%p] slot %d, class %p %s, weight %d : ", this, i, _csInfo.getClazz(i), s, _csInfo._weight[i]);
+         fprintf(stderr,"[%p] slot %" OMR_PRId32 ", class %#" OMR_PRIxPTR " %s, weight %" OMR_PRId32 " : ", this, i, _csInfo.getClazz(i), s, _csInfo._weight[i]);
          fflush(stderr);
          }
       sumWeight += _csInfo._weight[i];
@@ -2896,7 +2897,7 @@ TR_IPBCDataCallGraph::printWeights(TR::Compilation *comp)
       int32_t len;
       const char * s = _csInfo.getClazz(i) ? comp->fej9()->getClassNameChars((TR_OpaqueClassBlock*)_csInfo.getClazz(i), len) : "0";
 
-      fprintf(stderr, "%p %s %d\n", _csInfo.getClazz(i), s, _csInfo._weight[i]);
+      fprintf(stderr, "%#" OMR_PRIxPTR " %s %d\n", _csInfo.getClazz(i), s, _csInfo._weight[i]);
       }
    fprintf(stderr, "%d\n", _csInfo._residueWeight);
    }
@@ -3422,7 +3423,8 @@ void TR_IProfiler::setupEntriesInHashTable(TR_IProfiler *ip)
          if (pc == 0 ||
                pc == 0xffffffff)
             {
-            printf("invalid pc for entry %p %p\n", entry, pc);fflush(stdout);
+            printf("invalid pc for entry %p %#" OMR_PRIxPTR "\n", entry, pc);
+            fflush(stdout);
             prevEntry = entry;
             entry = entry->getNext();
             continue;
@@ -3480,7 +3482,7 @@ void TR_IProfiler::copyDataFromEntry(TR_IPBytecodeHashTableEntry *oldEntry, TR_I
             {
             for (int32_t i = 0; i < NUM_CS_SLOTS; i++)
                {
-               printf("got clazz %p weight %d\n", oldCSInfo->getClazz(i), oldCSInfo->_weight[i]);
+               printf("got clazz %#" OMR_PRIxPTR " weight %d\n", oldCSInfo->getClazz(i), oldCSInfo->_weight[i]);
                newCSInfo->setClazz(i, oldCSInfo->getClazz(i));
                newCSInfo->_weight[i] = oldCSInfo->_weight[i];
                }
@@ -3527,7 +3529,8 @@ void TR_IProfiler::checkMethodHashTable()
                 J9UTF8_LENGTH(signatureUTF8), J9UTF8_DATA(signatureUTF8), method);fflush(fout);
 #endif
          int32_t count = 0;
-         fprintf(fout,"\t has %d callers and %d -bytecode long:\n", 0, J9_BYTECODE_END_FROM_ROM_METHOD(getOriginalROMMethod(method))-J9_BYTECODE_START_FROM_ROM_METHOD(getOriginalROMMethod(method)));fflush(fout);
+         fprintf(fout,"\t has %d callers and %" OMR_PRIdPTR " -bytecode long:\n", 0, J9_BYTECODE_END_FROM_ROM_METHOD(getOriginalROMMethod(method)) - J9_BYTECODE_START_FROM_ROM_METHOD(getOriginalROMMethod(method)));
+         fflush(fout);
          uint32_t i=0;
 
          for (TR_IPMethodData* it = &entry->_caller; it; it = it->next)
@@ -3542,10 +3545,12 @@ void TR_IProfiler::checkMethodHashTable()
                J9UTF8 * caller_methodClazzUTF8;
                getClassNameSignatureFromMethod((J9Method*)meth, caller_methodClazzUTF8, caller_nameUTF8, caller_signatureUTF8);
 
-               fprintf(fout,"%p %.*s%.*s%.*s weight %d pc %p\n", meth,
-                  J9UTF8_LENGTH(caller_methodClazzUTF8), J9UTF8_DATA(caller_methodClazzUTF8), J9UTF8_LENGTH(caller_nameUTF8), J9UTF8_DATA(caller_nameUTF8),
+               fprintf(fout,"%p %.*s%.*s%.*s weight %" OMR_PRIu32 " pc %" OMR_PRIx32 "\n", meth,
+                  J9UTF8_LENGTH(caller_methodClazzUTF8), J9UTF8_DATA(caller_methodClazzUTF8),
+                  J9UTF8_LENGTH(caller_nameUTF8), J9UTF8_DATA(caller_nameUTF8),
                   J9UTF8_LENGTH(caller_signatureUTF8), J9UTF8_DATA(caller_signatureUTF8),
-                  it->getWeight(), it->getPCIndex());fflush(fout);
+                  it->getWeight(), it->getPCIndex());
+               fflush(fout);
                }
             else
                {
@@ -4355,11 +4360,11 @@ void printCsInfo(CallSiteProfileInfo& csInfo, TR::Compilation* comp, void* tag =
       if (comp)
          {
          char *clazzSig = TR::Compiler->cls.classSignature(comp, (TR_OpaqueClassBlock*)csInfo.getClazz(i), comp->trMemory());
-         fprintf(fout, "%p CLASS %d %p %s WEIGHT %d\n", tag, i, csInfo.getClazz(i), clazzSig, csInfo._weight[i]);
+         fprintf(fout, "%p CLASS %d %#" OMR_PRIxPTR " %s WEIGHT %d\n", tag, i, csInfo.getClazz(i), clazzSig, csInfo._weight[i]);
          }
       else
          {
-         fprintf(fout, "%p CLASS %d %p WEIGHT %d\n", tag, i, csInfo.getClazz(i), csInfo._weight[i]);
+         fprintf(fout, "%p CLASS %d %#" OMR_PRIxPTR " WEIGHT %d\n", tag, i, csInfo.getClazz(i), csInfo._weight[i]);
          }
       fflush(fout);
       }
@@ -4644,7 +4649,7 @@ void TR_AggregationHT::sortByNameAndPrint(TR_J9VMBase *fe)
          U_8* pc = (U_8*)ipbcCGData->getPC();
 
          size_t bcOffset = pc - (U_8*)J9_BYTECODE_START_FROM_ROM_METHOD(romMethod);
-         fprintf(stderr, "\tOffset %u\t", bcOffset);
+         fprintf(stderr, "\tOffset %" OMR_PRIuSIZE "\t", bcOffset);
          switch (*pc)
             {
             case JBinvokestatic:     fprintf(stderr, "JBinvokestatic\n"); break;
@@ -4663,7 +4668,7 @@ void TR_AggregationHT::sortByNameAndPrint(TR_J9VMBase *fe)
                {
                int32_t len;
                const char * s = fe->getClassNameChars((TR_OpaqueClassBlock*)cgData->getClazz(j), len);
-               fprintf(stderr, "\t\tW:%4u\tM:%p\t%.*s\n", cgData->_weight[j], cgData->getClazz(j), len, s);
+               fprintf(stderr, "\t\tW:%4u\tM:%#" OMR_PRIxPTR "\t%.*s\n", cgData->_weight[j], cgData->getClazz(j), len, s);
                }
             }
          fprintf(stderr, "\t\tW:%4u\n", cgData->_residueWeight);

--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -53,6 +53,7 @@
 #include "env/IO.hpp"
 #include "runtime/HookHelpers.hpp"
 #include "env/VerboseLog.hpp"
+#include "omrformatconsts.h"
 
 OMR::CodeCacheMethodHeader *getCodeCacheMethodHeader(char *p, int searchLimit, J9JITExceptionTable * metaData);
 
@@ -470,8 +471,8 @@ J9::CodeCache::dumpCodeCache()
    {
    self()->OMR::CodeCache::dumpCodeCache();
    printf("  |-- segment                = 0x%p\n", _segment );
-   printf("  |-- segment->heapBase      = 0x%08x\n", _segment->segmentBase() );
-   printf("  |-- segment->heapTop       = 0x%08x\n", _segment->segmentTop() );
+   printf("  |-- segment->heapBase      = 0x%08" OMR_PRIxPTR "\n", (uintptr_t)_segment->segmentBase() );
+   printf("  |-- segment->heapTop       = 0x%08" OMR_PRIxPTR "\n", (uintptr_t)_segment->segmentTop() );
    }
 
 #define HELPER_TRAMPOLINE_AREA_NAME "JIT helper trampoline area"

--- a/runtime/compiler/runtime/J9ValueProfiler.hpp
+++ b/runtime/compiler/runtime/J9ValueProfiler.hpp
@@ -31,6 +31,7 @@
 #include "infra/CriticalSection.hpp"
 #include "compile/Compilation.hpp"
 #include "infra/vector.hpp"
+#include "omrformatconsts.h"
 
 // Global lock used by Array & List profilers
 extern TR::Monitor *vpMonitor;
@@ -696,7 +697,7 @@ TR_EmbeddedHashTable<T, bits>::addKey(T value)
    if (dumpInfo)
       {
       OMR::CriticalSection lock(vpMonitor);
-      printf("Pre %X", value);
+      printf("Pre %" OMR_PRIX64, static_cast<uint64_t>(value));
       this->dumpInfo(TR::IO::Stdout);
       fflush(stdout);
       }
@@ -790,7 +791,7 @@ TR_EmbeddedHashTable<T, bits>::addKey(T value)
    if (dumpInfo)
       {
       OMR::CriticalSection lock(vpMonitor);
-      printf("Post %X", value);
+      printf("Post %" OMR_PRIX64, static_cast<uint64_t>(value));
       this->dumpInfo(TR::IO::Stdout);
       fflush(stdout);
       }
@@ -1042,7 +1043,7 @@ TR_EmbeddedHashTable<T, bits>::rearrange(HashFunction &hash)
       {
       for (size_t i = 0; i < length; ++i)
          {
-         printf("%d -> %d\n", i, plannedMoves[i]);
+         printf("%" OMR_PRIu64 " -> %" OMR_PRIu64 "\n", static_cast<uint64_t>(i), static_cast<uint64_t>(plannedMoves[i]));
          }
       }
 

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -60,6 +60,7 @@
 #include "runtime/J9ValueProfiler.hpp"
 #include "runtime/IProfiler.hpp"
 #include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
+#include "omrformatconsts.h"
 
 #if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64)
 #include "codegen/PicHelpers.hpp"
@@ -808,7 +809,7 @@ void dumpMethodsForClass(::FILE *fp, J9Class *classPointer)
       J9UTF8 * clazzUTRF8;
       getClassNameSignatureFromMethod(((J9Method *)&(resolvedMethods[i])), clazzUTRF8, nameUTF8, signatureUTF8);
 
-      fprintf(fp, "\t%u, %.*s.%.*s%.*s\n", &(resolvedMethods[i]), J9UTF8_LENGTH(clazzUTRF8), J9UTF8_DATA(clazzUTRF8), J9UTF8_LENGTH(nameUTF8), J9UTF8_DATA(nameUTF8), J9UTF8_LENGTH(signatureUTF8), J9UTF8_DATA(signatureUTF8));
+      fprintf(fp, "\t%" OMR_PRIuPTR ", %.*s.%.*s%.*s\n", (uintptr_t)&(resolvedMethods[i]), J9UTF8_LENGTH(clazzUTRF8), J9UTF8_DATA(clazzUTRF8), J9UTF8_LENGTH(nameUTF8), J9UTF8_DATA(nameUTF8), J9UTF8_LENGTH(signatureUTF8), J9UTF8_DATA(signatureUTF8));
       }
    }
 
@@ -842,13 +843,13 @@ void dumpInstanceFieldsForClass(::FILE *fp, J9Class *instanceClass, J9VMThread *
             J9UTF8* sigUTF = J9ROMFIELDSHAPE_SIGNATURE(romFieldCursor);
             IDATA offset;
 
-            fprintf(fp, "%u, %.*s, %.*s, %08x, ", instanceClass, J9UTF8_LENGTH(sigUTF), J9UTF8_DATA(sigUTF), J9UTF8_LENGTH(nameUTF), J9UTF8_DATA(nameUTF), romFieldCursor->modifiers);
+            fprintf(fp, "%" OMR_PRIuPTR ", %.*s, %.*s, %08x, ", (uintptr_t)instanceClass, J9UTF8_LENGTH(sigUTF), J9UTF8_DATA(sigUTF), J9UTF8_LENGTH(nameUTF), J9UTF8_DATA(nameUTF), romFieldCursor->modifiers);
 
             offset = javaVM->internalVMFunctions->instanceFieldOffset(vmThread, superclass, J9UTF8_DATA(nameUTF), J9UTF8_LENGTH(nameUTF), J9UTF8_DATA(sigUTF), J9UTF8_LENGTH(sigUTF), NULL, NULL, J9_LOOK_NO_JAVA);
 
             if (offset >= 0)
                {
-               fprintf(fp, "%d\n", offset + TR::Compiler->om.objectHeaderSizeInBytes());
+               fprintf(fp, "%" OMR_PRIuPTR "\n", offset + TR::Compiler->om.objectHeaderSizeInBytes());
                }
             else
                {
@@ -877,7 +878,7 @@ void dumpClassStaticsForClass(::FILE *fp, J9Class *clazz, J9VMThread *vmThread)
          J9UTF8* nameUTF = J9ROMFIELDSHAPE_NAME(romFieldCursor);
          J9UTF8* sigUTF = J9ROMFIELDSHAPE_SIGNATURE(romFieldCursor);
 
-         fprintf(fp, "%u, %.*s, %.*s, %08x, ", clazz, J9UTF8_LENGTH(sigUTF), J9UTF8_DATA(sigUTF), J9UTF8_LENGTH(nameUTF), J9UTF8_DATA(nameUTF), romFieldCursor->modifiers);
+         fprintf(fp, "%" OMR_PRIuPTR ", %.*s, %.*s, %08x, ", (uintptr_t)clazz, J9UTF8_LENGTH(sigUTF), J9UTF8_DATA(sigUTF), J9UTF8_LENGTH(nameUTF), J9UTF8_DATA(nameUTF), romFieldCursor->modifiers);
 
          void *address = javaVM->internalVMFunctions->staticFieldAddress(vmThread, clazz, J9UTF8_DATA(nameUTF), J9UTF8_LENGTH(nameUTF), J9UTF8_DATA(sigUTF), J9UTF8_LENGTH(sigUTF), NULL, NULL, J9_LOOK_NO_JAVA, NULL);
 
@@ -949,7 +950,7 @@ void dumpAllClasses(J9VMThread *vmThread)
       J9UTF8 * clazzUTRF8 = J9ROMCLASS_CLASSNAME(clazz->romClass);
 
       // print the class address
-      fprintf(fp, "%u, ", clazz);
+      fprintf(fp, "%" OMR_PRIuPTR ", ", (uintptr_t)clazz);
 
       J9ROMClass *romClass = clazz->romClass;
       // print the class name, for arrays get to the leaf array class and print that
@@ -1791,4 +1792,3 @@ void methodHandleJ2I_unwrapper(void **argsPtr, void **resPtr)
    j9object_t   methodHandle = (j9object_t)argsPtr[0];
    methodHandleJ2I(methodHandle, stack, vmThread);
    }
-

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -69,6 +69,7 @@
 #include "control/CompilationThread.hpp"
 #include "control/CompilationRuntime.hpp"
 #include "runtime/HWProfiler.hpp"
+#include "omrformatconsts.h"
 
 typedef std::set<TR_GCStackMap*, std::less<TR_GCStackMap*>, TR::typed_allocator<TR_GCStackMap*, TR::Region&>> GCStackMapSet;
 
@@ -347,7 +348,7 @@ createInternalPtrStackMapInJ9Format(
    // portion of the map will occupy.
    //
    if (debug("traceIP"))
-      printf("JIT Address %x\n", location);
+      printf("JIT Address %" OMR_PRIxPTR "\n", (uintptr_t)location);
    *location = (uint8_t) mapSize;
    if (debug("traceIP"))
       printf("Internal ptr map size = %d\n", *location);
@@ -358,15 +359,15 @@ createInternalPtrStackMapInJ9Format(
 
 
    if (debug("traceIP"))
-      printf("JIT Address %x\n", location);
+      printf("JIT Address %" OMR_PRIxPTR "\n", (uintptr_t)location);
    *((int16_t *) location) = (int16_t) indexOfFirstInternalPtr;
    if (debug("traceIP"))
-      printf("Index of first internal pointer = %d\n", (*((int16_t *) location)));
+      printf("Index of first internal pointer = %" OMR_PRId16 "\n", (*((int16_t *) location)));
    location += 2;
 
    int32_t offsetOfFirstInternalPtr = trStackAtlas->getOffsetOfFirstInternalPointer();
    if (debug("traceIP"))
-      printf("JIT Address %x\n", location);
+      printf("JIT Address %" OMR_PRIxPTR "\n", (uintptr_t)location);
    *((int16_t *) location) = (int16_t) offsetOfFirstInternalPtr;
    if (debug("traceIP"))
       printf("Offset of first internal pointer = %d\n", (*((int16_t *) location)));
@@ -375,7 +376,7 @@ createInternalPtrStackMapInJ9Format(
    // Fill in how many distinct pinning array temps exist
    //
    if (debug("traceIP"))
-      printf("JIT Address %x\n", location);
+      printf("JIT Address %" OMR_PRIxPTR "\n", (uintptr_t)location);
    *location = (uint8_t) (map->getNumDistinctPinningArrays() + numPinningArraysOnlyForInternalPtrRegs);
    if (debug("traceIP"))
       printf("Number of distinct pinning arrays = %d\n", *location);
@@ -401,7 +402,7 @@ createInternalPtrStackMapInJ9Format(
        //
        *location = (uint8_t) (currElement->getData()->getInternalPointerAuto()->getGCMapIndex() - indexOfFirstInternalPtr);
        if (debug("traceIP"))
-          printf("JIT : location %x first internal ptr index %d firstptr %d\n", location, currElement->getData()->getInternalPointerAuto()->getGCMapIndex(), indexOfFirstInternalPtr);
+          printf("JIT : location %" OMR_PRIxPTR " first internal ptr index %d firstptr %d\n", (uintptr_t)location, currElement->getData()->getInternalPointerAuto()->getGCMapIndex(), indexOfFirstInternalPtr);
        location++;
        int32_t numInternalPtrsForThisPinningArray = 1;
        //
@@ -418,7 +419,7 @@ createInternalPtrStackMapInJ9Format(
             {
             *location = (uint8_t) (internalPtrPair->getInternalPointerAuto()->getGCMapIndex() - indexOfFirstInternalPtr);
             if (debug("traceIP"))
-               printf("JIT : location %x internal ptr index %d firstptr %d\n", location, internalPtrPair->getInternalPointerAuto()->getGCMapIndex(), indexOfFirstInternalPtr);
+               printf("JIT : location %" OMR_PRIxPTR " internal ptr index %d firstptr %d\n", (uintptr_t)location, internalPtrPair->getInternalPointerAuto()->getGCMapIndex(), indexOfFirstInternalPtr);
             location++;
             numInternalPtrsForThisPinningArray++;
             searchElement = searchElement->getNextElement();
@@ -436,7 +437,7 @@ createInternalPtrStackMapInJ9Format(
        //
        *((location - numInternalPtrsForThisPinningArray) - 1) = numInternalPtrsForThisPinningArray;
        if (debug("traceIP"))
-          printf("In VMJ9 numInternalPtrs = %d and memory %x\n", numInternalPtrsForThisPinningArray, (location - numInternalPtrsForThisPinningArray));
+          printf("In VMJ9 numInternalPtrs = %d and memory %" OMR_PRIxPTR "\n", numInternalPtrsForThisPinningArray, (uintptr_t)(location - numInternalPtrsForThisPinningArray));
        totalPointers = totalPointers + 1 + numInternalPtrsForThisPinningArray;
        }
 
@@ -493,7 +494,8 @@ createStackMap(
       map->setRegisterBits((1<<cg->getInternalPtrMapBit()));
       if (debug("traceIP"))
          {
-         printf("JIT address %x (lowCode %x) method %s with 4 byte offsets (%d) for register map %d (GC map %x ip map %x)\n", location, lowCode, comp->signature(), fourByteOffsets, map->getRegisterMap(), map, map->getInternalPointerMap());
+         printf("JIT address %" OMR_PRIxPTR " (lowCode %" OMR_PRIxPTR ") method %s with 4 byte offsets (%d) for register map %d (GC map %" OMR_PRIxPTR " ip map %" OMR_PRIxPTR ")\n",\
+             (uintptr_t)location, (uintptr_t)lowCode, comp->signature(), fourByteOffsets, map->getRegisterMap(), (uintptr_t)map, (uintptr_t)map->getInternalPointerMap());
          fflush(stdout);
          }
       }
@@ -548,7 +550,7 @@ createStackMap(
       *location = (uint8_t) internalPtrMap->getSize();
 
       if (debug("traceIP"))
-         printf("JIT Address %x Internal ptr map size = %d\n", location, *location);
+         printf("JIT Address %" OMR_PRIxPTR " Internal ptr map size = %d\n", (uintptr_t)location, *location);
 
       location++;
 
@@ -557,7 +559,7 @@ createStackMap(
       *location = (uint8_t) internalPtrMap->getNumDistinctPinningArrays();
 
       if (debug("traceIP"))
-         printf("JIT Address %x Num pinning arrays = %d\n", location, *location);
+         printf("JIT Address %" OMR_PRIxPTR " Num pinning arrays = %d\n", (uintptr_t)location, *location);
 
       location++;
 
@@ -571,7 +573,7 @@ createStackMap(
          //
          *location = (uint8_t) (currElement->getData()->getPinningArrayPointer()->getGCMapIndex() - indexOfFirstInternalPtr);
          if (debug("traceIP"))
-            printf("JIT Address %x Pinning array = %d\n", location, *location);
+            printf("JIT Address %" OMR_PRIxPTR " Pinning array = %d\n", (uintptr_t)location, *location);
          //
          // Skip over the byte corresponding to number of derived register pointers
          // per base array; to be filled in later.
@@ -582,7 +584,7 @@ createStackMap(
          //
          *location = (uint8_t) currElement->getData()->getInternalPtrRegNum();
          if (debug("traceIP"))
-            printf("JIT : internal ptr reg num %d address %x\n", *location, location);
+            printf("JIT : internal ptr reg num %d address %" OMR_PRIxPTR "\n", *location, (uintptr_t)location);
          location++;
 
          int32_t numInternalPtrsForThisPinningArray = 1;
@@ -600,7 +602,7 @@ createStackMap(
                {
                *location = (uint8_t) internalPtrPair->getInternalPtrRegNum();
                if (debug("traceIP"))
-                  printf("JIT : internal ptr reg num %d address %x\n", *location, location);
+                  printf("JIT : internal ptr reg num %d address %" OMR_PRIxPTR "\n", *location, (uintptr_t)location);
                location++;
                numInternalPtrsForThisPinningArray++;
                searchElement = searchElement->getNextElement();
@@ -618,7 +620,7 @@ createStackMap(
           //
          *((location - numInternalPtrsForThisPinningArray) - 1) = numInternalPtrsForThisPinningArray;
          if (debug("traceIP"))
-            printf("JIT Address %x Num internal ptrs for this array = %d\n", ((location - numInternalPtrsForThisPinningArray) - 1),numInternalPtrsForThisPinningArray);
+            printf("JIT Address %" OMR_PRIxPTR " Num internal ptrs for this array = %d\n", (uintptr_t)((location - numInternalPtrsForThisPinningArray) - 1), numInternalPtrsForThisPinningArray);
          }
       }
 
@@ -637,7 +639,7 @@ createStackMap(
 
    if (debug("traceIP"))
       {
-      printf("Start of map %x end of map %x (lowCode %x)\n", startLocation, (location+mapSize), lowCode);
+      printf("Start of map %" OMR_PRIxPTR " end of map %" OMR_PRIxPTR " (lowCode %" OMR_PRIxPTR ")\n", (uintptr_t)startLocation, (uintptr_t)(location + mapSize), (uintptr_t)lowCode);
       diagnostic("Map bits are being emitted at %x\n", location);
       diagnostic("Number of slots mapped %d\n", map->getNumberOfSlotsMapped());
       int mapBytes = (map->getNumberOfSlotsMapped() + 7) >> 3;


### PR DESCRIPTION
Eliminates numerous `-Wformat` warnings.