### PR TITLE
Add -Xlp test support for Mac

### DIFF
--- a/test/functional/VM_Test/playlist.xml
+++ b/test/functional/VM_Test/playlist.xml
@@ -204,14 +204,16 @@
 	<test>
 		<testCaseName>xlpTests</testCaseName>
 		<variations>
-			<variation>Mode109</variation>
-			<variation>Mode609</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) -Dplatform=$(PLATFORM) -cp $(Q)$(TEST_RESROOT)$(D)VM_Test.jar$(Q) \
 	j9vm.runner.Menu -test=$(Q)j9vm.test.xlp$(Q) -exe=$(Q)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(Q) \
 	-jar=$(Q)$(TEST_RESROOT)$(D)VM_Test.jar$(Q) \
 	-xids=all,$(PLATFORM),$(VARIATION); \
 	$(TEST_STATUS)</command>
+		<!-- Temporarily disable this test on mac, issue  https://github.com/eclipse/openj9/issues/11374 -->
+		<platformRequirements>^os.osx</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -229,6 +231,8 @@
 		<variations>
 			<variation>Mode109</variation>
 			<variation>Mode110</variation>
+			<variation>Mode609</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) -Dplatform=$(PLATFORM) -cp $(Q)$(TEST_RESROOT)$(D)VM_Test.jar$(Q) \
 	j9vm.runner.Menu -test=$(Q)j9vm.test.xlpcodecache$(Q) -exe=$(Q)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(Q) \

--- a/test/functional/VM_Test/src/j9vm/runner/Runner.java
+++ b/test/functional/VM_Test/src/j9vm/runner/Runner.java
@@ -33,6 +33,7 @@ public class Runner {
 		LINUX,
 		WINDOWS,
 		ZOS,
+		MAC,
 		UNKNOWN
 	}
 	
@@ -78,6 +79,8 @@ public class Runner {
 				osName = OSName.WINDOWS;
 			} else if (OSSpec.contains("z/os")) {
 				osName = OSName.ZOS;
+			} else if (OSSpec.contains("mac")) {
+				osName = OSName.MAC;
 			} else {
 				System.out.println("Runner couldn't determine underlying OS. Got OS Name:" + OSSpec);
 				osName = OSName.UNKNOWN;

--- a/test/functional/VM_Test/src/j9vm/test/xlp/XlpOptionsTestRunner.java
+++ b/test/functional/VM_Test/src/j9vm/test/xlp/XlpOptionsTestRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -204,6 +204,7 @@ public class XlpOptionsTestRunner extends Runner {
 			break;
 			
 		case LINUX:
+		case MAC:
 		case WINDOWS:
 			/* No -Xlp option */
 			xlpOptionsList.add(new XlpOption(null, false));
@@ -616,6 +617,7 @@ public class XlpOptionsTestRunner extends Runner {
 						switch(osName) {
 						case AIX:
 						case LINUX:
+						case MAC:
 						case WINDOWS:
 							if (line.indexOf(XlpUtil.XLP_PAGE_TYPE_NOT_USED) != -1) {
 								pageTypeFound = true;
@@ -666,6 +668,7 @@ public class XlpOptionsTestRunner extends Runner {
 						switch(osName) {
 						case AIX:
 						case LINUX:
+						case MAC:
 						case WINDOWS:
 							if (line.indexOf(XlpUtil.XLP_PAGE_TYPE_NOT_USED) != -1) {
 								requestedPageType = XlpUtil.XLP_PAGE_TYPE_NOT_USED;

--- a/test/functional/VM_Test/src/j9vm/test/xlpcodecache/XlpCodeCacheOptionsTestRunner.java
+++ b/test/functional/VM_Test/src/j9vm/test/xlpcodecache/XlpCodeCacheOptionsTestRunner.java
@@ -156,6 +156,7 @@ public class XlpCodeCacheOptionsTestRunner extends Runner {
 			break;
 
 		case LINUX:
+		case MAC:
 		case WINDOWS:
 			/* No -Xlp option */
 			xlpOptionsList.add(new XlpOption(null, false));


### PR DESCRIPTION
Exclude xlpTests due to https://github.com/eclipse/openj9/issues/11374

Run xlpCodeCacheTests in compressedrefs as well as XL. Run xlpTests with
JIT instead of -Xint, the test will run faster.

Fixes https://github.com/eclipse/openj9/issues/11171

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>