### PR TITLE
Fix exception message on illegal sync on value type/value based obj

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -392,17 +392,6 @@ setCurrentExceptionFromJIT(J9VMThread *currentThread, UDATA exceptionNumber, j9o
 	return J9_JITHELPER_ACTION_THROW;
 }
 
-static void*
-setCurrentExceptionNLSWithArgsFromJIT(J9VMThread *currentThread, U_32 moduleName, U_32 messageNumber, UDATA exceptionNumber, ...)
-{
-	va_list args;
-	TIDY_BEFORE_THROW();
-	va_start(args, exceptionNumber);
-	currentThread->javaVM->internalVMFunctions->setCurrentExceptionNLSWithArgs(currentThread, moduleName, messageNumber, exceptionNumber, args);
-	va_end(args);
-	return J9_JITHELPER_ACTION_THROW;
-}
-
 static VMINLINE void*
 setCurrentExceptionNLSFromJIT(J9VMThread *currentThread, UDATA exceptionNumber, U_32 moduleName, U_32 messageNumber)
 {
@@ -1593,6 +1582,9 @@ fast_jitMonitorEnterImpl(J9VMThread *currentThread, j9object_t syncObject, bool 
 	if (monstatus <= J9_OBJECT_MONITOR_BLOCKING) {
 		slowPathRequired = true;
 		currentThread->floatTemp1 = (void*)monstatus;
+#if JAVA_SPEC_VERSION >= 16
+		currentThread->floatTemp2 = (void*)syncObject;
+#endif /* JAVA_SPEC_VERSION >= 16 */
 	}
 	return slowPathRequired;
 }
@@ -1622,12 +1614,18 @@ slow_jitMonitorEnterImpl(J9VMThread *currentThread, bool forMethod)
 		}
 #if JAVA_SPEC_VERSION >= 16
 		if (J9_OBJECT_MONITOR_VALUE_TYPE_IMSE == monstatus) {
+			j9object_t syncObject = (j9object_t)currentThread->floatTemp2;
+			J9UTF8 *className = J9ROMCLASS_CLASSNAME(J9OBJECT_CLAZZ(currentThread, syncObject)->romClass);
+			TIDY_BEFORE_THROW();
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-			addr = setCurrentExceptionNLSWithArgsFromJIT(currentThread, J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_TYPE, J9VMCONSTANTPOOL_JAVALANGILLEGALMONITORSTATEEXCEPTION);
+			currentThread->javaVM->internalVMFunctions->setCurrentExceptionNLSWithArgs(currentThread, J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_TYPE, 
+					J9VMCONSTANTPOOL_JAVALANGILLEGALMONITORSTATEEXCEPTION, J9UTF8_LENGTH(className), J9UTF8_DATA(className));
 #else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			Assert_CodertVM_true(J9_ARE_ALL_BITS_SET(currentThread->javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_VALUE_BASED_EXCEPTION));
-			addr = setCurrentExceptionNLSWithArgsFromJIT(currentThread, J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_BASED, J9VMCONSTANTPOOL_JAVALANGVIRTUALMACHINEERROR);
+			currentThread->javaVM->internalVMFunctions->setCurrentExceptionNLSWithArgs(currentThread, J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_BASED, 
+					J9VMCONSTANTPOOL_JAVALANGVIRTUALMACHINEERROR, J9UTF8_LENGTH(className), J9UTF8_DATA(className));
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+			addr = J9_JITHELPER_ACTION_THROW;
 			goto done;
 		}
 #endif /* JAVA_SPEC_VERSION >= 16 */


### PR DESCRIPTION
1. Message J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_TYPE
and J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_BASED take
class name length and class name string as params. Fix the code to 
pass in these params.

2. Save syncObject to currentThread->floatTemp2 so that we can 
access it from slow_jitMonitorEnterImpl() to get the class name.

3. Remove setCurrentExceptionNLSWithArgsFromJIT().
setCurrentExceptionNLSWithArgsFromJIT() passes va_list to
setCurrentExceptionNLSWithArgs(), but the last param 
of setCurrentExceptionNLSWithArgs() is not va_list. Args cannot 
be forwarded between variadic functions this way.

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>