### PR TITLE
Remove dead/unreferenced data in ROMClasses

### DIFF
--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -450,7 +450,7 @@ ClassFileOracle::walkAttributes()
 			_isSynthetic = true;
 			break;
 		case CFR_ATTRIBUTE_SourceFile:
-			if (!hasSourceFile()) {
+			if (!hasSourceFile() && _context->shouldPreserveSourceFileName()) {
 				_sourceFile = (J9CfrAttributeSourceFile *)attrib;
 				markConstantUTF8AsReferenced(_sourceFile->sourceFileIndex);
 			}

--- a/runtime/bcutil/ROMClassBuilder.hpp
+++ b/runtime/bcutil/ROMClassBuilder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -104,10 +104,7 @@ private:
 		UDATA variableInfoSize;
 		UDATA utf8sSize;
 		UDATA rawClassDataSize;
-		UDATA varHandleMethodTypeLookupTableSize;
 	};
-
-	
 
 	/* NOTE: Be sure to update J9DbgROMClassBuilder in j9nonbuilder.h when changing the state variables below. */
 	J9JavaVM *_javaVM;

--- a/runtime/bcutil/ROMClassWriter.hpp
+++ b/runtime/bcutil/ROMClassWriter.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -104,9 +104,6 @@ public:
 
 	bool isOK() const { return OK == _buildResult; }
 	BuildResult getBuildResult() const { return _buildResult; }
-	U_32 getVarHandleMethodTypePaddedSize() { return _constantPoolMap->getVarHandleMethodTypePaddedCount() * sizeof(U_16); }
-
-
 
 private:
 	class AnnotationWriter;


### PR DESCRIPTION
This pull request fixes the following issues in the ROMClass builder that prevented ROMClass serialization in JITServer (#11331) from working correctly.
- The total size of the ROMClass (the `romSize` field) was calculated incorrectly: it included the size of the variable handle method type lookup table twice. As a result, many ROMClasses on jdk11+ include an unused zero-filled range at the end.
- When debug info is excluded from a ROMClass (e.g. with `-Xnolinenumbers`), the source file name string was still included in the UTF8 section, even though it's not referenced anywhere in the ROMClass.