### PR TITLE
--add-exports and opens to TestFileLocking for Java 16+

### DIFF
--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2020 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -761,7 +761,7 @@
 	<test>
 		<testCaseName>TestFileLocking</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	--illegal-access=permit \
+	--add-exports java.base/openj9.internal.tools.attach.target=ALL-UNNAMED \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=no \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestFileLocking \

--- a/test/functional/Java8andUp/src/org/openj9/test/fileLock/TestFileLocking.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/fileLock/TestFileLocking.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+
+import org.openj9.test.util.VersionCheck;
 
 import org.testng.Assert;
 import org.testng.AssertJUnit;
@@ -216,6 +218,10 @@ public class TestFileLocking {
 		}
 		cmdElements.add("-classpath");
 		cmdElements.add(classpath);
+		if (VersionCheck.major() >= 16) {
+			cmdElements.add("--add-opens");
+			cmdElements.add("java.base/openj9.internal.tools.attach.target=ALL-UNNAMED");
+		}
 		cmdElements.add(LOCKER_CMD);
 		cmdElements.add(lockFileName);
 		cmdElements.add(lockType);


### PR DESCRIPTION
Due to JEP 396 Strongly Encapsulate JDK Internals by Default

Issue https://github.com/eclipse/openj9/issues/11419

Passing grinders.
jdk11: https://ci.eclipse.org/openj9/view/Test/job/Grinder/1373
jdk16: https://ci.eclipse.org/openj9/view/Test/job/Grinder/1374