### PR TITLE
Remove dependence of Inlining table relocations on the existence of virtual guards

### DIFF
--- a/doc/compiler/aot/InlinedMethods.md
+++ b/doc/compiler/aot/InlinedMethods.md
@@ -96,30 +96,15 @@ pool, and `bar` is named in `foo`'s constant pool. Therefore, in order to
 materialize the `J9Method` of `baz`, one first needs the `J9Method` of `bar`,
 which first requires the `J9Method` of `foo`.
 
-Generating external relocations for inlined methods requires the 
-existence of Guards. Guards are used to gate execution of regions of 
-code. When a method is inlined, a guard is generated for that inlined 
-method. It is possible for a guard to be removed for various reasons. 
-Currently, an inlined method cannot be validated/relocated without an 
-associated guard<sup>1</sup>. As such, if a guard is removed, it is 
-still kept aside so that the information it holds can be used 
-to create an external relocation. If a guard is removed, the Inlined Method 
-/ Profiled Inlined Method relocations are generated; if the guard remains, 
-the Inlined Method with NOP Guard / Profiled Inlined Method with Guard 
-relocations are generated.
-
-Unless the [SVM](https://github.com/eclipse/openj9/blob/master/doc/compiler/aot/SymbolValidationManager.md)
+If the inlined method has a guard assocated with it, then the Inlined Method
+with NOP Guard / Profiled Inlined Method with Guard relocations are 
+generated. If not, then the Inlined Method / Profiled Inlined Method
+relocations are generated. Additionally, unless the 
+[SVM](https://github.com/eclipse/openj9/blob/master/doc/compiler/aot/SymbolValidationManager.md)
 is enabled, the inlined method external relocations are the
 last entries added to the list; if the SVM is enabled, the SVM validation
 records are added next - part of the validation that would've been done by
 the inlined method validation procedure is delegated to the SVM.
-
-<hr/>
-
-<sup>1</sup> This is a problem that will be fixed soon<sup>TM</sup> 
-as features like OSR, NextGenHCR, and FSD cannot otherwise be supported 
-for AOT (see [#11060](https://github.com/eclipse/openj9/issues/11060)).
-
 
 # Validating Inlined Sites 
 
@@ -212,16 +197,9 @@ valid entries by this point.
 
 If the SVM is enabled, if all SVM validations pass then it is (almost)
 not possible for any of the various tests for both Inlined Method and 
-Profiled Inlined Method to fail; there are two exceptions:
-
-1. if `inlinedSiteCanBeActivated` returns false.
-2. if the caller of the inlined method is not relocated in the inlining table.
-
-1 can happen because of debug or other JVM restrictions. 2 can happen 
-because of the current limitation of depending on the existence of 
-guards to relocate the inlining table; if for whatever reason an 
-inlined body does not have a guard associated with it, the relocation 
-infrastructure will not be aware of that inlined method.
+Profiled Inlined Method to fail; the exception is if 
+`inlinedSiteCanBeActivated` returns false which can happen because of
+debug or other JVM restrictions.
 
 Because the SVM enables far more optimization, it is not immediately
 obvious whether it is safe to execute the code. Without validating

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -379,6 +379,9 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
       case TR_InlinedAbstractMethodWithNopGuard:
       case TR_InlinedInterfaceMethod:
       case TR_InlinedVirtualMethod:
+      case TR_InlinedStaticMethod:
+      case TR_InlinedSpecialMethod:
+      case TR_InlinedAbstractMethod:
          {
          TR_RelocationRecordInlinedMethod *imRecord = reinterpret_cast<TR_RelocationRecordInlinedMethod *>(reloRecord);
          uintptr_t destinationAddress = reinterpret_cast<uintptr_t>(relocation->getTargetAddress());
@@ -399,7 +402,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          TR_ResolvedMethod *resolvedMethod;
          if (kind == TR_InlinedInterfaceMethodWithNopGuard ||
              kind == TR_InlinedInterfaceMethod ||
-             kind == TR_InlinedAbstractMethodWithNopGuard)
+             kind == TR_InlinedAbstractMethodWithNopGuard ||
+             kind == TR_InlinedAbstractMethod)
             {
             TR_InlinedCallSite *inlinedCallSite = &comp->getInlinedCallSite(inlinedSiteIndex);
             TR_AOTMethodInfo *aotMethodInfo = (TR_AOTMethodInfo *)inlinedCallSite->_methodInfo;
@@ -436,7 +440,11 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          imRecord->setCpIndex(reloTarget, cpIndexOrData);
          imRecord->setRomClassOffsetInSharedCache(reloTarget, romClassOffsetInSharedCache);
 
-         if (kind != TR_InlinedInterfaceMethod && kind != TR_InlinedVirtualMethod)
+         if (kind != TR_InlinedInterfaceMethod
+             && kind != TR_InlinedVirtualMethod
+             && kind != TR_InlinedSpecialMethod
+             && kind != TR_InlinedStaticMethod
+             && kind != TR_InlinedAbstractMethod)
             {
             reinterpret_cast<TR_RelocationRecordNopGuard *>(imRecord)->setDestinationAddress(reloTarget, destinationAddress);
             }

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -48,6 +48,7 @@
 #include "il/Node_inlines.hpp"
 #include "ilgen/IlGenRequest.hpp"
 #include "infra/List.hpp"
+#include "optimizer/Inliner.hpp"
 #include "optimizer/OptimizationManager.hpp"
 #include "optimizer/Optimizer.hpp"
 #include "optimizer/TransformUtil.hpp"
@@ -1135,6 +1136,71 @@ J9::Compilation::isGeneratedReflectionMethod(TR_ResolvedMethod * method)
    return false;
    }
 
+TR_ExternalRelocationTargetKind
+J9::Compilation::getReloTypeForMethodToBeInlined(TR_VirtualGuardSelection *guard, TR::Node *callNode, TR_OpaqueClassBlock *receiverClass)
+   {
+   TR_ExternalRelocationTargetKind reloKind = OMR::Compilation::getReloTypeForMethodToBeInlined(guard, callNode, receiverClass);
+
+   if (callNode && self()->compileRelocatableCode())
+      {
+      if (guard && guard->_kind == TR_ProfiledGuard)
+         {
+         if (guard->_type == TR_MethodTest)
+            reloKind = TR_ProfiledMethodGuardRelocation;
+         else if (guard->_type == TR_VftTest)
+            reloKind = TR_ProfiledClassGuardRelocation;
+         }
+      else
+         {
+         TR::MethodSymbol *methodSymbol = callNode->getSymbolReference()->getSymbol()->castToMethodSymbol();
+
+         if (methodSymbol->isSpecial())
+            {
+            reloKind = TR_InlinedSpecialMethod;
+            }
+         else if (methodSymbol->isStatic())
+            {
+            reloKind = TR_InlinedStaticMethod;
+            }
+         else if (receiverClass
+                  && TR::Compiler->cls.isAbstractClass(self(), receiverClass)
+                  && methodSymbol->getResolvedMethodSymbol()->getResolvedMethod()->isAbstract())
+            {
+            reloKind = TR_InlinedAbstractMethod;
+            }
+         else if (methodSymbol->isVirtual())
+            {
+            reloKind = TR_InlinedVirtualMethod;
+            }
+         else if (methodSymbol->isInterface())
+            {
+            reloKind = TR_InlinedInterfaceMethod;
+            }
+         }
+
+      if (reloKind == TR_NoRelocation)
+         {
+         TR_InlinedCallSite *site = self()->getCurrentInlinedCallSite();
+         TR_OpaqueMethodBlock *caller;
+         if (site)
+            {
+            TR_AOTMethodInfo *aotMethodInfo = (TR_AOTMethodInfo *)site->_methodInfo;
+            caller = aotMethodInfo->resolvedMethod->getNonPersistentIdentifier();
+            }
+         else
+            {
+            caller = self()->getMethodBeingCompiled()->getNonPersistentIdentifier();
+            }
+
+         TR_ASSERT_FATAL(false, "Can't find relo kind for Caller %p Callee %p TR_ByteCodeInfo %p\n",
+                         caller,
+                         callNode->getSymbol()->castToResolvedMethodSymbol()->getResolvedMethod()->getNonPersistentIdentifier(),
+                         callNode->getByteCodeInfo());
+         }
+      }
+
+   return reloKind;
+   }
 
 bool
 J9::Compilation::compilationShouldBeInterrupted(TR_CallingContext callingContext)

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1116,6 +1116,12 @@ J9::Compilation::addAOTNOPSite()
    return site;
    }
 
+bool
+J9::Compilation::incInlineDepth(TR::ResolvedMethodSymbol * method, TR_ByteCodeInfo & bcInfo, int32_t cpIndex, TR::SymbolReference *callSymRef, bool directCall, TR_PrexArgInfo *argInfo)
+   {
+   TR_ASSERT_FATAL(callSymRef == NULL, "Should not be calling this API for non-NULL symref!\n");
+   return OMR::CompilationConnector::incInlineDepth(method, bcInfo, cpIndex, callSymRef, directCall, argInfo);
+   }
 
 bool
 J9::Compilation::isGeneratedReflectionMethod(TR_ResolvedMethod * method)

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -281,6 +281,8 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
 
    bool isGeneratedReflectionMethod(TR_ResolvedMethod *method);
 
+   TR_ExternalRelocationTargetKind getReloTypeForMethodToBeInlined(TR_VirtualGuardSelection *guard, TR::Node *callNode, TR_OpaqueClassBlock *receiverClass);
+
    // cache J9 VM pointers
    TR_OpaqueClassBlock *getObjectClassPointer();
    TR_OpaqueClassBlock *getRunnableClassPointer();

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -276,6 +276,9 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    TR_CHTable *getCHTable() const { return _transientCHTable; }
 
    // Inliner
+   using OMR::CompilationConnector::incInlineDepth;
+   bool incInlineDepth(TR::ResolvedMethodSymbol *, TR_ByteCodeInfo &, int32_t cpIndex, TR::SymbolReference *callSymRef, bool directCall, TR_PrexArgInfo *argInfo = 0);
+
    bool isGeneratedReflectionMethod(TR_ResolvedMethod *method);
 
    // cache J9 VM pointers

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -109,7 +109,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 19;
+   static const uint16_t MINOR_NUMBER = 20;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -2736,7 +2736,7 @@ TR_MultipleCallTargetInliner::eliminateTailRecursion(
 
    //please don't move this if. It needs to be done after all early exits but exactly before
    //we do any transformations
-   if (!comp()->incInlineDepth(calleeSymbol, callNode->getByteCodeInfo(), callNode->getSymbolReference()->getCPIndex(), callNode->getSymbolReference(), !callNode->getOpCode().isCallIndirect(), 0))
+   if (!comp()->incInlineDepth(calleeSymbol, callNode, !callNode->getOpCode().isCallIndirect(), guard, calleeResolvedMethod->classOfMethod(), 0))
       {
       return false;
       }

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -454,7 +454,12 @@ bool TR_InlinerBase::inlineCallTarget(TR_CallStack *callStack, TR_CallTarget *ca
    calltarget->_prexArgInfo = TR_PrexArgInfo::enhance(calltarget->_prexArgInfo, argInfo, comp());
    argInfo = getUtil()->computePrexInfo(calltarget);
 
-   if (!comp()->incInlineDepth(calltarget->_calleeSymbol, calltarget->_myCallSite->_callNode->getByteCodeInfo(), calltarget->_myCallSite->_callNode->getSymbolReference()->getCPIndex(), calltarget->_myCallSite->_callNode->getSymbolReference(), !calltarget->_myCallSite->_isIndirectCall, argInfo))
+   if (!comp()->incInlineDepth(calltarget->_calleeSymbol,
+                               calltarget->_myCallSite->_callNode,
+                               !calltarget->_myCallSite->_isIndirectCall,
+                               calltarget->_guard,
+                               calltarget->_receiverClass,
+                               argInfo))
 		{
 		return false;
 		}

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -111,7 +111,7 @@ J9::ValuePropagation::transformCallToNodeWithHCRGuard(TR::TreeTop *callTree, TR:
    TR::ResolvedMethodSymbol *calleeSymbol = callNode->getSymbol()->castToResolvedMethodSymbol();
 
    // Add the call to inlining table
-   if (!comp()->incInlineDepth(calleeSymbol, callNode->getByteCodeInfo(), callNode->getSymbolReference()->getCPIndex(), callNode->getSymbolReference(), !callNode->getOpCode().isCallIndirect(), 0))
+   if (!comp()->incInlineDepth(calleeSymbol, callNode, !callNode->getOpCode().isCallIndirect(), NULL, calleeSymbol->getResolvedMethod()->classOfMethod(), 0))
       {
       if (trace())
          traceMsg(comp(), "Cannot inline call %p, quit transforming it into a constant\n", callNode);

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -587,8 +587,14 @@ TR_RelocationRecord::create(TR_RelocationRecord *storage, TR_RelocationRuntime *
       case TR_InlinedStaticMethodWithNopGuard:
          reloRecord = new (storage) TR_RelocationRecordInlinedStaticMethodWithNopGuard(reloRuntime, record);
          break;
+      case TR_InlinedStaticMethod:
+         reloRecord = new (storage) TR_RelocationRecordInlinedStaticMethod(reloRuntime, record);
+         break;
       case TR_InlinedSpecialMethodWithNopGuard:
          reloRecord = new (storage) TR_RelocationRecordInlinedSpecialMethodWithNopGuard(reloRuntime, record);
+         break;
+      case TR_InlinedSpecialMethod:
+         reloRecord = new (storage) TR_RelocationRecordInlinedSpecialMethod(reloRuntime, record);
          break;
       case TR_InlinedVirtualMethodWithNopGuard:
          reloRecord = new (storage) TR_RelocationRecordInlinedVirtualMethodWithNopGuard(reloRuntime, record);
@@ -604,6 +610,9 @@ TR_RelocationRecord::create(TR_RelocationRecord *storage, TR_RelocationRuntime *
          break;
       case TR_InlinedAbstractMethodWithNopGuard:
          reloRecord = new (storage) TR_RelocationRecordInlinedAbstractMethodWithNopGuard(reloRuntime, record);
+         break;
+      case TR_InlinedAbstractMethod:
+         reloRecord = new (storage) TR_RelocationRecordInlinedAbstractMethod(reloRuntime, record);
          break;
       case TR_ProfiledInlinedMethodRelocation:
          reloRecord = new (storage) TR_RelocationRecordProfiledInlinedMethod(reloRuntime, record);
@@ -2907,6 +2916,20 @@ TR_RelocationRecordInlinedStaticMethodWithNopGuard::updateSucceededStats(TR_AOTS
    aotStats->staticMethods.numSucceededValidations++;
    }
 
+
+// TR_RelocationRecordInlinedStaticMethod
+char *
+TR_RelocationRecordInlinedStaticMethod::name()
+   {
+   return "TR_InlinedStaticMethod";
+   }
+
+TR_OpaqueMethodBlock *
+TR_RelocationRecordInlinedStaticMethod::getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpIndex, TR_OpaqueMethodBlock *callerMethod)
+   {
+   return getStaticMethodFromCP(reloRuntime, void_cp, cpIndex);
+   }
+
 // TR_InlinedSpecialMethodWithNopGuard
 char *
 TR_RelocationRecordInlinedSpecialMethodWithNopGuard::name()
@@ -2930,6 +2953,19 @@ void
 TR_RelocationRecordInlinedSpecialMethodWithNopGuard::updateSucceededStats(TR_AOTStats *aotStats)
    {
    aotStats->specialMethods.numSucceededValidations++;
+   }
+
+// TR_RelocationRecordInlinedSpecialMethod
+char *
+TR_RelocationRecordInlinedSpecialMethod::name()
+   {
+   return "TR_InlinedSpecialMethod";
+   }
+
+TR_OpaqueMethodBlock *
+TR_RelocationRecordInlinedSpecialMethod::getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpIndex, TR_OpaqueMethodBlock *callerMethod)
+   {
+   return getSpecialMethodFromCP(reloRuntime, void_cp, cpIndex);
    }
 
 // TR_InlinedVirtualMethodWithNopGuard
@@ -2971,18 +3007,6 @@ char *
 TR_RelocationRecordInlinedVirtualMethod::name()
    {
    return "TR_InlinedVirtualMethod";
-   }
-
-void
-TR_RelocationRecordInlinedVirtualMethod::print(TR_RelocationRuntime *reloRuntime)
-   {
-   Base::print(reloRuntime);
-   }
-
-void
-TR_RelocationRecordInlinedVirtualMethod::preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget)
-   {
-   Base::preparePrivateData(reloRuntime, reloTarget);
    }
 
 TR_OpaqueMethodBlock *
@@ -3038,18 +3062,6 @@ TR_RelocationRecordInlinedInterfaceMethod::name()
    return "TR_InlinedInterfaceMethod";
    }
 
-void
-TR_RelocationRecordInlinedInterfaceMethod::print(TR_RelocationRuntime *reloRuntime)
-   {
-   TR_RelocationRecordInlinedMethod::print(reloRuntime);
-   }
-
-void
-TR_RelocationRecordInlinedInterfaceMethod::preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget)
-   {
-   TR_RelocationRecordInlinedMethod::preparePrivateData(reloRuntime, reloTarget);
-   }
-
 TR_OpaqueMethodBlock *
 TR_RelocationRecordInlinedInterfaceMethod::getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpIndex, TR_OpaqueMethodBlock *callerMethod)
    {
@@ -3092,6 +3104,19 @@ void
 TR_RelocationRecordInlinedAbstractMethodWithNopGuard::updateSucceededStats(TR_AOTStats *aotStats)
    {
    aotStats->abstractMethods.numSucceededValidations++;
+   }
+
+// TR_RelocationRecordInlinedAbstractMethod
+char *
+TR_RelocationRecordInlinedAbstractMethod::name()
+   {
+   return "TR_InlinedAbstractMethod";
+   }
+
+TR_OpaqueMethodBlock *
+TR_RelocationRecordInlinedAbstractMethod::getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpIndex, TR_OpaqueMethodBlock *callerMethod)
+   {
+   return getAbstractMethodFromCP(reloRuntime, void_cp, cpIndex, callerMethod);
    }
 
 // TR_ProfiledInlinedMethod
@@ -6049,4 +6074,7 @@ uint32_t TR_RelocationRecord::_relocationRecordHeaderSizeTable[TR_NumExternalRel
    sizeof(TR_RelocationRecordResolvedTrampolinesBinaryTemplate),                     // TR_ResolvedTrampolines                          = 101
    sizeof(TR_RelocationRecordBlockFrequencyBinaryTemplate),                          // TR_BlockFrequency                               = 102
    sizeof(TR_RelocationRecordBinaryTemplate),                                        // TR_RecompQueuedFlag                             = 103
+   sizeof(TR_RelocationRecordInlinedMethodBinaryTemplate),                           // TR_InlinedStaticMethod                          = 104
+   sizeof(TR_RelocationRecordInlinedMethodBinaryTemplate),                           // TR_InlinedSpecialMethod                         = 105
+   sizeof(TR_RelocationRecordInlinedMethodBinaryTemplate),                           // TR_InlinedAbstractMethod                        = 106
    };

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -3010,7 +3010,7 @@ TR_RelocationRecordInlinedVirtualMethod::name()
    }
 
 TR_OpaqueMethodBlock *
-TR_RelocationRecordInlinedVirtualMethod::getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpIndex)
+TR_RelocationRecordInlinedVirtualMethod::getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpIndex, TR_OpaqueMethodBlock *callerMethod)
    {
    return getVirtualMethodFromCP(reloRuntime, void_cp, cpIndex);
    }

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -862,7 +862,7 @@ class TR_RelocationRecordInlinedVirtualMethod: public TR_RelocationRecordInlined
       TR_RelocationRecordInlinedVirtualMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordInlinedMethod(reloRuntime, record) {}
       virtual char *name();
    private:
