### PR TITLE
JVM_LoadLibrary() must use lazy library loading by default

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -3692,7 +3692,7 @@ JVM_LoadLibrary(const char *libName)
 		} else {
 			PORT_ACCESS_FROM_JAVAVM(javaVM);
 			UDATA handle = 0;
-			UDATA flags = 0;
+			UDATA flags = J9_ARE_ANY_BITS_SET(javaVM->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_LAZY_SYMBOL_RESOLUTION) ? J9PORT_SLOPEN_LAZY : 0;
 			UDATA slOpenResult = j9sl_open_shared_library((char *)libName, &handle, flags);
 
 			Trc_SC_LoadLibrary_OpenShared(libName);

--- a/test/functional/cmdLineTests/defaultLazySymbolResolution/playlist.xml
+++ b/test/functional/cmdLineTests/defaultLazySymbolResolution/playlist.xml
@@ -44,11 +44,6 @@
 		<types>
 			<type>native</type>
 		</types>
-		<subsets>
-			<!-- disable for 15+ https://github.com/eclipse/openj9/issues/11076 -->
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>


### PR DESCRIPTION
Re-include cmdLineTester_defaultLazySymbolResolution for jdk15+

Resolves https://github.com/eclipse/openj9/issues/11076

See https://github.com/eclipse/openj9/blob/master/runtime/vm/vmbootlib.c#L182-L183

This is a change in behavior for OpenJ9, as prior to jdk15 bootstrap libraries don't use lazy resolution. However it matches the Hotspot behavior. Also note that libraries loaded early in bootstrap don't use lazy resolution since registerBootstrapLibrary() is still called. https://github.com/eclipse/openj9/blob/master/runtime/j9vm/jvm.c#L3686

Tested via personal build and grinder https://ci.eclipse.org/openj9/view/Test/job/Grinder/1355