### PR TITLE
Update lockWordAlignment asm package

### DIFF
--- a/test/functional/cmdLineTests/lockWordAlignment/alignmentSettings.mk
+++ b/test/functional/cmdLineTests/lockWordAlignment/alignmentSettings.mk
@@ -1,5 +1,5 @@
 ##############################################################################
-#  Copyright (c) 2019, 2020 IBM Corp. and others
+#  Copyright (c) 2019, 2021 IBM Corp. and others
 #
 #  This program and the accompanying materials are made available under
 #  the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,11 +20,11 @@
 #  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 ##############################################################################
 
-ADD_EXPORTS=
-ASM_JAR=$(LIB_DIR)$(D)asm-all.jar
+ADD_EXPORTS_VM=
+ADD_EXPORTS_ASM=
 # ADD_EXPORTS needs to set for JDK9 and up
 # if JDK_VERSION is not 8
 ifeq ($(filter 8, $(JDK_VERSION)),)
- ADD_EXPORTS=--add-exports=java.base/com.ibm.oti.vm=ALL-UNNAMED
- ASM_JAR=$(LIB_DIR)$(D)asm.jar
+ ADD_EXPORTS_VM=--add-exports=java.base/com.ibm.oti.vm=ALL-UNNAMED
+ ADD_EXPORTS_ASM=--add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED
 endif

--- a/test/functional/cmdLineTests/lockWordAlignment/build.xml
+++ b/test/functional/cmdLineTests/lockWordAlignment/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2020 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,7 +33,6 @@
 	<property name="PROJECT_ROOT" location="." />
 	<property name="src" location="./src"/>
 	<property name="build" location="./bin"/>
-	<property name="LIB" value="asm_all"/>
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
 
 	<target name="init">
@@ -53,9 +52,6 @@
 			<then>
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/asm-all.jar" />
-					</classpath>
 				</javac>
 			</then>
 			<else>
@@ -63,20 +59,26 @@
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}" />
 					<compilerarg line='${addExports}' />
-					<classpath>
-						<pathelement location="${LIB_DIR}/asm-all.jar" />
-					</classpath>
 				</javac>
 			</else>
 		</if>
 	</target>
 
 	<target name="generateTestClass" depends="compile" description="Generate test class files ">
+		<if>
+			<equals arg1="${JDK_VERSION}" arg2="8"/>
+			<then>
+				<property name="addExports" value="" />
+			</then>
+			<else>
+				<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED" />
+			</else>
+		</if>			
 		<property name="build.javaexecutable" value="${TEST_JDK_HOME}/bin/java"/>
 		<java classname="IntLongObjectAlignmentTestGenerator" failonerror="true" fork="true" logError="true" jvm="${build.javaexecutable}">
+			<jvmarg line='${addExports}' />
 			<classpath>
 				<pathelement path="${build}"/>
-				<pathelement location="${LIB_DIR}/asm-all.jar" />
 			</classpath>
 		</java>
 	</target>

--- a/test/functional/cmdLineTests/lockWordAlignment/playlist.xml
+++ b/test/functional/cmdLineTests/lockWordAlignment/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS)$(SQ) \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS_VM)$(SQ) \
 		-DEXEP=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)javap$(Q) -DOLWMODE=standard -DJDK_VERSION=$(JDK_VERSION) \
 		-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) \
 		-DOBJECTJARPATH= -jar $(CMDLINETESTER_JAR) -DRESDIR=$(Q)$(JVM_TEST_ROOT)$(D)cmdline_options_testresources$(Q) \
@@ -52,8 +52,8 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(ASM_JAR)$(P)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(Q)$(TEST_RESROOT)$(D)$(Q) i; \
-		$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS)$(SQ) \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS_ASM) -cp $(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(Q)$(TEST_RESROOT)$(D)$(Q) i; \
+		$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS_VM)$(SQ) \
 		-DEXEP=$(SQ)$(TEST_JDK_HOME)$(D)bin$(D)javap$(SQ) -DOLWMODE=i -DJDK_VERSION=$(JDK_VERSION) \
 		-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) \
 		-DOBJECTJARPATH=$(Q)$(TEST_RESROOT)$(D)object_i.jar$(Q) \
@@ -77,8 +77,8 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(ASM_JAR)$(P)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(Q)$(TEST_RESROOT)$(D)$(Q) ii; \
-		$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS)$(SQ) \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS_ASM) -cp $(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(Q)$(TEST_RESROOT)$(D)$(Q) ii; \
+		$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS_VM)$(SQ) \
 		-DEXEP=$(SQ)$(TEST_JDK_HOME)$(D)bin$(D)javap$(SQ) -DOLWMODE=ii -DJDK_VERSION=$(JDK_VERSION) \
 		-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) \
 		-DOBJECTJARPATH=$(Q)$(TEST_RESROOT)$(D)object_ii.jar$(Q) \
