### PR TITLE
Reduce heap size for cores, remove -Xint running cmdline tests

### DIFF
--- a/test/functional/cmdLineTests/J9security/playlist.xml
+++ b/test/functional/cmdLineTests/J9security/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
 		-DTESTJ9SECURITYJARPATH=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
-		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)j9SecurityTest.xml$(Q) \
+		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)j9SecurityTest.xml$(Q) \
 		-verbose -explainExcludes -nonZeroExitWhenError; \
 		$(TEST_STATUS)</command>
 		<levels>

--- a/test/functional/cmdLineTests/callsitedbgddrext/callsiteddrtests.xml
+++ b/test/functional/cmdLineTests/callsitedbgddrext/callsiteddrtests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2018, 2018 IBM Corp. and others
+  Copyright (c) 2018, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,7 +48,7 @@
   <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
   <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
   <exec command="rm -f $DUMPFILE$" />
-  <command>$EXE$ -Xaot:forceaot,count=0 -Xshareclasses:name=$CACHENAME$ $CP$ $XDUMP$ $PROGRAM$</command>
+  <command>$EXE$ -Xmx4m -Xaot:forceaot,count=0 -Xshareclasses:name=$CACHENAME$ $CP$ $XDUMP$ $PROGRAM$</command>
   <output regex="no" type="success">Moved disk 0 to 1</output>
   <output regex="no" type="success">System dump written</output>
   <!-- check for unexpected core dumps -->

--- a/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2018, 2020 IBM Corp. and others
+Copyright (c) 2018, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<variation>NoOptions</variation>
 		</variations>
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl zos ; \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
 	-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
@@ -55,7 +55,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<variation>NoOptions</variation>
 		</variations>
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl zos ; \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
 	-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
@@ -84,7 +84,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<variation>NoOptions</variation>
 		</variations>
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl zos ; \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
 	-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \

--- a/test/functional/cmdLineTests/classesdbgddrext/classesddrtests.xml
+++ b/test/functional/cmdLineTests/classesdbgddrext/classesddrtests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2017, 2018 IBM Corp. and others
+  Copyright (c) 2017, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,7 +48,7 @@
   <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
   <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
   <exec command="rm -f $DUMPFILE$" />
-  <command>$EXE$ -Xaot:forceaot,count=0 -Xshareclasses:name=$CACHENAME$ $CP$ $XDUMP$ $PROGRAM$</command>
+  <command>$EXE$ -Xmx4m -Xaot:forceaot,count=0 -Xshareclasses:name=$CACHENAME$ $CP$ $XDUMP$ $PROGRAM$</command>
   <output regex="no" type="success">Moved disk 0 to 1</output>
   <output regex="no" type="success">System dump written</output>
   <!-- check for unexpected core dumps -->

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-Copyright (c) 2019, 2020 IBM Corp. and others
+Copyright (c) 2019, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
     <variable name="READIPINFOFORRAS_MESSAGE" value="enabled network query to determine host name and IP address for RAS."/>
     <variable name="NOREADIPINFOFORRAS_MESSAGE" value="disabled network query to determine host name and IP address for RAS."/>
 
-    <variable name="JVM_HEAP_LIMIT" value="-Xmx512m"/>
+    <variable name="JVM_HEAP_LIMIT" value="-Xmx64m"/>
     <variable name="ONOUTOFMEMORYERROR_EQUALS" value="-XX:OnOutOfMemoryError="/>
     <variable name="ONOUTOFMEMORYERROR_JAR" value="-cp $Q$$JARPATH$$Q$ OnOutOfMemoryErrorTest"/>
     <variable name="JAVALANGOUTOFMEMORYERROR" value="java.lang.OutOfMemoryError:"/>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2020 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,7 @@
 		<command>$(JAVA_COMMAND) -Xdump $(JVM_OPTIONS) -DFIBJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-DJARPATH=$(Q)$(TEST_RESROOT)$(D)cmdLineTest_J9tests.jar$(Q) \
 	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) \
