### PR TITLE
Improve JITServer client compilation thread activation policy

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1052,8 +1052,9 @@ public:
    const std::string &getJITServerSslRootCerts() const { return _sslRootCerts; }
    void  setJITServerSslRootCerts(const std::string &cert) { _sslRootCerts = cert; }
 
-   bool serverHasLowPhysicalMemory() const { return _serverHasLowPhysicalMemory; }
-   void setServerHasLowPhysicalMemory(bool isLowMemory) { _serverHasLowPhysicalMemory = isLowMemory; }
+   void setCompThreadActivationPolicy(JITServer::CompThreadActivationPolicy newPolicy) { _activationPolicy = newPolicy; }
+   JITServer::CompThreadActivationPolicy getCompThreadActivationPolicy() const { return _activationPolicy; }
+   uint64_t getCachedFreePhysicalMemoryB() const { return _cachedFreePhysicalMemoryB; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    static void replenishInvocationCount(J9Method* method, TR::Compilation* comp);
@@ -1272,7 +1273,7 @@ private:
    std::string                   _sslRootCerts;
    PersistentVector<std::string> _sslKeys;
    PersistentVector<std::string> _sslCerts;
-   bool _serverHasLowPhysicalMemory;
+   JITServer::CompThreadActivationPolicy _activationPolicy;
 #endif /* defined(J9VM_OPT_JITSERVER) */
    }; // CompilationInfo
 }

--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -626,9 +626,16 @@ JITServerHelpers::postStreamFailure(OMRPortLibrary *portLibrary, TR::Compilation
    _nextConnectionRetryTime = current_time + _waitTimeMs;
    _serverAvailable = false;
 
-   // Reset the low memory flag in case we never reconnect to the server
+   // Reset the activation policy flag in case we never reconnect to the server
    // and client compiles locally or connects to a new server
-   compInfo->setServerHasLowPhysicalMemory(false);
+   compInfo->setCompThreadActivationPolicy(JITServer::CompThreadActivationPolicy::AGGRESSIVE);
+   if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCompilationThreads) ||
+        TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseJITServer))
+      {
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+                                     "t=%6u client has lost connection, resetting activation policy to AGGRESSIVE",
+                                     (uint32_t) compInfo->getPersistentInfo()->getElapsedTime());
+      }
    }
 
 void

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,6 +69,30 @@ enum RemoteCompilationModes
    NONE = 0,
    CLIENT,
    SERVER,
+   };
+
+enum ServerMemoryState
+   {
+   VERY_LOW = 0,
+   LOW,
+   NORMAL,
+   };
+
+enum CompThreadActivationPolicy
+   {
+   // Order is important, we use comparison operators
+   // on policy states and for indexing into the name array
+   SUSPEND = 0,
+   MAINTAIN,
+   SUBDUE,
+   AGGRESSIVE,
+   };
+
+static const char *compThreadActivationPolicyNames[] = {
+   "SUSPEND",
+   "MAINTAIN",
+   "SUBDUE",
+   "AGGRESSIVE",
    };
 }
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -109,7 +109,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 17;
+   static const uint16_t MINOR_NUMBER = 18;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -217,14 +217,15 @@ public:
    /**
       @brief Function invoked by server when compilation is aborted
    */
-   void writeError(uint32_t statusCode)
+   template <typename ...T>
+   void writeError(uint32_t statusCode, T... args)
       {
       try
          {
          if (TR::Options::getVerboseOption(TR_VerboseJITServer))
             TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d MessageType::compilationFailure: statusCode %u",
                   TR::compInfoPT->getCompThreadId(), statusCode);
-         write(MessageType::compilationFailure, statusCode);
+         write(MessageType::compilationFailure, statusCode, args...);
          }
       catch (std::exception &e)
          {

--- a/runtime/compiler/runtime/CompileService.cpp
+++ b/runtime/compiler/runtime/CompileService.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,5 +46,5 @@ void J9CompileDispatcher::compile(JITServer::ServerStream *stream)
          }
       } // end critical section
    // If we reached this point there was a memory allocation failure
-   stream->writeError(compilationLowPhysicalMemory);
+   stream->writeError(compilationLowPhysicalMemory, JITServer::ServerMemoryState::VERY_LOW);
    }


### PR DESCRIPTION
When the server is running low on memory, clients need to reduce
the number of active compilation threads so that the remaining memory
doesn't get exhausted as quickly.
Previous implementation in #11323 would suspend threads when the server
was low on memory, and resume them once more memory becomes available.
However, it suffered from constant oscillations in thread activations:
i.e. clients would be notified of low server memory, suspend threads,
more memory on the server would become available, meaning all the clients
would resume their threads, causing the server to run out of memory again,
and the cycle would repeat.

This commit improves the previous implementation by using 2 new enums
to represent client's thread activation policy and server's memory state.

`JITServer::CompThreadActivationPolicy` and `JITServer::ServerMemoryState`.

`JITServer::ServerMemoryState` has 3 states indicating how much free
memory
is left on the server. Each client receives an update at the end of each
compilation.
- `NORMAL`: there is enough memory available
- `LOW`: given the current number of clients, the server might run out of
memory soon
- `VERY_LOW`: the server is about to exhaust its memory and completely
stop all compilations.

`JITServer::CompThreadActivationPolicy` has 4 states indicating the manner in which
client's compilation threads should be suspended/resumed.
- `AGGRESSIVE`: the default policy, activates new compilation threads
more aggressively than non-JITServer JVM.
- `SUSPENDED`: (`VERY_LOW < server_memory <= LOW`) - server is running out
of memory, active threads should be suspended (down to 1), no new
threads can start. If server's memory situation improves, threads
can be resumed.
- `DISABLED`: (`server_memory <= VERY_LOW`) - server is about to exhaust
memory, suspend all but 1 compilation thread, client is prohibited
from resuming threads even if memory situation improves
- `SUBDUED`: (`server_memory > LOW`) - this policy can only be entered
after `SUSPENDED`. Client is allowed to resume threads but activation
thresholds are much higher than in `AGGRESSIVE` policy.