### PR TITLE
AArch64: Do explicit NULLCHK on interface call node

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -3194,7 +3194,21 @@ J9::ARM64::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node *node, boo
             && opCode.isIndirect()
             && (cg->getNumberBytesReadInaccessible() > TR::Compiler->om.offsetOfObjectVftField()))
          {
-         needExplicitCheck = false;
+         TR::SymbolReference *methodSymRef = firstChild->getSymbolReference();
+         TR::MethodSymbol *methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();
+         // Currently, we do not have instructions to access receiver for interface calls in main line code.
+         // Thus, we need to do null check explictly.
+         if (!methodSymbol->isInterface())
+            {
+            needExplicitCheck = false;
+            }
+         else
+            {
+            if (comp->getOption(TR_TraceCG))
+               {
+               traceMsg(comp, "\nExcplicit NULLCHK on interface call [%p]\n", firstChild);
+               }
+            }
          }
       else if (opCode.getOpCodeValue() == TR::iushr
             && (cg->getNumberBytesReadInaccessible() > cg->fe()->getOffsetOfContiguousArraySizeField()))


### PR DESCRIPTION
Our current implementation of interface call does not emit instruction
to access receiver in main line code. Thus, implicit NULLCHK is not possible
for interface call. This commit changes NULLCHK evaluator to
do explicit NULLCHK for interface call node.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>