-	-Xint -jar $(CMDLINETESTER_JAR) \
+	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)j9tests_Java_common.xml$(Q) \
 	-xids all,$(PLATFORM) -plats all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)j9tests_exclude.xml$(Q) \
 	-explainExcludes -nonZeroExitWhenError; \
@@ -50,7 +50,7 @@
 		<command>$(JAVA_COMMAND) -Xdump $(JVM_OPTIONS) -DFIBJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-DJARPATH=$(Q)$(TEST_RESROOT)$(D)cmdLineTest_J9tests.jar$(Q) \
 	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) \
-	-Xint -jar $(CMDLINETESTER_JAR) \
+	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)j9tests_Java8.xml$(Q) \
 	-xids all,$(PLATFORM) -plats all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)j9tests_exclude.xml$(Q) \
 	-explainExcludes -nonZeroExitWhenError; \
@@ -74,7 +74,7 @@
 		<testCaseName>cmdLineTest_J9test</testCaseName>
 		<command>$(JAVA_COMMAND) -Xdump $(JVM_OPTIONS) -DFIBJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) \
-	-Xint -jar $(CMDLINETESTER_JAR) \
+	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)j9tests_Java9.xml$(Q) \
 	-xids all,$(PLATFORM) -plats all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)j9tests_exclude.xml$(Q) \
 	-explainExcludes -nonZeroExitWhenError; \
@@ -99,7 +99,7 @@
 		<command>$(JAVA_COMMAND) -Xdump $(JVM_OPTIONS) -DFIBJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-DJARPATH=$(Q)$(TEST_RESROOT)$(D)cmdLineTest_J9tests.jar$(Q) \
 	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) \
-	-Xint -jar $(CMDLINETESTER_JAR) \
+	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)j9tests.xml$(Q) \
 	-xids all,$(PLATFORM) -plats all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)j9tests_exclude.xml$(Q) \
 	-explainExcludes -nonZeroExitWhenError; \
@@ -123,7 +123,7 @@
 	-DNATIVEVMARGS=$(Q)$(JAVA_SHARED_LIBRARIES_DIR)$(D)nativevmargs$(Q) \
 	-DJVMLIBPATH=$(Q)$(J9VM_PATH)$(Q) \
 	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) \
-	-Xint -jar $(CMDLINETESTER_JAR) \
+	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)j9tests_native.xml$(Q) \
 	-xids all,$(PLATFORM) -plats all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)j9tests_exclude.xml$(Q) \
 	-explainExcludes -nonZeroExitWhenError; \

--- a/test/functional/cmdLineTests/cmdlinetestertests/cmdlinetests.xml
+++ b/test/functional/cmdLineTests/cmdlinetestertests/cmdlinetests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2009, 2018 IBM Corp. and others
+  Copyright (c) 2009, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,7 +26,7 @@
 
 <suite id="CmdLineTester Tests" timeout="600">
 
- <variable name="J9CMDLINE" value="$EXE$ -DRESJAR=$Q$$RESJAR$$Q$ -DTESTDIR=$Q$$TESTDIR$$Q$ -DCMDLINETESTERJAR=$Q$$CMDLINETESTERJAR$$Q$ -DRUN_SCRIPT_STRING=$Q$$RUN_SCRIPT_STRING$$Q$ -Dcmdlinetester.test=testval -Xint -jar $Q$$CMDLINETESTERJAR$$Q$ -explainExcludes -config $Q$$TESTDIR$$file.separator$" />
+ <variable name="J9CMDLINE" value="$EXE$ -DRESJAR=$Q$$RESJAR$$Q$ -DTESTDIR=$Q$$TESTDIR$$Q$ -DCMDLINETESTERJAR=$Q$$CMDLINETESTERJAR$$Q$ -DRUN_SCRIPT_STRING=$Q$$RUN_SCRIPT_STRING$$Q$ -Dcmdlinetester.test=testval -jar $Q$$CMDLINETESTERJAR$$Q$ -explainExcludes -config $Q$$TESTDIR$$file.separator$" />
 
  <test id="Test 1 (correct number of passes/fails reported)">
   <command>$J9CMDLINE$test1.xml$Q$</command>

