### PR TITLE
Convert `concurrent-mark-end` to `gc-op` in GMP concurrent increment 

### DIFF
--- a/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.hpp
+++ b/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -249,6 +249,12 @@ public:
 	virtual void enableVerbose();
 	virtual void disableVerbose();
 
+	/**
+	 * Return termination reason for concurrent collection.
+	 * @param stats concurrent stats
+	 * @return string representing the reason for termination
+	 */ 
+	const char *getConcurrentTerminationReason(MM_ConcurrentPhaseStatsBase *stats);
 };
 
 #endif /* VERBOSEHANDLEROUTPUTVLHGC_HPP_ */


### PR DESCRIPTION
https://github.com/eclipse/openj9/issues/11239
This is the OpenJ9 part to convert `concurrent-mark-end` to `gc-op` in GMP concurrent increment.

- Implement new API to get termination reason
	`MM_VerboseHandlerOutputVLHGC::getReasonForTermination()`
- Adding timing of start/end of concurrent in `MM_IncrementalGenerationalGC`
- Replace `concurrent-mark-end` with `gc-op`
- Move `scanbytes` as attribute of `trace-info`

depends: https://github.com/eclipse/omr/pull/5736
closes: https://github.com/eclipse/openj9/issues/11239

Signed-off-by: Enson Guo <enson.guo@ibm.com>