### PR TITLE
Add FSD support for AOT

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -560,6 +560,14 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          }
          break;
 
+      case TR_InlinedMethodPointer:
+         {
+         TR_RelocationRecordInlinedMethodPointer *impRecord = reinterpret_cast<TR_RelocationRecordInlinedMethodPointer *>(reloRecord);
+
+         impRecord->setInlinedSiteIndex(reloTarget, reinterpret_cast<uintptr_t>(relocation->getTargetAddress()));
+         }
+         break;
+
       case TR_ClassPointer:
          {
          TR_RelocationRecordClassPointer *cpRecord = reinterpret_cast<TR_RelocationRecordClassPointer *>(reloRecord);
@@ -1470,6 +1478,18 @@ J9::AheadOfTimeCompile::dumpRelocationHeaderData(uint8_t *cursor, bool isVerbose
                                       mpRecord->classChainIdentifyingLoaderOffsetInSharedCache(reloTarget),
                                       mpRecord->classChainForInlinedMethod(reloTarget),
                                       mpRecord->vTableSlot(reloTarget));
+            }
+         }
+         break;
+
+      case TR_InlinedMethodPointer:
+         {
+         TR_RelocationRecordInlinedMethodPointer *impRecord = reinterpret_cast<TR_RelocationRecordInlinedMethodPointer *>(reloRecord);
+
+         self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+         if (isVerbose)
+            {
+            traceMsg(self()->comp(), "\nInlined Method Pointer: Inlined site index = %d", impRecord->inlinedSiteIndex(reloTarget));
             }
          }
          break;

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -1150,6 +1150,18 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          }
          break;
 
+      case TR_Breakpoint:
+         {
+         TR_RelocationRecordBreakpointGuard *bpgRecord = reinterpret_cast<TR_RelocationRecordBreakpointGuard *>(reloRecord);
+
+         int32_t inlinedSiteIndex     = static_cast<int32_t>(reinterpret_cast<uintptr_t>(relocation->getTargetAddress()));
+         uintptr_t destinationAddress = reinterpret_cast<uintptr_t>(relocation->getTargetAddress2());
+
+         bpgRecord->setInlinedSiteIndex(reloTarget, inlinedSiteIndex);
+         bpgRecord->setDestinationAddress(reloTarget, destinationAddress);
+         }
+         break;
+
       default:
          TR_ASSERT(false, "Unknown relo type %d!\n", kind);
          comp->failCompilation<J9::AOTRelocationRecordGenerationFailure>("Unknown relo type %d!\n", kind);
@@ -1992,6 +2004,20 @@ J9::AheadOfTimeCompile::dumpRelocationHeaderData(uint8_t *cursor, bool isVerbose
          if (isVerbose)
             {
             traceMsg(self()->comp(), "\n Frequency offset %lld", bfRecord->frequencyOffset(reloTarget));
+            }
+         }
+         break;
+
+      case TR_Breakpoint:
+         {
+         TR_RelocationRecordBreakpointGuard *bpgRecord = reinterpret_cast<TR_RelocationRecordBreakpointGuard *>(reloRecord);
+
+         self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+         if (isVerbose)
+            {
+            traceMsg(self()->comp(), "\n Breakpoint Guard: Inlined site index = %d, destinationAddress = %p",
+                     bpgRecord->inlinedSiteIndex(reloTarget),
+                     bpgRecord->destinationAddress(reloTarget));
             }
          }
          break;

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -3010,6 +3010,11 @@ static TR_ExternalRelocationTargetKind getReloKindFromGuardSite(TR::CodeGenerato
             TR_ASSERT(false, "unexpected profiled guard test type");
          break;
 
+      case TR_BreakpointGuard:
+         traceMsg(cg->comp(), "TR_Breakpoint\n");
+         type = TR_Breakpoint;
+         break;
+
       default:
          TR_ASSERT(false, "got a unknown/non-AOT guard at AOT site");
          cg->comp()->failCompilation<J9::AOTRelocationRecordGenerationFailure>("Unknown/non-AOT guard at AOT site");
@@ -3067,6 +3072,14 @@ static void processAOTGuardSites(TR::CodeGenerator *cg, uint32_t inlinedCallSize
          case TR_CheckMethodExit:
          case TR_HCR:
             cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)(*it)->getLocation(),
+                                                                             (uint8_t *)(*it)->getDestination(),
+                                                                             type, cg),
+                             __FILE__, __LINE__, NULL);
+            break;
+
+         case TR_Breakpoint:
+            cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)(*it)->getLocation(),
+                                                                             (uint8_t *)(*it)->getGuard()->getCurrentInlinedSiteIndex(),
                                                                              (uint8_t *)(*it)->getDestination(),
                                                                              type, cg),
                              __FILE__, __LINE__, NULL);

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8747,6 +8747,16 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                options->setOption(TR_EnableOSR, false);
                }
 
