### PR TITLE
PlatformLoggingMXBean.setLoggerLevel() should allow null level

### DIFF
--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
@@ -300,13 +300,19 @@ public final class LoggingMXBeanImpl
 			// a valid level name.
 /*[IF Sidecar19-SE]*/
 			try {
-				Object newLevel = level_parse.invoke(null, levelName);
+				Object newLevel = null;
+				if (levelName != null) {
+					newLevel = level_parse.invoke(null, levelName);
+				}
 				logger_setLevel.invoke(logger, newLevel);
 			} catch (Exception e) {
 				throw handleError(e);
 			}
 /*[ELSE]*/
-			Level newLevel = Level.parse(levelName);
+			Level newLevel = null;
+			if (levelName != null) {
+				newLevel = Level.parse(levelName);
+			}
 			logger.setLevel(newLevel);
 /*[ENDIF]*/
 		} else {


### PR DESCRIPTION
A null level is allowed according to the spec. The implementation is
calling a parse helper which doesn't accept null values.

Problem discovered via OpenJDK test
java/lang/management/PlatformLoggingMXBean/LoggingMXBeanTest.java

Tested java/lang/management/PlatformLoggingMXBean/LoggingMXBeanTest.java via grinder, which both passed
jdk8 - https://ci.eclipse.org/openj9/view/Test/job/Grinder/1306
jdk11 - https://ci.eclipse.org/openj9/view/Test/job/Grinder/1305
