### PR TITLE
Add AOT support for Method Handles

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -666,6 +666,18 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          }
          break;
 
+      case TR_ValidateArbitraryObjectClassFromCP:
+         {
+         TR_RelocationRecordValidateArbitraryObjectClassFromCP *aocpRecord = reinterpret_cast<TR_RelocationRecordValidateArbitraryObjectClassFromCP *>(reloRecord);
+
+         TR::ArbitraryObjectClassFromCPRecord *svmRecord = reinterpret_cast<TR::ArbitraryObjectClassFromCPRecord *>(relocation->getTargetAddress());
+
+         aocpRecord->setClassID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_class));
+         aocpRecord->setBeholderID(reloTarget, symValManager->getIDFromSymbol(svmRecord->_beholder));
+         aocpRecord->setCpIndex(reloTarget, svmRecord->_cpIndex);
+         }
+         break;
+
       case TR_ValidateDefiningClassFromCP:
          {
          TR_RelocationRecordValidateDefiningClassFromCP *dcpRecord = reinterpret_cast<TR_RelocationRecordValidateDefiningClassFromCP *>(reloRecord);
@@ -1560,6 +1572,7 @@ J9::AheadOfTimeCompile::dumpRelocationHeaderData(uint8_t *cursor, bool isVerbose
       case TR_ValidateStaticClassFromCP:
       case TR_ValidateClassFromITableIndexCP:
       case TR_ValidateDeclaringClassFromFieldOrStatic:
+      case TR_ValidateArbitraryObjectClassFromCP:
          {
          TR_RelocationRecordValidateClassFromCP *cpRecord = reinterpret_cast<TR_RelocationRecordValidateClassFromCP *>(reloRecord);
 
@@ -1575,6 +1588,8 @@ J9::AheadOfTimeCompile::dumpRelocationHeaderData(uint8_t *cursor, bool isVerbose
                recordType = "Class From ITable Index CP";
             else if (kind == TR_ValidateDeclaringClassFromFieldOrStatic)
                recordType = "Declaring Class From Field or Static";
+            else if (kind == TR_ValidateArbitraryObjectClassFromCP)
+               recordType = "Arbitrary Object Class From CP";
             else
                TR_ASSERT_FATAL(false, "Unknown relokind %d!\n", kind);
 

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -471,6 +471,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          break;
 
       case TR_ValidateClass:
+      case TR_ValidateArbitraryObjectClass:
          {
          TR_RelocationRecordValidateClass *vcRecord = reinterpret_cast<TR_RelocationRecordValidateClass *>(reloRecord);
 
@@ -1411,6 +1412,7 @@ J9::AheadOfTimeCompile::dumpRelocationHeaderData(uint8_t *cursor, bool isVerbose
          break;
 
       case TR_ValidateClass:
+      case TR_ValidateArbitraryObjectClass:
          {
          TR_RelocationRecordValidateClass *vcRecord = reinterpret_cast<TR_RelocationRecordValidateClass *>(reloRecord);
 

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1337,12 +1337,12 @@ J9::SymbolReferenceTable::findOrCreateStringSymbol(TR::ResolvedMethodSymbol * ow
       sym->setConstString();
    else
       {
-      if (comp()->compileRelocatableCode())
-         comp()->failCompilation<J9::AOTHasPatchedCPConstant>("Patched Constant not supported in AOT.");
-
+      // if (comp()->compileRelocatableCode())
+      //    comp()->failCompilation<J9::AOTHasPatchedCPConstant>("Patched Constant not supported in AOT.");
       sym->setNonSpecificConstObject();
+      static_cast<TR_ResolvedJ9Method*>(owningMethod)->validateArbitraryObjectClassFromConstantPool(comp(), stringConst, cpIndex);
       }
-
+   
    return symRef;
    }
 

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1299,7 +1299,12 @@ TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateStringSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex)
    {
    TR_ResolvedMethod * owningMethod = owningMethodSymbol->getResolvedMethod();
-   void * stringConst = owningMethod->stringConstant(cpIndex);
+   void * stringConst = owningMethod->stringConstant(comp(), cpIndex);
+   if (!stringConst)
+      {
+      comp()->failCompilation<J9::AOTRelocationRecordGenerationFailure>("AOT Relocation Failed for Patched Constant failed.");
+      }
+
    TR::SymbolReference * symRef;
    bool isString = true;
    if (owningMethod->isUnresolvedString(cpIndex))
@@ -1340,7 +1345,7 @@ J9::SymbolReferenceTable::findOrCreateStringSymbol(TR::ResolvedMethodSymbol * ow
       // if (comp()->compileRelocatableCode())
       //    comp()->failCompilation<J9::AOTHasPatchedCPConstant>("Patched Constant not supported in AOT.");
       sym->setNonSpecificConstObject();
-      static_cast<TR_ResolvedJ9Method*>(owningMethod)->validateArbitraryObjectClassFromConstantPool(comp(), stringConst, cpIndex);
+      // static_cast<TR_ResolvedJ9Method*>(owningMethod)->validateArbitraryObjectClassFromConstantPool(comp(), stringConst, cpIndex);
       }
    
    return symRef;

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2185,6 +2185,7 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
             case compilationAotValidateExceptionHookFailure:
             case compilationAotBlockFrequencyReloFailure:
             case compilationAotRecompQueuedFlagReloFailure:
+            case compilationAotArbitraryObjectClassReloFailure:
                // switch to JIT for these cases (we don't want to relocate again)
                entry->_doNotUseAotCodeFromSharedCache = true;
                tryCompilingAgain = true;

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1543,7 +1543,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto recv = client->getRecvData<TR_ResolvedJ9Method *, int32_t>();
          auto mirror = std::get<0>(recv);
          auto cpIndex = std::get<1>(recv);
-         client->write(response, mirror->stringConstant(cpIndex),
+         client->write(response, mirror->stringConstant(comp, cpIndex),
                        mirror->isUnresolvedString(cpIndex, true),
                        mirror->isUnresolvedString(cpIndex, false));
          }

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -216,6 +216,8 @@ char *compilationErrorNames[]={
    "compilationStreamVersionIncompatible", //compilationFirstJITServerFailure+3
    "compilationStreamInterrupted", //compilationFirstJITServerFailure+4
 #endif /* defined(J9VM_OPT_JITSERVER) */
+   "compilationAotHasInvokeSpecialInterface", //61
+   "compilationAotArbitraryObjectClassReloFailure", //62
    "compilationMaxError",
 };
 

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -83,6 +83,7 @@ typedef enum {
    compilationAotValidateExceptionHookFailure      = 57,
    compilationAotBlockFrequencyReloFailure         = 58,
    compilationAotRecompQueuedFlagReloFailure       = 59,
+   compilationAotArbitraryObjectClassReloFailure   = 60,
 #if defined(J9VM_OPT_JITSERVER)
    compilationFirstJITServerFailure,
    compilationStreamFailure                        = compilationFirstJITServerFailure,

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1074,6 +1074,10 @@ public:
    virtual bool isStringCompressionEnabledVM();
    virtual void *getInvokeExactThunkHelperAddress(TR::Compilation *comp, TR::SymbolReference *glueSymRef, TR::DataType dataType);
 
+   virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t sigLength, J9ConstantPool * constantPool) { return NULL; }
+   virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t length, TR_ResolvedMethod *method, bool isVettedForAOT=false) { return NULL; }
+   virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t length, TR_OpaqueMethodBlock *method, bool isVettedForAOT=false) { return NULL; }
+
 protected:
 
    enum // _flags
@@ -1112,6 +1116,8 @@ public:
    virtual int32_t               getNewArrayTypeFromClass(TR_OpaqueClassBlock *clazz);
    virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t length, TR_ResolvedMethod *method, bool isVettedForAOT=false);
    virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t length, TR_OpaqueMethodBlock *method, bool isVettedForAOT=false);
+   virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t sigLength, J9ConstantPool * constantPool);
+
    virtual TR_OpaqueClassBlock * getBaseComponentClass(TR_OpaqueClassBlock * clazz, int32_t & numDims);
    virtual TR_OpaqueClassBlock * getSystemClassFromClassName(const char * name, int32_t length, bool isVettedForAOT=false);
    virtual TR_YesNoMaybe      isInstanceOf(TR_OpaqueClassBlock *instanceClass, TR_OpaqueClassBlock *castClass, bool instanceIsFixed, bool castIsFixed = true, bool optimizeForAOT=false);
@@ -1148,8 +1154,6 @@ public:
    virtual uint32_t               getPrimitiveArrayOffsetInJavaVM(uint32_t arrayType);
 
    virtual TR_StaticFinalData dereferenceStaticFinalAddress(void *staticAddress, TR::DataType addressType);
-
-   TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t sigLength, J9ConstantPool * constantPool);
 
 private:
    void transformJavaLangClassIsArrayOrIsPrimitive( TR::Compilation *, TR::Node * callNode,  TR::TreeTop * treeTop, int32_t andMask);

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1576,11 +1576,11 @@ TR_ResolvedRelocatableJ9Method::validateArbitraryObjectClassFromConstantPool(TR:
       clazz = comp->fej9()->getObjectClassAt((uintptr_t)arbitraryObject); 
       }
 
-   // if (comp->getOption(TR_UseSymbolValidationManager))
-   //    {
-   //    return comp->getSymbolValidationManager()->addArbitraryObjectClassFromCPRecord(clazz, cp(), cpIndex);
-   //    }
-   // else
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      return comp->getSymbolValidationManager()->addArbitraryObjectClassFromCPRecord(clazz, cp(), cpIndex);
+      }
+   else
       {
       return storeValidationRecordIfNecessary(comp, cp(), cpIndex, reloKind, ramMethod(), reinterpret_cast<J9Class *>(clazz));
       }

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1624,11 +1624,20 @@ cpType2trType(UDATA cpType)
    }
 
 void *
