### PR TITLE
Revert "Add cpu feature info to javacore"

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1925,7 +1925,6 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
          else
             {
             TR::Compiler->relocatableTarget.cpu = TR::CPU::customize(compInfo->reloRuntime()->getProcessorDescriptionFromSCC(fe, curThread));
-            jitConfig->relocatableTargetProcessor = TR::Compiler->relocatableTarget.cpu.getProcessorDescription();
             }
          }
 

--- a/runtime/compiler/env/ProcessorDetection.cpp
+++ b/runtime/compiler/env/ProcessorDetection.cpp
@@ -657,7 +657,4 @@ TR_J9VM::initializeProcessorType()
       {
       TR_ASSERT(0,"Unknown target");
       }
-
-   _jitConfig->targetProcessor = TR::Compiler->target.cpu.getProcessorDescription();
-   _jitConfig->relocatableTargetProcessor = TR::Compiler->relocatableTarget.cpu.getProcessorDescription();
    }

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3924,8 +3924,6 @@ typedef struct J9JITConfig {
 	U_8* (*codeCacheWarmAlloc)(void *codeCache);
 	U_8* (*codeCacheColdAlloc)(void *codeCache);
 	void ( *printAOTHeaderProcessorFeatures)(struct TR_AOTHeader * aotHeaderAddress, char * buff, const size_t BUFF_SIZE);
-	struct OMRProcessorDesc targetProcessor;
-	struct OMRProcessorDesc relocatableTargetProcessor;
 #if defined(J9VM_OPT_JITSERVER)
 	int32_t (*startJITServer)(struct J9JITConfig *jitConfig);
 	int32_t (*waitJITServerTermination)(struct J9JITConfig *jitConfig);

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -5262,10 +5262,10 @@ JavaCoreDumpWriter::writeJavaLangThreadInfo (J9VMThread* vmThread)
 void
 JavaCoreDumpWriter::writeCPUinfo(void)
 {
-	OMRPORT_ACCESS_FROM_J9PORT(_PortLibrary);
+	PORT_ACCESS_FROM_PORT(_PortLibrary);
 
-	UDATA bound = omrsysinfo_get_number_CPUs_by_type(J9PORT_CPU_BOUND);
-	UDATA target = omrsysinfo_get_number_CPUs_by_type(J9PORT_CPU_TARGET);
+	UDATA bound = j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_BOUND);
+	UDATA target = j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_TARGET);
 
 	_OutputStream.writeCharacters(
 			"NULL\n");
@@ -5273,10 +5273,10 @@ JavaCoreDumpWriter::writeCPUinfo(void)
 			"1CICPUINFO     CPU Information\n"
 			"NULL           ------------------------------------------------------------------------\n"
 			"2CIPHYSCPU     Physical CPUs: ");
-	_OutputStream.writeInteger(omrsysinfo_get_number_CPUs_by_type(J9PORT_CPU_PHYSICAL), "%i\n");
+	_OutputStream.writeInteger(j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_PHYSICAL), "%i\n");
 	_OutputStream.writeCharacters(
 			"2CIONLNCPU     Online CPUs: ");
-	_OutputStream.writeInteger(omrsysinfo_get_number_CPUs_by_type(J9PORT_CPU_ONLINE), "%i\n");
+	_OutputStream.writeInteger(j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_ONLINE), "%i\n");
 	_OutputStream.writeCharacters(
 			"2CIBOUNDCPU    Bound CPUs: ");
 	_OutputStream.writeInteger(bound, "%i\n");
@@ -5291,37 +5291,7 @@ JavaCoreDumpWriter::writeCPUinfo(void)
 	_OutputStream.writeCharacters(
 			"2CITARGETCPU   Target CPUs: ");
 	_OutputStream.writeInteger(target, "%i\n");
-	
-	char buff[400];
-	intptr_t rc = -1;
-	if (_VirtualMachine->jitConfig) {
-		rc = omrsysinfo_get_processor_feature_string(&_VirtualMachine->jitConfig->targetProcessor, buff, sizeof(buff));
-		if (rc != -1) {
-			_OutputStream.writeCharacters(
-				"2CIJITFEATURE  CPU features (JIT): ");
-			_OutputStream.writeCharacters(buff);
-			_OutputStream.writeCharacters("\n");
-		}
 
-		rc = omrsysinfo_get_processor_feature_string(&_VirtualMachine->jitConfig->relocatableTargetProcessor, buff, sizeof(buff));
-		if (rc != -1) {
-			_OutputStream.writeCharacters(
-	   			"2CIAOTFEATURE  CPU features (AOT): ");
-			_OutputStream.writeCharacters(buff);
-			_OutputStream.writeCharacters("\n");
-		}
-	}
-	else {
-		OMRProcessorDesc processorDescription;
-		omrsysinfo_get_processor_description(&processorDescription);
-		rc = omrsysinfo_get_processor_feature_string(&processorDescription, buff, sizeof(buff));
-		if (rc != -1) {
-			_OutputStream.writeCharacters(
-				"2CIINTFEATURE  CPU features (INT): ");
-			_OutputStream.writeCharacters(buff);
-			_OutputStream.writeCharacters("\n");
-		}
-	}
 	return;
 }
 


### PR DESCRIPTION
Reverts eclipse/openj9#11215 because OMR promotion of the dependent change has not happened. This will fix the build break.