### PR TITLE
Store client's VM phase in JITServer client session

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8783,7 +8783,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
          // startup and with hints we move this expensive compilation during startup
          // thus affecting startup time
          // To minimize risk, add hot/scorching hints only if we are in startup mode
-         if (jitConfig->javaVM->phase != J9VM_PHASE_NOT_STARTUP)
+         if (TR::Compiler->vm.isVMInStartupPhase(jitConfig))
             {
             TR_Hotness hotness = that->_methodBeingCompiled->_optimizationPlan->getOptLevel();
             if (hotness == hot)
@@ -8807,7 +8807,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
       // Look only during startup to avoid creating too many hints.
       // If SCC is larger we could store hints for more methods
       //
-      if (jitConfig->javaVM->phase != J9VM_PHASE_NOT_STARTUP)
+      if (TR::Compiler->vm.isVMInStartupPhase(jitConfig))
          {
          if (scratchSegmentProvider.regionBytesAllocated() > TR::Options::_memExpensiveCompThreshold)
             {

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -3302,7 +3302,7 @@ remoteCompile(
       client->buildCompileRequest(compiler->getPersistentInfo()->getClientUID(), seqNo, lastCriticalSeqNo, romMethodOffset, method,
                                   clazz, *compInfoPT->getMethodBeingCompiled()->_optimizationPlan, detailsStr,
                                   details.getType(), unloadedClasses, illegalModificationList, classInfoTuple, optionsStr, recompMethodInfoStr,
-                                  chtableUpdates.first, chtableUpdates.second, useAotCompilation);
+                                  chtableUpdates.first, chtableUpdates.second, useAotCompilation, TR::Compiler->vm.isVMInStartupPhase(compInfoPT->getJitConfig()));
       JITServer::MessageType response;
       while(!handleServerMessage(client, compiler->fej9vm(), response));
 

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -343,7 +343,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       auto req = stream->readCompileRequest<uint64_t, uint32_t, uint32_t, uint32_t, J9Method *, J9Class*,
          TR_OptimizationPlan, std::string, J9::IlGeneratorMethodDetailsType,
          std::vector<TR_OpaqueClassBlock*>, std::vector<TR_OpaqueClassBlock*>, 
-         JITServerHelpers::ClassInfoTuple, std::string, std::string, std::string, std::string, bool>();
+         JITServerHelpers::ClassInfoTuple, std::string, std::string, std::string, std::string, bool, bool>();
 
       clientId                           = std::get<0>(req);
       seqNo                              = std::get<1>(req); // Sequence number at the client
@@ -397,6 +397,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          throw std::bad_alloc();
 
       setClientData(clientSession); // Cache the session data into CompilationInfoPerThreadRemote object
+      clientSession->setIsInStartupPhase(std::get<17>(req));
       } // End critical section
 
      if (TR::Options::getVerboseOption(TR_VerboseJITServer))

--- a/runtime/compiler/env/J9VMEnv.cpp
+++ b/runtime/compiler/env/J9VMEnv.cpp
@@ -508,3 +508,15 @@ J9::VMEnv::getInterpreterVTableOffset()
 #endif /* defined(J9VM_OPT_JITSERVER) */
    return sizeof(J9Class);
    }
+
+bool
+J9::VMEnv::isVMInStartupPhase(J9JITConfig *jitConfig)
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      return TR::compInfoPT->getClientData()->isInStartupPhase();
+      }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+   return jitConfig->javaVM->phase != J9VM_PHASE_NOT_STARTUP;
+   }

--- a/runtime/compiler/env/J9VMEnv.hpp
+++ b/runtime/compiler/env/J9VMEnv.hpp
@@ -116,7 +116,8 @@ public:
    uintptr_t thisThreadGetGSOperandAddressOffset(TR::Compilation *comp);
    uintptr_t thisThreadGetGSHandlerAddressOffset(TR::Compilation *comp);
    size_t getInterpreterVTableOffset();
-
+   
+   bool isVMInStartupPhase(J9JITConfig *jitConfig);
    };
 
 }

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -47,7 +47,8 @@ ClientSessionData::ClientSessionData(uint64_t clientUID, uint32_t seqNo) :
    _rtResolve(false),
    _registeredJ2IThunksMap(decltype(_registeredJ2IThunksMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _registeredInvokeExactJ2IThunksSet(decltype(_registeredInvokeExactJ2IThunksSet)::allocator_type(TR::Compiler->persistentAllocator())),
-   _wellKnownClasses()
+   _wellKnownClasses(),
+   _isInStartupPhase(false)
    {
    updateTimeOfLastAccess();
    _javaLangClassPtr = NULL;
@@ -715,7 +716,6 @@ ClientSessionData::cacheWellKnownClassChainOffsets(unsigned int includedClasses,
           (WELL_KNOWN_CLASS_COUNT - numClasses) * sizeof(classChainOffsets[0]));
    _wellKnownClasses._wellKnownClassChainOffsets = wellKnownClassChainOffsets;
    }
-
 
 ClientSessionHT*
 ClientSessionHT::allocate()

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -454,6 +454,9 @@ class ClientSessionData
    void cacheWellKnownClassChainOffsets(unsigned int includedClasses, size_t numClasses,
                                         const uintptr_t *classChainOffsets, const void *wellKnownClassChainOffsets);
 
+   bool isInStartupPhase() const { return _isInStartupPhase; }
+   void setIsInStartupPhase(bool isInStartupPhase) { _isInStartupPhase = isInStartupPhase; }
+ 
    private:
    const uint64_t _clientUID;
    int64_t  _timeOfLastAccess; // in ms
@@ -523,6 +526,8 @@ class ClientSessionData
 
    WellKnownClassesCache _wellKnownClasses;
    TR::Monitor *_wellKnownClassesMonitor;
+   
+   bool _isInStartupPhase;
    }; // class ClientSessionData
 
 


### PR DESCRIPTION
Server needs to know when client is in startup phase,
so that it can insert JIT hints for compilations that
are expensive, i.e. hot/scorching compilations or
memory/cpu intensive ones.
This commit stores whether this information in the client session.

Closes: #11386