--- a/test/functional/cmdLineTests/defaultLazySymbolResolution/playlist.xml
+++ b/test/functional/cmdLineTests/defaultLazySymbolResolution/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@
 			<variation>Mode601</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DJ9JAR=$(Q)$(TEST_RESROOT)$(D)VM_Test.jar$(Q) \
-	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)defaultLazySymbolResolution.xml$(Q) \
 	-xids all,$(PLATFORM) -explainExcludes -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>

--- a/test/functional/cmdLineTests/dscr/playlist.xml
+++ b/test/functional/cmdLineTests/dscr/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
-	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)dscr.xml$(Q) -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>os.aix</platformRequirements>

--- a/test/functional/cmdLineTests/dumpromtests/dumpromclasstests.xml
+++ b/test/functional/cmdLineTests/dumpromtests/dumpromclasstests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2011, 2018 IBM Corp. and others
+  Copyright (c) 2011, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,7 +42,7 @@
   <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
   <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
   <exec command="rm -f $DUMPFILE$" />
-  <command>$EXE$ $AGENTLIB$ $CP_HANOI$ $XDUMP$ $PROGRAM_HANOI$</command>
+  <command>$EXE$ -Xmx4m $AGENTLIB$ $CP_HANOI$ $XDUMP$ $PROGRAM_HANOI$</command>
   <output regex="no" type="success">Moved disk 0 to 1</output>
   <output regex="no" type="success">System dump written</output>
   <!-- check for unexpected core dumps -->
@@ -77,7 +77,7 @@
   <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
   <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
   <exec command="rm -f $DUMPFILE$" />
-  <command>$EXE$ $AGENTLIB$ $CP_GENERALTEST$ $XDUMP$ $PROGRAM_TATC$</command>
+  <command>$EXE$ -Xmx4m $AGENTLIB$ $CP_GENERALTEST$ $XDUMP$ $PROGRAM_TATC$</command>
   <output regex="no" type="success">@com.ibm.tests.typeAnnotation.TestAnn(site=classAnnotation)</output>
   <output regex="no" type="success">System dump written</output>
   <!-- check for unexpected core dumps -->

--- a/test/functional/cmdLineTests/forceLazySymbolResolution/playlist.xml
+++ b/test/functional/cmdLineTests/forceLazySymbolResolution/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@
 			<variation>Mode601</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DJ9JAR=$(Q)$(TEST_RESROOT)$(D)VM_Test.jar$(Q) \
-	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)forceLazySymbolResolution.xml$(Q) \
 	-xids all,$(PLATFORM) -explainExcludes -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>

--- a/test/functional/cmdLineTests/gcRegressionTests/playlist.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2020 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,7 +32,7 @@
 			<variation>Mode610</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)gcRegressionTests.jar$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
-		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -Xint -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)gcRegressionTests.xml$(Q) \
+		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)gcRegressionTests.xml$(Q) \
 		-verbose -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)gcRegressionTests_excludes.xml$(Q) -nonZeroExitWhenError; \
 		$(TEST_STATUS)</command>
 		<levels>
@@ -52,7 +52,7 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)gcRegressionTests.jar$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
-		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -Xint -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)gcRegressionTests.xml$(Q) \
+		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)gcRegressionTests.xml$(Q) \
 		-verbose -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)gcRegressionTests_excludes.xml$(Q) -nonZeroExitWhenError; \
 		$(TEST_STATUS)</command>
 		<platformRequirements>arch.riscv</platformRequirements>
@@ -72,7 +72,7 @@
 			<variation>Mode301</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)gcRegressionTests.jar$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
