### PR TITLE
Remove empty jdk folder after move

### DIFF
--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -1582,6 +1582,7 @@ def download_boot_jdk(bootJDKVersion, bootJDK) {
                 unzip "\$sdkFile" -d .
                 sdkFolder=`ls -d */`
                 mv "\$sdkFolder"* ${bootJDK}/
+                rm -r "\$sdkFolder"
             else
                 gzip -cd "\$sdkFile" | tar xof - -C ${bootJDK} --strip=${dirStrip}
             fi


### PR DESCRIPTION
When 11220 went through, this caused an issue
on Windows. When a bootjdk is downloaded, we leave
behind the empty jdk folder (eg. jdk8u275-b01).
This causes the git clone to fail. Rather than
adding back the cleanws which is slow, we rm the
empty folder to provice a clean workspace again.

Related #10779 #11220
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>