-TR_ResolvedRelocatableJ9Method::stringConstant(I_32 cpIndex)
+TR_ResolvedRelocatableJ9Method::stringConstant(TR::Compilation *comp, I_32 cpIndex)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
 
-   return (void *) ((U_8 *)&(((J9RAMStringRef *) romLiterals())[cpIndex].stringObject));
+   void * stringConst = TR_ResolvedJ9Method::stringConstant(comp, cpIndex);
+   if (stringConst)
+      {
+      bool validated = validateArbitraryObjectClassFromConstantPool(comp, stringConst, cpIndex);
+      if (validated)
+         {
+         return stringConst;
+         }
+      }
+   return 0;
    }
 
 bool
@@ -6190,7 +6199,7 @@ TR_ResolvedJ9Method::intConstant(I_32 cpIndex)
    }
 
 void *
-TR_ResolvedJ9Method::stringConstant(I_32 cpIndex)
+TR_ResolvedJ9Method::stringConstant(TR::Compilation *comp, I_32 cpIndex)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
    return &((J9RAMStringRef *) literals())[cpIndex].stringObject;

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -364,7 +364,7 @@ public:
    virtual uint64_t                longConstant(int32_t cpIndex);
    virtual float *                 floatConstant(int32_t cpIndex);
    virtual double *                doubleConstant(int32_t cpIndex, TR_Memory *);