-		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -Xint -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)gcRegressionTests.xml$(Q) \
+		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)gcRegressionTests.xml$(Q) \
 		-verbose -explainExcludes -xids all,$(PLATFORM),Mode301 -plats all,$(PLATFORM),Mode301 -xlist $(Q)$(TEST_RESROOT)$(D)gcRegressionTests_excludes.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
 		$(TEST_STATUS)</command>
 		<levels>

--- a/test/functional/cmdLineTests/gptest/playlist.xml
+++ b/test/functional/cmdLineTests/gptest/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,7 +38,7 @@
 	-DJVMLIBPATH=$(Q)$(TEST_JDK_HOME)$(D)jre$(D)bin$(D)j9vm$(Q) \
 	-DFIBTARGET=$(Q)VMBench$(D)FibBench$(Q) \
 	-DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
-	-Xint -jar $(CMDLINETESTER_JAR) \
+	-jar $(CMDLINETESTER_JAR) \
 	-config  $(Q)$(TEST_RESROOT)$(D)gptests.xml$(Q) -verbose -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)cmdlineopttest_exclude.xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}	</command>
 		<platformRequirements>^os.win</platformRequirements>
@@ -74,7 +74,7 @@
 	-DJVMLIBPATH=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)j9vm$(Q) \
 	-DFIBTARGET=$(Q)VMBench$(D)FibBench$(Q) \
 	-DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
-	-Xint -jar $(CMDLINETESTER_JAR) \
+	-jar $(CMDLINETESTER_JAR) \
 	-config  $(Q)$(TEST_RESROOT)$(D)gptests.xml$(Q) -verbose -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)cmdlineopttest_exclude.xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}	</command>
 		<platformRequirements>^os.win</platformRequirements>

--- a/test/functional/cmdLineTests/jep178staticLinkingTest/playlist.xml
+++ b/test/functional/cmdLineTests/jep178staticLinkingTest/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2016, 2019 IBM Corp. and others
+Copyright (c) 2016, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
 	<test>
 		<testCaseName>cmdLineTester_jep178_staticLinking_SE80</testCaseName>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DJAVATEST_ROOT=$(Q)$(JAVATEST_ROOT)$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) \
 	-DJAVA_EXECUTABLE_DIR=$(Q)$(TEST_JDK_HOME)$(D)bin$(Q) \
@@ -62,7 +62,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	</test>
 	<test>
 		<testCaseName>cmdLineTester_jep178_staticLinking</testCaseName>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DJAVATEST_ROOT=$(Q)$(JAVATEST_ROOT)$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) \
 	-DJAVA_EXECUTABLE_DIR=$(Q)$(TEST_JDK_HOME)$(D)bin$(Q) \

--- a/test/functional/cmdLineTests/lazyClassLoadingTest/playlist.xml
+++ b/test/functional/cmdLineTests/lazyClassLoadingTest/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2020 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,7 @@
 		<testCaseName>cmdLineTester_LazyClassLoading</testCaseName>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 		$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DJ9JAR=$(Q)$(TEST_RESROOT)$(D)lazyClassLoadingTest.jar$(Q) \
-	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) \
+	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)lazyClassLoading.xml$(Q) \
 	-nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>

--- a/test/functional/cmdLineTests/locales/playlist.xml
+++ b/test/functional/cmdLineTests/locales/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
-	-DEXE=$(SQ)bash $(TEST_RESROOT)$(D)run_all_locales.sh $(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) \
+	-DEXE=$(SQ)bash $(TEST_RESROOT)$(D)run_all_locales.sh $(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)locales.xml$(Q) -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>^os.win</platformRequirements>

--- a/test/functional/cmdLineTests/modularityddrtests/modularityddrtests.xml
+++ b/test/functional/cmdLineTests/modularityddrtests/modularityddrtests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2018, 2018 IBM Corp. and others
+  Copyright (c) 2018, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,7 +38,7 @@
   <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
   <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
   <exec command="rm -f $DUMPFILE$" />
