### PR TITLE
Tag classes generated for OpenJDK MethodHandles during resolution

### DIFF
--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1843,6 +1843,23 @@ exit:
 
 		return result;
 	}
+
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	/**
+	 * Determine if a J9Method belongs to a class generated for OpenJDK MethodHandles.
+	 *
+	 * @param method the J9Method to be checked
+	 *
+	 * @return true if the method belongs to an OJDK MH generated class. Otherwise,
+	 * return false.
+	 */
+	static VMINLINE bool
+	methodFromOJDKMHGeneratedClass(J9Method *method)
+	{
+		J9Class *methodClass = J9_CLASS_FROM_METHOD(method);
+		return J9_ARE_ALL_BITS_SET(methodClass->classFlags, J9ClassIsGeneratedForOJDKMethodHandle);
+	}
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 };
 
 #endif /* VMHELPERS_HPP_ */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -84,6 +84,7 @@
 #define J9ClassHasReferences 0x10000
 #define J9ClassRequiresPrePadding 0x20000
 #define J9ClassIsValueBased 0x40000
+#define J9ClassIsGeneratedForOJDKMethodHandle 0x80000
 
 
 /* @ddr_namespace: map_to_type=J9FieldFlags */


### PR DESCRIPTION
Tag the classes, which are generated for OpenJDK MethodHandles so that
the JIT can identify them. The classes are found using the
`MemberName->vmtarget` method, and they are tagged using the
J9ClassIsGeneratedForOJDKMethodHandle flag during resolution.

Tagging during resolution == tagging before first usage of the method.

An helper, `VM_VMHelpers::methodFromOJDKMHGeneratedClass`, is also added
so that the JIT can identify methods which belong to the classes
generated for OpenJDK MethodHandles.

CI builds are skipped because OJDK MHs are currently disabled in OpenJ9.

[ci skip]

Co-authored-by: Jack Lu <Jack.S.Lu@ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>