### PR TITLE
Include classloader name and module version in stack trace

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/Util.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/Util.java
@@ -2,7 +2,7 @@
 package com.ibm.oti.util;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,13 +31,25 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
+import java.util.Optional;
+import java.util.Set;
+
+/*[IF JAVA_SPEC_VERSION >= 11]*/
+import java.lang.module.ResolvedModule;
+import jdk.internal.module.ModuleReferenceImpl;
+/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
+
+import com.ibm.oti.vm.VM;
+import com.ibm.oti.vm.VMLangAccess;
 
 public final class Util {
 
 	private static final String defaultEncoding;
+	private static final VMLangAccess vmLangAccess;
 
 	static {
-		String encoding = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty("os.encoding"); //$NON-NLS-1$
+		vmLangAccess = VM.getVMLangAccess();
+		String encoding = vmLangAccess.internalGetProperties().getProperty("os.encoding"); //$NON-NLS-1$
 		if (encoding != null) {
 			try {
 				"".getBytes(encoding); //$NON-NLS-1$
@@ -286,25 +298,46 @@ public static void appendLnTo(Appendable buf) {
  * @param e StackTraceElement to add
  * @param elementSource location of the source file.  May be null.
  * @param buf Receiver for the text
- * @param extended add additional information
+ * @param includeExtendedInfo Whether or not to include extended info, such as classloader name or module version
  */
-public static void printStackTraceElement(StackTraceElement e, Object elementSource, Appendable buf, boolean extended) {
-	/*[IF Sidecar19-SE]*/
-	final java.lang.String modName = e.getModuleName();
-	if (null != modName) {
+public static void printStackTraceElement(StackTraceElement e, Object elementSource, Appendable buf, boolean includeExtendedInfo) {
+	/*[IF JAVA_SPEC_VERSION >= 11]*/
+	boolean classLoaderNameIncluded = false;
+	final String classLoaderName = e.getClassLoaderName();
+	/**
+	 * The classloader name will only be included in the trace if the classloader isn't a built-in classloader,
+	 * or if it is the "app" classloader and the calling class is Throwable/StackFrame.
+	 */
+	if ((null != classLoaderName)
+			&& (!classLoaderName.isEmpty())
+			&& (includeExtendedInfo || includeClassLoaderName(e))
+	) {
+		classLoaderNameIncluded = true;
+		appendTo(buf, classLoaderName);
+		appendTo(buf, "/"); //$NON-NLS-1$
+	}
+
+	final String modName = e.getModuleName();
+	if ((null == modName) || (modName.isEmpty())) {
+		/* If the classloader name was included but there is no module name, note the empty module in the trace */
+		if (classLoaderNameIncluded) {
+			appendTo(buf, "/"); //$NON-NLS-1$
+		}
+	} else {
+		/* Append the module name if it exists */
 		appendTo(buf, modName);
-		if (extended) {
+		if (includeExtendedInfo || includeModuleVersion(e)) {
 			String mVer = e.getModuleVersion();
-			if (null != mVer) {
+			if ((null != mVer) && (!mVer.isEmpty())) {
+				/* Append the module version if it exists */
 				appendTo(buf, "@"); //$NON-NLS-1$
 				appendTo(buf, mVer);
 			}
 		}
 		appendTo(buf, "/"); //$NON-NLS-1$
-	} else if (extended) {
-		appendTo(buf, "app//"); //$NON-NLS-1$
 	}
-	/*[ENDIF] Sidecar19-SE*/
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
+
 	appendTo(buf, e.getClassName());
 	appendTo(buf, "."); //$NON-NLS-1$
 	appendTo(buf, e.getMethodName());
@@ -349,5 +382,59 @@ public static void printStackTraceElement(StackTraceElement e, Object elementSou
 		}
 	}
 }
+
+/*[IF JAVA_SPEC_VERSION >= 11]*/
+/**
+ * Helper method for printStackTraceElement to check if the classloader name
+ * should be included in the stack trace for the provided StackTraceElement.
+ *
+ * @param element The StackTraceElement to check
+ * @return true if the classloader name should be included, false otherwise
+ */
+private static boolean includeClassLoaderName(StackTraceElement element) {
+	return vmLangAccess.getIncludeClassLoaderName(element);
+}
+
+/**
+ * Helper method for printStackTraceElement to check if the module version
+ * should be included in the stack trace for the provided StackTraceElement.
+ *
+ * The module version should not be included for modules that are non-upgradeable.
+ *
+ * @param element The StackTraceElement to check
+ * @return true if the module version should be included, false otherwise
+ */
+private static boolean includeModuleVersion(StackTraceElement element) {
+	boolean includeModuleVersion = vmLangAccess.getIncludeModuleVersion(element);
+
+	if (includeModuleVersion) {
+		/* includeModuleVersion should only be set to true if the module is not a non-upgradeable module */
+		includeModuleVersion = !NonUpgradeableModules.moduleNames.contains(element.getModuleName());
+	}
+
+	return includeModuleVersion;
+}
+
+/**
+ * NonUpgradeableModules statically determines the set of non-upgradeable modules
+ * by checking the module names that are recorded in the hashes of the java.base
+ * module. If a module name is contained within this set, then the module is a
+ * non-upgradeable module. Non-upgradeable modules should not have their module
+ * version displayed in a stack trace if the calling class is Throwable or StackFrame.
+ */
+private static class NonUpgradeableModules {
+	static Set<String> moduleNames;
+
+	static {
+		Optional<ResolvedModule> javaBaseModule = ModuleLayer.boot().configuration().findModule("java.base"); //$NON-NLS-1$
+
+		if (javaBaseModule.isPresent()) {
+			ResolvedModule resolvedJavaBaseModule = javaBaseModule.get();
+			ModuleReferenceImpl javaBaseModuleRef = (ModuleReferenceImpl) resolvedJavaBaseModule.reference();
+			moduleNames = javaBaseModuleRef.recordedHashes().names();
+		}
+	}
+}
+/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
 
 }

--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar16]*/
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corp. and others
+ * Copyright (c) 2012, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -176,4 +176,22 @@ public interface VMLangAccess {
 	 * @param theClass The class to prepare
 	 */
 	public void prepare(Class<?> theClass);
+
+	/*[IF JAVA_SPEC_VERSION >= 11]*/
+	/**
+	 * Returns whether the classloader name should be included in the stack trace for the provided StackTraceElement.
+	 *
+	 * @param element The StackTraceElement to check
+	 * @return true if the classloader name should be included, false otherwise
+	 */
+	public boolean getIncludeClassLoaderName(StackTraceElement element);
+
+	/**
+	 * Returns whether the module version should be included in the stack trace for the provided StackTraceElement.
+	 *
+	 * @param element The StackTraceElement to check
+	 * @return true if the module version should be included, false otherwise
+	 */
+	public boolean getIncludeModuleVersion(StackTraceElement element);
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
 }

--- a/jcl/src/java.base/share/classes/java/lang/StackTraceElement.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackTraceElement.java
@@ -4,7 +4,7 @@ package java.lang;
 import com.ibm.oti.util.Util;
 
 /*******************************************************************************
- * Copyright (c) 2002, 2020 IBM Corp. and others
+ * Copyright (c) 2002, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,11 +32,13 @@ import com.ibm.oti.util.Util;
  */
 public final class StackTraceElement implements java.io.Serializable {
 	private static final long serialVersionUID = 6992337162326171013L;
-	/*[IF Sidecar19-SE]*/	
+	/*[IF JAVA_SPEC_VERSION >= 11]*/
 	private final String moduleName;
 	private final String moduleVersion;
 	private final String classLoaderName;
-	/*[ENDIF]*/
+	private transient boolean includeClassLoaderName;
+	private transient boolean includeModuleVersion;
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
 	private final String declaringClass;
 	private final String methodName;
 	private final String fileName;
@@ -53,18 +55,25 @@ public final class StackTraceElement implements java.io.Serializable {
  */
 public StackTraceElement(String cls, String method, String file, int line) {
 	if (cls == null || method == null) throw new NullPointerException();
-	/*[IF Sidecar19-SE]*/
+	/*[IF JAVA_SPEC_VERSION >= 11]*/
 	moduleName = null;
 	moduleVersion = null;
 	classLoaderName = null;
-	/*[ENDIF]*/	
+	/**
+	 * includeClassLoaderName and includeModuleVersion are initialized to
+	 * true for publicly constructed StackTraceElements, as this information
+	 * is to be included when the element is printed.
+	 */
+	includeClassLoaderName = true;
+	includeModuleVersion = true;
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
 	declaringClass = cls;
 	methodName = method;
 	fileName = file;
 	lineNumber = line;
 }
 
-/*[IF Sidecar19-SE]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 /**
  * Create a StackTraceElement from the parameters.
  * 
@@ -86,6 +95,13 @@ public StackTraceElement(String classLoaderName, String module, String version, 
 	fileName = file;
 	lineNumber = line;
 	this.classLoaderName = classLoaderName;
+	/**
+	 * includeClassLoaderName and includeModuleVersion are initialized to
+	 * true for publicly constructed StackTraceElements, as this information
+	 * is to be included when the element is printed.
+	 */
+	includeClassLoaderName = true;
+	includeModuleVersion = true;
 }
 
 /**
@@ -96,15 +112,22 @@ public StackTraceElement(String classLoaderName, String module, String version, 
 public String getClassLoaderName() {
 	return classLoaderName;
 }
-/*[ENDIF]*/
+/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
 
 @SuppressWarnings("unused")
 private StackTraceElement() {
-	/*[IF Sidecar19-SE]*/
+	/*[IF JAVA_SPEC_VERSION >= 11]*/
 	moduleName = null;
 	moduleVersion = null;
 	classLoaderName = null;
-	/*[ENDIF]*/	
+	/**
+	 * includeClassLoaderName and includeModuleVersion are initialized to
+	 * false for internally constructed StackTraceElements, as these fields
+	 * are to be set natively.
+	 */
+	includeClassLoaderName = false;
+	includeModuleVersion = false;
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
 	declaringClass = null;
 	methodName = null;
 	fileName = null;
@@ -139,7 +162,7 @@ public boolean equals(Object obj) {
 	return true;
 }
 
-/*[IF Sidecar19-SE]*/
+/*[IF JAVA_SPEC_VERSION >= 11]*/
 /**
  * Answers the name of the module to which the execution point represented by this stack trace element belongs.
  * 
@@ -157,8 +180,57 @@ public String getModuleName() {
 public String getModuleVersion() {
 	return moduleVersion;
 }
-/*[ENDIF]*/
- 
+
+/**
+ * Returns whether the classloader name should be included in the stack trace for the provided StackTraceElement.
+ *
+ * @return true if the classloader name should be included, false otherwise.
+ */
+boolean getIncludeClassLoaderName() {
+	return includeClassLoaderName;
+}
+
+/**
+ * Returns whether the module version should be included in the stack trace for the provided StackTraceElement.
+ *
+ * @return true if the module version should be included, false otherwise.
+ */
+boolean getIncludeModuleVersion() {
+	return includeModuleVersion;
+}
+
+/**
+ * Set the includeClassLoaderName and includeModuleVersion fields for this StackTraceElement.
+ *
+ * @param classLoader the classloader for the StackTraceElement.
+ */
+void setIncludeInfoFlags(ClassLoader classLoader) {
+	/**
+	 * If the classloader is one of the Platform or Bootstrap built-in classloaders,
+	 * don't include its name or module version in the stack trace. If it is the
+	 * Application/System built-in classloader, don't include the class name, but
+	 * include the module version.
+	 */
+	if ((null == classLoader)
+		|| (ClassLoader.getPlatformClassLoader() == classLoader) // VM: Extension ClassLoader
+		|| (ClassLoader.bootstrapClassLoader == classLoader) // VM: System ClassLoader
+	) {
+		includeClassLoaderName = false;
+		includeModuleVersion = false;
+	} else if ((ClassLoader.getSystemClassLoader() == classLoader)) { // VM: Application ClassLoader
+		includeClassLoaderName = false;
+	}
+}
+
+/**
+ * Disable including the classloader name and the module version for this StackTraceElement.
+ */
+void disableIncludeInfoFlags() {
+	includeClassLoaderName = false;
+	includeModuleVersion = false;
+}
+/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
+
 /**
  * Returns the full name (i.e. including package) of the class where this
  * stack trace element is executing.
@@ -216,14 +288,14 @@ public int hashCode() {
 	// either both methodName and declaringClass are null, or neither are null
 	if (methodName == null) return 0;	// all unknown methods hash the same
 	int hashCode = methodName.hashCode() ^ declaringClass.hashCode();	// declaringClass never null if methodName is non-null
-	/*[IF Sidecar19-SE]*/	
+	/*[IF JAVA_SPEC_VERSION >= 11]*/
 	if (null != moduleName) {
 		hashCode ^= moduleName.hashCode();
 	}
 	if (null != moduleVersion) {
 		hashCode ^= moduleVersion.hashCode();
 	}
-	/*[ENDIF]*/
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
 	return hashCode;
 }
  
@@ -243,7 +315,21 @@ public boolean isNativeMethod() {
 @Override
 public String toString() {
 	StringBuilder buf = new StringBuilder(80);
-	Util.printStackTraceElement(this, source, buf, false);
+	boolean includeExtendedInfo = false;
+	/*[IF JAVA_SPEC_VERSION >= 11]*/
+	/**
+	 * includeExtendedInfo is essentially a check to see if this StackTraceElement
+	 * was created using a public constructor. Both includeClassLoaderName and
+	 * includeModuleVersion are initialized to true in the public constructors,
+	 * since these pieces of information are to be included in the stack trace.
+	 *
+	 * It's also possible that both of these flags are set to true natively,
+	 * in which case we still want to include extended info when printing the
+	 * stack trace.
+	 */
+	includeExtendedInfo = includeClassLoaderName && includeModuleVersion;
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
+	Util.printStackTraceElement(this, source, buf, includeExtendedInfo);
 	return buf.toString();
 }
 

--- a/jcl/src/java.base/share/classes/java/lang/StackWalker.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackWalker.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2020 IBM Corp. and others
+ * Copyright (c) 2016, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -391,8 +391,19 @@ public final class StackWalker {
 					moduleVersion = versionInfo.get().toString();
 				}
 			}
-			return new StackTraceElement(classLoaderName, moduleName, moduleVersion, className, methodName, fileName,
+
+			StackTraceElement element = new StackTraceElement(classLoaderName, moduleName, moduleVersion, className, methodName, fileName,
 					lineNumber);
+
+			/**
+			 * Disable including classloader name and module version in stack trace output
+			 * until StackWalker StackTraceElement include info flags can be set properly.
+			 *
+			 * See: https://github.com/eclipse/openj9/issues/11774
+			 */
+			element.disableIncludeInfoFlags();
+
+			return element;
 		}
 
 		/*[IF JAVA_SPEC_VERSION >= 10]*/

--- a/jcl/src/java.base/share/classes/java/lang/Throwable.java
+++ b/jcl/src/java.base/share/classes/java/lang/Throwable.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -489,14 +489,13 @@ private void readObject(ObjectInputStream s)
 	}
 }
 
-/* 
- * CMVC 97756 try to continue printing as much as possible of the stack trace even
- *            in the presence of OutOfMemoryErrors.
- */
-
 /**
- * Print stack trace
- *  
+ * Print stack trace.
+ *
+ * The stack trace is constructed with appendTo() and avoids allocating Objects (i.e. Strings)
+ * to try to continue printing as much as possible of the stack trace even in the presence of
+ * OutOfMemoryErrors (CMVC 97756).
+ *
  * @param	err	
  * 			the specified print stream/writer 
  * @param	parentStack	
@@ -591,18 +590,19 @@ private StackTraceElement[] printStackTrace(
 		return null;
 	}
 	for (int i=0; i < stack.length - duplicates; i++) {
+		StackTraceElement element = stack[i];
 		if (!outOfMemory) {
 			try {
-				appendTo(err, "\tat " + stack[i], indents);			 //$NON-NLS-1$
+				appendTo(err, "\tat " + element, indents); //$NON-NLS-1$
 			} catch(OutOfMemoryError e) {
 				outOfMemory = true;
 			}
 		}
 		if (outOfMemory) {
 			appendTo(err, "\tat ", indents); //$NON-NLS-1$
-			Util.printStackTraceElement(stack[i], null, err, false);
+			Util.printStackTraceElement(element, null, err, false);
 		}
-		appendLnTo(err);		
+		appendLnTo(err);
 	}
 	if (duplicates > 0) {
 		if (!outOfMemory) {

--- a/jcl/src/java.base/share/classes/java/lang/VMAccess.java
+++ b/jcl/src/java.base/share/classes/java/lang/VMAccess.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar16]*/
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corp. and others
+ * Copyright (c) 2012, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -225,4 +225,28 @@ final class VMAccess implements VMLangAccess {
 	public void prepare(Class<?> theClass) {
 		J9VMInternals.prepare(theClass);
 	}
+
+	/*[IF JAVA_SPEC_VERSION >= 11]*/
+	/**
+	 * Returns whether the classloader name should be included in the stack trace for the provided StackTraceElement.
+	 *
+	 * @param element The StackTraceElement to check
+	 * @return true if the classloader name should be included, false otherwise
+	 */
+	@Override
+	public boolean getIncludeClassLoaderName(StackTraceElement element) {
+		return element.getIncludeClassLoaderName();
+	}
+
+	/**
+	 * Returns whether the module version should be included in the stack trace for the provided StackTraceElement.
+	 *
+	 * @param element The StackTraceElement to check
+	 * @return true if the module version should be included, false otherwise
+	 */
+	@Override
+	public boolean getIncludeModuleVersion(StackTraceElement element) {
+		return element.getIncludeModuleVersion();
+	}
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
 }

--- a/runtime/jcl/common/jclexception.c
+++ b/runtime/jcl/common/jclexception.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,6 +30,10 @@
 #include "rommeth.h"
 #include "vm_api.h"
 #include "ut_j9jcl.h"
+
+#if JAVA_SPEC_VERSION >= 11
+static void setStackTraceElementFields(J9VMThread *vmThread, j9object_t element, J9ClassLoader *classLoader);
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 static UDATA getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, UDATA bytecodeOffset, J9ROMClass * romClass, J9ROMMethod * romMethod, J9UTF8 * fileName, UDATA lineNumber, J9ClassLoader* classLoader, J9Class* ramClass);
 
@@ -185,6 +189,9 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, UDATA bytecode
 						J9VMJAVALANGSTACKTRACEELEMENT_SET_MODULEVERSION(vmThread, element, module->version);
 					}
 				}
+#if JAVA_SPEC_VERSION >= 11
+				setStackTraceElementFields(vmThread, element, classLoader);
+#endif /* JAVA_SPEC_VERSION >= 11 */
 			}
 
 			/* Fill in method class */
@@ -372,3 +379,38 @@ retry:
 
 	return result;
 }
