### PR TITLE
Update JavaRuntimeVersion test (jrvTest) to handle more variants

### DIFF
--- a/test/functional/cmdline_options_testresources/src/JavaRuntimeVersion.java
+++ b/test/functional/cmdline_options_testresources/src/JavaRuntimeVersion.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,27 +23,45 @@
 public class JavaRuntimeVersion {
 
 	/**
-	 * example java.runtime.version: pxa6460sr11-20120403_01 (SR11)
+	 * example java.runtime.version's:
+	 *  1.8.0_272-b10
+	 *  8.0.7.0 - pxa6480sr7-20200922_01(SR7)
+	 *  11.0.10-internal
+	 *  11.0.10+5
+	 *  obsolete: pxa6460sr11-20120403_01 (SR11)
 	 */
 	public static void main(String[] args) {
-        String runTimeVersion =System.getProperty("java.runtime.version");
+        String runTimeVersion = System.getProperty("java.runtime.version");
 
         System.out.println("java.runtime.version is:" + runTimeVersion);
 
         String[] properties = runTimeVersion.split("\\s|-");
-        if (properties.length < 2) {
-                throw new IllegalArgumentException (
-                                "cannot locate platform info/time stamp from " + runTimeVersion);
+        String[] versionParts = properties[0].split("\\+");
+        if (versionParts.length > 2) {
+        	throw new IllegalArgumentException ("invalid version: " + properties[0]);
         }
-        String plat = properties[0];
-        String time = properties[1];
-
-        System.out.println("Plat:      " + plat);
-        System.out.println("TimeStamp: " + time);
+        String intialVersion = versionParts[0];
+        if (intialVersion.startsWith("1.8") || intialVersion.startsWith("8.")) {
+        	// Java 8 can have an underscore
+            if (!intialVersion.matches("[1-9][0-9\\.]+") && !intialVersion.matches("[1-9][0-9\\.]+_[1-9][0-9]*")) {
+            	throw new IllegalArgumentException ("invalid version: " + intialVersion);
+            }
+        } else {
+	        if (!intialVersion.matches("[1-9][0-9\\.]+")) {
+	        	throw new IllegalArgumentException ("invalid version: " + intialVersion);
+	        }
+        }
+        		
+        if ((versionParts.length > 1) && !versionParts[1].matches("[1-9][0-9]*")) {
+        	throw new IllegalArgumentException ("invalid build: " + versionParts[1]);
+        }
+ 
+        System.out.println("Version:  " + properties[0]);
+        for (int i = 1; i < properties.length; i++) {
+        	System.out.println("optional: " + properties[i]);
+        }
 
         System.out.println("JavaRuntimeVersion Test OK");
-		
-
 	}
 
 }


### PR DESCRIPTION
The original test cmdLineTester_jrvTest fails on java.runtime.version
release versions like "11.0.10+5", it works in the builds because they
use versions like "11.0.10+5-internal".

I ran this manually on a number of builds, I think it will work for all the variants.
Note cmdLineTester_jrvTest only runs on xlinux.