### PR TITLE
Disable J9 NativeMethodHandle & GenerateJLIClassesHelper for OJDK MH

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/GenerateJLIClassesHelper.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/GenerateJLIClassesHelper.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-OpenJ9]*/
+/*[INCLUDE-IF Sidecar19-SE-OpenJ9 & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
  * Copyright (c) 2017, 2020 IBM Corp. and others
  *

--- a/jcl/src/java.base/share/classes/java/lang/invoke/NativeMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/NativeMethodHandle.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Panama | (JAVA_SPEC_VERSION >= 16)]*/
+/*[INCLUDE-IF (Panama | (JAVA_SPEC_VERSION >= 16)) & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
  * Copyright (c) 2009, 2020 IBM Corp. and others
  *


### PR DESCRIPTION
For OpenJDK MH, disabling OpenJ9 `NativeMethodHandle` & `GenerateJLIClassesHelper`
allows us to use the OpenJDK versions of those classes.

This allows OpenJ9 JDK16 to be built successfully with OpenJDK MHs.

Co-authored-by: Jack Lu <Jack.S.Lu@ibm.com>
Co-authored-by: Tobi Ajila <atobia@ca.ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>