-  <command>$EXE$ $XDUMP$ $PROGRAM$</command>
+  <command>$EXE$ -Xmx4m $XDUMP$ $PROGRAM$</command>
   <output regex="no" type="success">System dump written</output>
   <!-- check for unexpected core dumps -->
   <output regex="no" type="failure">0001.dmp</output>

--- a/test/functional/cmdLineTests/reflectCache/playlist.xml
+++ b/test/functional/cmdLineTests/reflectCache/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DREFLECTCACHETESTJAR=$(Q)$(TEST_RESROOT)$(D)reflectCache.jar$(Q) \
-	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)reflectcache_test.xml$(Q) -explainExcludes \
 	-xids all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)reflectcache_exclude.xml$(Q) -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>

--- a/test/functional/cmdLineTests/shareClassTests/BadStackMap/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/BadStackMap/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DJARPATH=$(Q)$(TEST_RESROOT)$(D)badStackMap.jar$(Q) \
-	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)shareClassesBadStackMap.xml$(Q) -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
 		<levels>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-2.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2012, 2019 IBM Corp. and others
+  Copyright (c) 2012, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -538,7 +538,7 @@
 	<exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
 	
 	<test id="Test 105: Design 40220: Corrupt the cache." timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $SYSDUMP$ $JAVADUMP$ $SNAPDUMP$ $currentMode$,verbose,testFakeCorruption -version</command>
+		<command>$JAVA_EXE$ -Xmx4m $SYSDUMP$ $JAVADUMP$ $SNAPDUMP$ $currentMode$,verbose,testFakeCorruption -version</command>
 		<output type="success" caseSensitive="no" regex="no" showMatch="yes">Cache CRC is incorrect indicating a corrupt cache</output>
 		<output type="required" caseSensitive="yes" regex="no" showMatch="yes">Processing dump event</output>
 		<output type="required" caseSensitive="yes" regex="no" showMatch="yes">JVM requested System dump using</output>
@@ -619,7 +619,7 @@
 	</test>
 
 	<test id="Test 111: Design 40220: Force a dump on a previously corrupted cache." timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $SYSDUMP$ $JAVADUMP$ $SNAPDUMP$ $currentMode$,printStats,forceDumpIfCorrupt</command>
+		<command>$JAVA_EXE$ -Xmx4m $SYSDUMP$ $JAVADUMP$ $SNAPDUMP$ $currentMode$,printStats,forceDumpIfCorrupt</command>
 		<output type="success" caseSensitive="no" regex="no">Shared cache "ShareClassesCMLTests" is corrupt</output>
 		<output type="required" caseSensitive="yes" regex="no">Processing dump event</output>
 		<output type="required" caseSensitive="yes" regex="no" showMatch="yes">Processing dump event</output>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-4.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-4.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2012, 2018 IBM Corp. and others
+  Copyright (c) 2012, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -120,7 +120,7 @@
 	<exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
 	
 	<test id="Test 180-a: Create a system dump by using a shared cache with enableBCI option and with a JVMTI agent" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $SYSDUMP$,events=vmstop $currentMode$,reset,enableBCI $AGENT_NOCLASSMODIFICATION$ $CP_HANOI$ $PROGRAM_HANOI$</command>
+		<command>$JAVA_EXE$ -Xmx4m $SYSDUMP$,events=vmstop $currentMode$,reset,enableBCI $AGENT_NOCLASSMODIFICATION$ $CP_HANOI$ $PROGRAM_HANOI$</command>
 		<output type="success" regex="no">Moved disk 0 to 1</output>
 		<output type="required" regex="no" >System dump written</output>
 		<!-- check for unexpected core dumps -->
@@ -177,7 +177,7 @@
 	<exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
 	
 	<test id="Test 180-e: Create a system dump by using a shared cache with enableBCI option and without a JVMTI agent" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $SYSDUMP$,events=vmstop $currentMode$,reset,enableBCI $CP_HANOI$ $PROGRAM_HANOI$</command>
