### PR TITLE
Add extra U_64 data field to Indexable Object Headers

### DIFF
--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -501,6 +501,24 @@ J9::ObjectModel::offsetOfDiscontiguousArraySizeField()
    {
    return compressObjectReferences() ? offsetof(J9IndexableObjectDiscontiguousCompressed, size) : offsetof(J9IndexableObjectDiscontiguousFull, size);
    }
+
+#if defined(TR_TARGET_64BIT)
+uintptr_t
+J9::ObjectModel::offsetOfContiguousDataAddrField()
+   {
+   return compressObjectReferences()
+		? offsetof(J9IndexableObjectContiguousCompressed, dataAddr)
+		: offsetof(J9IndexableObjectContiguousFull, dataAddr);
+   }
+
+uintptr_t
+J9::ObjectModel::offsetOfDiscontiguousDataAddrField()
+   {
+   return compressObjectReferences()
+		? offsetof(J9IndexableObjectDiscontiguousCompressed, dataAddr)
+		: offsetof(J9IndexableObjectDiscontiguousFull, dataAddr);
+   }
+#endif /* TR_TARGET_64BIT */
 
 
 uintptr_t

--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -118,6 +118,10 @@ public:
    uintptr_t offsetOfDiscontiguousArraySizeField();
    uintptr_t objectHeaderSizeInBytes();
    uintptr_t offsetOfIndexableSizeField();
+#if defined(TR_TARGET_64BIT)
+   uintptr_t offsetOfContiguousDataAddrField();
+   uintptr_t offsetOfDiscontiguousDataAddrField();
+#endif /* TR_TARGET_64BIT */
 
    /**
    * @brief Returns the read barrier type of VM's GC

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1024,6 +1024,10 @@ UDATA TR_J9VMBase::getOffsetOfBackfillOffsetField()                 {return offs
 
 UDATA TR_J9VMBase::getOffsetOfContiguousArraySizeField()            {return TR::Compiler->om.offsetOfContiguousArraySizeField();}
 UDATA TR_J9VMBase::getOffsetOfDiscontiguousArraySizeField()         {return TR::Compiler->om.offsetOfDiscontiguousArraySizeField();}
+#if defined(TR_TARGET_64BIT)
+UDATA TR_J9VMBase::getOffsetOfContiguousDataAddrField()             {return TR::Compiler->om.offsetOfContiguousDataAddrField();}
+UDATA TR_J9VMBase::getOffsetOfDiscontiguousDataAddrField()          {return TR::Compiler->om.offsetOfDiscontiguousDataAddrField();}
+#endif /* TR_TARGET_64BIT */
 UDATA TR_J9VMBase::getJ9ObjectContiguousLength()                    {return TR::Compiler->om.offsetOfContiguousArraySizeField();}
 UDATA TR_J9VMBase::getJ9ObjectDiscontiguousLength()                 {return TR::Compiler->om.offsetOfContiguousArraySizeField();}
 

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -503,6 +503,10 @@ public:
    virtual uintptr_t         getIdentityHashSaltPolicy();
    virtual uintptr_t         getJ9JavaClassRamShapeShift();
    virtual uintptr_t         getObjectHeaderShapeMask();