-      virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex);
+      virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex, TR_OpaqueMethodBlock *callerMethod);
    };
 
 class TR_RelocationRecordInlinedInterfaceMethodWithNopGuard : public TR_RelocationRecordNopGuard

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -808,6 +808,16 @@ class TR_RelocationRecordInlinedStaticMethodWithNopGuard : public TR_RelocationR
       virtual void updateSucceededStats(TR_AOTStats *aotStats);
    };
 
+class TR_RelocationRecordInlinedStaticMethod: public TR_RelocationRecordInlinedMethod
+   {
+   public:
+      TR_RelocationRecordInlinedStaticMethod() {}
+      TR_RelocationRecordInlinedStaticMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordInlinedMethod(reloRuntime, record) {}
+      virtual char *name();
+   private:
+      virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex, TR_OpaqueMethodBlock *callerMethod);
+   };
+
 
 class TR_RelocationRecordInlinedSpecialMethodWithNopGuard : public TR_RelocationRecordNopGuard
    {
@@ -820,6 +830,16 @@ class TR_RelocationRecordInlinedSpecialMethodWithNopGuard : public TR_Relocation
       virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex, TR_OpaqueMethodBlock *callerMethod);
       virtual void updateFailedStats(TR_AOTStats *aotStats);
       virtual void updateSucceededStats(TR_AOTStats *aotStats);
