### PR TITLE
Remove dead code surrounded by the OPENJDK_METHODHANDLES JPP flag

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/CallSite.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/CallSite.java
@@ -110,11 +110,5 @@ public abstract class CallSite {
 		}
 		return initialTargetHandleCache;
 	}
-	
-/*[IF OPENJDK_METHODHANDLES]*/
-	static CallSite makeSite(MethodHandle mh, String str, MethodType mt, Object obj, Class<?> cls) {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();		
-	}
-/*[ENDIF] OPENJDK_METHODHANDLES */
 }
 

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2485,24 +2485,6 @@ public class MethodHandles {
 			return cls;
 		}
 		/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
-		
-		/*[IF OPENJDK_METHODHANDLES]*/
-		MemberName resolveOrFail(byte b, MemberName mn) throws ReflectiveOperationException {
-			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-		}
-
-		MemberName resolveOrFail(byte b, Class<?> cls, String str, MethodType mt) throws NoSuchMethodException, IllegalAccessException {
-			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-		}
-
-		MemberName resolveOrFail(byte b, Class<?> cls1, String str, Class<?> cls2) throws NoSuchFieldException, IllegalAccessException {
-			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-		}
-		
-		MethodHandle linkMethodHandleConstant(byte b, Class<?> cls, String str, Object obj) throws ReflectiveOperationException {
-			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-		}
-		/*[ENDIF] OPENJDK_METHODHANDLES */
 	}
 	
 	static MethodHandle filterArgument(MethodHandle target, int pos, MethodHandle filter) {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -509,12 +509,7 @@ public abstract class VarHandle extends VarHandleInternal
 						/* Clone the MethodHandles with the exact types if different set of exactTypes are provided. */
 						MethodType exactType = exactTypes[index];
 						if (exactType != null) {
-							/*[IF OPENJDK_METHODHANDLES]*/
-							MethodHandle operationMH = operationMHs[index];
-							operationMHs[index] = operationMH.copyWith(exactType, operationMH.form);
-							/*[ELSE]*/
 							operationMHs[index] = operationMHs[index].cloneWithNewType(exactType);
-							/*[ENDIF] OPENJDK_METHODHANDLES */
 						}
 						operationMHs[index] = permuteHandleJ9ToReference(operationMHs[index]);
 					}
@@ -1380,12 +1375,7 @@ public abstract class VarHandle extends VarHandleInternal
 			if (lookupTypes != exactTypes) {
 				for (AccessMode accessMode : AccessMode.values()) {
 					int index = accessMode.ordinal();
-					/*[IF OPENJDK_METHODHANDLES]*/
-					MethodHandle operationMH = operationMHs[index];
-					operationMHs[index] = operationMH.copyWith(exactTypes[index], operationMH.form);
-					/*[ELSE]*/
 					operationMHs[index] = operationMHs[index].cloneWithNewType(exactTypes[index]);
-					/*[ENDIF] OPENJDK_METHODHANDLES */
 				}
 			}
 		} catch (IllegalAccessException | NoSuchMethodException e) {
@@ -1724,9 +1714,7 @@ public abstract class VarHandle extends VarHandleInternal
 	private static VarHandle asDirect(VarHandle varHandle) {
 		return varHandle.asDirect();
 	}
-/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
-/*[IF (JAVA_SPEC_VERSION >= 15) | OPENJDK_METHODHANDLES]*/
 	/**
 	 * Return the MethodHandle corresponding to the integer-value of the AccessMode.
 	 * 
@@ -1737,7 +1725,7 @@ public abstract class VarHandle extends VarHandleInternal
 	MethodHandle getMethodHandle(int i) {
 		return handleTable[i];
 	}
-/*[ENDIF] (JAVA_SPEC_VERSION >= 15) | OPENJDK_METHODHANDLES */
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	MethodType accessModeTypeUncached(
 		/*[IF JAVA_SPEC_VERSION >= 16]*/


### PR DESCRIPTION
Now, OpenJ9 classes `CallSite`, `VarHandle` and `MethodHandles` are completely
disabled for the `OPENJDK_METHODHANDLES JPP` flag.

`OPENJDK_METHODHANDLES` wrapped code blocks within the above-mentioned
three classes will no longer be invoked. So, those code blocks are being
removed.

Follow-up: https://github.com/eclipse/openj9/pull/11357

Co-authored-by: Jack Lu <Jack.S.Lu@ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>