### PR TITLE
Use TR::MemoryReference::create API

### DIFF
--- a/runtime/compiler/z/codegen/DFPTreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/DFPTreeEvaluator.cpp
@@ -2640,7 +2640,7 @@ deloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * srcM
    TR::MemoryReference * hiMR;
    if (loMR == NULL)
       {
-      loMR = generateS390MemoryReference(node, cg);
+      loMR =  TR::MemoryReference::create(cg, node);
       }
    hiMR = generateS390MemoryReference(*loMR, 8, cg);
    // FP reg pairs for long double: FPR0 & FPR2, FPR4 & FPR6, FPR1 & FPR3, FPR5 & FPR7 etc..
@@ -2675,9 +2675,9 @@ destoreHelper(TR::Node * node, TR::CodeGenerator * cg)
       valueChild = node->getFirstChild();
       }
   // source returns a reg pair, so... TODO
-  TR::Register * srcReg = cg->evaluate(valueChild);
+   TR::Register * srcReg = cg->evaluate(valueChild);
 
-   TR::MemoryReference * loMR = generateS390MemoryReference(node, cg);
+   TR::MemoryReference * loMR = TR::MemoryReference::create(cg, node);
    TR::MemoryReference * hiMR = generateS390MemoryReference(*loMR, 8, cg);
 
    generateRXInstruction(cg, TR::InstOpCode::STD, node, srcReg->getHighOrder(), loMR);

--- a/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
@@ -4737,7 +4737,7 @@ J9::Z::TreeEvaluator::pdloadVectorEvaluatorHelper(TR::Node *node, TR::CodeGenera
    // generateVSIInstruction() API will call separateIndexRegister() to separate the index
    // register by emitting an LA instruction. If there's a need for large displacement adjustment,
    // LAY will be emitted instead.
-   TR::MemoryReference* sourceMR = generateS390MemoryReference(node, cg, false);
+   TR::MemoryReference* sourceMR = TR::MemoryReference::create(cg, node);
 
    // Index of the first byte to load, counting from the right ranging from 0-15.
    uint8_t indexFromTheRight = TR_VECTOR_REGISTER_SIZE - 1;
@@ -5780,7 +5780,7 @@ J9::Z::TreeEvaluator::pdstoreVectorEvaluatorHelper(TR::Node *node, TR::CodeGener
    // generateVSIInstruction() API will call separateIndexRegister() to separate the index
    // register by emitting an LA instruction. If there's a need for large displacement adjustment,
    // LAY will be emitted instead.
-   TR::MemoryReference * targetMR = generateS390MemoryReference(node, cg, false);
+   TR::MemoryReference * targetMR = TR::MemoryReference::create(cg, node);;
 
    // 0 we store 1 byte, 15 we store 16 bytes
    uint8_t lengthToStore = TR_VECTOR_REGISTER_SIZE - 1;

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -4342,7 +4342,7 @@ J9::Z::TreeEvaluator::ardbariEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       bool dynLitPoolLoad = false;
       resultReg = TR::TreeEvaluator::checkAndAllocateReferenceRegister(node, cg, dynLitPoolLoad);
       // MemRef can generate BRCL to unresolved data snippet if needed.
-      TR::MemoryReference* loadMemRef = generateS390MemoryReference(node, cg);
+      TR::MemoryReference* loadMemRef = TR::MemoryReference::create(cg, node);
 
       if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_S390_GUARDED_STORAGE))
          {
@@ -4536,7 +4536,7 @@ J9::Z::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 
    // We need to evaluate all the children first before we generate memory reference
    // since it will screw up the code sequence for patching when we do symbol resolution.
-   TR::MemoryReference *tempMR = generateS390MemoryReference(node, cg);
+   TR::MemoryReference *tempMR = TR::MemoryReference::create(cg, node);
    TR::InstOpCode::Mnemonic storeOp = usingCompressedPointers ? TR::InstOpCode::ST : TR::InstOpCode::getStoreOpCode();
    TR::Instruction * instr = generateRXInstruction(cg, storeOp, node, opCodeIsIndirect ? compressedRegister : sourceRegister, tempMR);
 


### PR DESCRIPTION
Use TR::MemoryReference::create API for constructing memory reference from node.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>