+            // Disable recompilation for sync compiles in FSD mode. An app thread that blocks
+            // on compilation releases VM Access. If class redefinition occurs during a
+            // recompilation, the application thread can no longer OSR out to the interpreter;
+            // it is forced to return to the oldStartPC (to jump to a helper) which may not
+            // necessarily be valid.
+            if (compiler->getOption(TR_FullSpeedDebug) && !that->_compInfo.asynchronousCompilation())
+               {
+               compiler->getOptions()->setAllowRecompilation(false);
+               }
+
             // Check to see if there is sufficient physical memory available for this compilation
             if (compiler->getOption(TR_EnableSelfTuningScratchMemoryUsageBeforeCompile))
                {

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8181,8 +8181,19 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                }
             TR_ASSERT(!that->_methodBeingCompiled->isOutOfProcessCompReq(), "JITServer should not change options passed by client");
 #endif /* defined(J9VM_OPT_JITSERVER) */
+
             bool aotCompilationReUpgradedToWarm = false;
-            if (that->_methodBeingCompiled->_useAotCompilation)
+
+            // When FSD is enabled, involuntary OSR is also enabled. This means that the code
+            // size increases because of all of the catch block + code blocks, and the data
+            // size increases because of the additional information required in the the
+            // J9JITExceptionTable. This means that for applications that do not use a very
+            // large SCC, the number of methods that can now be put into the SCC reduces.
+            // In this scenario, startup is dominated by the number of AOT loads can that be
+            // performed rather than code quality. Therefore, disabling AOT Warm during startup
+            // disables inlining, thus dramatically reducing the code & data size.
+            if (that->_methodBeingCompiled->_useAotCompilation
+                && !TR::Options::getCmdLineOptions()->getOption(TR_FullSpeedDebug))
                {
                // In some circumstances AOT compilations are performed at warm
                if ((TR::Options::getCmdLineOptions()->getAggressivityLevel() == TR::Options::AGGRESSIVE_AOT ||

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2335,11 +2335,16 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
        (*vmHooks)->J9HookDisable(vmHooks, J9HOOK_VM_PUT_STATIC_FIELD) ||
        (*vmHooks)->J9HookDisable(vmHooks, J9HOOK_VM_SINGLE_STEP))
       {
-        static bool TR_DisableFullSpeedDebug = feGetEnv("TR_DisableFullSpeedDebug")?1:0;
-      #if defined(J9VM_JIT_FULL_SPEED_DEBUG)
+         static bool TR_DisableFullSpeedDebug = (feGetEnv("TR_DisableFullSpeedDebug") != NULL);
+         static bool TR_DisableFullSpeedDebugAOT = (feGetEnv("TR_DisableFullSpeedDebugAOT") != NULL);
+#if defined(J9VM_JIT_FULL_SPEED_DEBUG)
          if (TR_DisableFullSpeedDebug)
             {
             return false;
+            }
+         else if (TR_DisableFullSpeedDebugAOT)
+            {
+            doAOT = false;
             }
 
          self()->setOption(TR_FullSpeedDebug);
@@ -2349,9 +2354,9 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
          //setOption(TR_DisableInterpreterProfiling, true);
 
          initializeFSD(javaVM);
-      #else
+#else
          return false;
-      #endif
+#endif
       }
 
    bool exceptionEventHooked = false;

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2349,7 +2349,6 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
          //setOption(TR_DisableInterpreterProfiling, true);
 
          initializeFSD(javaVM);
-         doAOT = false;
       #else
          return false;
       #endif
@@ -2536,9 +2535,6 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
                }
             }
          }
