### PR TITLE
Capture more information in SymRefTab fatal assert

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -862,8 +862,9 @@ J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * ow
    if (resolved)
       {
       bool isStatic = false;
+      TR_OpaqueClassBlock* fromResolvedJ9Method = NULL;
       containingClass =
-         owningMethod->definingClassFromCPFieldRef(comp(), cpIndex, isStatic);
+         owningMethod->definingClassFromCPFieldRef(comp(), cpIndex, isStatic, &fromResolvedJ9Method);
 
       if (comp()->compileRelocatableCode())
          {
@@ -871,11 +872,13 @@ J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * ow
             containingClass != NULL,
             "failed to get defining class of field ref cpIndex=%d in owning method J9Method=%p\n"
             "\tTR_ResolvedJ9Method::definingClassFromCPFieldRef=%p, TR_ResolvedRelocatableJ9Method::definingClassFromCPFieldRef=%p\n"
+            "\tfromResolvedJ9Method=%p\n"
             "\tTR_UseSymbolValidationManager=%d",
             cpIndex,
             owningMethod->getNonPersistentIdentifier(),
             owningMethod->TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp(), owningMethod->cp(), cpIndex, isStatic),
             static_cast<TR_ResolvedRelocatableJ9Method *>(owningMethod)->definingClassFromCPFieldRef(comp(), cpIndex, isStatic),
+            fromResolvedJ9Method,
             comp()->getOption(TR_UseSymbolValidationManager));
          }
       else

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2024,9 +2024,13 @@ TR_OpaqueClassBlock *
 TR_ResolvedRelocatableJ9Method::definingClassFromCPFieldRef(
    TR::Compilation *comp,
    I_32 cpIndex,
-   bool isStatic)
+   bool isStatic,
+   TR_OpaqueClassBlock** fromResolvedJ9Method)
    {
    TR_OpaqueClassBlock *clazz = TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp, cp(), cpIndex, isStatic);
+   if (fromResolvedJ9Method != NULL) {
+      *fromResolvedJ9Method = clazz;
+   }
 
    bool valid = false;
    if (comp->getOption(TR_UseSymbolValidationManager))
@@ -7247,9 +7251,14 @@ TR_OpaqueClassBlock *
 TR_ResolvedJ9Method::definingClassFromCPFieldRef(
    TR::Compilation *comp,
    I_32 cpIndex,
-   bool isStatic)
+   bool isStatic,
+   TR_OpaqueClassBlock** fromResolvedJ9Method)
    {
-   return definingClassFromCPFieldRef(comp, cp(), cpIndex, isStatic);
+   auto result = definingClassFromCPFieldRef(comp, cp(), cpIndex, isStatic);
+   if (fromResolvedJ9Method != NULL) {
+      *fromResolvedJ9Method = result;
+   }
+   return result;
    }
 
 bool

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -430,7 +430,7 @@ public:
 
    static TR_OpaqueClassBlock  * definingClassFromCPFieldRef(TR::Compilation *comp, J9ConstantPool *constantPool, int32_t cpIndex, bool isStatic);
    static TR_OpaqueClassBlock  * definingClassAndFieldShapeFromCPFieldRef(TR::Compilation *comp, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic, J9ROMFieldShape **field);
-   virtual TR_OpaqueClassBlock * definingClassFromCPFieldRef(TR::Compilation *comp, int32_t cpIndex, bool isStatic);
+   virtual TR_OpaqueClassBlock * definingClassFromCPFieldRef(TR::Compilation *comp, int32_t cpIndex, bool isStatic, TR_OpaqueClassBlock** fromResolvedJ9Method = NULL);
 
    virtual char *                  fieldNameChars(int32_t cpIndex, int32_t & len);
    virtual char *                  staticNameChars(int32_t cpIndex, int32_t & len);
@@ -596,7 +596,7 @@ public:
 
    virtual bool                    staticAttributes( TR::Compilation *, int32_t cpIndex, void * *, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate, bool isStore, bool * unresolvedInCP, bool needsAOTValidation);
 
-   virtual TR_OpaqueClassBlock * definingClassFromCPFieldRef(TR::Compilation *comp, int32_t cpIndex, bool isStatic);
+   virtual TR_OpaqueClassBlock * definingClassFromCPFieldRef(TR::Compilation *comp, int32_t cpIndex, bool isStatic, TR_OpaqueClassBlock** fromResolvedJ9Method = NULL);
 
    virtual int32_t                 virtualCallSelector(uint32_t cpIndex);
    virtual char *                  fieldSignatureChars(int32_t cpIndex, int32_t & len);


### PR DESCRIPTION
To continue investigating #9416, further information is needed from the
assert message. Specifically, when
`TR_ResolvedRelocatableJ9Method::definingClassFromCPFieldRef` is invoked
from `SymbolReferenceTable::findOrCreateShadowSymbol`, which happens
under old AOT during startup, it would be useful to know what the call
to `TR_ResolvedJ9Method::definingClassFromCPFieldRef` that is inside
`TR_ResolvedRelocatableJ9Method::definingClassFromCPFieldRef` returns.
To find out, this commit adds an optional out parameter to both
implementations of `definingClassFromCPFieldRef`. The signature of two
must match because one overloads the other. Inside
`TR_ResolvedRelocatableJ9Method::definingClassFromCPFieldRef`, the out
parameter, when one is specified, is assigned the result of the call to
`TR_ResolvedJ9Method::definingClassFromCPFieldRef`.
Inside `TR_ResolvedJ9Method::definingClassFromCPFieldRef`, the out
parameter is assigned the same value as the returned value.

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>