### PR TITLE
AArch64: Change -fpic to -fPIC

### DIFF
--- a/runtime/makelib/targets.mk.linux.inc.ftl
+++ b/runtime/makelib/targets.mk.linux.inc.ftl
@@ -273,7 +273,7 @@ CPPFLAGS += -DLINUX -D_REENTRANT
 </#if>
 
 <#-- Add Position Independent compile flag -->
-<#if uma.spec.processor.amd64 || uma.spec.processor.arm || uma.spec.processor.s390 || uma.spec.processor.riscv64>
+<#if uma.spec.processor.amd64 || uma.spec.processor.arm || uma.spec.processor.aarch64 || uma.spec.processor.s390 || uma.spec.processor.riscv64>
   CFLAGS += -fPIC
   CXXFLAGS += -fPIC
 <#elseif uma.spec.processor.ppc>


### PR DESCRIPTION
`-fpic` and `-fPIC` options are mixed in the build for AArch64 Linux.
This commit changes `-fpic` to `-fPIC` to make the options consistent.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>