### PR TITLE
Support exception event hooks in AOT

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2173,6 +2173,7 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
             case compilationAOTNoSupportForAOTFailure:
             case compilationAOTValidateTMFailure:
             case compilationAOTRelocationRecordGenerationFailure:
+            case compilationAotValidateExceptionHookFailure:
                // switch to JIT for these cases (we don't want to relocate again)
                entry->_doNotUseAotCodeFromSharedCache = true;
                tryCompilingAgain = true;

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2369,7 +2369,6 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
       {
       self()->setOption(TR_DisableThrowToGoto);
       self()->setReportByteCodeInfoAtCatchBlock();
-      doAOT = false;
       }
 
    // Determine whether or not to generate method enter and exit hooks

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -437,6 +437,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          vmInfo._processID = fe->getProcessID();
          vmInfo._canMethodEnterEventBeHooked = fe->canMethodEnterEventBeHooked();
          vmInfo._canMethodExitEventBeHooked = fe->canMethodExitEventBeHooked();
+         vmInfo._canExceptionEventBeHooked = fe->canExceptionEventBeHooked();
          vmInfo._usesDiscontiguousArraylets = TR::Compiler->om.usesDiscontiguousArraylets();
          vmInfo._isIProfilerEnabled = fe->getIProfiler();
          vmInfo._arrayletLeafLogSize = TR::Compiler->om.arrayletLeafLogSize();

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -205,14 +205,15 @@ char *compilationErrorNames[]={
    "compilationILGenUnsupportedValueTypeOperationFailure", //53
    "compilationAOTRelocationRecordGenerationFailure", //54
    "compilationAotPatchedCPConstant", //55
+   "compilationAotHasInvokeSpecialInterface", //56
+   "compilationAotValidateExceptionHookFailure", //57
 #if defined(J9VM_OPT_JITSERVER)
-   "compilationStreamFailure", //56
-   "compilationStreamLostMessage", // 57
-   "compilationStreamMessageTypeMismatch", // 58
-   "compilationStreamVersionIncompatible", // 59
-   "compilationStreamInterrupted", // 60
+   "compilationStreamFailure", //compilationFirstJITServerFailure=58
+   "compilationStreamLostMessage", // compilationFirstJITServerFailure+1
+   "compilationStreamMessageTypeMismatch", //compilationFirstJITServerFailure+2
+   "compilationStreamVersionIncompatible", //compilationFirstJITServerFailure+3
+   "compilationStreamInterrupted", //compilationFirstJITServerFailure+4
 #endif /* defined(J9VM_OPT_JITSERVER) */
-   "compilationAotHasInvokeSpecialInterface", //61
    "compilationMaxError",
 };
 

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -79,6 +79,8 @@ typedef enum {
    compilationILGenUnsupportedValueTypeOperationFailure = 53,
    compilationAOTRelocationRecordGenerationFailure = 54,
    compilationAotPatchedCPConstant                 = 55,
+   compilationAotHasInvokeSpecialInterface         = 56,
+   compilationAotValidateExceptionHookFailure      = 57,
 #if defined(J9VM_OPT_JITSERVER)
    compilationFirstJITServerFailure,
    compilationStreamFailure                        = compilationFirstJITServerFailure,
@@ -87,7 +89,6 @@ typedef enum {
    compilationStreamVersionIncompatible            = compilationFirstJITServerFailure+3,
    compilationStreamInterrupted                    = compilationFirstJITServerFailure+4,
 #endif /* defined(J9VM_OPT_JITSERVER) */
-   compilationAotHasInvokeSpecialInterface, //60
    /* please insert new codes before compilationMaxError which is used in jar2jxe to test the error codes range */
    /* If new codes are added then add the corresponding names in compilationErrorNames table in rossa.cpp */
    compilationMaxError /* must be the last one */

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3135,6 +3135,18 @@ TR_J9VMBase::methodsCanBeInlinedEvenIfEventHooksEnabled()
    return false;
    }
 
+bool
+TR_J9VMBase::canExceptionEventBeHooked()
+   {
+   J9JavaVM * javaVM = _jitConfig->javaVM;
+   J9HookInterface * * vmHooks = javaVM->internalVMFunctions->getVMHookInterface(javaVM);
+
+   bool catchCanBeHooked = ((*vmHooks)->J9HookDisable(vmHooks, J9HOOK_VM_EXCEPTION_CATCH) != 0);
+   bool throwCanBeHooked = ((*vmHooks)->J9HookDisable(vmHooks, J9HOOK_VM_EXCEPTION_THROW) != 0);
+
+   return (catchCanBeHooked || throwCanBeHooked);
+   }
+
 
 TR::TreeTop *
 TR_J9VMBase::lowerMethodHook(TR::Compilation * comp, TR::Node * root, TR::TreeTop * treeTop)

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -944,6 +944,8 @@ public:
    virtual bool canMethodExitEventBeHooked();
    virtual bool methodsCanBeInlinedEvenIfEventHooksEnabled();
 
+   virtual bool canExceptionEventBeHooked();
+
    TR::TreeTop * lowerMethodHook(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
    TR::TreeTop * lowerArrayLength(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
    TR::TreeTop * lowerContigArrayLength(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -246,6 +246,14 @@ TR_J9ServerVM::canMethodExitEventBeHooked()
    return vmInfo->_canMethodExitEventBeHooked;
    }
 
+bool
+TR_J9ServerVM::canExceptionEventBeHooked()
+   {
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+   return vmInfo->_canExceptionEventBeHooked;
+   }
+
 TR_OpaqueClassBlock *
 TR_J9ServerVM::getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer)
    {

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -69,6 +69,7 @@ public:
    virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method) override;
    virtual bool canMethodEnterEventBeHooked() override;
    virtual bool canMethodExitEventBeHooked() override;
+   virtual bool canExceptionEventBeHooked() override;
    virtual TR_OpaqueClassBlock * getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer) override;
    virtual void * getClassLoader(TR_OpaqueClassBlock * classPointer) override;
    virtual TR_OpaqueClassBlock * getClassOfMethod(TR_OpaqueMethodBlock *method) override;

--- a/runtime/compiler/runtime/J9Runtime.hpp
+++ b/runtime/compiler/runtime/J9Runtime.hpp
@@ -181,6 +181,7 @@ typedef struct TR_AOTMethodHeader {
 #define TR_AOTMethodHeader_UsesSymbolValidationManager               0x00000020
 #define TR_AOTMethodHeader_TMDisabled                                0x00000040
 #define TR_AOTMethodHeader_CompressedMethodInCache                   0x00000080
+#define TR_AOTMethodHeader_IsNotCapableOfExceptionHook               0x00000100
 
 
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -303,6 +303,7 @@ class ClientSessionData
       uintptr_t _processID;
       bool _canMethodEnterEventBeHooked;
       bool _canMethodExitEventBeHooked;
+      bool _canExceptionEventBeHooked;
       bool _usesDiscontiguousArraylets;
       bool _isIProfilerEnabled;
       int32_t _arrayletLeafLogSize;

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1580,6 +1580,11 @@ createMethodMetaData(
          aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_IsNotCapableOfMethodEnterTracing;
          }
 
+      if (!vm->canExceptionEventBeHooked())
+         {
+         aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_IsNotCapableOfExceptionHook;
+         }
+
       if (comp->getOption(TR_DisableTM))
          {
          aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_TMDisabled;

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -217,6 +217,13 @@ TR_RelocationRuntime::prepareRelocateAOTCodeAndData(J9VMThread* vmThread,
       return NULL; // fail
       }
 
+   if (fej9->canExceptionEventBeHooked()
+       && (_aotMethodHeaderEntry->flags & TR_AOTMethodHeader_IsNotCapableOfExceptionHook))
+      {
+      setReturnCode(compilationAotValidateExceptionHookFailure);
+      return NULL;
+      }
+
    // Check the flags related to string compression
    if (_aotMethodHeaderEntry->flags & TR_AOTMethodHeader_UsesEnableStringCompressionFolding)
       {


### PR DESCRIPTION
At JIT bootstrap, if the compiler detects that an exception event could
be hooked, it prevents AOT compilation. There isn't any apparent reason
for why this should be the case. This PR allows AOT compilation to
occur if an exception event can be hooked. However, if a method was
AOT compiled with the assumption that no exception event could be
hooked then the method isn't loaded.

Small test I wrote:
```
class SpecialException extends Throwable {
}

class ExceptionTest {

        public int count;
        public int sleep;

        public ExceptionTest() {
                count = 0;
        }

        public void doSomeWork(boolean doThrow) throws SpecialException {
                count++;
                if (doThrow) {
                        throw new SpecialException();
                }

        }
}

public class TestAOTException {

        public static void main(String args[]) throws SpecialException {

                ExceptionTest test = new ExceptionTest();

                for (int i = 0; i < 1000; i++) {
                        test.doSomeWork(false);
                }

                try {
                        Thread.sleep(4000);
                } catch (InterruptedException e) {}

                try {
                        test.doSomeWork(true);
                } catch (SpecialException e) {
                        System.out.println("Caught Exception, count = " + test.count);
                }
        }
}
```
### Enabling exception hook on second run but not first
```
[dsouzai@localhost testAOTException]$ ../jdk11/bin/java -Xshareclasses:name=test_aot_exception '-Xjit:count=100,verbose={compilePerformance},vlog=vlog,disableSuffixLogs' TestAOTException
Caught Exception, count = 1001
[dsouzai@localhost testAOTException]$ ../jdk11/bin/java -Xshareclasses:name=test_aot_exception '-Xjit:count=100,verbose={compilePerformance},vlog=vlog,disableSuffixLogs' TestAOTException
Caught Exception, count = 1001
```
Note the body gets loaded if no hook is specified:
```
[dsouzai@localhost testAOTException]$ grep 'doSomeWork' vlog 
 (cold) Compiling ExceptionTest.doSomeWork(Z)V  OrdinaryMethod j9m=00000000001C5120 t=60 compThreadID=0 memLimit=262144 KB freePhysicalMemory=13106 MB
+ (AOT load) ExceptionTest.doSomeWork(Z)V @ 00007FB1114C6AC0-00007FB1114C6C15 Q_SZ=31 Q_SZI=31 QW=140 j9m=00000000001C5120 bcsz=23 time=42us compThreadID=0
```
However, when the hook is specified, the method is not loaded:
```
[dsouzai@localhost testAOTException]$ ../jdk11/bin/java -Xshareclasses:name=test_aot_exception '-Xjit:count=100,verbose={compilePerformance},vlog=vlog,disableSuffixLogs' -Xdump:java:events=throw,filter=SpecialException TestAOTException
JVMDUMP039I Processing dump event "throw", detail "SpecialException" at 2020/12/11 16:16:19 - please wait.
JVMDUMP032I JVM requested Java dump using '/home/dsouzai/dev/src/openj9/testAOTException/javacore.20201211.161619.24322.0001.txt' in response to an event
JVMDUMP010I Java dump written to /home/dsouzai/dev/src/openj9/testAOTException/javacore.20201211.161619.24322.0001.txt
JVMDUMP013I Processed dump event "throw", detail "SpecialException".
Caught Exception, count = 1001
[dsouzai@localhost testAOTException]$ grep 'doSomeWork' vlog 
 (cold) Compiling ExceptionTest.doSomeWork(Z)V  OrdinaryMethod j9m=00000000001D8220 t=140 compThreadID=0 memLimit=262144 KB freePhysicalMemory=13108 MB
! (cold) ExceptionTest.doSomeWork(Z)V time=57us compilationAotValidateExceptionHookFailure memLimit=262144 KB freePhysicalMemory=13108 MB mem=[region=64 system=16384]KB
```
The javacore shows an interpreted method:
```
[dsouzai@localhost testAOTException]$ grep 'doSomeWork' javacore.20201211.161619.24322.0001.txt
4XESTACKTRACE                at ExceptionTest.doSomeWork(TestAOTException.java:16)
```

### Enabling exception hook on both runs
```
[dsouzai@localhost testAOTException]$ ../jdk11/bin/java -Xshareclasses:name=test_aot_exception '-Xjit:count=100,verbose={compilePerformance},vlog=vlog,disableSuffixLogs' -Xdump:java:events=throw,filter=SpecialException TestAOTException
JVMDUMP039I Processing dump event "throw", detail "SpecialException" at 2020/12/11 16:12:45 - please wait.
JVMDUMP032I JVM requested Java dump using '/home/dsouzai/dev/src/openj9/testAOTException/javacore.20201211.161245.23696.0001.txt' in response to an event
JVMDUMP010I Java dump written to /home/dsouzai/dev/src/openj9/testAOTException/javacore.20201211.161245.23696.0001.txt
JVMDUMP013I Processed dump event "throw", detail "SpecialException".
Caught Exception, count = 1001
[dsouzai@localhost testAOTException]$ ../jdk11/bin/java -Xshareclasses:name=test_aot_exception '-Xjit:count=100,verbose={compilePerformance},vlog=vlog,disableSuffixLogs' -Xdump:java:events=throw,filter=SpecialException TestAOTException
JVMDUMP039I Processing dump event "throw", detail "SpecialException" at 2020/12/11 16:12:52 - please wait.
JVMDUMP032I JVM requested Java dump using '/home/dsouzai/dev/src/openj9/testAOTException/javacore.20201211.161252.23729.0001.txt' in response to an event
JVMDUMP010I Java dump written to /home/dsouzai/dev/src/openj9/testAOTException/javacore.20201211.161252.23729.0001.txt
JVMDUMP013I Processed dump event "throw", detail "SpecialException".
Caught Exception, count = 1001
```
Notice now body is loaded:
```
[dsouzai@localhost testAOTException]$ grep 'doSomeWork' vlog 
 (cold) Compiling ExceptionTest.doSomeWork(Z)V  OrdinaryMethod j9m=00000000001CD0C8 t=50 compThreadID=0 memLimit=262144 KB freePhysicalMemory=13108 MB
+ (AOT load) ExceptionTest.doSomeWork(Z)V @ 00007FD3D4FD8940-00007FD3D4FD8A95 Q_SZ=27 Q_SZI=27 QW=137 j9m=00000000001CD0C8 bcsz=23 time=152us compThreadID=0
```
Additionally, the javacore shows a compiled body:
```
[dsouzai@localhost testAOTException]$ grep 'doSomeWork' javacore.20201211.161252.23729.0001.txt
4XESTACKTRACE                at ExceptionTest.doSomeWork(TestAOTException.java:16(Compiled Code))
```
Added benefit; if the hook is not specified in the second run, we will still successfully load. This is because the code is still perfectly functional; it's just less optimized:
```
[dsouzai@localhost testAOTException]$ ../jdk11/bin/java -Xshareclasses:name=test_aot_exception '-Xjit:count=100,verbose={compilePerformance},vlog=vlog,disableSuffixLogs' TestAOTException
Caught Exception, count = 1001
[dsouzai@localhost testAOTException]$ grep 'doSomeWork' vlog 
 (cold) Compiling ExceptionTest.doSomeWork(Z)V  OrdinaryMethod j9m=00000000001C5120 t=60 compThreadID=0 memLimit=262144 KB freePhysicalMemory=13106 MB
+ (AOT load) ExceptionTest.doSomeWork(Z)V @ 00007F17A1085B80-00007F17A1085CD5 Q_SZ=30 Q_SZI=30 QW=147 j9m=00000000001C5120 bcsz=23 time=39us compThreadID=0
```