-   virtual void *                  stringConstant(int32_t cpIndex);
+   virtual void *                  stringConstant(TR::Compilation *comp, int32_t cpIndex);
    virtual bool                    isUnresolvedString(int32_t cpIndex, bool optimizeForAOT = false);
    /** \brief
     *     Retrieves the underlying type information for a given constant dynamic.
@@ -589,7 +589,7 @@ public:
    virtual bool                    validateArbitraryObjectClassFromConstantPool(TR::Compilation *comp, void * arbitraryObject, uint32_t cpIndex, TR_ExternalRelocationTargetKind reloKind = TR_ValidateArbitraryObjectClass);
    virtual bool                    validateArbitraryClass( TR::Compilation *comp, J9Class *clazz);
 
-   virtual void *                  stringConstant(int32_t cpIndex);
+   virtual void *                  stringConstant(TR::Compilation * comp, int32_t cpIndex);
    virtual bool                    isUnresolvedString(int32_t cpIndex, bool optimizeForAOT = false);
    virtual void *                  methodTypeConstant(int32_t cpIndex);
    virtual bool                    isUnresolvedMethodType(int32_t cpIndex);

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -318,16 +318,16 @@ public:
 
    virtual void *                  resolvedMethodAddress();
    virtual void *                  startAddressForJittedMethod();
-   virtual void *                  startAddressForJNIMethod( TR::Compilation *);
+   virtual void *                  startAddressForJNIMethod(TR::Compilation *);
    virtual void *                  startAddressForJITInternalNativeMethod();
    virtual void *                  startAddressForInterpreterOfJittedMethod();
-   virtual bool                    isWarmCallGraphTooBig(uint32_t bcIndex,  TR::Compilation *);
-   virtual void                    setWarmCallGraphTooBig(uint32_t bcIndex,  TR::Compilation *);
+   virtual bool                    isWarmCallGraphTooBig(uint32_t bcIndex, TR::Compilation *);
+   virtual void                    setWarmCallGraphTooBig(uint32_t bcIndex, TR::Compilation *);
    virtual void                    getFaninInfo(uint32_t *count, uint32_t *weight, uint32_t *otherBucketWeight = NULL);
    virtual bool                    getCallerWeight(TR_ResolvedJ9Method *caller, uint32_t *weight, uint32_t pcIndex=~0);
 
 
-   virtual intptr_t               getInvocationCount();
+   virtual intptr_t                getInvocationCount();
    virtual bool                    setInvocationCount(intptr_t oldCount, intptr_t newCount);
    virtual bool                    isSameMethod(TR_ResolvedMethod *);
 
@@ -343,12 +343,14 @@ public:
 
    static TR_OpaqueClassBlock *    getClassFromCP(TR_J9VMBase *fej9, J9ConstantPool *cp, TR::Compilation *comp, uint32_t cpIndex);
    static TR_OpaqueClassBlock *    getClassOfStaticFromCP(TR_J9VMBase *fej9, J9ConstantPool *cp, int32_t cpIndex);
+   static void *                   getArbitraryObjectFromCP(TR_J9VMBase *fej9, J9ConstantPool *cp, I_32 cpIndex);
 
    virtual void *                  ramConstantPool();
    virtual void *                  constantPool();
-   virtual TR_OpaqueClassBlock *   getClassFromConstantPool( TR::Compilation *, uint32_t cpIndex, bool returnClassForAot=false);
-   virtual bool                    validateClassFromConstantPool( TR::Compilation *comp, J9Class *clazz, uint32_t cpIndex, TR_ExternalRelocationTargetKind reloKind = TR_ValidateClass);
-   virtual bool                    validateArbitraryClass( TR::Compilation *comp, J9Class *clazz);
+   virtual TR_OpaqueClassBlock *   getClassFromConstantPool(TR::Compilation *, uint32_t cpIndex, bool returnClassForAot=false);
+   virtual bool                    validateClassFromConstantPool(TR::Compilation *comp, J9Class *clazz, uint32_t cpIndex, TR_ExternalRelocationTargetKind reloKind = TR_ValidateClass);
+   virtual bool                    validateArbitraryObjectClassFromConstantPool(TR::Compilation *comp, void * arbitraryObject, uint32_t cpIndex, TR_ExternalRelocationTargetKind reloKind = TR_ValidateArbitraryObjectClass);
+   virtual bool                    validateArbitraryClass(TR::Compilation *comp, J9Class *clazz);
 
    virtual char *                  getClassNameFromConstantPool(uint32_t cpIndex, uint32_t &length);
    virtual char *                  getMethodSignatureFromConstantPool(int32_t cpIndex, int32_t & len);
@@ -584,6 +586,7 @@ public:
 
    virtual TR_OpaqueClassBlock *   getClassFromConstantPool( TR::Compilation *, uint32_t cpIndex, bool returnClassToAOT = false);
    virtual bool                    validateClassFromConstantPool( TR::Compilation *comp, J9Class *clazz, uint32_t cpIndex, TR_ExternalRelocationTargetKind reloKind = TR_ValidateClass);
+   virtual bool                    validateArbitraryObjectClassFromConstantPool(TR::Compilation *comp, void * arbitraryObject, uint32_t cpIndex, TR_ExternalRelocationTargetKind reloKind = TR_ValidateArbitraryObjectClass);
    virtual bool                    validateArbitraryClass( TR::Compilation *comp, J9Class *clazz);
 
    virtual void *                  stringConstant(int32_t cpIndex);

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1187,7 +1187,7 @@ TR_ResolvedJ9JITServerMethod::fieldOrStaticName(I_32 cpIndex, int32_t & len, TR_
    }
 
 void *
-TR_ResolvedJ9JITServerMethod::stringConstant(I_32 cpIndex)
+TR_ResolvedJ9JITServerMethod::stringConstant(TR::Compilation *comp, I_32 cpIndex)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
    _stream->write(JITServer::MessageType::ResolvedMethod_stringConstant, _remoteMirror, cpIndex);

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -290,8 +290,10 @@ class TR_ResolvedRelocatableJ9JITServerMethod : public TR_ResolvedJ9JITServerMet
 
    virtual TR_OpaqueClassBlock * definingClassFromCPFieldRef(TR::Compilation *comp, int32_t cpIndex, bool isStatic, TR_OpaqueClassBlock **fromResolvedJ9Method = NULL) override;
    virtual TR_OpaqueClassBlock * getClassFromConstantPool(TR::Compilation *, uint32_t cpIndex, bool returnClassToAOT = false) override;
+   virtual void *                stringConstant(TR::Compilation *comp, I_32 cpIndex) override;
    virtual bool                  validateClassFromConstantPool(TR::Compilation *comp, J9Class *clazz, uint32_t cpIndex, TR_ExternalRelocationTargetKind reloKind = TR_ValidateClass) override;
    virtual bool                  validateArbitraryClass(TR::Compilation *comp, J9Class *clazz) override;
+   virtual bool                  validateArbitraryObjectClassFromConstantPool(TR::Compilation *comp, void * arbitraryObject, uint32_t cpIndex, TR_ExternalRelocationTargetKind reloKind) override;
    virtual bool                  isUnresolvedString(int32_t cpIndex, bool optimizeForAOT = false) override;
    virtual void *                methodTypeConstant(int32_t cpIndex) override;
    virtual bool                  isUnresolvedMethodType(int32_t cpIndex) override;

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -197,7 +197,7 @@ public:
    virtual char * getMethodNameFromConstantPool(int32_t cpIndex, int32_t & len) override;
    virtual char * fieldOrStaticNameChars(int32_t cpIndex, int32_t & len) override;
    virtual bool isSubjectToPhaseChange(TR::Compilation *comp) override;
-   virtual void * stringConstant(int32_t cpIndex) override;
+   virtual void * stringConstant(TR::Compilation * comp, int32_t cpIndex) override;
    virtual TR_ResolvedMethod *getResolvedHandleMethod(TR::Compilation *, int32_t cpIndex, bool * unresolvedInCP) override;
    virtual bool isUnresolvedMethodTypeTableEntry(int32_t cpIndex) override;
    virtual void * methodTypeTableEntryAddress(int32_t cpIndex) override;

--- a/runtime/compiler/ras/DebugExt.cpp
+++ b/runtime/compiler/ras/DebugExt.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/ras/DebugExt.cpp
+++ b/runtime/compiler/ras/DebugExt.cpp
@@ -3651,6 +3651,7 @@ TR_DebugExt::dxPrintAOTinfo(void *addr)
          case TR_ValidateInstanceField:
          case TR_ValidateStaticField:
          case TR_ValidateClass:
+         case TR_ValidateArbitraryObjectClass:
             {
             TR_RelocationRecordValidateField *record = (TR_RelocationRecordValidateField *) reloRecord;
             _dbgPrintf("0x%-16x  0x%-16x  0x%-16x  0x%-16x", record->inlinedSiteIndex, record->constantPool, record->cpIndex, record->classChainOffsetInSharedCache);

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -1052,6 +1052,18 @@ class TR_RelocationRecordValidateClass : public TR_RelocationRecordConstantPoolW
       virtual int32_t failureCode();
    };
 
+class TR_RelocationRecordValidateArbitraryObjectClass : public TR_RelocationRecordValidateClass
+   {
+   public:
+      TR_RelocationRecordValidateArbitraryObjectClass() {}
+      TR_RelocationRecordValidateArbitraryObjectClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateClass(reloRuntime, record) {}
+      virtual char *name();      
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+
+   protected:
+      virtual int32_t failureCode();
+   };
+
 class TR_RelocationRecordValidateInstanceField : public TR_RelocationRecordValidateClass
    {
    public:

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -1180,6 +1180,15 @@ class TR_RelocationRecordValidateClassFromCP : public TR_RelocationRecord
       uint32_t cpIndex(TR_RelocationTarget *reloTarget);
    };
 
+class TR_RelocationRecordValidateArbitraryObjectClassFromCP : public TR_RelocationRecordValidateClassFromCP
+   {
+   public:
+      TR_RelocationRecordValidateArbitraryObjectClassFromCP() {}
+      TR_RelocationRecordValidateArbitraryObjectClassFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateClassFromCP(reloRuntime, record) {}
+      virtual char *name() { return "TR_RelocationRecordValidateArbitraryObjectClassFromCP"; }
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
 class TR_RelocationRecordValidateDefiningClassFromCP : public TR_RelocationRecord
    {
    public:

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -811,8 +811,6 @@ TR::SymbolValidationManager::addArbitraryObjectClassFromCPRecord(TR_OpaqueClassB
    if (recordExists(&byName))
       return true; // already have an equivalent ClassByName
 
-   // we don't need a special record for classByName
-   // we do need one for ClassFromConstantPool because the cpIndex does not point to a Class but an arbitrary object
    bool added;
    if (!isAlreadyValidated(clazz)) // save a ClassChainRecord
       added = addClassRecordWithChain(new (_region) ArbitraryObjectClassFromCPRecord(clazz, beholder, cpIndex));

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -226,6 +226,23 @@ struct DefiningClassFromCPRecord : public ClassValidationRecord
    TR_OpaqueClassBlock * _beholder;
    uint32_t  _cpIndex;
    bool      _isStatic;
+   };
+
+struct ArbitraryObjectClassFromCPRecord : public ClassValidationRecordWithChain
+   {
+   ArbitraryObjectClassFromCPRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueClassBlock *beholder, uint32_t cpIndex)
+      : ClassValidationRecordWithChain(TR_ValidateArbitraryObjectClassFromCP, clazz),
+        _class(clazz),
+        _beholder(beholder),
+        _cpIndex(cpIndex)
+      {}
+
+   virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
+   virtual void printFields();
+
+   TR_OpaqueClassBlock * _class;
+   TR_OpaqueClassBlock * _beholder;
+   uint32_t  _cpIndex;
    };
 
 struct StaticClassFromCPRecord : public ClassValidationRecord
@@ -677,6 +694,7 @@ public:
    bool addClassByNameRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueClassBlock *beholder);
    bool addProfiledClassRecord(TR_OpaqueClassBlock *clazz);
    bool addClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, uint32_t cpIndex);
+   bool addArbitraryObjectClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, uint32_t cpIndex);
    bool addDefiningClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, uint32_t cpIndex, bool isStatic = false);
    bool addStaticClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, uint32_t cpIndex);
    bool addArrayClassFromComponentClassRecord(TR_OpaqueClassBlock *arrayClass, TR_OpaqueClassBlock *componentClass);
@@ -726,7 +744,7 @@ public:
    bool validateClassFromITableIndexCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex);
    bool validateDeclaringClassFromFieldOrStaticRecord(uint16_t definingClassID, uint16_t beholderID, int32_t cpIndex);
    bool validateConcreteSubClassFromClassRecord(uint16_t childClassID, uint16_t superClassID);
-
+   bool validateArbitraryObjectClassFromCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex);
    bool validateClassChainRecord(uint16_t classID, void *classChain);
 
    bool validateMethodFromClassRecord(uint16_t methodID, uint16_t beholderID, uint32_t index);


### PR DESCRIPTION
# NonSVM implementation summary:
## AOT compile run
- our record needs these 4 pieces of information
```
InlinedSiteIndex
cpIndex
constantPool (not sure why this pointer is needed as we can get constantPool from inlinedSiteIndex)
classChain of j9class of arbitrary object
```
- introduce `TR_ResolvedRelocatableJ9Method::validateArbitraryObjectClassFromConstantPool` which will handle adding both SVM and NonSVM validation records
- looking to reuse `storeValidationRecordIfNecessary`, add new type `TR_ValidateArbitraryObjectClass`

## AOT load run 
- `TR_RelocationRecordValidateArbitraryObjectClass::applyRelocation()` should contain the special logic for the AOT load run validation
  - use InlinedSiteIndex to find J9Method then from J9Method we can find J9ConstantPool
  - `J9ConstantPool[cpIndex]` gives us the arbitrary object
  - from the arbitrary object we can get J9Class
  - check the J9Class against classChain for the shape check
  - call getClassFromSignature() on classChain head name for the visibility check
- `TR_RelocationRecordValidateArbitraryObjectClass` will need to be created, could extend from `TR_RelocationRecordValidateClass`, only `applyRelocation()` need to be overriden
- `initializeCommonAOTRelocationHeader` and `dumpRelocationHeaderData` and `TR_RelocationRecord::create` all need a new case (`TR_ValidateArbitraryObjectClass`)
- Issue: https://github.com/eclipse/openj9/issues/4850
- depends on: https://github.com/eclipse/omr/pull/5750

Signed-off-by: Harry Yu <harryyu1994@gmail.com>