@@ -102,8 +102,8 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(ASM_JAR)$(P)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(Q)$(TEST_RESROOT)$(D)$(Q) iii; \
-		$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS)$(SQ) \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS_ASM) -cp $(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(Q)$(TEST_RESROOT)$(D)$(Q) iii; \
+		$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS_VM)$(SQ) \
 		-DEXEP=$(SQ)$(TEST_JDK_HOME)$(D)bin$(D)javap$(SQ) -DOLWMODE=iii -DJDK_VERSION=$(JDK_VERSION) \
 		-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) \
 		-DOBJECTJARPATH=$(Q)$(TEST_RESROOT)$(D)object_iii.jar$(Q) \
@@ -127,8 +127,8 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(ASM_JAR)$(P)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(Q)$(TEST_RESROOT)$(D)$(Q) d; \
-		$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS)$(SQ) \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS_ASM) -cp $(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(Q)$(TEST_RESROOT)$(D)$(Q) d; \
+		$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS_VM)$(SQ) \
 		-DEXEP=$(SQ)$(TEST_JDK_HOME)$(D)bin$(D)javap$(SQ) -DOLWMODE=d -DJDK_VERSION=$(JDK_VERSION) \
 		-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) \
 		-DOBJECTJARPATH=$(Q)$(TEST_RESROOT)$(D)object_d.jar$(Q) \

--- a/test/functional/cmdLineTests/lockWordAlignment/src/CreateTestObjectJar.java
+++ b/test/functional/cmdLineTests/lockWordAlignment/src/CreateTestObjectJar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corp. and others
+ * Copyright (c) 2015, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,16 +23,16 @@
 import java.lang.IllegalArgumentException;
 import java.io.File;
 
-import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+import static jdk.internal.org.objectweb.asm.Opcodes.ACC_PRIVATE;
 
 import java.io.FileOutputStream;
 import java.io.ByteArrayInputStream;
 import java.util.zip.ZipOutputStream;
 import java.util.zip.ZipEntry;
 
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.FieldVisitor;
-import org.objectweb.asm.ClassReader;
+import jdk.internal.org.objectweb.asm.ClassWriter;
+import jdk.internal.org.objectweb.asm.FieldVisitor;
+import jdk.internal.org.objectweb.asm.ClassReader;
 
 public class CreateTestObjectJar {
 

--- a/test/functional/cmdLineTests/lockWordAlignment/src/IntLongObjectAlignmentTestGenerator.java
+++ b/test/functional/cmdLineTests/lockWordAlignment/src/IntLongObjectAlignmentTestGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,35 +20,35 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
-import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
-import static org.objectweb.asm.Opcodes.ACC_STATIC;
-import static org.objectweb.asm.Opcodes.ACC_SUPER;
-import static org.objectweb.asm.Opcodes.ALOAD;
-import static org.objectweb.asm.Opcodes.ASTORE;
-import static org.objectweb.asm.Opcodes.GETSTATIC;
-import static org.objectweb.asm.Opcodes.IFEQ;
-import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
-import static org.objectweb.asm.Opcodes.INVOKESTATIC;
-import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
-import static org.objectweb.asm.Opcodes.LCMP;
-import static org.objectweb.asm.Opcodes.LCONST_0;
-import static org.objectweb.asm.Opcodes.LLOAD;
-import static org.objectweb.asm.Opcodes.LREM;
-import static org.objectweb.asm.Opcodes.LSTORE;
-import static org.objectweb.asm.Opcodes.RETURN;
-import static org.objectweb.asm.Opcodes.V1_7;
+import static jdk.internal.org.objectweb.asm.Opcodes.ACC_PRIVATE;
+import static jdk.internal.org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static jdk.internal.org.objectweb.asm.Opcodes.ACC_STATIC;
+import static jdk.internal.org.objectweb.asm.Opcodes.ACC_SUPER;
+import static jdk.internal.org.objectweb.asm.Opcodes.ALOAD;
+import static jdk.internal.org.objectweb.asm.Opcodes.ASTORE;
+import static jdk.internal.org.objectweb.asm.Opcodes.GETSTATIC;
+import static jdk.internal.org.objectweb.asm.Opcodes.IFEQ;
+import static jdk.internal.org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static jdk.internal.org.objectweb.asm.Opcodes.INVOKESTATIC;
+import static jdk.internal.org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static jdk.internal.org.objectweb.asm.Opcodes.LCMP;
+import static jdk.internal.org.objectweb.asm.Opcodes.LCONST_0;
+import static jdk.internal.org.objectweb.asm.Opcodes.LLOAD;
+import static jdk.internal.org.objectweb.asm.Opcodes.LREM;
+import static jdk.internal.org.objectweb.asm.Opcodes.LSTORE;
+import static jdk.internal.org.objectweb.asm.Opcodes.RETURN;
+import static jdk.internal.org.objectweb.asm.Opcodes.V1_7;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.FieldVisitor;
-import org.objectweb.asm.Label;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
+import jdk.internal.org.objectweb.asm.ClassWriter;
+import jdk.internal.org.objectweb.asm.FieldVisitor;
+import jdk.internal.org.objectweb.asm.Label;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.org.objectweb.asm.Opcodes;
+import jdk.internal.org.objectweb.asm.Type;
 
 public class IntLongObjectAlignmentTestGenerator {
 


### PR DESCRIPTION
- Use internal asm package for lockWordAlignment
- Fix build and test failure
- Related issue: https://github.com/eclipse/openj9/issues/11419
[skip ci]

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>