### PR TITLE
Call correct print function for Unresolved Call Snippet

### DIFF
--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -952,7 +952,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390UnresolvedCallSnippet * snippet)
       }
    helperLookupOffset <<= 24;
 
-   print(pOutFile, (TR::S390CallSnippet *) snippet);
+   snippet->print(pOutFile, this);
 
    printPrefix(pOutFile, NULL, bufferPos, sizeof(uintptr_t));
    trfprintf(pOutFile, "DC   \t%p \t\t# Address Of Constant Pool", getOwningMethod(methodSymRef)->constantPool());


### PR DESCRIPTION
In the change that refactors and moves J9 specific part of call snippet to OpenJ9, change in a print function for Unresolved Call Snippet was missed and it was calling old print function from OMR which was removed. This was causing an unexpected behaviour when tracing is enabled. This commit fixes that by calling the correct version of print function for S390J9CallSnippet while tracing.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>