### PR TITLE
Fix resolved trampoline reservation on JITServer

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -187,6 +187,7 @@ J9::Compilation::Compilation(int32_t id,
    _clientData(NULL),
    _globalMemory(*::trPersistentMemory, heapMemoryRegion),
    _perClientMemory(_trMemory),
+   _methodsRequiringTrampolines(getTypedAllocator<TR_OpaqueMethodBlock *>(self()->allocator())),
 #endif /* defined(J9VM_OPT_JITSERVER) */
    _osrProhibitedOverRangeOfTrees(false),
    _useTracingBuffer(false),

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -357,6 +357,8 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
       {
       _trMemory = &_globalMemory;
       }
+
+   TR::list<TR_OpaqueMethodBlock *>& getMethodsRequiringTrampolines() { return _methodsRequiringTrampolines; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    TR::SymbolValidationManager *getSymbolValidationManager() { return _symbolValidationManager; }
@@ -481,6 +483,11 @@ private:
 
    TR_Memory *_perClientMemory;
    TR_Memory _globalMemory;
+   // This list contains RAM method pointers of resolved methods
+   // that require method trampolines.
+   // It needs to be sent to the client at the end of compilation
+   // so that trampolines can be reserved there.
+   TR::list<TR_OpaqueMethodBlock *> _methodsRequiringTrampolines;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    TR::SymbolValidationManager *_symbolValidationManager;

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -148,13 +148,25 @@ outOfProcessCompilationEnd(
 
    JITServer::ServerMemoryState memoryState = computeServerMemoryState(compInfoPT->getCompilationInfo());
 
+   // Send methods requring resolved trampolines in this compilation to the client
+   std::vector<TR_OpaqueMethodBlock *> methodsRequiringTrampolines;
+   if (comp->getMethodsRequiringTrampolines().size() > 0)
+      {
+      methodsRequiringTrampolines.reserve(comp->getMethodsRequiringTrampolines().size());
+      for (auto it : comp->getMethodsRequiringTrampolines())
+         {
+         methodsRequiringTrampolines.push_back(it);
+         }
+      }
+
    entry->_stream->finishCompilation(codeCacheStr, dataCacheStr, chTableData,
                                      std::vector<TR_OpaqueClassBlock*>(classesThatShouldNotBeNewlyExtended->begin(), classesThatShouldNotBeNewlyExtended->end()),
                                      logFileStr, svmSymbolToIdStr,
                                      (resolvedMirrorMethodsPersistIPInfo) ?
                                                          std::vector<TR_ResolvedJ9Method*>(resolvedMirrorMethodsPersistIPInfo->begin(), resolvedMirrorMethodsPersistIPInfo->end()) :
                                                          std::vector<TR_ResolvedJ9Method*>(),
-                                     *entry->_optimizationPlan, serializedRuntimeAssumptions, memoryState
+                                     *entry->_optimizationPlan, serializedRuntimeAssumptions, memoryState,
+                                     methodsRequiringTrampolines
                                      );
    compInfoPT->clearPerCompilationCaches();
 

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1843,9 +1843,18 @@ TR_J9ServerVM::getClassFromCP(J9ConstantPool *cp)
    }
 
 void
-TR_J9ServerVM::reserveTrampolineIfNecessary(TR::Compilation *, TR::SymbolReference *symRef, bool inBinaryEncoding)
+TR_J9ServerVM::reserveTrampolineIfNecessary(TR::Compilation *comp, TR::SymbolReference *symRef, bool inBinaryEncoding)
    {
-   // Not necessary in JITServer server mode
+   // We only need to reserve trampolines on the client when
+   // we need a resolved trampoline for a non-AOT compilation
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   if (!comp->compileRelocatableCode()
+       && _compInfoPT->getClientData()->getOrCacheVMInfo(stream)->_needsMethodTrampolines
+       && !symRef->isUnresolved())
+      {
+      TR_OpaqueMethodBlock *ramMethod = symRef->getSymbol()->castToResolvedMethodSymbol()->getResolvedMethod()->getPersistentIdentifier();
+      comp->getMethodsRequiringTrampolines().push_front(ramMethod);
+      }
    }
 
 intptr_t

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -102,7 +102,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 22;
+   static const uint16_t MINOR_NUMBER = 23;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -324,6 +324,7 @@ class ClientSessionData
 #endif
       bool _isHotReferenceFieldRequired;
       UDATA _osrGlobalBufferSize;
+      bool _needsMethodTrampolines;
       }; // struct VMInfo
 
    /**


### PR DESCRIPTION
Previously, we didn't have JITServer specific code
for handling method trampoline reservations because we assumed
that all methods can be called without trampolines.
This is true for x86, where code repository is enabled by default,
but leads to crashes on Power.

There are 2 types of method trampolines: resolved and unresolved,
corresponding to the types of method calls they enable.
In baseline JIT compilation (no JITServer, no AOT) we reserve
trampolines during codegen and they are patched during method execution.
However, for AOT and JITServer reservation during codegen would not
work, since compiled code is executed by a different VM that doesn't
have trampolines reserved.
AOT uses 2 relocation types to handle this:

1. For unresolved trampolines, we create a `TR_Trampolines` relocation.
This relocation is also added for JITServer compilations so this case
is already handled.

2. For resolved trampolines, AOT only allows their use (and thus resolved
call dispatch) when SVM is enabled because `TR_ResolvedTrampolines`
relocation requires SVM. This is a problem for JITServer, since non-AOT
compilations do not use SVM and we don't want to use unresolved dispatch
for every call.

This commit keeps track of methods for which resolved trampoline is
needed during compilation on the server and sends the list to the client
at the end of the compilation. Once the client receives compiled method
and allocates code cache, it will reserve trampolines.