+#if defined(TR_TARGET_64BIT)
+   virtual uintptr_t         getOffsetOfContiguousDataAddrField();
+   virtual uintptr_t         getOffsetOfDiscontiguousDataAddrField();
+#endif /* TR_TARGET_64BIT */
 
    virtual bool               assumeLeftMostNibbleIsZero();
 

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -6076,12 +6076,12 @@ static void genHeapAlloc(
 #ifdef J9VM_INTERP_FLAGS_IN_CLASS_SLOT
          if ( (node->getOpCodeValue() == TR::anewarray || node->getOpCodeValue() == TR::newarray))
             {
-            // All arrays in combo builds will always be at least 12 bytes in size in all specs:
+            // All arrays in combo builds will always be at least 20 bytes in size in all specs:
             //
-            // 1)  class pointer + contig length + one or more elements
-            // 2)  class pointer + 0 + 0 (for zero length arrays)
+            // 1)  class pointer + contig length + dataAddr + one or more elements
+            // 2)  class pointer + 0 + 0 (for zero length arrays) + dataAddr
             //
-            TR_ASSERT(J9_GC_MINIMUM_OBJECT_SIZE >= 8, "Expecting a minimum object size >= 8 (actual minimum is %d)\n", J9_GC_MINIMUM_OBJECT_SIZE);
+            TR_ASSERT(J9_GC_MINIMUM_INDEXABLE_OBJECT_SIZE >= 8, "Expecting a minimum indexable object size >= 8 (actual minimum is %d)\n", J9_GC_MINIMUM_INDEXABLE_OBJECT_SIZE);
 
             generateRegMemInstruction(
                LEARegMem(),
@@ -6920,9 +6920,9 @@ static void genInitArrayHeader(
    // of an array:
    // - Zero sized arrays have the following layout:
    // - The smallest array possible is a byte array with 1 element which would have a layout:
-   //   #bits per section (compressed refs): | 32 bits |  32 bits   |     32 bits      | 32 bits |
-   //   zero sized arrays:                   |  class  | mustBeZero |       size       | padding |
-   //   smallest contiguous array:           |  class  |    size    | 1 byte + padding | padding |
+   //   #bits per section (compressed refs): | 32 bits |  32 bits   | 32 bits | 32 bits |   32 bits   |   32 bits    |
+   //   zero sized arrays:                   |  class  | mustBeZero |  size   | padding |          dataAddr          |
+   //   smallest contiguous array:           |  class  |    size    |      dataAddr     | 1 byte + padding |  other  |
    //   This also reflects the minimum object size which is 16 bytes.
    int32_t arrayDiscontiguousSizeOffset = fej9->getOffsetOfDiscontiguousArraySizeField();
    TR::MemoryReference *arrayDiscontiguousSizeMR = generateX86MemoryReference(objectReg, arrayDiscontiguousSizeOffset, cg);
@@ -7040,10 +7040,20 @@ static bool genZeroInitObject2(
    auto headerSize = isArrayNew ? TR::Compiler->om.contiguousArrayHeaderSizeInBytes() : TR::Compiler->om.objectHeaderSizeInBytes();
    // If we are using full refs both contiguous and discontiguous array header have the same size, in which case we must adjust header size
    // slightly so that rep stosb can initialize the size field of zero sized arrays appropriately
-   if (!cg->comp()->target().is32Bit() && !TR::Compiler->om.compressObjectReferences() && isArrayNew)
+   //   #bits per section (compressed refs): | 32 bits |  32 bits   | 32 bits | 32 bits |   32 bits   |   32 bits    |
+   //   zero sized arrays:                   |  class  | mustBeZero |   size  | padding |          dataAddr          |
+   //   smallest contiguous array:           |  class  |    size    |      dataAddr     | 1 byte + padding |  other  |
+   //   In order for us to successfully initialize the size field of a zero sized array in compressed refs
+   //   we must subtract 8 bytes (sizeof(dataAddr)) from header size. And in case of full refs we must
+   //   subtract 16 bytes from the header in order to properly initialize the zero sized field. We can
+   //   accomplish that by simply subtracting the offset of dataAddr field, which is 8 for compressed refs
+   //   and 16 for full refs.
+#if defined(TR_TARGET_64BIT)
+   if (!cg->comp()->target().is32Bit() && isArrayNew)
       {
-      headerSize -= 8;
+      headerSize -= static_cast<TR_J9VMBase *>(cg->fe())->getOffsetOfContiguousDataAddrField();
       }
+#endif /* TR_TARGET_64BIT */
    TR_ASSERT(headerSize >= 4, "Object/Array header must be >= 4.");
    objectSize -= headerSize;
 
@@ -7889,7 +7899,7 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
                 (comp->target().is32Bit() || comp->useCompressedPointers()))
                {
                generateMemImmInstruction(SMemImm4(), node,
-                  generateX86MemoryReference(targetReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg),
+                  generateX86MemoryReference(targetReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg),
                   0, cg);
                shouldInitZeroSizedArrayHeader = false;
                }

--- a/runtime/gc_base/IndexableObjectAllocationModel.cpp
+++ b/runtime/gc_base/IndexableObjectAllocationModel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -119,14 +119,21 @@ MM_IndexableObjectAllocationModel::initializeIndexableObject(MM_EnvironmentBase 
 {
 	/* Set array object header and size (in elements) and set  description spine pointer */
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
+	GC_ArrayObjectModel *indexableObjectModel = &extensions->indexableObjectModel;
 	J9IndexableObject *spine = (J9IndexableObject*)initializeJavaObject(env, allocatedBytes);
 	_allocateDescription.setSpine(spine);
 	if (NULL != spine) {
 		/* Set the array size */
 		if (getAllocateDescription()->isChunkedArray()) {
-			extensions->indexableObjectModel.setSizeInElementsForDiscontiguous(spine, _numberOfIndexedFields);
+			indexableObjectModel->setSizeInElementsForDiscontiguous(spine, _numberOfIndexedFields);
+#if defined(J9VM_ENV_DATA64)
+			indexableObjectModel->setDataAddrForDiscontiguous(spine, NULL);
+#endif /* J9VM_ENV_DATA64 */
 		} else {
-			extensions->indexableObjectModel.setSizeInElementsForContiguous(spine, _numberOfIndexedFields);
+			indexableObjectModel->setSizeInElementsForContiguous(spine, _numberOfIndexedFields);
+#if defined(J9VM_ENV_DATA64)
+			indexableObjectModel->setDataAddrForContiguous(spine);
+#endif /* J9VM_ENV_DATA64 */
 		}
 	}
 

--- a/runtime/gc_glue_java/ArrayletObjectModel.cpp
+++ b/runtime/gc_glue_java/ArrayletObjectModel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,6 +57,18 @@ GC_ArrayletObjectModel::AssertArrayletIsDiscontiguous(J9IndexableObject *objPtr)
 			Assert_MM_true((getSpineSize(objPtr) + remainderBytes + extensions->getObjectAlignmentInBytes()) > arrayletLeafSize);
 		}
 	}
+}
+
+void
+GC_ArrayletObjectModel::AssertContiguousArrayletLayout(J9IndexableObject *objPtr)
+{
+        Assert_MM_true(InlineContiguous == getArrayLayout(objPtr));
+}
+
+void
+GC_ArrayletObjectModel::AssertDiscontiguousArrayletLayout(J9IndexableObject *objPtr)
+{
+        Assert_MM_true(Discontiguous == getArrayLayout(objPtr));
 }
 
 GC_ArrayletObjectModel::ArrayLayout

--- a/runtime/gc_glue_java/ArrayletObjectModel.hpp
+++ b/runtime/gc_glue_java/ArrayletObjectModel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -831,6 +831,160 @@ public:
 		return getSpineSize(J9GC_J9OBJECT_CLAZZ(arrayPtr, this), layout, getSizeInElements(arrayPtr));
 	}
 
+#if defined(J9VM_ENV_DATA64)
+
+	/**
+	 * Gets data pointer of a contiguous indexable object.
+	 * Helper to get dataAddr field of contiguous indexable objects.
+	 *
+	 * @return Pointer which points to indexable object data
+	 */
+	MMINLINE void **
+	dataAddrSlotForContiguous(J9IndexableObject *arrayPtr)
+	{
+		AssertContiguousArrayletLayout(arrayPtr);
+		bool const compressed = compressObjectReferences();
+		void **dataAddrPtr = NULL;
+		if (compressed) {
+			dataAddrPtr = &((J9IndexableObjectContiguousCompressed *)arrayPtr)->dataAddr;
+		} else {
+			dataAddrPtr = &((J9IndexableObjectContiguousFull *)arrayPtr)->dataAddr;
+		}
+		return dataAddrPtr;
+	}
+
+	/**
+	 * Gets data pointer of a discontiguous indexable object.
+	 * Helper to get dataAddr field of discontiguous indexable objects.
+	 *
+	 * @return Pointer which points to discontiguous indexable object data
+	 */
+	MMINLINE void **
+	dataAddrSlotForDiscontiguous(J9IndexableObject *arrayPtr)
+	{
+		/* If double mapping is enabled only, arraylet will have a discontiguous layout.
+		 * If sparse-heap is enabled, arraylet will have a contiguous layout. For now
+		 * we can't simply Assert only the discontiguous case because there could also
+		 * exist hybrid arraylets (which will be dicontinued in the future) */
+		bool const compressed = compressObjectReferences();
+		void **dataAddrPtr = NULL;
+		if (compressed) {
+			dataAddrPtr = &((J9IndexableObjectDiscontiguousCompressed *)arrayPtr)->dataAddr;
+		} else {
+			dataAddrPtr = &((J9IndexableObjectDiscontiguousFull *)arrayPtr)->dataAddr;
+		}
+		return dataAddrPtr;
+	}
+
+	/**
+	 * Sets data pointer of a contiguous indexable object.
+	 * Sets the data pointer of a contiguous indexable object; in this case
+	 * dataAddr will point directly into the data right after dataAddr field
+	 * (data resides in heap).
+	 *
+	 * @param arrayPtr      Pointer to the indexable object whose size is required
+	 */
+	MMINLINE void
+	setDataAddrForContiguous(J9IndexableObject *arrayPtr)
+	{
+		void **dataAddrPtr = dataAddrSlotForContiguous(arrayPtr);
+		void *dataAddr = (void *)((UDATA)arrayPtr + contiguousHeaderSize());
+		*dataAddrPtr = dataAddr;
+	}
+
+	/**
+	 * Sets data pointer of a discontiguous indexable object.
+	 * Sets the data pointer of a discontiguous indexable object; in this case
+	 * dataAddr will point to the contiguous representation of the data
+	 * which resides outside the heap (assuming double map/sparse-heap is enabled).
+	 * In case double map is disabled, the dataAddr will point to the first arrayoid
+	 * of the discontiguous indexable object, which also resides right after dataAddr
+	 * field.
+	 *
+	 * @param arrayPtr      Pointer to the indexable object whose size is required
+	 * @param dataAddr      Pointer which points to indexable object data
+	 */
+	MMINLINE void
+	setDataAddrForDiscontiguous(J9IndexableObject *arrayPtr, void *address)
+	{
+		/* If double mapping is enabled only, arraylet will have a discontiguous layout.
+		 * If sparse-heap is enabled, arraylet will have a contiguous layout. For now
+		 * we can't simply Assert only the discontiguous case because there could also
+		 * exist hybrid arraylets (which will be dicontinued in the future) */
+		void *calculatedDataAddr = address;
+		void **dataAddrPtr = dataAddrSlotForDiscontiguous(arrayPtr);
+
+		/* If calculatedDataAddr is NULL then we make dataAddr point to the first arrayoid */
+		/* Later on, when sparse-heap is enabled by default, we must assert dataAddr is not NULL */
+		if (NULL == calculatedDataAddr) {
+			calculatedDataAddr = (void *)((UDATA)arrayPtr + discontiguousHeaderSize());
+		}
+
+		*dataAddrPtr = calculatedDataAddr;
+	}
+
+	/**
+	 * Returns data pointer associated with a contiguous Indexable object.
+	 * Data pointer will always be pointing at the arraylet data. In this
+	 * case the data pointer will be pointing to address immediately after
+	 * the header.
+	 *
+	 * @param arrayPtr      Pointer to the indexable object whose size is required
+	 * @return data address associated with the Indexable object
+	 */
+	MMINLINE void *
+	getDataAddrForContiguous(J9IndexableObject *arrayPtr)
+	{
+		void *dataAddr = *dataAddrSlotForContiguous(arrayPtr);
+		return dataAddr;
+	}
+
+	/**
+	 * Returns data pointer associated with a discontiguous Indexable object.
+	 * Data pointer will always be pointing at the arraylet data. In this
+	 * case the data pointer will be pointing to address immediately after
+	 * the header (the arrayoid), except when double mapping or sparse-heap
+	 * is enabled. In these cases, the data pointer will point to the
+	 * contiguous representation of the data; hence returning that pointer.
+	 *
+	 * @param arrayPtr      Pointer to the indexable object whose size is required
+	 * @return data address associated with the Indexable object
+	 */
+	MMINLINE void *
+	getDataAddrForDiscontiguous(J9IndexableObject *arrayPtr)
+	{
+		/* If double mapping is enabled only, arraylet will have a discontiguous layout.
+		 * If sparse-heap is enabled, arraylet will have a contiguous layout. For now we
+		 * Assert only the discontiguous case until sparse-heap is introduced. */
+		AssertDiscontiguousArrayletLayout(arrayPtr);
+		void *dataAddr = *dataAddrSlotForDiscontiguous(arrayPtr);
+		return dataAddr;
+	}
+
+	/**
+	 * Returns data pointer associated with the Indexable object.
+	 * Data pointer will always be pointing at the arraylet data. In all
+	 * cases the data pointer will be pointing to address immediately after
+	 * the header, except when double mapping is enabled. In this case,
+	 * if double mapping is enabled and arraylet was double mapped
+	 * successfully the data pointer will point to the contiguous
+	 * representation of the data; hence returning that pointer.
+	 *
+	 * @param arrayPtr      Pointer to the indexable object whose size is required
+	 * @return data address associated with the Indexable object
+	 */
+	MMINLINE void *
+	getDataAddrForIndexableObject(J9IndexableObject *arrayPtr)
+	{
+		ArrayLayout layout = getArrayLayout(arrayPtr);
+		bool isDiscontiguous = (layout != InlineContiguous);
+
+		return isDiscontiguous
+			? getDataAddrForDiscontiguous(arrayPtr)
+			: getDataAddrForContiguous(arrayPtr);
+	}
+#endif /* J9VM_ENV_DATA64 */
+
 	/**
 	 * Returns the header size of a given indexable object. The arraylet layout is determined base on "small" size.
 	 * @param arrayPtr Ptr to an array for which header size will be returned
@@ -948,5 +1102,15 @@ public:
 	 * Asserts that an Arraylet has indeed discontiguous layout
 	 */
 	void AssertArrayletIsDiscontiguous(J9IndexableObject *objPtr);
+
+	/**
+	 * Asserts that an Arraylet has true contiguous layout
+	 */
+	void AssertContiguousArrayletLayout(J9IndexableObject *objPtr);
+
+	/**
+	 * Asserts that an Arraylet has true discontiguous layout
+	 */
+	void AssertDiscontiguousArrayletLayout(J9IndexableObject *objPtr);
 };
 #endif /* ARRAYLETOBJECTMODEL_ */

--- a/runtime/gc_include/ObjectAllocationAPI.hpp
+++ b/runtime/gc_include/ObjectAllocationAPI.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,15 +48,77 @@ class MM_ObjectAllocationAPI
 	 * Data members
 	 */
 private:
-	const UDATA _gcAllocationType;
+	const uintptr_t _gcAllocationType;
 #if defined(J9VM_GC_BATCH_CLEAR_TLH)
-	const UDATA _initializeSlotsOnTLHAllocate;
+	const uintptr_t _initializeSlotsOnTLHAllocate;
 #endif /* J9VM_GC_BATCH_CLEAR_TLH */
-	const UDATA _objectAlignmentInBytes;
+	const uintptr_t _objectAlignmentInBytes;
 
 #if defined (J9VM_GC_SEGREGATED_HEAP)
 	const J9VMGCSizeClasses *_sizeClasses;
 #endif /* J9VM_GC_SEGREGATED_HEAP */
+
+	VMINLINE void
+	initializeIndexableSlots(bool initializeSlots, uintptr_t dataSize, void *dataAddr)
+	{
+		if (initializeSlots) {
+			memset(dataAddr, 0, dataSize);
+		}
+	}
+
+	VMINLINE void
+	initializeContiguousIndexableObject(J9VMThread *currentThread, bool initializeSlots, J9Class *arrayClass, uint32_t size, uintptr_t dataSize, j9object_t *objectHeader)
+	{
+		bool isCompressedReferences = J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(currentThread);
+
+		if (isCompressedReferences) {
+			uintptr_t headerSize = sizeof(J9IndexableObjectContiguousCompressed);
+			J9IndexableObjectContiguousCompressed *header = (J9IndexableObjectContiguousCompressed*)*objectHeader;
+			header->clazz = (uint32_t)(uintptr_t)arrayClass;
+			header->size = size;
+			void *dataAddr = (void *)((uintptr_t)header + headerSize);
+#if defined(J9VM_ENV_DATA64)
+			header->dataAddr = dataAddr;
+#endif /* J9VM_ENV_DATA64 */
+			initializeIndexableSlots(initializeSlots, dataSize, dataAddr);
+		} else {
+			uintptr_t headerSize = sizeof(J9IndexableObjectContiguousFull);
+			J9IndexableObjectContiguousFull *header = (J9IndexableObjectContiguousFull*)*objectHeader;
+			header->clazz = (uintptr_t)arrayClass;
+			header->size = size;
+			void *dataAddr = (void *)((uintptr_t)header + headerSize);
+#if defined(J9VM_ENV_DATA64)
+			header->dataAddr = dataAddr;
+#endif /* J9VM_ENV_DATA64 */
+			initializeIndexableSlots(initializeSlots, dataSize, dataAddr);
+		}
+	}
+
+	VMINLINE void
+	initializeDiscontiguousIndexableObject(J9VMThread *currentThread, J9Class *arrayClass, j9object_t *objectHeader)
+	{
+		bool isCompressedReferences = J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(currentThread);
+
+		if (isCompressedReferences) {
+			J9IndexableObjectDiscontiguousCompressed *header = (J9IndexableObjectDiscontiguousCompressed*)*objectHeader;
+			header->clazz = (uint32_t)(uintptr_t)arrayClass;
+			header->mustBeZero = 0;
+			header->size = 0;
+#if defined(J9VM_ENV_DATA64)
+			uintptr_t headerSize = sizeof(J9IndexableObjectDiscontiguousCompressed);
+			header->dataAddr = (void *)((uintptr_t)header + headerSize);
+#endif /* J9VM_ENV_DATA64 */
+		} else {
+			J9IndexableObjectDiscontiguousFull *header = (J9IndexableObjectDiscontiguousFull*)*objectHeader;
+			header->clazz = (uintptr_t)arrayClass;
+			header->mustBeZero = 0;
+			header->size = 0;
+#if defined(J9VM_ENV_DATA64)
+			uintptr_t headerSize = sizeof(J9IndexableObjectDiscontiguousFull);
+			header->dataAddr = (void *)((uintptr_t)header + headerSize);
+#endif /* J9VM_ENV_DATA64 */
+		}
+	}
 
 protected:
 public:
@@ -67,7 +129,7 @@ public:
 private:
 
 	VMINLINE j9object_t
-	inlineAllocateIndexableObjectImpl(J9VMThread *currentThread, J9Class *arrayClass, U_32 size, UDATA dataSize, bool validSize, bool initializeSlots = true, bool memoryBarrier = true)
+	inlineAllocateIndexableObjectImpl(J9VMThread *currentThread, J9Class *arrayClass, uint32_t size, uintptr_t dataSize, bool validSize, bool initializeSlots = true, bool memoryBarrier = true)
 	{
 		j9object_t instance = NULL;
 
@@ -80,13 +142,18 @@ private:
 #endif /* J9VM_ENV_DATA64 */
 			{
 				/* Calculate the size of the object */
-				UDATA const headerSize = J9VMTHREAD_CONTIGUOUS_HEADER_SIZE(currentThread);
-				UDATA const dataSize = ((UDATA)size) * J9ARRAYCLASS_GET_STRIDE(arrayClass);
-				UDATA allocateSize = (dataSize + headerSize + _objectAlignmentInBytes - 1) & ~(UDATA)(_objectAlignmentInBytes - 1);
+				uintptr_t const headerSize = J9VMTHREAD_CONTIGUOUS_HEADER_SIZE(currentThread);
+				uintptr_t const dataSize = ((uintptr_t)size) * J9ARRAYCLASS_GET_STRIDE(arrayClass);
+				uintptr_t allocateSize = ROUND_UP_TO_POWEROF2(dataSize + headerSize, _objectAlignmentInBytes);
+#if defined(J9VM_ENV_DATA64)
+				if (allocateSize < J9_GC_MINIMUM_INDEXABLE_OBJECT_SIZE) {
+					allocateSize = J9_GC_MINIMUM_INDEXABLE_OBJECT_SIZE;
+				}
+#else /* !J9VM_ENV_DATA64 */
 				if (allocateSize < J9_GC_MINIMUM_OBJECT_SIZE) {
 					allocateSize = J9_GC_MINIMUM_OBJECT_SIZE;
 				}
-
+#endif /* J9VM_ENV_DATA64 */
 				/* Allocate the memory */
 				j9object_t objectHeader = NULL;
 
@@ -94,11 +161,11 @@ private:
 
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
 				case OMR_GC_ALLOCATION_TYPE_TLH:
-					if (allocateSize <= ((UDATA) currentThread->heapTop - (UDATA) currentThread->heapAlloc)) {
-						U_8 *heapAlloc = currentThread->heapAlloc;
-						UDATA afterAlloc = (UDATA)heapAlloc + allocateSize;
+					if (allocateSize <= ((uintptr_t) currentThread->heapTop - (uintptr_t) currentThread->heapAlloc)) {
+						uint8_t *heapAlloc = currentThread->heapAlloc;
+						uint8_t *afterAlloc = heapAlloc + allocateSize;
 						objectHeader = (j9object_t)heapAlloc;
-						currentThread->heapAlloc = (U_8 *)afterAlloc;
+						currentThread->heapAlloc = afterAlloc;
 #if defined(J9VM_GC_TLH_PREFETCH_FTA)
 						currentThread->tlhPrefetchFTA -= allocateSize;
 #endif /* J9VM_GC_TLH_PREFETCH_FTA */
@@ -121,18 +188,18 @@ private:
 					if (allocateSize <= J9VMGC_SIZECLASSES_MAX_SMALL_SIZE_BYTES) {
 
 						/* fetch the size class based on the allocation size */
-						UDATA slotsRequested = allocateSize / sizeof(UDATA);
-						UDATA sizeClassIndex = _sizeClasses->sizeClassIndex[slotsRequested];
+						uintptr_t slotsRequested = allocateSize / sizeof(uintptr_t);
+						uintptr_t sizeClassIndex = _sizeClasses->sizeClassIndex[slotsRequested];
 
 						/* Ensure the cache for the current size class is not empty. */
 						J9VMGCSegregatedAllocationCacheEntry *cacheEntry =
-								(J9VMGCSegregatedAllocationCacheEntry *)((UDATA)currentThread + J9_VMTHREAD_SEGREGATED_ALLOCATION_CACHE_OFFSET
+								(J9VMGCSegregatedAllocationCacheEntry *)((uintptr_t)currentThread + J9_VMTHREAD_SEGREGATED_ALLOCATION_CACHE_OFFSET
 										+ (sizeClassIndex * sizeof(J9VMGCSegregatedAllocationCacheEntry)));
-						UDATA cellSize = _sizeClasses->smallCellSizes[sizeClassIndex];
+						uintptr_t cellSize = _sizeClasses->smallCellSizes[sizeClassIndex];
 
-						if (cellSize <= ((UDATA) cacheEntry->top - (UDATA) cacheEntry->current)) {
+						if (cellSize <= ((uintptr_t) cacheEntry->top - (uintptr_t) cacheEntry->current)) {
 							objectHeader = (j9object_t)cacheEntry->current;
-							cacheEntry->current = (UDATA *) ((UDATA) cacheEntry->current + cellSize);
+							cacheEntry->current = (uintptr_t *) ((uintptr_t) cacheEntry->current + cellSize);
 							/* The metronome pre write barrier might scan this object - always zero it */
 							initializeSlots = true;
 						} else {
@@ -150,29 +217,25 @@ private:
 				}
 
 				/* Initialize the object */
-				if (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(currentThread)) {
-					J9IndexableObjectContiguousCompressed *header = (J9IndexableObjectContiguousCompressed*)objectHeader;
-					header->clazz = (U_32)(UDATA)arrayClass;
-					header->size = size;
-					if (initializeSlots) {
-						memset(header + 1, 0, dataSize);
-					}
-				} else {
-					J9IndexableObjectContiguousFull *header = (J9IndexableObjectContiguousFull*)objectHeader;
-					header->clazz = (UDATA)arrayClass;
-					header->size = size;
-					if (initializeSlots) {
-						memset(header + 1, 0, dataSize);
-					}
-				}
+				initializeContiguousIndexableObject(currentThread, initializeSlots, arrayClass, size, dataSize, &objectHeader);
+
 				if (memoryBarrier) {
 					VM_AtomicSupport::writeBarrier();
 				}
 				instance = objectHeader;
 			}
 		} else {
+#if defined(J9VM_ENV_DATA64)
+			/* Calculate size of indexable object */
+			uintptr_t const headerSize = J9VMTHREAD_DISCONTIGUOUS_HEADER_SIZE(currentThread);
+			uintptr_t allocateSize = ROUND_UP_TO_POWEROF2(headerSize, _objectAlignmentInBytes);
+			/* Discontiguous header size is always equal or greater than J9_GC_MINIMUM_INDEXABLE_OBJECT_SIZE; therefore,
+			 * there's no need to check if allocateSize is less than J9_GC_MINIMUM_INDEXABLE_OBJECT_SIZE
+			 */
+#else
 			/* Zero-length array is discontiguous - assume minimum object size */
-			UDATA allocateSize = J9_GC_MINIMUM_OBJECT_SIZE;
+			uintptr_t allocateSize = J9_GC_MINIMUM_OBJECT_SIZE;
+#endif /* J9VM_ENV_DATA64 */
 
 			/* Allocate the memory */
 			j9object_t objectHeader = NULL;
@@ -181,11 +244,11 @@ private:
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
 			case OMR_GC_ALLOCATION_TYPE_TLH:
 
-				if (allocateSize <= ((UDATA) currentThread->heapTop - (UDATA) currentThread->heapAlloc)) {
-					U_8 *heapAlloc = currentThread->heapAlloc;
-					UDATA afterAlloc = (UDATA)heapAlloc + allocateSize;
+				if (allocateSize <= ((uintptr_t) currentThread->heapTop - (uintptr_t) currentThread->heapAlloc)) {
+					uint8_t *heapAlloc = currentThread->heapAlloc;
+					uint8_t *afterAlloc = heapAlloc + allocateSize;
 					objectHeader = (j9object_t) heapAlloc;
-					currentThread->heapAlloc = (U_8 *)afterAlloc;
+					currentThread->heapAlloc = afterAlloc;
 #if defined(J9VM_GC_TLH_PREFETCH_FTA)
 					currentThread->tlhPrefetchFTA -= allocateSize;
 #endif /* J9VM_GC_TLH_PREFETCH_FTA */
@@ -201,18 +264,18 @@ private:
 				if (allocateSize <= J9VMGC_SIZECLASSES_MAX_SMALL_SIZE_BYTES) {
 
 					/* fetch the size class based on the allocation size */
-					UDATA slotsRequested = allocateSize / sizeof(UDATA);
-					UDATA sizeClassIndex = _sizeClasses->sizeClassIndex[slotsRequested];
+					uintptr_t slotsRequested = allocateSize / sizeof(uintptr_t);
+					uintptr_t sizeClassIndex = _sizeClasses->sizeClassIndex[slotsRequested];
 
 					/* Ensure the cache for the current size class is not empty. */
 					J9VMGCSegregatedAllocationCacheEntry *cacheEntry =
-							(J9VMGCSegregatedAllocationCacheEntry *)((UDATA)currentThread + J9_VMTHREAD_SEGREGATED_ALLOCATION_CACHE_OFFSET
+							(J9VMGCSegregatedAllocationCacheEntry *)((uintptr_t)currentThread + J9_VMTHREAD_SEGREGATED_ALLOCATION_CACHE_OFFSET
 									+ (sizeClassIndex * sizeof(J9VMGCSegregatedAllocationCacheEntry)));
-					UDATA cellSize = _sizeClasses->smallCellSizes[sizeClassIndex];
+					uintptr_t cellSize = _sizeClasses->smallCellSizes[sizeClassIndex];
 
-					if (cellSize <= ((UDATA) cacheEntry->top - (UDATA) cacheEntry->current)) {
+					if (cellSize <= ((uintptr_t) cacheEntry->top - (uintptr_t) cacheEntry->current)) {
 						objectHeader = (j9object_t) cacheEntry->current;
-						cacheEntry->current = (UDATA *) ((UDATA) cacheEntry->current + cellSize);
+						cacheEntry->current = (uintptr_t *) ((uintptr_t) cacheEntry->current + cellSize);
 					} else {
 						return NULL;
 					}
@@ -228,17 +291,8 @@ private:
 			}
 
 			/* Initialize the object */
-			if (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(currentThread)) {
-				J9IndexableObjectDiscontiguousCompressed *header = (J9IndexableObjectDiscontiguousCompressed*)objectHeader;
-				header->clazz = (U_32)(UDATA)arrayClass;
-				header->mustBeZero = 0;
-				header->size = 0;
-			} else {
-				J9IndexableObjectDiscontiguousFull *header = (J9IndexableObjectDiscontiguousFull*)objectHeader;
-				header->clazz = (UDATA)arrayClass;
-				header->mustBeZero = 0;
-				header->size = 0;
-			}
+			initializeDiscontiguousIndexableObject(currentThread, arrayClass, &objectHeader);
+
 			if (memoryBarrier) {
 				VM_AtomicSupport::writeBarrier();
 			}
@@ -274,9 +328,9 @@ public:
 		j9object_t instance = NULL;
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP) || defined(J9VM_GC_SEGREGATED_HEAP)
 		/* Calculate the size of the object */
-		UDATA const headerSize = J9VMTHREAD_OBJECT_HEADER_SIZE(currentThread);
-		UDATA dataSize = clazz->totalInstanceSize;
-		UDATA allocateSize = (dataSize + headerSize + _objectAlignmentInBytes - 1) & ~(UDATA)(_objectAlignmentInBytes - 1);
+		uintptr_t const headerSize = J9VMTHREAD_OBJECT_HEADER_SIZE(currentThread);
+		uintptr_t dataSize = clazz->totalInstanceSize;
+		uintptr_t allocateSize = ROUND_UP_TO_POWEROF2(dataSize + headerSize, _objectAlignmentInBytes);
 		if (allocateSize < J9_GC_MINIMUM_OBJECT_SIZE) {
 			allocateSize = J9_GC_MINIMUM_OBJECT_SIZE;
 		}
@@ -285,10 +339,10 @@ public:
 		switch(_gcAllocationType) {
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
 		case OMR_GC_ALLOCATION_TYPE_TLH:
-			if (allocateSize <= ((UDATA) currentThread->heapTop - (UDATA) currentThread->heapAlloc)) {
-				U_8 *heapAlloc = currentThread->heapAlloc;
-				UDATA afterAlloc = (UDATA)heapAlloc + allocateSize;
-				currentThread->heapAlloc = (U_8 *)afterAlloc;
+			if (allocateSize <= ((uintptr_t) currentThread->heapTop - (uintptr_t) currentThread->heapAlloc)) {
+				uint8_t *heapAlloc = currentThread->heapAlloc;
+				uint8_t *afterAlloc = heapAlloc + allocateSize;
+				currentThread->heapAlloc = afterAlloc;
 #if defined(J9VM_GC_TLH_PREFETCH_FTA)
 				currentThread->tlhPrefetchFTA -= allocateSize;
 #endif /* J9VM_GC_TLH_PREFETCH_FTA */
@@ -309,18 +363,18 @@ public:
 			if (allocateSize <= J9VMGC_SIZECLASSES_MAX_SMALL_SIZE_BYTES) {
 
 				/* fetch the size class based on the allocation size */
-				UDATA slotsRequested = allocateSize / sizeof(UDATA);
-				UDATA sizeClassIndex = _sizeClasses->sizeClassIndex[slotsRequested];
+				uintptr_t slotsRequested = allocateSize / sizeof(uintptr_t);
+				uintptr_t sizeClassIndex = _sizeClasses->sizeClassIndex[slotsRequested];
 
 				/* Ensure the cache for the current size class is not empty. */
 				J9VMGCSegregatedAllocationCacheEntry *cacheEntry =
-						(J9VMGCSegregatedAllocationCacheEntry *)((UDATA)currentThread + J9_VMTHREAD_SEGREGATED_ALLOCATION_CACHE_OFFSET
+						(J9VMGCSegregatedAllocationCacheEntry *)((uintptr_t)currentThread + J9_VMTHREAD_SEGREGATED_ALLOCATION_CACHE_OFFSET
 								+ (sizeClassIndex * sizeof(J9VMGCSegregatedAllocationCacheEntry)));
-				UDATA cellSize = _sizeClasses->smallCellSizes[sizeClassIndex];
+				uintptr_t cellSize = _sizeClasses->smallCellSizes[sizeClassIndex];
 
-				if (cellSize <= ((UDATA) cacheEntry->top - (UDATA) cacheEntry->current)) {
+				if (cellSize <= ((uintptr_t) cacheEntry->top - (uintptr_t) cacheEntry->current)) {
 					instance = (j9object_t) cacheEntry->current;
-					cacheEntry->current = (UDATA *) ((UDATA) cacheEntry->current + cellSize);
+					cacheEntry->current = (uintptr_t *) ((uintptr_t) cacheEntry->current + cellSize);
 					/* The metronome pre write barrier might scan this object - always zero it */
 					initializeSlots = true;
 				} else {
@@ -339,13 +393,13 @@ public:
 		/* Initialize the object */
 		if (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(currentThread)) {
 			J9ObjectCompressed *objectHeader = (J9ObjectCompressed*) instance;
-			objectHeader->clazz = (U_32)(UDATA)clazz;
+			objectHeader->clazz = (uint32_t)(uintptr_t)clazz;
 			if (initializeSlots) {
 				memset(objectHeader + 1, 0, dataSize);
 			}
 		} else {
 			J9ObjectFull *objectHeader = (J9ObjectFull*) instance;
-			objectHeader->clazz = (UDATA)clazz;
+			objectHeader->clazz = (uintptr_t)clazz;
 			if (initializeSlots) {
 				memset(objectHeader + 1, 0, dataSize);
 			}
@@ -369,24 +423,24 @@ public:
 	}
 
 	VMINLINE j9object_t
-	inlineAllocateIndexableValueTypeObject(J9VMThread *currentThread, J9Class *arrayClass, U_32 size, bool initializeSlots = true, bool memoryBarrier = true, bool sizeCheck = true)
+	inlineAllocateIndexableValueTypeObject(J9VMThread *currentThread, J9Class *arrayClass, uint32_t size, bool initializeSlots = true, bool memoryBarrier = true, bool sizeCheck = true)
 	{
-		UDATA dataSize = ((UDATA)size) * J9ARRAYCLASS_GET_STRIDE(arrayClass);
+		uintptr_t dataSize = ((uintptr_t)size) * J9ARRAYCLASS_GET_STRIDE(arrayClass);
 		bool validSize = true;
 #if !defined(J9VM_ENV_DATA64)
-		validSize = !sizeCheck || (size < ((U_32)J9_MAXIMUM_INDEXABLE_DATA_SIZE / J9ARRAYCLASS_GET_STRIDE(arrayClass)));
+		validSize = !sizeCheck || (size < ((uint32_t)J9_MAXIMUM_INDEXABLE_DATA_SIZE / J9ARRAYCLASS_GET_STRIDE(arrayClass)));
 #endif /* J9VM_ENV_DATA64 */
 		return inlineAllocateIndexableObjectImpl(currentThread, arrayClass, size, dataSize, validSize, initializeSlots, memoryBarrier);
 	}
 
 	VMINLINE j9object_t
-	inlineAllocateIndexableObject(J9VMThread *currentThread, J9Class *arrayClass, U_32 size, bool initializeSlots = true, bool memoryBarrier = true, bool sizeCheck = true)
+	inlineAllocateIndexableObject(J9VMThread *currentThread, J9Class *arrayClass, uint32_t size, bool initializeSlots = true, bool memoryBarrier = true, bool sizeCheck = true)
 	{
-		UDATA scale = ((J9ROMArrayClass*)(arrayClass->romClass))->arrayShape;
-		UDATA dataSize = ((UDATA)size) << scale;
+		uintptr_t scale = ((J9ROMArrayClass*)(arrayClass->romClass))->arrayShape;
+		uintptr_t dataSize = ((uintptr_t)size) << scale;
 		bool validSize = true;
 #if !defined(J9VM_ENV_DATA64)
-		validSize = !sizeCheck || (size < ((U_32)J9_MAXIMUM_INDEXABLE_DATA_SIZE >> scale));
+		validSize = !sizeCheck || (size < ((uint32_t)J9_MAXIMUM_INDEXABLE_DATA_SIZE >> scale));
 #endif /* J9VM_ENV_DATA64 */
 		return inlineAllocateIndexableObjectImpl(currentThread, arrayClass, size, dataSize, validSize, initializeSlots, memoryBarrier);
 	}

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -458,6 +458,8 @@ extern "C" {
 
 #define J9_GC_MINIMUM_OBJECT_SIZE 0x10
 #if defined(J9VM_ENV_DATA64)
+#define J9_GC_INDEXABLE_DATA_FIELD_SIZE sizeof(void *)
+#define J9_GC_MINIMUM_INDEXABLE_OBJECT_SIZE (J9_GC_MINIMUM_OBJECT_SIZE + J9_GC_INDEXABLE_DATA_FIELD_SIZE)
 #define J9_GC_MARK_MAP_LOG_SIZEOF_UDATA 0x6
 #define J9_GC_MARK_MAP_UDATA_MASK 0x3F
 #else /* J9VM_ENV_DATA64 */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2967,11 +2967,17 @@ typedef struct J9IndexableObjectContiguous {
 #if defined(J9VM_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 	U_32 padding;
 #endif /* J9VM_ENV_DATA64 && !OMR_GC_COMPRESSED_POINTERS */
+#if defined(J9VM_ENV_DATA64)
+	void *dataAddr;
+#endif /* J9VM_ENV_DATA64 */
 } J9IndexableObjectContiguous;
 
 typedef struct J9IndexableObjectContiguousCompressed {
 	U_32 clazz;
 	U_32 size;
+#if defined(J9VM_ENV_DATA64)
+	void *dataAddr;
+#endif /* J9VM_ENV_DATA64 */
 } J9IndexableObjectContiguousCompressed;
 
 typedef struct J9IndexableObjectContiguousFull {
@@ -2979,6 +2985,7 @@ typedef struct J9IndexableObjectContiguousFull {
 	U_32 size;
 #if defined(J9VM_ENV_DATA64)
 	U_32 padding;
+	void *dataAddr;
 #endif /* J9VM_ENV_DATA64 */
 } J9IndexableObjectContiguousFull;
 
@@ -2989,6 +2996,9 @@ typedef struct J9IndexableObjectDiscontiguous {
 #if defined(OMR_GC_COMPRESSED_POINTERS) || !defined(J9VM_ENV_DATA64)
 	U_32 padding;
 #endif /* OMR_GC_COMPRESSED_POINTERS || !J9VM_ENV_DATA64 */
+#if defined(J9VM_ENV_DATA64)
+	void *dataAddr;
+#endif /* J9VM_ENV_DATA64 */
 } J9IndexableObjectDiscontiguous;
 
 typedef struct J9IndexableObjectDiscontiguousCompressed {
@@ -2996,6 +3006,9 @@ typedef struct J9IndexableObjectDiscontiguousCompressed {
 	U_32 mustBeZero;
 	U_32 size;
 	U_32 padding;
+#if defined(J9VM_ENV_DATA64)
+	void *dataAddr;
+#endif /* J9VM_ENV_DATA64 */
 } J9IndexableObjectDiscontiguousCompressed;
 
 typedef struct J9IndexableObjectDiscontiguousFull {
@@ -3004,6 +3017,8 @@ typedef struct J9IndexableObjectDiscontiguousFull {
 	U_32 size;
 #if !defined(J9VM_ENV_DATA64)
 	U_32 padding;
+#else /* J9VM_ENV_DATA64 */
+	void *dataAddr;
 #endif /* !J9VM_ENV_DATA64 */
 } J9IndexableObjectDiscontiguousFull;
 


### PR DESCRIPTION
Preliminary work to incorporate extra 64 bit field to Indexable object headers. In case of contiguous arraylets the extra field will hold the address of where the data starts, which is right after the header. In case of discontiguous arraylets the extra field will hold the address of:

- The contiguous double mapped region (assuming double map is enabled).
- The contiguous sparse-heap region outside the heap (assuming sparse heap is enabled).
- If double mapping an sparse heap are both disabled, dataAddr will point to the address right adter the header, in this case to the first arrayoid.

This is the first phase concerning a series of deliverable. Here, we introduce the extra U_64 data field along with helper functions such as getters and setters that will be needed in the future. Now `dataAddr` is only introduced and never used. Once it’s stable we’ll deliver the second phase of changes that makes use of `dataAddr`. `dataAddr` is only available in 64 bit platforms.

Please refer to https://github.com/eclipse/openj9/issues/11438 for more info. This set of changes concern part of the first action item of such issue.

Depends on: https://github.com/eclipse/openj9/pull/11320

Signed-off-by: Igor Braga <higorb1@gmail.com>