### PR TITLE
Add Involuntary OSR support for AOT

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2968,8 +2968,7 @@ static void addSVMValidationRecords(TR::CodeGenerator *cg)
    if (cg->comp()->getOption(TR_UseSymbolValidationManager))
       {
       // Add the flags in TR_AOTMethodHeader on the compile run
-      J9JITDataCacheHeader *aotMethodHeader = (J9JITDataCacheHeader *)cg->comp()->getAotMethodDataStart();
-      TR_AOTMethodHeader *aotMethodHeaderEntry = (TR_AOTMethodHeader *)(aotMethodHeader + 1);
+      TR_AOTMethodHeader *aotMethodHeaderEntry = cg->comp()->getAotMethodHeaderEntry();
       aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_UsesSymbolValidationManager;
 
       for (auto it = validationRecords.begin(); it != validationRecords.end(); it++)

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -358,6 +358,13 @@ J9::Compilation::printCompYieldStatsMatrix()
       }
    }
 
+TR_AOTMethodHeader *
+J9::Compilation::getAotMethodHeaderEntry()
+   {
+   J9JITDataCacheHeader *aotMethodHeader = (J9JITDataCacheHeader *)self()->getAotMethodDataStart();
+   TR_AOTMethodHeader *aotMethodHeaderEntry =  (TR_AOTMethodHeader *)(aotMethodHeader + 1);
+   return aotMethodHeaderEntry;
+   }
 
 TR::Node *
 J9::Compilation::findNullChkInfo(TR::Node *node)

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -147,6 +147,8 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    void * getAotMethodDataStart() const { return _aotMethodDataStart; }
    void setAotMethodDataStart(void *p) { _aotMethodDataStart = p; }
 
+   TR_AOTMethodHeader * getAotMethodHeaderEntry();
+
    TR::Node *findNullChkInfo(TR::Node *node);
 
    bool isAlignStackMaps() { return J9::Compilation::target().cpu.isARM(); }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2185,6 +2185,7 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
             case compilationAotValidateExceptionHookFailure:
             case compilationAotBlockFrequencyReloFailure:
             case compilationAotRecompQueuedFlagReloFailure:
+            case compilationAOTValidateOSRFailure:
                // switch to JIT for these cases (we don't want to relocate again)
                entry->_doNotUseAotCodeFromSharedCache = true;
                tryCompilingAgain = true;

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -10130,9 +10130,8 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
                UDATA dataSize, codeSize;
 
                TR_ASSERT(comp, "AOT compilation that succeeded must have a compilation object");
-               J9JITDataCacheHeader *aotMethodHeader      = (J9JITDataCacheHeader *)comp->getAotMethodDataStart();
-               TR_ASSERT(aotMethodHeader, "The header must have been set");
-               TR_AOTMethodHeader   *aotMethodHeaderEntry = (TR_AOTMethodHeader *)(aotMethodHeader + 1);
+               TR_ASSERT(comp->getAotMethodDataStart(), "The header must have been set");
+               TR_AOTMethodHeader   *aotMethodHeaderEntry = comp->getAotMethodHeaderEntry();
 
                dataStart = (U_8 *)aotMethodHeaderEntry->compileMethodDataStartPC;
                dataSize  = aotMethodHeaderEntry->compileMethodDataSize;
@@ -10280,8 +10279,7 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
                   // Must reclaim code cache, metadata, jittedBodyInfo, persistentMethodInfo,
                   // assumptions and RI records that could have been allocated.
                   //