+   };
+
+class TR_RelocationRecordInlinedSpecialMethod: public TR_RelocationRecordInlinedMethod
+   {
+   public:
+      TR_RelocationRecordInlinedSpecialMethod() {}
+      TR_RelocationRecordInlinedSpecialMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordInlinedMethod(reloRuntime, record) {}
+      virtual char *name();
+   private:
+      virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex, TR_OpaqueMethodBlock *callerMethod);
    };
 
 class TR_RelocationRecordInlinedVirtualMethodWithNopGuard : public TR_RelocationRecordNopGuard
@@ -837,13 +857,10 @@ class TR_RelocationRecordInlinedVirtualMethodWithNopGuard : public TR_Relocation
 
 class TR_RelocationRecordInlinedVirtualMethod: public TR_RelocationRecordInlinedMethod
    {
-   typedef TR_RelocationRecordInlinedMethod Base;
    public:
       TR_RelocationRecordInlinedVirtualMethod() {}
       TR_RelocationRecordInlinedVirtualMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordInlinedMethod(reloRuntime, record) {}
       virtual char *name();
-      virtual void print(TR_RelocationRuntime *reloRuntime);
-      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
    private:
       virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex);
    };
@@ -869,8 +886,6 @@ class TR_RelocationRecordInlinedInterfaceMethod: public TR_RelocationRecordInlin
       TR_RelocationRecordInlinedInterfaceMethod() {}
       TR_RelocationRecordInlinedInterfaceMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordInlinedMethod(reloRuntime, record) {}
       virtual char *name();