+		<command>$JAVA_EXE$ -Xmx4m $SYSDUMP$,events=vmstop $currentMode$,reset,enableBCI $CP_HANOI$ $PROGRAM_HANOI$</command>
 		<output type="success" regex="no">Moved disk 0 to 1</output>
 		<output type="required" regex="no">System dump written</output>
 		<!-- check for unexpected core dumps -->
@@ -248,7 +248,7 @@
 	<exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
 	
 	<test id="Test 181-b: Create a system dump by using previously created cache in read only mode with a JVMTI agent that has retransformation enabled" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $SYSDUMP$,events=vmstop $currentMode$,enableBCI,readonly $AGENT_RETRANSFORM$ $CP_HANOI$ $PROGRAM_HANOI$</command>
+		<command>$JAVA_EXE$ -Xmx4m $SYSDUMP$,events=vmstop $currentMode$,enableBCI,readonly $AGENT_RETRANSFORM$ $CP_HANOI$ $PROGRAM_HANOI$</command>
 		<output type="success" regex="no">Moved disk 0 to 1</output>
 		<output type="required" regex="no">System dump written</output>
 		<!-- check for unexpected core dumps -->
@@ -305,7 +305,7 @@
 	<exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
 	
 	<test id="Test 182-b: Create a system dump using previously created cache in read only mode with a JVMTI agent that has retransformation disabled" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $SYSDUMP$,events=vmstop $currentMode$,enableBCI,readonly $AGENT_NOCLASSMODIFICATION$ $CP_HANOI$ $PROGRAM_HANOI$</command>
+		<command>$JAVA_EXE$ -Xmx4m $SYSDUMP$,events=vmstop $currentMode$,enableBCI,readonly $AGENT_NOCLASSMODIFICATION$ $CP_HANOI$ $PROGRAM_HANOI$</command>
 		<output type="success" regex="no">Moved disk 0 to 1</output>
 		<output type="required" regex="no">System dump written</output>
 		<!-- check for unexpected core dumps -->

--- a/test/functional/cmdLineTests/shareClassTests/StorageKey/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/StorageKey/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
   distribution and is available at https://www.eclipse.org/legal/epl-2.0/
@@ -26,7 +26,7 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
-	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)storageKey.xml$(Q) -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<platformRequirements>os.zos</platformRequirements>

--- a/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2018, 2020 IBM Corp. and others
+Copyright (c) 2018, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl zos ; \
 	cp $(CMDLINETESTER_RESJAR) .; \
 	$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) xf cmdlinetestresources.jar; \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
 	-DCONCAT=$(TEST_RESROOT)$(D)concatenate_dumps.sh \
@@ -61,7 +61,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl zos ; \
 	cp $(CMDLINETESTER_RESJAR) .; \
 	$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) xf cmdlinetestresources.jar; \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
 	-DCONCAT=$(TEST_RESROOT)$(D)concatenate_dumps.sh \

--- a/test/functional/cmdLineTests/shrcdbgddrext/shrcdbgextddrtests.xml
+++ b/test/functional/cmdLineTests/shrcdbgddrext/shrcdbgextddrtests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2018, 2019 IBM Corp. and others
+  Copyright (c) 2018, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,7 +74,7 @@
   <exec command="tso delete J9CORE1.DMP.*" platforms="zos_390-64.*" />
   <exec command="tso delete J9CORE1.DMP" platforms="zos_390-31.*" />
   <exec command="rm -f $DUMPFILE1$" />
-  <command>$EXE$ -Xshareclasses:name=$CACHENAME$ -XX:-ShareAnonymousClasses $CP$ $XDUMP$ $PROGRAM$</command>
+  <command>$EXE$ -Xmx4m -Xshareclasses:name=$CACHENAME$ -XX:-ShareAnonymousClasses $CP$ $XDUMP$ $PROGRAM$</command>
   <output regex="no" type="success">Moved disk 0 to 1</output>
   <output regex="no" type="success">System dump written</output>
   <!-- check for unexpected core dumps -->