-
-      if (self()->getOption(TR_FullSpeedDebug))
-         TR::Options::getAOTCmdLineOptions()->setOption(TR_MimicInterpreterFrameShape);
       }
 #endif
 

--- a/runtime/compiler/control/J9Recompilation.cpp
+++ b/runtime/compiler/control/J9Recompilation.cpp
@@ -335,6 +335,10 @@ J9::Recompilation::endOfCompilation()
          _bodyInfo->setDisableSampling(true);
          }
       }
+
+   // If we disallow recompilation then disable sampling
+   if (!_compilation->allowRecompilation())
+      _bodyInfo->setDisableSampling(true);
    }
 
 

--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -618,12 +618,17 @@ TR_CHTable::commitVirtualGuard(TR_VirtualGuard *info, List<TR_VirtualGuardSite> 
       TR_ResolvedMethod *breakpointedMethod = comp->getInlinedResolvedMethod(info->getCalleeIndex());
       TR_OpaqueMethodBlock *method = breakpointedMethod->getPersistentIdentifier();
       if (comp->fej9()->isMethodBreakpointed(method))
-         nopAssumptionIsValid = false;
-      ListIterator<TR_VirtualGuardSite> it(&sites);
-      for (TR_VirtualGuardSite *site = it.getFirst(); site; site = it.getNext())
          {
-         TR_PatchNOPedGuardSiteOnMethodBreakPoint
-            ::make(comp->fe(), comp->trPersistentMemory(), method, site->getLocation(), site->getDestination(), comp->getMetadataAssumptionList());
+         nopAssumptionIsValid = false;
+         }
+      else
+         {
+         ListIterator<TR_VirtualGuardSite> it(&sites);
+         for (TR_VirtualGuardSite *site = it.getFirst(); site; site = it.getNext())
+            {
+            TR_PatchNOPedGuardSiteOnMethodBreakPoint
+               ::make(comp->fe(), comp->trPersistentMemory(), method, site->getLocation(), site->getDestination(), comp->getMetadataAssumptionList());
+            }
          }
       }
    else if (info->getKind() == TR_ArrayStoreCheckGuard)

--- a/runtime/compiler/env/JITServerCHTable.cpp
+++ b/runtime/compiler/env/JITServerCHTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/env/JITServerCHTable.cpp
+++ b/runtime/compiler/env/JITServerCHTable.cpp
@@ -468,11 +468,16 @@ JITClientCommitVirtualGuard(const VirtualGuardInfoForCHTable *info, std::vector<
       TR_ResolvedMethod *breakpointedMethod = info->_inlinedResolvedMethod;
       TR_OpaqueMethodBlock *method = breakpointedMethod->getPersistentIdentifier();
       if (comp->fej9()->isMethodBreakpointed(method))
-         nopAssumptionIsValid = false;
-      for (TR_VirtualGuardSite &site : sites)
          {
-         TR_PatchNOPedGuardSiteOnMethodBreakPoint
-            ::make(comp->fe(), comp->trPersistentMemory(), method, site.getLocation(), site.getDestination(), comp->getMetadataAssumptionList());
+         nopAssumptionIsValid = false;
+         }
+      else
+         {
+         for (TR_VirtualGuardSite &site : sites)
+            {
+            TR_PatchNOPedGuardSiteOnMethodBreakPoint
+               ::make(comp->fe(), comp->trPersistentMemory(), method, site.getLocation(), site.getDestination(), comp->getMetadataAssumptionList());
+            }
          }
       }
    else if (info->_kind == TR_ArrayStoreCheckGuard)

--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -105,6 +105,7 @@ class TR_RuntimeAssumptionTable
    void notifyIllegalStaticFinalFieldModificationEvent(TR_FrontEnd *vm, void *key);
    void notifyClassRedefinitionEvent(TR_FrontEnd *vm, bool isSMP, void *oldKey, void *newKey);
    void notifyMutableCallSiteChangeEvent(TR_FrontEnd *vm, uintptr_t cookie);