-      virtual void print(TR_RelocationRuntime *reloRuntime);
-      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
    private:
       virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex, TR_OpaqueMethodBlock *callerMethod);
    };
@@ -888,6 +903,16 @@ class TR_RelocationRecordInlinedAbstractMethodWithNopGuard : public TR_Relocatio
       virtual void updateFailedStats(TR_AOTStats *aotStats);
       virtual void updateSucceededStats(TR_AOTStats *aotStats);
       virtual void createAssumptions(TR_RelocationRuntime *reloRuntime, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordInlinedAbstractMethod: public TR_RelocationRecordInlinedMethod
+   {
+   public:
+      TR_RelocationRecordInlinedAbstractMethod() {}
+      TR_RelocationRecordInlinedAbstractMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordInlinedMethod(reloRuntime, record) {}
+      virtual char *name();
+   private:
+      virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpIndex, TR_OpaqueMethodBlock *callerMethod);
    };
 
 class TR_RelocationRecordProfiledInlinedMethod : public TR_RelocationRecordInlinedMethod


### PR DESCRIPTION
See https://github.com/eclipse/openj9/issues/11060 for details.

The idea of this PR is:

* Leave the relocation of guards and the inlining table entry coupled
* Maintain relocation information for each inlining entry as we create it - use `incInlineDepth` to store information the "withoutNopGuard" relocations need
* If a guard doesn't exist for a given callsite, use the information stored for that callsite to generate one of the "withoutNopGuard" relocation
  * Create "withoutNopGuard" relocations for Static, Special, and Abstract inlined methods (Virtual and Interface already exist)

Depends on https://github.com/eclipse/omr/pull/5729
Depends on ~(and therefore currently contains commits from)~ https://github.com/eclipse/openj9/pull/11235

Closes https://github.com/eclipse/openj9/issues/11060