+
+#if JAVA_SPEC_VERSION >= 11
+/**
+ * Set the includeClassLoaderName and includeModuleVersion fields for a StackTraceElement.
+ *
+ * @param vmThread The VM thread.
+ * @param element The element to set fields for.
+ * @param classLoader The classloader to check.
+ */
+static void
+setStackTraceElementFields(J9VMThread *vmThread, j9object_t element, J9ClassLoader *classLoader) {
+	J9JavaVM *vm = vmThread->javaVM;
+	BOOLEAN includeClassLoaderName = TRUE;
+	BOOLEAN includeModuleVersion = TRUE;
+
+	/**
+	 * If the classloader is one of the Platform or Bootstrap built-in classloaders,
+	 * don't include its name or module version in the stack trace. If it is the
+	 * Application/System built-in classloader, don't include the class name, but
+	 * include the module version.
+	 */
+	if ((NULL == classLoader)
+		|| (vm->extensionClassLoader == classLoader) // JRE: Platform ClassLoader
+		|| (vm->systemClassLoader == classLoader) // JRE: Bootstrap ClassLoader
+	) {
+		includeClassLoaderName = FALSE;
+		includeModuleVersion = FALSE;
+	} else if (vm->applicationClassLoader == classLoader) { // JRE: System ClassLoader
+		includeClassLoaderName = FALSE;
+	}
+
+	J9VMJAVALANGSTACKTRACEELEMENT_SET_INCLUDECLASSLOADERNAME(vmThread, element, (U_32) includeClassLoaderName);
+	J9VMJAVALANGSTACKTRACEELEMENT_SET_INCLUDEMODULEVERSION(vmThread, element, (U_32) includeModuleVersion);
+}
+#endif /* JAVA_SPEC_VERSION >= 11 */

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2006, 2020 IBM Corp. and others
+Copyright (c) 2006, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -181,6 +181,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="java/lang/StackTraceElement" name="moduleVersion" signature="Ljava/lang/String;" flags="opt_module" versions="9-"/>
 	<fieldref class="java/lang/StackTraceElement" name="declaringClass" signature="Ljava/lang/String;"/>
 	<fieldref class="java/lang/StackTraceElement" name="classLoaderName" signature="Ljava/lang/String;" flags="opt_module" versions="9-"/>
