### PR TITLE
Update platforms exception Windows to use openssl 1.1.1i

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -153,7 +153,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '--openssl-version=1.1.1h'
+  extra_getsource_options: '--openssl-version=1.1.1i'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
This doesn't affect Windows, which will be handled separately via https://github.com/eclipse/openj9/issues/11407