### PR TITLE
(0.24.0) Update osgi jar name

### DIFF
--- a/test/functional/cmdLineTests/CDSAdaptorTest/.classpath
+++ b/test/functional/cmdLineTests/CDSAdaptorTest/.classpath
@@ -24,7 +24,7 @@
  -->
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="lib" path="resources/org.eclipse.osgi_3.16.100.v20200904-1304.jar"/>
+	<classpathentry kind="lib" path="resources/org.eclipse.osgi-3.16.100.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/test/functional/cmdLineTests/CDSAdaptorTest/cdsadaptortest.xml
+++ b/test/functional/cmdLineTests/CDSAdaptorTest/cdsadaptortest.xml
@@ -31,7 +31,7 @@
 	<variable name="XSHARECLASSES" value="-Xshareclasses:name=$CACHENAME$" />
 	
 	<!-- NOTE: Update the version of org.eclipse.osgi whenever new version are checked in -->
-	<variable name="OSGI_JAR_PATH" value="$TEST_MATERIAL_DIR$$CPDL$$LIB_DIR$$PATHSEP$org.eclipse.osgi_3.16.100.v20200904-1304.jar" />
+	<variable name="OSGI_JAR_PATH" value="$TEST_MATERIAL_DIR$$CPDL$$LIB_DIR$$PATHSEP$org.eclipse.osgi-3.16.100.jar" />
 	
 	<variable name="FRAMEWORK_BUNDLE_LOCATION" value="$TEST_MATERIAL_DIR$$PATHSEP$FrameworkBundles" />
 	<variable name="TEST_BUNDLE_LOCATION" value="$TEST_MATERIAL_DIR$$PATHSEP$CDSAdaptorOrphanTestBundles" />

--- a/test/functional/cmdLineTests/CDSAdaptorTest/resources/readme.txt
+++ b/test/functional/cmdLineTests/CDSAdaptorTest/resources/readme.txt
@@ -57,7 +57,7 @@ How to run:
 This test is available in the builds at jvmtest/VM/cdsadaptortest/cdsadaptortest.jar.
 Unzip the cdsadaptortest.jar and run following command:
 	
-	java -Xshareclasses -cp .:./org.eclipse.osgi_3.16.100.v20200904-1304.jar org.openj9.test.cdsadaptortest.CDSAdaptorOrphanTest -frameworkBundleLocation ./FrameworkBundles -testBundleLocation ./CDSAdaptorOrphanTestBundles
+	java -Xshareclasses -cp .:./org.eclipse.osgi-3.16.100.jar org.openj9.test.cdsadaptortest.CDSAdaptorOrphanTest -frameworkBundleLocation ./FrameworkBundles -testBundleLocation ./CDSAdaptorOrphanTestBundles
 	
 Version of org.eclipse.osgi and org.openj9.test.cds bundles in the above command may not be correct. 
 Please use the same version as present in cdsadaptortest.jar.


### PR DESCRIPTION
- Update osgi jar name
- Related to: https://github.com/AdoptOpenJDK/run-aqa/issues/62

Port https://github.com/eclipse/openj9/pull/11520 for the 0.24 release.