### PR TITLE
(0.24.0) Update platforms exception Windows to use openssl 1.1.1i

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -153,7 +153,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '--openssl-version=1.1.1h'
+  extra_getsource_options: '--openssl-version=1.1.1i'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
Cherry pick #11408 for the 0.24.0 release