### PR TITLE
Adjust expectations for *.cmd files

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/lineEndingsCheck.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/lineEndingsCheck.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corp. and others
+ * Copyright (c) 2017, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,7 +62,7 @@ timeout(time: 6, unit: 'HOURS') {
                                 break
                             case ~/.*text.*/:
                                 switch (it.toLowerCase()) {
-                                    case ~/.*\.bat|.*\.cmd/:
+                                    case ~/.*\.bat/:
                                         switch (TYPE) {
                                             case ~/.*CRLF line terminators.*/:
                                                 echo "Good windows script: '${it}' type: '${TYPE}'"


### PR DESCRIPTION
There are only two files that use that extension (`extract-vs-env.cmd` in each of jdk16 and jdknext) and they use LF line-ends. If we ever need to change them, the line-end checker should not insist the line-ends be switched to CR-LF.