### PR TITLE
Enable Dynamic Breadth First Scan Ordering for Balanced

### DIFF
--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -276,9 +276,8 @@ MM_ConfigurationIncrementalGenerational::initialize(MM_EnvironmentBase *env)
 	env->disableHotFieldDepthCopy();
 
 	if (result) {
-		if (extensions->scavengerScanOrdering != MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST) {
-			extensions->scavengerScanOrdering = MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_BREADTH_FIRST;
-		} else {
+		if (extensions->scavengerScanOrdering != MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_BREADTH_FIRST) {
+			extensions->scavengerScanOrdering = MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST;
 			extensions->adaptiveGcCountBetweenHotFieldSort = false;
 		}
 		extensions->setVLHGC(true);

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -1419,10 +1419,8 @@ MM_CopyForwardScheme::mainSetupForCopyForward(MM_EnvironmentVLHGC *env)
 	_failedToExpand = false;
 	_phantomReferenceRegionsToProcess = 0;
 
-	/* Sort all hot fields for all classes if scavenger dynamicBreadthFirstScanOrdering is enabled */
-	if (_extensions->scavengerScanOrdering == MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST) {
-		MM_HotFieldUtil::sortAllHotFieldData(_javaVM, _extensions->globalVLHGCStats.gcCount);
-	}
+	/* Sort all hot fields for all classes as dynamicBreadthFirstScanOrdering is enabled */
+	MM_HotFieldUtil::sortAllHotFieldData(_javaVM, _extensions->globalVLHGCStats.gcCount);
 
 	/* Cache of the mark map */
 	_markMap = env->_cycleState->_markMap;


### PR DESCRIPTION
Enable Dynamic Breadth-First Scan Ordering by default
for the Balanced GC policy.

Issue: #7552
Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>