### PR TITLE
Use getOriginalROMMethod under FSD mode

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -625,8 +625,8 @@ bool TR::CompilationInfo::shouldDowngradeCompReq(TR_MethodToBeCompiled *entry)
        !TR::Options::getCmdLineOptions()->getOption(TR_DontDowngradeToCold))
       {
       TR::PersistentInfo *persistentInfo = getPersistentInfo();
-      const J9ROMMethod * romMethod = methodDetails.getRomMethod();
       TR_J9VMBase *fe = TR_J9VMBase::get(_jitConfig, NULL);
+      const J9ROMMethod * romMethod = methodDetails.getRomMethod(fe);
 
       // Don't downgrade if method is JSR292. See CMVC 200145
       if (_J9ROMMETHOD_J9MODIFIER_IS_SET(romMethod, J9AccMethodHasMethodHandleInvokes))
@@ -7118,7 +7118,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
          {
          // Find the AOT body in the SCC
          //
-         *aotCachedMethod = findAotBodyInSCC(vmThread, entry->getMethodDetails().getRomMethod());
+         *aotCachedMethod = findAotBodyInSCC(vmThread, entry->getMethodDetails().getRomMethod(fe));
 
          // Validate the class chain of the class of the method being AOT loaded
          if (*aotCachedMethod && !fe->sharedCache()->classMatchesCachedVersion(J9_CLASS_FROM_METHOD(method)))

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -3039,7 +3039,7 @@ remoteCompilationEnd(
       {
       TR_ASSERT(entry->_useAotCompilation, "entry must be an AOT compilation");
       TR_ASSERT(entry->isRemoteCompReq(), "entry must be a remote compilation");
-      J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
+      J9ROMMethod *romMethod = comp->fej9()->getROMMethodFromRAMMethod(method);
       TR::CompilationInfo::storeAOTInSharedCache(
          vmThread,
          romMethod,

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -216,7 +216,7 @@ TR_J9SharedCache::getHint(J9VMThread * vmThread, J9Method *method)
    SCCHint result;
 
 #if defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
-   J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
+   J9ROMMethod * romMethod = fe()->getROMMethodFromRAMMethod(method);
 
    J9SharedDataDescriptor descriptor;
    descriptor.address = (U_8 *)&result;
@@ -296,7 +296,7 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
    if (newHint)
       {
       TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
-      J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
+      J9ROMMethod * romMethod = fej9->getROMMethodFromRAMMethod(method);
       J9VMThread * vmThread = fej9->getCurrentVMThread();
 
       char methodSignature[500];

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -750,6 +750,9 @@ TR_J9VMBase::TR_J9VMBase(
          break;
          }
 
+   if (TR::Options::getCmdLineOptions() && TR::Options::getCmdLineOptions()->getOption(TR_FullSpeedDebug))
+      setFSDIsEnabled(true);
+
    _sharedCache = NULL;
    if (TR::Options::sharedClassCache()
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5979,6 +5979,18 @@ TR_J9VMBase::getReportByteCodeInfoAtCatchBlock()
    return _compInfoPT->getCompilation()->getOptions()->getReportByteCodeInfoAtCatchBlock();
    }
 
+TR_OpaqueClassBlock *
+TR_J9VMBase::getClassFromCP(J9ConstantPool *cp)
+   {
+   return reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(cp));
+   }
+
+J9ROMMethod *
+TR_J9VMBase::getROMMethodFromRAMMethod(J9Method *ramMethod)
+   {
+   return fsdIsEnabled() ? getOriginalROMMethod(ramMethod) : J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
+   }
+
 /////////////////////////////////////////////////////
 // TR_J9VM
 /////////////////////////////////////////////////////
@@ -8151,18 +8163,6 @@ TR_J9VM::dereferenceStaticFinalAddress(void *staticAddress, TR::DataType address
          TR_ASSERT(0, "Unexpected type %s", addressType.toString());
       }
    return data;
-   }
-
-TR_OpaqueClassBlock *
-TR_J9VM::getClassFromCP(J9ConstantPool *cp)
-   {
-   return reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(cp));
-   }
-
-J9ROMMethod *
-TR_J9VM::getROMMethodFromRAMMethod(J9Method *ramMethod)
-   {
-   return J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
    }
 
 //////////////////////////////////////////////////////////

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1032,6 +1032,9 @@ public:
    virtual TR_OpaqueClassBlock * getClassFromNewArrayType(int32_t arrayType);
    virtual TR_OpaqueClassBlock * getClassFromNewArrayTypeNonNull(int32_t arrayType);
 
+   virtual TR_OpaqueClassBlock *getClassFromCP(J9ConstantPool *cp);
+   virtual J9ROMMethod *getROMMethodFromRAMMethod(J9Method *ramMethod);
+
    // --------------------------------------------------------------------------
    // Object model
    // --------------------------------------------------------------------------
@@ -1139,8 +1142,6 @@ public:
    virtual uint32_t               getPrimitiveArrayOffsetInJavaVM(uint32_t arrayType);
 
    virtual TR_StaticFinalData dereferenceStaticFinalAddress(void *staticAddress, TR::DataType addressType);
-   virtual TR_OpaqueClassBlock *getClassFromCP(J9ConstantPool *cp);
-   virtual J9ROMMethod *getROMMethodFromRAMMethod(J9Method *ramMethod);
 
    TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t sigLength, J9ConstantPool * constantPool);
 

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -306,6 +306,9 @@ public:
    bool traceIsEnabled() { return _flags.testAny(TraceIsEnabled); }
    void setTraceIsEnabled(bool b) { _flags.set(TraceIsEnabled, b); }
 
+   bool fsdIsEnabled() { return _flags.testAny(FSDIsEnabled); }
+   void setFSDIsEnabled(bool b) { _flags.set(FSDIsEnabled, b); }
+
    uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, char * fieldName, char * sig)
       {
       return getInstanceFieldOffset(classPointer, fieldName, (uint32_t)strlen(fieldName), sig, (uint32_t)strlen(sig));
@@ -1067,6 +1070,7 @@ protected:
    enum // _flags
       {
       TraceIsEnabled = 0x0000001,
+      FSDIsEnabled   = 0x0000002,
       DummyLastEnum
       };
 

--- a/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.cpp
+++ b/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.cpp
@@ -115,7 +115,7 @@ IlGeneratorMethodDetails::getRomClass() const
    }
 
 const J9ROMMethod *
-IlGeneratorMethodDetails::getRomMethod() const
+IlGeneratorMethodDetails::getRomMethod(TR_J9VMBase *fe)
    {
    return J9_ROM_METHOD_FROM_RAM_METHOD(self()->getMethod());
    }

--- a/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.cpp
+++ b/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.cpp
@@ -117,7 +117,7 @@ IlGeneratorMethodDetails::getRomClass() const
 const J9ROMMethod *
 IlGeneratorMethodDetails::getRomMethod(TR_J9VMBase *fe)
    {
-   return J9_ROM_METHOD_FROM_RAM_METHOD(self()->getMethod());
+   return fe->getROMMethodFromRAMMethod(self()->getMethod());
    }
 
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.hpp
+++ b/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.hpp
@@ -118,7 +118,7 @@ public:
    IlGeneratorMethodDetailsType getType() const;
 #endif /* defined(J9VM_OPT_JITSERVER) */
    virtual const J9ROMClass *getRomClass() const;
-   virtual const J9ROMMethod *getRomMethod() const;
+   virtual const J9ROMMethod *getRomMethod(TR_J9VMBase *fe);
 
 
    virtual TR_IlGenerator *getIlGenerator(TR::ResolvedMethodSymbol *methodSymbol,

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -390,7 +390,7 @@ TR_IProfiler::persistIprofileInfo(TR::ResolvedMethodSymbol *resolvedMethodSymbol
 
       // Allocate memory for every possible node in this method
       //
-      J9ROMMethod * romMethod = (J9ROMMethod *)J9_ROM_METHOD_FROM_RAM_METHOD((J9Method *)method);
+      J9ROMMethod * romMethod = comp->fej9()->getROMMethodFromRAMMethod((J9Method *)method);
 
       TR::Options * optionsJIT = TR::Options::getJITCmdLineOptions();
       TR::Options * optionsAOT = TR::Options::getAOTCmdLineOptions();
@@ -1272,7 +1272,7 @@ TR_IProfiler::persistentProfilingSample(TR_OpaqueMethodBlock *method, uint32_t b
       descriptor.type = J9SHR_ATTACHED_DATA_TYPE_JITPROFILE;
       descriptor.flags = J9SHR_ATTACHED_DATA_NO_FLAGS;
       J9VMThread *vmThread = ((TR_J9VM *)comp->fej9())->getCurrentVMThread();
-      J9ROMMethod * romMethod = (J9ROMMethod*)J9_ROM_METHOD_FROM_RAM_METHOD((J9Method *)method);
+      J9ROMMethod * romMethod = comp->fej9()->getROMMethodFromRAMMethod((J9Method *)method);
       IDATA dataIsCorrupt;
 
       TR_IPBCDataStorageHeader *store = (TR_IPBCDataStorageHeader *)scConfig->findAttachedData(vmThread, romMethod, &descriptor, &dataIsCorrupt);
@@ -1355,7 +1355,7 @@ TR_IProfiler::getJ9SharedDataDescriptorForMethod(J9SharedDataDescriptor * descri
    descriptor->type = J9SHR_ATTACHED_DATA_TYPE_JITPROFILE;
    descriptor->flags = J9SHR_ATTACHED_DATA_NO_FLAGS;
    J9VMThread *vmThread = ((TR_J9VM *)comp->fej9())->getCurrentVMThread();
-   J9ROMMethod * romMethod = (J9ROMMethod*)J9_ROM_METHOD_FROM_RAM_METHOD((J9Method *)method);
+   J9ROMMethod * romMethod = comp->fej9()->getROMMethodFromRAMMethod((J9Method *)method);
    IDATA dataIsCorrupt;
    TR_IPBCDataStorageHeader * store = (TR_IPBCDataStorageHeader *) scConfig->findAttachedData(vmThread, romMethod, descriptor, &dataIsCorrupt);
    if (store != (TR_IPBCDataStorageHeader *)descriptor->address)  // a stronger check, as found can be error value


### PR DESCRIPTION
When a method is breakpointed, the VM will copy part of the ROMMethod. Therefore, the result of `J9_ROM_METHOD_FROM_METHOD` may not be a pointer in the SCC. Therefore, this PR updates appropriate locations, that get the ROMMethod to do an SCC query, to acquire the ROMMethod by calling `getOriginalROMMethod` if FSD is enabled.

The remaining code that does `J9_ROM_METHOD_FROM_METHOD` should still be valid because the ROMMethod is only used to get the name of the method, or to get information about whether the method is static, native, etc. Additionaly, the ILGenerator uses the result of `getOriginalROMMethod` regardless of FSD when reading the bytecodes.

Fixes https://github.com/eclipse/openj9/issues/6303