+   void notifyMethodBreakpointed(TR_FrontEnd *fe, TR_OpaqueMethodBlock *method);
 
    int32_t getAssumptionCount(int32_t tableId) const { return assumptionCount[tableId]; }
    int32_t getReclaimedAssumptionCount(int32_t tableId) const { return reclaimedAssumptionCount[tableId]; }

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -8254,7 +8254,7 @@ TR_J9SharedCacheVM::canMethodExitEventBeHooked()
 bool
 TR_J9SharedCacheVM::methodsCanBeInlinedEvenIfEventHooksEnabled()
    {
-   return true;
+   return !TR::Options::getCmdLineOptions()->getOption(TR_FullSpeedDebug);
    }
 
 int32_t

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3137,7 +3137,7 @@ TR_J9VMBase::canMethodExitEventBeHooked()
    }
 
 bool
-TR_J9VMBase::methodsCanBeInlinedEvenIfEventHooksEnabled()
+TR_J9VMBase::methodsCanBeInlinedEvenIfEventHooksEnabled(TR::Compilation *comp)
    {
    return false;
    }
@@ -8252,9 +8252,9 @@ TR_J9SharedCacheVM::canMethodExitEventBeHooked()
    }
 
 bool
-TR_J9SharedCacheVM::methodsCanBeInlinedEvenIfEventHooksEnabled()
+TR_J9SharedCacheVM::methodsCanBeInlinedEvenIfEventHooksEnabled(TR::Compilation *comp)
    {
-   return !TR::Options::getCmdLineOptions()->getOption(TR_FullSpeedDebug);
+   return !comp->getOption(TR_FullSpeedDebug);
    }
 
 int32_t

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -949,7 +949,7 @@ public:
 
    virtual bool canMethodEnterEventBeHooked();
    virtual bool canMethodExitEventBeHooked();
-   virtual bool methodsCanBeInlinedEvenIfEventHooksEnabled();
+   virtual bool methodsCanBeInlinedEvenIfEventHooksEnabled(TR::Compilation *comp);
 
    virtual bool canExceptionEventBeHooked();
 
@@ -1202,7 +1202,7 @@ public:
 
    virtual bool               canMethodEnterEventBeHooked();
    virtual bool               canMethodExitEventBeHooked();
-   virtual bool               methodsCanBeInlinedEvenIfEventHooksEnabled();
+   virtual bool               methodsCanBeInlinedEvenIfEventHooksEnabled(TR::Compilation *comp);
    virtual TR_OpaqueClassBlock *getClassOfMethod(TR_OpaqueMethodBlock *method);
    virtual void               getResolvedMethods(TR_Memory *, TR_OpaqueClassBlock *, List<TR_ResolvedMethod> *);
    virtual TR_ResolvedMethod *getResolvedMethodForNameAndSignature(TR_Memory * trMemory, TR_OpaqueClassBlock * classPointer, const char* methodName, const char *signature);

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2330,9 +2330,9 @@ TR_J9SharedCacheServerVM::canMethodExitEventBeHooked()
    }
 
 bool
-TR_J9SharedCacheServerVM::methodsCanBeInlinedEvenIfEventHooksEnabled()
+TR_J9SharedCacheServerVM::methodsCanBeInlinedEvenIfEventHooksEnabled(TR::Compilation *comp)
    {
-   return true;
+   return !comp->getOption(TR_FullSpeedDebug);
    }
 
 int32_t

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -266,7 +266,7 @@ public:
    virtual bool traceableMethodsCanBeInlined() override;
    virtual bool canMethodEnterEventBeHooked() override;
    virtual bool canMethodExitEventBeHooked() override;
-   virtual bool methodsCanBeInlinedEvenIfEventHooksEnabled() override;
+   virtual bool methodsCanBeInlinedEvenIfEventHooksEnabled(TR::Compilation *comp) override;
    virtual int32_t getJavaLangClassHashCode(TR::Compilation * comp, TR_OpaqueClassBlock * clazzPointer, bool &hashCodeComputed) override;
    virtual bool javaLangClassGetModifiersImpl(TR_OpaqueClassBlock * clazzPointer, int32_t &result) override;
    virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, char * fieldName, uint32_t fieldLen, char * sig, uint32_t sigLen, UDATA options) override;

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -1132,9 +1132,10 @@ TR_J9ByteCodeIlGenerator::prependEntryCode(TR::Block * firstBlock)
    TR::Node * methodEnterHook = 0;
 
    static const char* disableMethodHookForCallees = feGetEnv("TR_DisableMethodHookForCallees");
