### PR TITLE
Update ROMClass walk to support JITServer ROMClass serialization on JDK 11+

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/RomClassWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/RomClassWalker.java
@@ -30,7 +30,9 @@ import static com.ibm.j9ddr.vm29.structure.J9ConstantPool.J9CPTYPE_FLOAT;
 import static com.ibm.j9ddr.vm29.structure.J9ConstantPool.J9CPTYPE_HANDLE_METHOD;
 import static com.ibm.j9ddr.vm29.structure.J9ConstantPool.J9CPTYPE_INSTANCE_METHOD;
 import static com.ibm.j9ddr.vm29.structure.J9ConstantPool.J9CPTYPE_INT;
+import static com.ibm.j9ddr.vm29.structure.J9ConstantPool.J9CPTYPE_INTERFACE_INSTANCE_METHOD;
 import static com.ibm.j9ddr.vm29.structure.J9ConstantPool.J9CPTYPE_INTERFACE_METHOD;
+import static com.ibm.j9ddr.vm29.structure.J9ConstantPool.J9CPTYPE_INTERFACE_STATIC_METHOD;
 import static com.ibm.j9ddr.vm29.structure.J9ConstantPool.J9CPTYPE_LONG;
 import static com.ibm.j9ddr.vm29.structure.J9ConstantPool.J9CPTYPE_METHODHANDLE;
 import static com.ibm.j9ddr.vm29.structure.J9ConstantPool.J9CPTYPE_METHOD_TYPE;
@@ -640,7 +642,9 @@ public class RomClassWalker extends ClassWalker {
 			} else if ((shapeDesc == J9CPTYPE_HANDLE_METHOD) ||
 					(shapeDesc == J9CPTYPE_STATIC_METHOD) || 
 					(shapeDesc == J9CPTYPE_INSTANCE_METHOD) ||
-					(shapeDesc == J9CPTYPE_INTERFACE_METHOD)) {
+					(shapeDesc == J9CPTYPE_INTERFACE_METHOD) ||
+					(shapeDesc == J9CPTYPE_INTERFACE_INSTANCE_METHOD) ||
+					(shapeDesc == J9CPTYPE_INTERFACE_STATIC_METHOD)) {
 				J9ROMMethodRefPointer ref = J9ROMMethodRefPointer.cast(cpEntry);
 				classWalkerCallback.addSlot(clazz, SlotType.J9_SRPNAS, ref.nameAndSignatureEA(), "cpFieldNAS");
 				classWalkerCallback.addSlot(clazz, SlotType.J9_U32, ref.classRefCPIndexEA(), "cpFieldClassRef");

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/RomClassWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/RomClassWalker.java
@@ -660,6 +660,9 @@ public class RomClassWalker extends ClassWalker {
 
 			} else if ((shapeDesc == J9CPTYPE_UNUSED) || (shapeDesc == J9CPTYPE_UNUSED8)) {
 				classWalkerCallback.addSlot(clazz, SlotType.J9_I64, I64Pointer.cast(cpEntry), "cpFieldUnused");
+
+			} else {
+				throw new CorruptDataException("Unknown CP entry type: " + shapeDesc);
 			}
 
 			cpEntry = cpEntry.addOffset(J9ROMConstantPoolItem.SIZEOF);

--- a/runtime/ddr/vmddrstructs.properties
+++ b/runtime/ddr/vmddrstructs.properties
@@ -238,6 +238,8 @@ ddrblob.typeoverride.J9ROMNameAndSignature.signature=J9SRP(struct J9UTF8)
 
 ddrblob.typeoverride.J9ROMMethodTypeRef.signature=J9SRP(struct J9UTF8)
 
+ddrblob.typeoverride.J9ROMConstantDynamicRef.nameAndSignature=J9SRP(struct J9ROMNameAndSignature)
+
 #AVL leftChild and rightChild pointers aren't regular wide pointers. They have AVL balance data encoded in them - so treat
 #them as IDATAs and handle them in the DDR AVL code.
 ddrblob.typeoverride.J9AVLTreeNode.leftChild:IDATA

--- a/runtime/util/romclasswalk.c
+++ b/runtime/util/romclasswalk.c
@@ -27,6 +27,7 @@
 #include "cfreader.h"
 #include "romclasswalk.h"
 #include "util_internal.h"
+#include "ut_j9util.h"
 
 static void allSlotsInROMMethodsSectionDo (J9ROMClass* romClass, J9ROMClassWalkCallbacks* callbacks, void* userData);
 static void allSlotsInROMFieldsSectionDo (J9ROMClass* romClass, J9ROMClassWalkCallbacks* callbacks, void* userData);
@@ -705,7 +706,7 @@ static void allSlotsInConstantPoolDo(J9ROMClass* romClass, J9ROMClassWalkCallbac
 
 			default:
 				/* unknown cp type - bail */
-				return;
+				Assert_Util_unreachable();
 		}
 	}
 }

