### PR TITLE
Capture the illegal access behavior in Class.newInstance()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/StackWalker.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackWalker.java
@@ -405,6 +405,12 @@ public final class StackWalker {
 
 			return element;
 		}
+		
+		@Override
+		public String toString() {
+			StackTraceElement stackTraceElement = toStackTraceElement();
+			return stackTraceElement.toString();
+		}
 
 		/*[IF JAVA_SPEC_VERSION >= 10]*/
 		/**


### PR DESCRIPTION
The change is to address the illegal access behavior in
Class.newInstance() when the --illegal-access option is
specified on the command line.

Fixes: #11523
Fixes: https://github.com/eclipse/openj9/issues/11522

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>