### PR TITLE
Remove VarHandle equals and hashCode

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -360,9 +360,6 @@ public abstract class VarHandle extends VarHandleInternal
 	final Class<?> fieldType;
 	final Class<?>[] coordinateTypes;
 	final int modifiers;
-/*[IF JAVA_SPEC_VERSION >= 12]*/
-	private int hashCode = 0;
-/*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 /*[IF JAVA_SPEC_VERSION >= 16]*/
 	final boolean exact;
@@ -692,72 +689,6 @@ public abstract class VarHandle extends VarHandleInternal
 	public Optional<VarHandleDesc> describeConstable() {
 		/* this method should be overridden by types that are supported */
 		return Optional.empty();
-	}
-
-	/**
-	 * Compares the specified object to this VarHandle and answer if they are equal.
-	 *
-	 * @param obj the object to compare
-	 * @return true if the specified object is equal to this VarHandle, false otherwise
-	 */
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-
-		if (!(obj instanceof VarHandle)) {
-			return false;
-		}
-
-		/* argument comparison */
-		VarHandle that = (VarHandle)obj;
-		if (!(this.fieldType.equals(that.fieldType) 
-			&& (this.modifiers == that.modifiers)
-			&& Arrays.equals(this.coordinateTypes, that.coordinateTypes))
-		) {
-			return false;
-		}
-
-		/* Compare properties of FieldVarHandle that are not captured in the parent class */
-		if (obj instanceof FieldVarHandle) {
-			if (!(this instanceof FieldVarHandle)) {
-				return false;
-			}
-
-			FieldVarHandle thisf = (FieldVarHandle)this;
-			FieldVarHandle thatf = (FieldVarHandle)obj;
-			if (!(thisf.definingClass.equals(thatf.definingClass)
-				&& thisf.fieldName.equals(thatf.fieldName))
-			) {
-				return false;
-			}
-			
-		}
-
-		return true;
-	}
-
-	/**
-	 * Answers an integer hash code for the VarHandle. VarHandle instances
-	 * which are equal answer the same value for this method.
-	 *
-	 * @return a hash for this VarHandle
-	 */
-	@Override
-	public int hashCode() {
-		if (hashCode == 0) {
-			hashCode = fieldType.hashCode();
-			for (Class<?> c : coordinateTypes) {
-				hashCode = 31 * hashCode + c.hashCode();
-			}
-
-			/* Add properties for FieldVarHandle */
-			if (this instanceof FieldVarHandle) {
-				hashCode = 31 * hashCode + ((FieldVarHandle)this).definingClass.hashCode();
-			}
-		}
-		return hashCode;
 	}
 
 	/**

--- a/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/Test_VarHandle.java
+++ b/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/Test_VarHandle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -108,47 +108,9 @@ public class Test_VarHandle {
 
 		logger.debug(testName + ": Descriptor of original class varType is: " + handle.varType().descriptorString());
 		logger.debug(testName + ": Descriptor of VarHandleDesc varType is: " + resolvedHandle.varType().descriptorString());
-		Assert.assertTrue(handle.equals(resolvedHandle));
-	}
 
-	/*
-	 * Test Java 12 API VarHandle.equals()
-	 */
-	@Test(groups = { "level.sanity" })
-	public void testVarHandleEquals() {
-		testVarHandleEqualsSub("testVarHandleEquals instance test: ", instanceTest, arrayTest2);
-		testVarHandleEqualsSub("testVarHandleEquals static test: ", staticTest, arrayTest2);
-		testVarHandleEqualsSub("testVarHandleEquals array test: ", arrayTest, arrayTest2);
-		testVarHandleEqualsSub("testVarHandleEquals array test: ", arrayTest2, instanceTest);
-	}
-
-	private void testVarHandleEqualsSub(String testName, VarHandle tester, VarHandle diffHandle) {
-		logger.debug(testName + " the same VarHandle should be equal to itself: " + tester.equals(tester));
-		Assert.assertTrue(tester.equals(tester));
-		logger.debug(testName + " different VarHandle instances should not be equal: " + !tester.equals(diffHandle));
-		Assert.assertTrue(!tester.equals(diffHandle));
-	}
-
-	/*
-	 * Test Java 12 API VarHandle.hashCode()
-	 */
-	@Test(groups = { "level.sanity" })
-	public void testVarHandleHashCode() {
-		testVarHandleHashCodeSub("testVarHandleHashCode instance test: ", instanceTest, instanceTestCopy);
-		testVarHandleHashCodeSub("testVarHandleHashCode static test: ", staticTest, staticTestCopy);
-		testVarHandleHashCodeSub("testVarHandleHashCode array test: ", arrayTest, arrayTestCopy);
-		testVarHandleHashCodeSub("testVarHandleHashCode array test 2: ", arrayTest2, arrayTest2Copy);
-	}
-
-	private void testVarHandleHashCodeSub(String testName, VarHandle tester, VarHandle copy) {
-		/*
-		 * The hashcode is stored for each instance once the method is called. Use a
-		 * replica of the handle for tests so its computed twice
-		 */
-		int testerHash = tester.hashCode();
-		int copyHash = copy.hashCode();
-		logger.debug(testName + " The same VarHandle should produce the same hash. " + (testerHash == copyHash));
-		Assert.assertTrue(testerHash == copyHash);
+		Assert.assertTrue(handle.varType().equals(resolvedHandle.varType()));
+		Assert.assertTrue(handle.coordinateTypes().equals(resolvedHandle.coordinateTypes()));
 	}
 
 	/*

--- a/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/Test_VarHandleDesc.java
+++ b/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/Test_VarHandleDesc.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -220,6 +220,7 @@ public class Test_VarHandleDesc {
 		VarHandle resolvedHandle = handleDesc.resolveConstantDesc(MethodHandles.lookup());
 
 		logger.debug(testName + " is running.");
-		Assert.assertTrue(handle.equals(resolvedHandle));
+		Assert.assertTrue(handle.varType().equals(resolvedHandle.varType()));
+		Assert.assertTrue(handle.coordinateTypes().equals(resolvedHandle.coordinateTypes()));
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/AdoptOpenJDK/run-aqa/issues/49

Port to 0.24: https://github.com/eclipse/openj9/pull/11533

- These methods were originally intended to be part of Java 12 and then removed. https://bugs.openjdk.java.net/browse/JDK-8215648
- updated Constants API functional tests

Signed-off-by: Theresa Mammarella <tmammare@redhat.com>