@@ -401,7 +401,7 @@
   <exec command="tso delete J9CORE2.DMP.*" platforms="zos_390-64.*" />
   <exec command="tso delete J9CORE2.DMP" platforms="zos_390-31.*" />
   <exec command="rm -f $DUMPFILE2$" />
-  <command>$EXE$  -Xjit:disableAsyncCompilation,count=20 $SHARECLASSESOPTION$ $CP$ $XDUMP2$ $PROGRAM$</command>
+  <command>$EXE$ -Xmx4m -Xjit:disableAsyncCompilation,count=20 $SHARECLASSESOPTION$ $CP$ $XDUMP2$ $PROGRAM$</command>
   <output regex="no" type="success">Moved disk 0 to 1</output>
   <output regex="no" type="success">System dump written</output>
   <!-- check for unexpected core dumps  -->

--- a/test/functional/cmdLineTests/sigabrtHandlingTest/playlist.xml
+++ b/test/functional/cmdLineTests/sigabrtHandlingTest/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@
 	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) \
 	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
-	-Xint -jar $(CMDLINETESTER_JAR) \
+	-jar $(CMDLINETESTER_JAR) \
 	-config  $(Q)$(TEST_RESROOT)$(D)sigabrtHandlingTest.xml$(Q) -verbose -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	${TEST_STATUS}	</command>
 		<platformRequirements></platformRequirements>

--- a/test/functional/cmdLineTests/softmxCmdOptTest/playlist.xml
+++ b/test/functional/cmdLineTests/softmxCmdOptTest/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,7 @@
 			<variation>Mode601</variation>
 			<variation>Mode501</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) \
 	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \

--- a/test/functional/cmdLineTests/stackSizeInfoTest/playlist.xml
+++ b/test/functional/cmdLineTests/stackSizeInfoTest/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,7 @@
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stack$(SQ) \
-	-Xint -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)StackSizeInfoTest.xml$(Q) \
+	-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)StackSizeInfoTest.xml$(Q) \
 	-verbose -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError ; \
 	${TEST_STATUS}</command>
 		<levels>

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattened32bitRefBackfillTest.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattened32bitRefBackfillTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2019, 2020 IBM Corp. and others
+  Copyright (c) 2019, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@
 		<exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
 		<exec command="rm -f $DUMPFILE$" />
 		<exec command="rm -f core*" />
-		<command showMatch="yes">$EXE$ $OPT$ $ARGS$ $JARS$ $PROGRAM$</command>
+		<command showMatch="yes">$EXE$ -Xmx24m $OPT$ $ARGS$ $JARS$ $PROGRAM$</command>
 		<output regex="no" type="success" showMatch="yes">System dump written</output>
 		<saveoutput regex="no" type="required" saveName="DUMPFILE" splitIndex="1" splitBy="System dump written to ">System dump written to </saveoutput>
 		<output regex="no" type="failure">Exception caught!</output>

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2019, 2020 IBM Corp. and others
+  Copyright (c) 2019, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@
 		<exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
 		<exec command="rm -f $DUMPFILE$" />
 		<exec command="rm -f core*" />
-		<command showMatch="yes">$EXE$ $ARGS$ $JARS$ $PROGRAM$</command>
+		<command showMatch="yes">$EXE$ -Xmx24m $ARGS$ $JARS$ $PROGRAM$</command>
 		<output regex="no" type="success" showMatch="yes">System dump written</output>
 		<saveoutput regex="no" type="required" saveName="DUMPFILE" splitIndex="1" splitBy="System dump written to ">System dump written to </saveoutput>
 		<output regex="no" type="failure">Exception caught!</output>

