### PR TITLE
jdk.internal.access.SharedSecrets is required for JDK15+

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -67,7 +67,11 @@ import static com.ibm.oti.util.Util.doesClassLoaderDescendFrom;
 
 /*[IF Sidecar19-SE]
 import jdk.internal.misc.Unsafe;
+/*[IF JAVA_SPEC_VERSION >= 15]*/
+import jdk.internal.access.SharedSecrets;
+/*[ELSE] JAVA_SPEC_VERSION >= 15
 import jdk.internal.misc.SharedSecrets;
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 import java.io.IOException;
 import jdk.internal.reflect.Reflection;
 import jdk.internal.reflect.CallerSensitive;


### PR DESCRIPTION
`jdk.internal.misc.SharedSecrets` is for `JDK11`;
`sun.misc.SharedSecrets` is for `JDK8`.

Note: this fixes JDK15 compilation error:
```
error: cannot find symbol
import jdk.internal.misc.SharedSecrets;
```

fyi @sharon-wang 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>