+	<fieldref class="java/lang/StackTraceElement" name="includeClassLoaderName" signature="Z" flags="opt_module" versions="9-"/>
+	<fieldref class="java/lang/StackTraceElement" name="includeModuleVersion" signature="Z" flags="opt_module" versions="9-"/>
 	<fieldref class="java/lang/StackTraceElement" name="methodName" signature="Ljava/lang/String;"/>
 	<fieldref class="java/lang/StackTraceElement" name="fileName" signature="Ljava/lang/String;"/>
 	<fieldref class="java/lang/StackTraceElement" name="lineNumber" signature="I"/>


### PR DESCRIPTION
Fixes: #11452
Fixes: #11447

Per the javadoc, if the classloader is named and it is not one of the built-in classloaders: Bootstrap, Platform or System (aka App), then it should be included when printing `StackTraceElement`.

[Javadoc](http://cr.openjdk.java.net/~iris/se/15/build/latest/api/java.base/java/lang/StackTraceElement.html#toString()):

> If a class is defined in an unnamed module then the second element is omitted as shown in "com.foo.loader//com.foo.bar.App.run(App.java:12)".

> If the class loader is a built-in class loader or is not named then the first element and its following "/" are omitted as shown in "acme@2.1/org.acme.Lib.test(Lib.java:80)". If the first element is omitted and the module is an unnamed module, the second element and its following "/" are also omitted as shown in "MyClass.mash(MyClass.java:9)".

The reference implementation appears to show `app/<MODULE>/` in some cases (eg. https://github.com/eclipse/openj9/issues/11452#issuecomment-754946992), which is the System/App classloader, a built-in classloader. Although this appears to contradict the javadoc, it seems to only apply when a stack trace is printed by a class other than `Throwable` or `StackFrame`, such as `ThreadInfo`.

This PR matches the RI in displaying the classloader name if the element's classloader is the System/App classloader for classes other than `Throwable` or `StackFrame`, since it's the expected output of the stack trace for users. So, we will only omit the classloader name if the classloader is one of the Built-in classloaders and the calling class is `Throwable` or `StackFrame`. 

Additionally, the RI shows the module version for `StackTraceElement`, `Throwable`, `StackFrame` and `ThreadInfo` by default for classes loaded by the App classloader, other than system module classes. For `ThreadInfo` or `StackTraceElement`s instantiated using a public constructor, the module version is always printed, even for modules such as `java.base`. This PR also matches this behaviour.

**Note: `StackFrame` output was not fixed in the PR and will be addressed in a future PR**. Opened: https://github.com/eclipse/openj9/issues/11774