--- a/test/functional/cmdLineTests/valuetypeddrtests/playlist.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2019, 2020 IBM Corp. and others
+Copyright (c) 2019, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</variations>
 		<command>
 			perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
-			$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint -XX:+EnableValhalla -Xverify:none \
+			$(JAVA_COMMAND) $(JVM_OPTIONS) -XX:+EnableValhalla -Xverify:none \
 			--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 			-DRESJAR=$(CMDLINETESTER_RESJAR) \
 			-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
@@ -66,7 +66,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</variations>
 		<command>
 			perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
-			$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint -XX:+EnableValhalla -Xverify:none \
+			$(JAVA_COMMAND) $(JVM_OPTIONS) -XX:+EnableValhalla -Xverify:none \
 			--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 			-DRESJAR=$(CMDLINETESTER_RESJAR) \
 			-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
@@ -104,7 +104,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</variations>
 		<command>
 			perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
-			$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint -XX:+EnableValhalla -Xverify:none \
+			$(JAVA_COMMAND) $(JVM_OPTIONS) -XX:+EnableValhalla -Xverify:none \
 			--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 			-DRESJAR=$(CMDLINETESTER_RESJAR) \
 			-DOPT=-Xint \
@@ -143,7 +143,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</variations>
 		<command>
 			perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
-			$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint -XX:+EnableValhalla -Xverify:none \
+			$(JAVA_COMMAND) $(JVM_OPTIONS) -XX:+EnableValhalla -Xverify:none \
 			--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 			-DRESJAR=$(CMDLINETESTER_RESJAR) \
 			-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \

--- a/test/functional/cmdLineTests/valuetypeddrtests/unflattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/unflattenedvaluetypeddrtests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2019, 2020 IBM Corp. and others
+  Copyright (c) 2019, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@
 		<exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
 		<exec command="rm -f $DUMPFILE$" />
 		<exec command="rm -f core*" />
-		<command showMatch="yes">$EXE$ $ARGS$ $JARS$ $PROGRAM$</command>
+		<command showMatch="yes">$EXE$ -Xmx24m $ARGS$ $JARS$ $PROGRAM$</command>
 		<output regex="no" type="success" showMatch="yes">System dump written</output>
 		<saveoutput regex="no" type="required" saveName="DUMPFILE" splitIndex="1" splitBy="System dump written to ">System dump written to </saveoutput>
 		<output regex="no" type="failure">Exception caught!</output>

--- a/test/functional/cmdLineTests/verboseVerification/playlist.xml
+++ b/test/functional/cmdLineTests/verboseVerification/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2010, 2019 IBM Corp. and others
+  Copyright (c) 2010, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,7 +26,7 @@
 	<test>
 		<testCaseName>cmdLineTester_VerboseVerification</testCaseName>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-		$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESOURCES_DIR=$(Q)$(RESOURCES_DIR)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -Xint -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)VerboseVerification.xml$(Q) -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)cmdlineopttest_exclude.xml$(Q) -nonZeroExitWhenError; \
+		$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESOURCES_DIR=$(Q)$(RESOURCES_DIR)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)VerboseVerification.xml$(Q) -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)cmdlineopttest_exclude.xml$(Q) -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>^arch.arm</platformRequirements>
 		<levels>

--- a/test/functional/cmdLineTests/xcheckjni/playlist.xml
+++ b/test/functional/cmdLineTests/xcheckjni/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	$(JAVA_COMMAND) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND)$(SQ) -Xint -jar $(CMDLINETESTER_JAR) \
+	$(JAVA_COMMAND) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND)$(SQ) -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)xcheckjni.xml$(Q) -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
 		<levels>


### PR DESCRIPTION
In order to reduce the size of the core files, set a smaller -Xmx rather
than using the default (25% of available memory) for tests that create
core files.

Remove -Xint when running the cmdlinetester.jar. Using -Xint is historic
and no longer required.

Closes https://github.com/eclipse/openj9/issues/11537