-   if ((fej9()->isMethodTracingEnabled(_methodSymbol->getResolvedMethod()->getPersistentIdentifier()) ||
-        TR::Compiler->vm.canMethodEnterEventBeHooked(comp()))
-         && (isOutermostMethod() || !disableMethodHookForCallees))
+   if ((fej9()->isMethodTracingEnabled(_methodSymbol->getResolvedMethod()->getPersistentIdentifier())
+        || (!comp()->getOption(TR_FullSpeedDebug)
+            && TR::Compiler->vm.canMethodEnterEventBeHooked(comp())))
+       && (isOutermostMethod() || !disableMethodHookForCallees))
       {
       methodEnterHook = genMethodEnterHook();
       }

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -6919,9 +6919,10 @@ TR_J9ByteCodeIlGenerator::genReturn(TR::ILOpCodes nodeop, bool monitorExit)
       }
 
    static const char* disableMethodHookForCallees = feGetEnv("TR_DisableMethodHookForCallees");
-   if ((fej9()->isMethodTracingEnabled(_methodSymbol->getResolvedMethod()->getPersistentIdentifier()) ||
-        TR::Compiler->vm.canMethodExitEventBeHooked(comp()))
-         && (isOutermostMethod() || !disableMethodHookForCallees))
+   if ((fej9()->isMethodTracingEnabled(_methodSymbol->getResolvedMethod()->getPersistentIdentifier())
+        || (!comp()->getOption(TR_FullSpeedDebug)
+            && TR::Compiler->vm.canMethodExitEventBeHooked(comp())))
+       && (isOutermostMethod() || !disableMethodHookForCallees))
       {
       TR::SymbolReference * methodExitSymRef = symRefTab()->findOrCreateReportMethodExitSymbolRef(_methodSymbol);
 

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -102,7 +102,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 22;
+   static const uint16_t MINOR_NUMBER = 23;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -1836,7 +1836,7 @@ TR_J9InlinerPolicy::inlineUnsafeCall(TR::ResolvedMethodSymbol *calleeSymbol, TR:
        !comp()->fej9()->traceableMethodsCanBeInlined())
       return false;
 
-   if ((TR::Compiler->vm.canAnyMethodEventsBeHooked(comp()) && !comp()->fej9()->methodsCanBeInlinedEvenIfEventHooksEnabled()) ||
+   if ((TR::Compiler->vm.canAnyMethodEventsBeHooked(comp()) && !comp()->fej9()->methodsCanBeInlinedEvenIfEventHooksEnabled(comp())) ||
        (comp()->fej9()->isAnyMethodTracingEnabled(calleeSymbol->getResolvedMethod()->getPersistentIdentifier()) &&
        !comp()->fej9()->traceableMethodsCanBeInlined()))
       return false;
@@ -2067,7 +2067,7 @@ TR_J9InlinerPolicy::isInlineableJNI(TR_ResolvedMethod *method,TR::Node *callNode
       return false;
       }
 
-   if ((TR::Compiler->vm.canAnyMethodEventsBeHooked(comp) && !comp->fej9()->methodsCanBeInlinedEvenIfEventHooksEnabled()) ||
+   if ((TR::Compiler->vm.canAnyMethodEventsBeHooked(comp) && !comp->fej9()->methodsCanBeInlinedEvenIfEventHooksEnabled(comp)) ||
        (comp->fej9()->isAnyMethodTracingEnabled(method->getPersistentIdentifier()) &&
         !comp->fej9()->traceableMethodsCanBeInlined()))
       return false;
@@ -4461,7 +4461,7 @@ TR_MultipleCallTargetInliner::exceedsSizeThreshold(TR_CallSite *callSite, int by
 
 bool TR_J9InlinerPolicy::canInlineMethodWhileInstrumenting(TR_ResolvedMethod *method)
    {
-   if ((TR::Compiler->vm.isSelectiveMethodEnterExitEnabled(comp()) && !comp()->fej9()->methodsCanBeInlinedEvenIfEventHooksEnabled()) ||
+   if ((TR::Compiler->vm.isSelectiveMethodEnterExitEnabled(comp()) && !comp()->fej9()->methodsCanBeInlinedEvenIfEventHooksEnabled(comp())) ||
          (comp()->fej9()->isAnyMethodTracingEnabled(method->getPersistentIdentifier()) &&
          !comp()->fej9()->traceableMethodsCanBeInlined()))
       return false;

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1071,14 +1071,14 @@ static int32_t calculateExceptionsSize(
       if (fourByteExceptionTableEntries)
          {
          entrySize = sizeof(J9JIT32BitExceptionTableEntry);
-         numberOfExceptionRangesWithBits |= 0x8000;
+         numberOfExceptionRangesWithBits |= J9_JIT_METADATA_WIDE_EXCEPTIONS;
          }
       else
          entrySize = sizeof(J9JIT16BitExceptionTableEntry);
 
       if (comp->getOption(TR_FullSpeedDebug))
          {
-         numberOfExceptionRangesWithBits |= 0x4000;
+         numberOfExceptionRangesWithBits |= J9_JIT_METADATA_HAS_BYTECODE_PC;
          entrySize += 4;
          }
 

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -2683,9 +2683,10 @@ TR_RelocationRecordInlinedMethod::inlinedSiteCanBeActivated(TR_RelocationRuntime
       return false;
       }
 
-   if (reloRuntime->fej9()->isAnyMethodTracingEnabled((TR_OpaqueMethodBlock *) currentMethod) ||
-       reloRuntime->fej9()->canMethodEnterEventBeHooked() ||
-       reloRuntime->fej9()->canMethodExitEventBeHooked())
+   if (reloRuntime->fej9()->isAnyMethodTracingEnabled((TR_OpaqueMethodBlock *) currentMethod)
+       || (!reloRuntime->comp()->getOption(TR_FullSpeedDebug)
+           && (reloRuntime->fej9()->canMethodEnterEventBeHooked()
+               || reloRuntime->fej9()->canMethodExitEventBeHooked())))
       {
       RELO_LOG(reloRuntime->reloLogger(), 6, "\tinlinedSiteCanBeActivated: target may need enter/exit tracing so disabling inline site\n");
       return false;

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -1765,6 +1765,17 @@ class TR_RelocationRecordMethodPointer : public TR_RelocationRecordPointer
       virtual void activatePointer(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
+class TR_RelocationRecordInlinedMethodPointer : public TR_RelocationRecordWithInlinedSiteIndex
+   {
+   public:
+      TR_RelocationRecordInlinedMethodPointer() {}
+      TR_RelocationRecordInlinedMethodPointer(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordWithInlinedSiteIndex(reloRuntime, record) {}
+      virtual char *name();
+
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
 class TR_RelocationRecordEmitClass : public TR_RelocationRecordWithInlinedSiteIndex
    {
    public:

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -163,6 +163,13 @@ struct TR_RelocationRecordRecompQueuedFlagPrivateData
    uint8_t *_addressToPatch;
    };
 
+struct TR_RelocationRecordBreakpointGuardPrivateData
+   {
+   bool _compensateGuard;
+   TR_OpaqueMethodBlock *_method;
+   uint8_t *_destinationAddress;
+   };
+
 union TR_RelocationRecordPrivateData
    {
    TR_RelocationRecordHelperAddressPrivateData helperAddress;
@@ -180,6 +187,7 @@ union TR_RelocationRecordPrivateData
    TR_RelocationRecordResolvedTrampolinesPrivateData resolvedTrampolines;
    TR_RelocationRecordBlockFrequencyPrivateData blockFrequency;
    TR_RelocationRecordRecompQueuedFlagPrivateData recompQueuedFlag;
+   TR_RelocationRecordBreakpointGuardPrivateData breakpointGuard;
    };
 
 enum TR_RelocationRecordAction
@@ -1829,6 +1837,23 @@ class TR_RelocationRecordMethodCallAddress : public TR_RelocationRecord
 
    private:
       uint8_t *computeTargetMethodAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *baseLocation);
+   };
+
+class TR_RelocationRecordBreakpointGuard : public TR_RelocationRecordWithInlinedSiteIndex
+   {
+   public:
+      TR_RelocationRecordBreakpointGuard() {}
+      TR_RelocationRecordBreakpointGuard(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record)
+         : TR_RelocationRecordWithInlinedSiteIndex(reloRuntime, record) {}
+
+      virtual char *name() { return "TR_Breakpoint"; }
+      virtual void print(TR_RelocationRuntime *reloRuntime);
+
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+
+      void setDestinationAddress(TR_RelocationTarget *reloTarget, uintptr_t destinationAddress);
+      uintptr_t destinationAddress(TR_RelocationTarget *reloTarget);
    };
 
 #endif   // RELOCATION_RECORD_INCL

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -70,7 +70,7 @@ typedef enum TR_AOTFeatureFlags
    TR_FeatureFlag_DisableTraps                       = 0x00000010,
    TR_FeatureFlag_TLHPrefetch                        = 0x00000020,
    TR_FeatureFlag_MethodTrampolines                  = 0x00000040,
-   // Available                                      = 0x00000080,
+   TR_FeatureFlag_FSDEnabled                         = 0x00000080,
    TR_FeatureFlag_HCREnabled                         = 0x00000100,
    TR_FeatureFlag_SIMDEnabled                        = 0x00000200,     //set and tested for s390
    TR_FeatureFlag_AsyncCompilation                   = 0x00000400,     //async compilation - switch to interpreter code NOT generated

--- a/runtime/nls/jitm/j9jit.nls
+++ b/runtime/nls/jitm/j9jit.nls
@@ -160,6 +160,14 @@ J9NLS_RELOCATABLE_CODE_METHOD_TRAMPOLINE_MISMATCH.user_response=Destroy and recr
 J9NLS_RELOCATABLE_CODE_METHOD_TRAMPOLINE_MISMATCH.link=dita:///diag/appendixes/cmdline/cmdline_x.dita#cmdline_x/xshareclasses-reset
 # END NON-TRANSLATABLE
 
+J9NLS_RELOCATABLE_CODE_FSD_MISMATCH=FSD Enabled feature mismatch. Ignoring AOT code in shared class cache.
+# START NON-TRANSLATABLE
+J9NLS_RELOCATABLE_CODE_FSD_MISMATCH.explanation=The JVM is not running in the same FSD mode as the one that generated the code in the SCC.
+J9NLS_RELOCATABLE_CODE_FSD_MISMATCH.system_action=The compiler will not generate AOT code. AOT code from the shared class cache will not be used.
+J9NLS_RELOCATABLE_CODE_FSD_MISMATCH.user_response=Destroy and recreate the AOT code in the shared class cache for the current platform using the -Xshareclasses:reset option.
+J9NLS_RELOCATABLE_CODE_FSD_MISMATCH.link=dita:///diag/appendixes/cmdline/cmdline_x.dita#cmdline_x/xshareclasses-reset
+# END NON-TRANSLATABLE
+
 J9NLS_RELOCATABLE_CODE_HCR_MISMATCH=HCR Enabled feature mismatch. Ignoring AOT code in shared class cache.
 # START NON-TRANSLATABLE
 J9NLS_RELOCATABLE_CODE_HCR_MISMATCH.explanation=The JVM is not running in the same HCR mode as the one that generated the code in the SCC.

--- a/runtime/nls/jitm/j9jit.nls
+++ b/runtime/nls/jitm/j9jit.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2020 IBM Corp. and others
+# Copyright (c) 2000, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this


### PR DESCRIPTION
Depends on ~(and therefore contains commits from)~ https://github.com/eclipse/openj9/pull/11553
Depends on ~(and therefore contains commits from)~ https://github.com/eclipse/openj9/pull/11879
Depends on https://github.com/eclipse/omr/pull/5814

This PR contains the changes necessary for enabling FSD for AOT:

- Adds Breakpoint Guard relocations
- Adds Feature Flag validation for FSD
- Improves FSD performance by no longer emitting method enter/exit hooks as these events are dealt with using involuntary OSR
- Modifies how a `TR_MethodPointer` relocation materializes a method pointer

Closes https://github.com/eclipse/openj9/issues/11376