--- a/runtime/util/romclasswalk.c
+++ b/runtime/util/romclasswalk.c
@@ -180,6 +180,21 @@ void allSlotsInROMClassDo(J9ROMClass* romClass,
 		}
 	}
 
+#if JAVA_SPEC_VERSION >= 11
+	/* walk nest members SRPs block */
+	if (0 != romClass->nestMemberCount) {
+		srpCursor = J9ROMCLASS_NESTMEMBERS(romClass);
+		count = romClass->nestMemberCount;
+		rangeValid = callbacks->validateRangeCallback(romClass, srpCursor, count * sizeof(J9SRP), userData);
+		if (rangeValid) {
+			callbacks->sectionCallback(romClass, srpCursor, count * sizeof(J9SRP), "nestMembersSRPs", userData);
+			for (; count > 0; count--) {
+				callbacks->slotCallback(romClass, J9ROM_UTF8, srpCursor++, "nestMemberUTF8", userData);
+			}
+		}
+	}
+#endif /* JAVA_SPEC_VERSION >= 11 */
+
 	/* add CP NAS section */
 	firstMethod = J9ROMCLASS_ROMMETHODS(romClass);
 	count = (U_32)(((UDATA)firstMethod - (UDATA)srpCursor) / (sizeof(J9SRP) * 2));

--- a/runtime/util/romclasswalk.c
+++ b/runtime/util/romclasswalk.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -691,6 +691,11 @@ static void allSlotsInConstantPoolDo(J9ROMClass* romClass, J9ROMClassWalkCallbac
 			case J9CPTYPE_METHODHANDLE:
 				callbacks->slotCallback(romClass, J9ROM_U32, &((J9ROMMethodHandleRef *)&constantPool[index])->methodOrFieldRefIndex, "cpFieldMethodOrFieldRef", userData);
 				callbacks->slotCallback(romClass, J9ROM_U32, &((J9ROMMethodHandleRef *)&constantPool[index])->handleTypeAndCpType, "cpFieldHandleTypeAndCpType", userData);
+				break;
+
+			case J9CPTYPE_CONSTANT_DYNAMIC:
+				callbacks->slotCallback(romClass, J9ROM_NAS, &((J9ROMConstantDynamicRef *)&constantPool[index])->nameAndSignature, "cpFieldNAS", userData);
+				callbacks->slotCallback(romClass, J9ROM_U32, &((J9ROMConstantDynamicRef *)&constantPool[index])->bsmIndexAndCpType, "cpFieldBSMIndexAndCpType", userData);
 				break;
 
 			case J9CPTYPE_UNUSED:


### PR DESCRIPTION
This pull request fixes the following issues in the ROMClass walk implementation that prevented ROMClass serialization in JITServer (#11331) from working correctly.

- Constant dynamic CP entries were not visited.
- Nest members were not visited.
- Source debug extension was erroneously handled as a `J9UTF8` string while it is actually stored as a `J9SourceDebugExtension` structure.

The DDR ROMClass walker is also updated to reflect (most of) these changes. Note that DDR currently doesn't seem to handle any struct fields that are only present in JDK 11+ (such as `nestHost` and `nestMembers` in `J9ROMClass`), but fixing that would be out of scope of this PR.