### PR TITLE
Only load initialized class from SCC into iprofiler data (v0.24.0)

### DIFF
--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -3153,7 +3153,13 @@ TR_IPBCDataCallGraph::loadFromPersistentCopy(TR_IPBCDataStorageHeader * storage,
          if (comp->fej9()->sharedCache()->isROMClassOffsetInSharedCache(csInfoClazzOffset, &romClass))
             ramClass = ((TR_J9VM *)comp->fej9())->matchRAMclassFromROMclass((J9ROMClass *)romClass, comp);
 
-         if (ramClass)
+         // Optimizer and the codegen assume receiver classes of a call from profiling data are initialized,
+         // otherwise they shouldn't show up in the profile. But classes from iprofiling data from last run
+         // may be uninitialized in load time, as the program behavior may change in the second run. Thus
+         // we need to verify that a class is initialized, otherwise optimizer or codegen will make wrong
+         // transformation based on invalid assumption.
+         //
+         if (ramClass && comp->fej9()->isClassInitialized((TR_OpaqueClassBlock*)ramClass))
             {
             _csInfo.setClazz(i, (uintptr_t)ramClass);
             _csInfo._weight[i] = store->_csInfo._weight[i];


### PR DESCRIPTION
Profiled class from last run might not get used in the second run. If
we don't check its initialization status, the profiling data might
be inconsistent with the class hierarchy, resulting in bad inlining
decision or even wrong optimization.

For issue: #11179 

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>