### PR TITLE
Add illegalAccessPermit for TestRefreshGCSpecialClassesCache

### DIFF
--- a/test/functional/JavaAgentTest/playlist.xml
+++ b/test/functional/JavaAgentTest/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -121,6 +121,7 @@
 			<variation>Mode107</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	--illegal-access=permit \
 	--add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED  --add-opens=java.base/java.lang=ALL-UNNAMED \
 	--add-exports=java.base/jdk.internal.org.objectweb.asm.commons=ALL-UNNAMED \
 	-javaagent:$(Q)$(TEST_RESROOT)$(D)javaagenttest.jar$(Q) \


### PR DESCRIPTION
- add --illegal-access=permit in TestRefreshGCSpecialClassesCache
- related to: https://github.com/eclipse/openj9/issues/11419

[skip ci]
Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>