### PR TITLE
Fix bug related to sequencing scheme in JITServer

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1036,7 +1036,7 @@ public:
    TR::Monitor *getclassesCachedAtServerMonitor() const { return _classesCachedAtServerMonitor; }
    TR::Monitor *getSequencingMonitor() const { return _sequencingMonitor; }
    uint32_t getCompReqSeqNo() const { return _compReqSeqNo; }
-   uint32_t incCompReqSeqNo() { return _compReqSeqNo++; }
+   uint32_t incCompReqSeqNo() { return ++_compReqSeqNo; }
    uint32_t getLastCriticalSeqNo() const { return _lastCriticalCompReqSeqNo; }
    void setLastCriticalSeqNo(uint32_t seqNo) { _lastCriticalCompReqSeqNo = seqNo; }
 

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -393,7 +393,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       // Obtain monitor RAII style because creating a new hastable entry may throw bad_alloc
       OMR::CriticalSection compilationMonitorLock(compInfo->getCompilationMonitor());
       compInfo->getClientSessionHT()->purgeOldDataIfNeeded(); // Try to purge old data
-      if (!(clientSession = compInfo->getClientSessionHT()->findOrCreateClientSession(clientId, seqNo, &sessionDataWasEmpty)))
+      if (!(clientSession = compInfo->getClientSessionHT()->findOrCreateClientSession(clientId, criticalSeqNo, &sessionDataWasEmpty)))
          throw std::bad_alloc();
 
       setClientData(clientSession); // Cache the session data into CompilationInfoPerThreadRemote object

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -34,7 +34,7 @@
 
 
 ClientSessionData::ClientSessionData(uint64_t clientUID, uint32_t seqNo) : 
-   _clientUID(clientUID), _expectedSeqNo(seqNo), _maxReceivedSeqNo(seqNo), _lastProcessedCriticalSeqNo(seqNo), 
+   _clientUID(clientUID), _maxReceivedSeqNo(seqNo), _lastProcessedCriticalSeqNo(seqNo), 
    _OOSequenceEntryList(NULL), _chTable(NULL),
    _romClassMap(decltype(_romClassMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _J9MethodMap(decltype(_J9MethodMap)::allocator_type(TR::Compiler->persistentAllocator())),
@@ -749,7 +749,7 @@ ClientSessionHT::~ClientSessionHT()
 // If the clientUID does not already exist in the HT, insert a new blank entry.
 // Must have compilation monitor in hand when calling this function.
 // Side effects: _inUse is incremented on the ClientSessionData
-//               _expectedSeqNo is populated if a new ClientSessionData is created
+//               _lastProcessedCriticalSeqNo is populated if a new ClientSessionData is created
 //                timeOflastAccess is updated with curent time.
 ClientSessionData *
 ClientSessionHT::findOrCreateClientSession(uint64_t clientUID, uint32_t seqNo, bool *newSessionWasCreated)

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -401,8 +401,6 @@ class ClientSessionData
    TR_MethodToBeCompiled *getOOSequenceEntryList() const { return _OOSequenceEntryList; }
    void setOOSequenceEntryList(TR_MethodToBeCompiled *m) { _OOSequenceEntryList = m; }
    TR_MethodToBeCompiled *notifyAndDetachFirstWaitingThread();
-   uint32_t getExpectedSeqNo() const { return _expectedSeqNo; }
-   void setExpectedSeqNo(uint32_t seqNo) { _expectedSeqNo = seqNo; }
    uint32_t getLastProcessedCriticalSeqNo() const { return _lastProcessedCriticalSeqNo; }
    void setLastProcessedCriticalSeqNo(uint32_t seqNo) { _lastProcessedCriticalSeqNo = seqNo; }
    uint32_t getMaxReceivedSeqNo() const { return _maxReceivedSeqNo; }
@@ -474,14 +472,13 @@ class ClientSessionData
    TR::Monitor *_romMapMonitor;
    TR::Monitor *_classMapMonitor;
    TR::Monitor *_classChainDataMapMonitor;
-   // The following monitor is used to protect access to _expectedSeqNo and
+   // The following monitor is used to protect access to _lastProcessedCriticalSeqNo and
    // the list of out-of-sequence compilation requests (_OOSequenceEntryList)
    TR::Monitor *_sequencingMonitor;
    TR::Monitor *_constantPoolMapMonitor;
    // Compilation requests that arrived out-of-sequence wait in
    // _OOSequenceEntryList for their turn to be processed
    TR_MethodToBeCompiled *_OOSequenceEntryList;
-   uint32_t _expectedSeqNo; // used for ordering compilation requests from the same client
    uint32_t _maxReceivedSeqNo; // the largest seqNo received from this client
 
    uint32_t _lastProcessedCriticalSeqNo; // highest seqNo processed request carrying info that needs to be applied in order


### PR DESCRIPTION
JITServer implements a sequencing scheme to apply CHTable updates
and class unload events in the order they happened at the client.
Description of the bug:
A compilation request can be viewed as having 3 attributes:
1) seqNo; the sequence number for the request
2) criticalSeqNo; Specifies the request that must apply its updates
before this request does so
3) lastProcessedCriticalSeqNo; Specifies the last request that has
already applied its updates

The very first compilation request has the following attributes:
 {seqNo=0,  criticalSeqNo=0,  lastProcessedCriticalSeqNo=0}
This allows the first request to pass immediately because
criticalSeqNo==lastProcessedCriticalSeqNo
The second compilation request has the following attributes:
 {seqNo=1,  criticalSeqNo=0,  lastProcessedCriticalSeqNo=0}
So seqNo=1 depends on seqNo=0, but because
criticalSeqNo==lastProcessedCriticalSeqNo, it can too pass
immediately leading to a potential race condition.

The solution is to start the counting for seqNo from 1, so the
first request will look like:
 {seqNo=1,  criticalSeqNo=0,  lastProcessedCriticalSeqNo=0}
and can proceed immediately
The next request will look like:
 {seqNo=2,  criticalSeqNo=1,  lastProcessedCriticalSeqNo=0}
and must wait for lastProcessedCriticalSeqNo to become 1 before
it can proceed.
The problem is when the client attaches to the server, the server
dies and then another server comes up. This server will have
lastProcessedCriticalSeqNo==0 from the initialization, but the
first request will have some criticalSeqNo=N > 0 and may
wait forever for lastProcessedCriticalSeqNo to reach the value N.
To deal with this aspect, the very first request, which is the one
to create the ClientSession, will set lastProcessedCriticalSeqNo to
its own criticalSeqNo.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>