### PR TITLE
Exclude special.system on AIX XL

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -384,6 +384,11 @@ ppc64_aix_uma:
 #========================================#
 ppc64_aix_xl:
   extends: ['ppc64_aix', 'largeheap']
+  excluded_tests:
+    8:
+      - special.system
+    11:
+      - special.system
 #========================================#
 # AIX PPC 64bits Large Heap /w CMake
 #========================================#


### PR DESCRIPTION
I'm going to add AIX XL to the nightly build. Start testing with
special.system testing disabled to see if the build machines can handle
the load, we can evaluate turning them on later.

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>