### PR TITLE
(0.24.0) JVM_LoadLibrary() must use lazy library loading by default

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -3692,7 +3692,7 @@ JVM_LoadLibrary(const char *libName)
 		} else {
 			PORT_ACCESS_FROM_JAVAVM(javaVM);
 			UDATA handle = 0;
-			UDATA flags = 0;
+			UDATA flags = J9_ARE_ANY_BITS_SET(javaVM->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_LAZY_SYMBOL_RESOLUTION) ? J9PORT_SLOPEN_LAZY : 0;
 			UDATA slOpenResult = j9sl_open_shared_library((char *)libName, &handle, flags);
 
 			Trc_SC_LoadLibrary_OpenShared(libName);

--- a/test/functional/cmdLineTests/defaultLazySymbolResolution/playlist.xml
+++ b/test/functional/cmdLineTests/defaultLazySymbolResolution/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2020, 2020 IBM Corp. and others
+  Copyright (c) 2020, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,11 +44,6 @@
 		<types>
 			<type>native</type>
 		</types>
-		<subsets>
-			<!-- disable for 15+ https://github.com/eclipse/openj9/issues/11076 -->
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>


### PR DESCRIPTION
Re-include cmdLineTester_defaultLazySymbolResolution for jdk15+

Issue https://github.com/eclipse/openj9/issues/11076

Cherry pick https://github.com/eclipse/openj9/issues/11591 for the 0.24 release, and fixed the copyright date in the release branch.