### PR TITLE
(0.24.0) Temporarily disable xlpCodeCacheTests on AIX since it fails

### DIFF
--- a/test/functional/VM_Test/playlist.xml
+++ b/test/functional/VM_Test/playlist.xml
@@ -224,7 +224,7 @@
 		</impls>
 	</test>
 
-		<test>
+	<test>
 		<testCaseName>xlpCodeCacheTests</testCaseName>
 		<variations>
 			<variation>Mode109</variation>
@@ -235,6 +235,8 @@
 	-jar=$(Q)$(TEST_RESROOT)$(D)VM_Test.jar$(Q) \
 	-xids=all,$(PLATFORM),$(VARIATION); \
 	$(TEST_STATUS)</command>
+		<!-- Temporarily disable this test on AIX, issue https://github.com/eclipse/openj9/issues/11104 -->
+		<platformRequirements>^os.aix</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
Issue https://github.com/eclipse/openj9/issues/11104

Cherry pick https://github.com/eclipse/openj9/pull/11460 for the 0.24 release.