-                  J9JITDataCacheHeader *aotMethodHeader      = (J9JITDataCacheHeader *)comp->getAotMethodDataStart();
-                  TR_AOTMethodHeader   *aotMethodHeaderEntry = (TR_AOTMethodHeader *)(aotMethodHeader + 1);
+                  TR_AOTMethodHeader   *aotMethodHeaderEntry = comp->getAotMethodHeaderEntry();
                   J9JITDataCacheHeader *cacheEntry = (J9JITDataCacheHeader *)aotMethodHeaderEntry->compileMethodDataStartPC;
                   J9JITDataCacheHeader *exceptionTableCacheEntry = (J9JITDataCacheHeader *)((U_8 *)cacheEntry + aotMethodHeaderEntry->offsetToExceptionTable);
                   J9JITExceptionTable *metaData = (J9JITExceptionTable *) (exceptionTableCacheEntry + 1);

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -96,9 +96,8 @@ outOfProcessCompilationEnd(
 
    TR::CodeCache *codeCache = comp->cg()->getCodeCache();
 
-   J9JITDataCacheHeader *aotMethodHeader      = (J9JITDataCacheHeader *)comp->getAotMethodDataStart();
-   TR_ASSERT(aotMethodHeader, "The header must have been set");
-   TR_AOTMethodHeader   *aotMethodHeaderEntry = (TR_AOTMethodHeader *)(aotMethodHeader + 1);
+   TR_ASSERT(comp->getAotMethodDataStart(), "The header must have been set");
+   TR_AOTMethodHeader   *aotMethodHeaderEntry = comp->getAotMethodHeaderEntry();
 
    U_8 *codeStart = (U_8 *)aotMethodHeaderEntry->compileMethodCodeStartPC;
    OMR::CodeCacheMethodHeader *codeCacheHeader = (OMR::CodeCacheMethodHeader*)codeStart;

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -209,8 +209,9 @@ char *compilationErrorNames[]={
    "compilationAotValidateExceptionHookFailure", //57
    "compilationAotBlockFrequencyReloFailure", //58
    "compilationAotRecompQueuedFlagReloFailure", //59
+   "compilationAOTValidateOSRFailure", //60
 #if defined(J9VM_OPT_JITSERVER)
-   "compilationStreamFailure", //compilationFirstJITServerFailure=60
+   "compilationStreamFailure", //compilationFirstJITServerFailure=61
    "compilationStreamLostMessage", // compilationFirstJITServerFailure+1
    "compilationStreamMessageTypeMismatch", //compilationFirstJITServerFailure+2
    "compilationStreamVersionIncompatible", //compilationFirstJITServerFailure+3

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -83,6 +83,7 @@ typedef enum {
    compilationAotValidateExceptionHookFailure      = 57,
    compilationAotBlockFrequencyReloFailure         = 58,
    compilationAotRecompQueuedFlagReloFailure       = 59,
+   compilationAOTValidateOSRFailure                = 60,
 #if defined(J9VM_OPT_JITSERVER)
    compilationFirstJITServerFailure,
    compilationStreamFailure                        = compilationFirstJITServerFailure,

--- a/runtime/compiler/env/J9VMEnv.cpp
+++ b/runtime/compiler/env/J9VMEnv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/env/J9VMEnv.cpp
+++ b/runtime/compiler/env/J9VMEnv.cpp
@@ -442,7 +442,7 @@ J9::VMEnv::OSRFrameSizeInBytes(TR::Compilation *comp, TR_OpaqueMethodBlock* meth
 bool
 J9::VMEnv::ensureOSRBufferSize(TR::Compilation *comp, uintptr_t osrFrameSizeInBytes, uintptr_t osrScratchBufferSizeInBytes, uintptr_t osrStackFrameSizeInBytes)
    {
-   return comp->fej9()->ensureOSRBufferSize(osrFrameSizeInBytes, osrScratchBufferSizeInBytes, osrStackFrameSizeInBytes);
+   return comp->fej9()->ensureOSRBufferSize(comp, osrFrameSizeInBytes, osrScratchBufferSizeInBytes, osrStackFrameSizeInBytes);
    }
 
 uintptr_t

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1073,7 +1073,7 @@ UDATA TR_J9VMBase::getOffsetOfJLThreadJ9Thread()
 UDATA TR_J9VMBase::getOSRFrameHeaderSizeInBytes()                   {return sizeof(J9OSRFrame);}
 UDATA TR_J9VMBase::getOSRFrameSizeInBytes(TR_OpaqueMethodBlock* method)  {return osrFrameSize((J9Method*) method);}
 
-bool TR_J9VMBase::ensureOSRBufferSize(uintptr_t osrFrameSizeInBytes, uintptr_t osrScratchBufferSizeInBytes, uintptr_t osrStackFrameSizeInBytes)
+bool TR_J9VMBase::ensureOSRBufferSize(TR::Compilation *comp, uintptr_t osrFrameSizeInBytes, uintptr_t osrScratchBufferSizeInBytes, uintptr_t osrStackFrameSizeInBytes)
    {
    J9JavaVM *vm = _jitConfig->javaVM;
    return ::ensureOSRBufferSize(vm, osrFrameSizeInBytes, osrScratchBufferSizeInBytes, osrStackFrameSizeInBytes);
@@ -9026,6 +9026,21 @@ TR_J9SharedCacheVM::canRememberClass(TR_OpaqueClassBlock *classPtr)
    if (_sharedCache)
       return (_sharedCache->rememberClass((J9Class *) classPtr, false) != NULL);
    return false;
+   }
+
+bool
+TR_J9SharedCacheVM::ensureOSRBufferSize(TR::Compilation *comp, uintptr_t osrFrameSizeInBytes, uintptr_t osrScratchBufferSizeInBytes, uintptr_t osrStackFrameSizeInBytes)
+   {
+   bool valid = TR_J9VMBase::ensureOSRBufferSize(comp, osrFrameSizeInBytes, osrScratchBufferSizeInBytes, osrStackFrameSizeInBytes);
+   if (valid)
+      {
+      TR_AOTMethodHeader *aotMethodHeaderEntry = comp->getAotMethodHeaderEntry();
+      aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_UsesOSR;
+      aotMethodHeaderEntry->_osrBufferInfo._frameSizeInBytes = osrFrameSizeInBytes;
+      aotMethodHeaderEntry->_osrBufferInfo._scratchBufferSizeInBytes = osrScratchBufferSizeInBytes;
+      aotMethodHeaderEntry->_osrBufferInfo._stackFrameSizeInBytes = osrStackFrameSizeInBytes;
+      }
+   return valid;
    }
 
 //////////////////////////////////////////////////////////

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5312,8 +5312,7 @@ TR_J9VMBase::reserveTrampolineIfNecessary(TR::Compilation * comp, TR::SymbolRefe
    TR::CodeCache *newCache = curCache; // optimistically assume that we will manage to allocate trampoline from current code cache
    if (isAOT_DEPRECATED_DO_NOT_USE() && isRecursive)
       {
-      J9JITDataCacheHeader *aotMethodHeader = (J9JITDataCacheHeader *)comp->getAotMethodDataStart();
-      TR_AOTMethodHeader *aotMethodHeaderEntry =  (TR_AOTMethodHeader *)(aotMethodHeader + 1);
+      TR_AOTMethodHeader *aotMethodHeaderEntry =  comp->getAotMethodHeaderEntry();
       aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_NeedsRecursiveMethodTrampolineReservation; // Set flag in TR_AOTMethodHeader
       //newCache = curCache; // done above
       }

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -512,7 +512,7 @@ public:
 
    virtual uintptr_t         getOSRFrameHeaderSizeInBytes();
    virtual uintptr_t         getOSRFrameSizeInBytes(TR_OpaqueMethodBlock* method);
-   virtual bool               ensureOSRBufferSize(uintptr_t osrFrameSizeInBytes, uintptr_t osrScratchBufferSizeInBytes, uintptr_t osrStackFrameSizeInBytes);
+   virtual bool               ensureOSRBufferSize(TR::Compilation *comp, uintptr_t osrFrameSizeInBytes, uintptr_t osrScratchBufferSizeInBytes, uintptr_t osrStackFrameSizeInBytes);
 
    virtual bool               generateCompressedPointers();
    virtual bool               generateCompressedLockWord();
@@ -1259,6 +1259,8 @@ public:
 
    virtual J9Class *              getClassForAllocationInlining( TR::Compilation *comp, TR::SymbolReference *classSymRef);
    virtual bool canRememberClass(TR_OpaqueClassBlock *classPtr);
+
+   virtual bool               ensureOSRBufferSize(TR::Compilation *comp, uintptr_t osrFrameSizeInBytes, uintptr_t osrScratchBufferSizeInBytes, uintptr_t osrStackFrameSizeInBytes);
    };
 
 #endif

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -102,7 +102,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 20;
+   static const uint16_t MINOR_NUMBER = 21;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -1350,8 +1350,7 @@ J9::TransformUtil::foldStaticFinalFieldImpl(TR::Compilation *comp, TR::Node *nod
       if (sym->getRecognizedField() == TR::Symbol::Java_lang_String_enableCompression)
          {
          // Add the flags in TR_AOTMethodHeader
-         J9JITDataCacheHeader *aotMethodHeader = (J9JITDataCacheHeader *)comp->getAotMethodDataStart();
-         TR_AOTMethodHeader *aotMethodHeaderEntry = (TR_AOTMethodHeader *)(aotMethodHeader + 1);
+         TR_AOTMethodHeader *aotMethodHeaderEntry = comp->getAotMethodHeaderEntry();
          aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_UsesEnableStringCompressionFolding;
          TR_ASSERT(node->getDataType() == TR::Int32, "Java_lang_String_enableCompression must be Int32");
          bool fieldValue = ((TR_J9VM *) comp->fej9())->dereferenceStaticFinalAddress(sym->castToStaticSymbol()->getStaticAddress(), TR::Int32).dataInt32Bit != 0;

--- a/runtime/compiler/runtime/J9Runtime.hpp
+++ b/runtime/compiler/runtime/J9Runtime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/runtime/J9Runtime.hpp
+++ b/runtime/compiler/runtime/J9Runtime.hpp
@@ -152,9 +152,10 @@ typedef enum
 *     2.0    Java7
 *     2.1    Java7
 *     3.0    Java 8
+*     4.0    Java 8+ with OSR
 */
 
-#define TR_AOTMethodHeader_MajorVersion   3
+#define TR_AOTMethodHeader_MajorVersion   4
 #define TR_AOTMethodHeader_MinorVersion   0
 
 typedef struct TR_AOTMethodHeader {
@@ -163,12 +164,18 @@ typedef struct TR_AOTMethodHeader {
    uint32_t  offsetToRelocationDataItems;
    uint32_t  offsetToExceptionTable;
    uint32_t  offsetToPersistentInfo;
+   uint32_t  flags;
    uintptr_t compileMethodCodeStartPC;
    uintptr_t compileMethodCodeSize;
    uintptr_t compileMethodDataStartPC;
    uintptr_t compileMethodDataSize;
    uintptr_t unused;
-   uint32_t flags;
+   struct
+      {
+      uintptr_t _frameSizeInBytes;
+      uintptr_t _scratchBufferSizeInBytes;
+      uintptr_t _stackFrameSizeInBytes;
+      } _osrBufferInfo;
    } TR_AOTMethodHeader;
 
 
@@ -182,6 +189,7 @@ typedef struct TR_AOTMethodHeader {
 #define TR_AOTMethodHeader_TMDisabled                                0x00000040
 #define TR_AOTMethodHeader_CompressedMethodInCache                   0x00000080
 #define TR_AOTMethodHeader_IsNotCapableOfExceptionHook               0x00000100
+#define TR_AOTMethodHeader_UsesOSR                                   0x00000200
 
 
 

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1018,8 +1018,7 @@ createStackAtlas(
 void AOTRAS_traceMetaData(TR_J9VMBase *vm, TR_MethodMetaData *data, TR::Compilation *comp)
    {
    traceMsg(comp, "<relocatableDataMetaDataCG>\n");
-   J9JITDataCacheHeader *aotMethodHeader = (J9JITDataCacheHeader *)comp->getAotMethodDataStart();
-   TR_AOTMethodHeader *aotMethodHeaderEntry =  (TR_AOTMethodHeader *)(aotMethodHeader + 1);
+   TR_AOTMethodHeader *aotMethodHeaderEntry = comp->getAotMethodHeaderEntry();
 
    traceMsg(comp, "%s\n", comp->signature());
    traceMsg(comp, "%-12s", "startPC");
@@ -1173,8 +1172,7 @@ populateBodyInfo(
 #endif
          )
          {
-         J9JITDataCacheHeader *aotMethodHeader = (J9JITDataCacheHeader *)comp->getAotMethodDataStart();
-         TR_AOTMethodHeader *aotMethodHeaderEntry =  (TR_AOTMethodHeader *)(aotMethodHeader + 1);
+         TR_AOTMethodHeader *aotMethodHeaderEntry =  comp->getAotMethodHeaderEntry();
          aotMethodHeaderEntry->offsetToPersistentInfo = 0;
          }
 

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -259,6 +259,20 @@ TR_RelocationRuntime::prepareRelocateAOTCodeAndData(J9VMThread* vmThread,
       return NULL;
       }
 
+   if (_aotMethodHeaderEntry->flags & TR_AOTMethodHeader_UsesOSR)
+      {
+
+      if (!comp->getOption(TR_EnableOSR) ||
+          !fej9->ensureOSRBufferSize(comp,
+                                     _aotMethodHeaderEntry->_osrBufferInfo._frameSizeInBytes,
+                                     _aotMethodHeaderEntry->_osrBufferInfo._scratchBufferSizeInBytes,
+                                     _aotMethodHeaderEntry->_osrBufferInfo._stackFrameSizeInBytes))
+         {
+         setReturnCode(compilationAOTValidateOSRFailure);
+         return NULL;
+         }
+      }
+
    _exceptionTableCacheEntry = (J9JITDataCacheHeader *)((uint8_t *)cacheEntry + _aotMethodHeaderEntry->offsetToExceptionTable);
 
    if (_exceptionTableCacheEntry->type == J9_JIT_DCE_EXCEPTION_INFO)
@@ -734,6 +748,11 @@ TR_RelocationRuntime::relocateMethodMetaData(UDATA codeRelocationAmount, UDATA d
        _exceptionTable->riData)
       {
       _exceptionTable->riData = (void *) (((U_8 *)_exceptionTable->riData) + dataRelocationAmount);
+      }
+
+   if (_exceptionTable->osrInfo)
+      {
+      _exceptionTable->osrInfo = (void *) (((U_8 *)_exceptionTable->osrInfo) + dataRelocationAmount);
       }
 
 #if defined(J9VM_OPT_JITSERVER)


### PR DESCRIPTION
Depends on ~(and therefore currently contains commits from)~ https://github.com/eclipse/openj9/pull/11552

See https://github.com/eclipse/openj9/issues/4849 for details, specifically about Involuntary OSR.

The PR adds
* Some refactoring changes wrt getting the AOT method entry from the SCC.
* Validation to ensure the emergency buffer for OSR is sufficient for the method to be loaded prior to loading it.