### PR TITLE
Transform OpenJDK MethodHandle methods

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -67,6 +67,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     compiler/optimizer/StringPeepholes.cpp \
     compiler/optimizer/UnsafeFastPath.cpp \
     compiler/optimizer/VarHandleTransformer.cpp \
+    compiler/optimizer/MethodHandleTransformer.cpp \
     compiler/optimizer/VPBCDConstraint.cpp \
     compiler/optimizer/TreeLowering.cpp \
     omr/compiler/codegen/Analyser.cpp \

--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1022,6 +1022,9 @@
    java_lang_invoke_MethodHandle_linkToSpecial,
    java_lang_invoke_MethodHandle_linkToVirtual,
    java_lang_invoke_MethodHandle_linkToInterface,
+   java_lang_invoke_DirectMethodHandle_internalMemberName,
+   java_lang_invoke_DirectMethodHandle_internalMemberNameEnsureInit,
+   java_lang_invoke_DirectMethodHandle_constructorMethod,
    java_lang_invoke_MethodHandles_getStackClass,
    java_lang_invoke_MethodHandle_type,
    java_lang_invoke_MethodHandle_undoCustomizationLogic,

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3114,6 +3114,18 @@ TR_J9VMBase::isMethodTracingEnabled(TR_OpaqueMethodBlock *method)
    }
 
 bool
+TR_J9VMBase::isLambdaFormGeneratedMethod(TR_OpaqueMethodBlock *method)
+   {
+   return VM_VMHelpers::isLambdaFormGeneratedMethod(vmThread(), (J9Method *)method);
+   }
+
+bool
+TR_J9VMBase::isLambdaFormGeneratedMethod(TR_ResolvedMethod *method)
+   {
+   return isLambdaFormGeneratedMethod(method->getPersistentIdentifier());
+   }
+
+bool
 TR_J9VMBase::isSelectiveMethodEnterExitEnabled()
    {
    return false;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4064,6 +4064,7 @@ TR_J9VMBase::canDereferenceAtCompileTimeWithFieldSymbol(TR::Symbol * fieldSymbol
       case TR::Symbol::Java_lang_invoke_PrimitiveHandle_rawModifiers:
       case TR::Symbol::Java_lang_invoke_PrimitiveHandle_defc:
       case TR::Symbol::Java_lang_invoke_VarHandle_handleTable:
+      case TR::Symbol::Java_lang_invoke_MethodHandleImpl_LoopClauses_clauses:
          {
          return true;
          }

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4859,6 +4859,51 @@ TR_J9VMBase::targetMethodFromMethodHandle(uintptr_t methodHandle)
    return targetMethodFromMemberName(vmentry);
    }
 
+J9JNIMethodID*
+TR_J9VMBase::jniMethodIdFromMemberName(uintptr_t memberName)
+   {
+   TR_ASSERT(haveAccess(), "jniMethodIdFromMemberName requires VM access");
+   return (J9JNIMethodID *)J9OBJECT_U64_LOAD(vmThread(), memberName, vmThread()->javaVM->vmindexOffset);
+   }
+
+J9JNIMethodID*
+TR_J9VMBase::jniMethodIdFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex)
+   {
+   auto knot = comp->getKnownObjectTable();
+   if (objIndex != TR::KnownObjectTable::UNKNOWN &&
+       knot &&
+       !knot->isNull(objIndex))
+      {
+      TR::VMAccessCriticalSection jniMethodId(this);
+      uintptr_t object = knot->getPointer(objIndex);
+      return jniMethodIdFromMemberName(object);
+      }
+   return NULL;
+   }
+
+int32_t
+TR_J9VMBase::vTableOrITableIndexFromMemberName(uintptr_t memberName)
+   {
+   TR_ASSERT(haveAccess(), "vTableOrITableIndexFromMemberName requires VM access");
+   auto methodID = jniMethodIdFromMemberName(memberName);
+   return (int32_t)methodID->vTableIndex;
+   }
+
+int32_t
+TR_J9VMBase::vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex)
+   {
+   auto knot = comp->getKnownObjectTable();
+   if (objIndex != TR::KnownObjectTable::UNKNOWN &&
+       knot &&
+       !knot->isNull(objIndex))
+      {
+      TR::VMAccessCriticalSection vTableOrITableIndex(this);
+      uintptr_t object = knot->getPointer(objIndex);
+      return vTableOrITableIndexFromMemberName(object);
+      }
+   return -1;
+    }
+
 TR::KnownObjectTable::Index
 TR_J9VMBase::getKnotIndexOfInvokeCacheArrayAppendixElement(TR::Compilation *comp, uintptr_t *invokeCacheArray)
    {
@@ -5716,6 +5761,12 @@ bool
 TR_J9VMBase::isBeingCompiled(TR_OpaqueMethodBlock * method, void * startPC)
    {
    return _compInfo->isQueuedForCompilation((J9Method *)method, startPC);
+   }
+
+U_32
+TR_J9VMBase::vTableSlotToVirtualCallOffset(U_32 vTableSlot)
+   {
+   return TR::Compiler->vm.getInterpreterVTableOffset() - vTableSlot;
    }
 
 U_32

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -714,6 +714,7 @@ public:
    virtual bool               startAsyncCompile(TR_OpaqueMethodBlock *methodInfo, void *oldStartPC, bool *queued, TR_OptimizationPlan *optimizationPlan  = NULL);
    virtual bool               isBeingCompiled(TR_OpaqueMethodBlock *methodInfo, void *startPC);
    virtual uint32_t           virtualCallOffsetToVTableSlot(uint32_t offset);
+   virtual uint32_t           vTableSlotToVirtualCallOffset(uint32_t vTableSlot);
    virtual void *             addressOfFirstClassStatic(TR_OpaqueClassBlock *);
 
    virtual TR_ResolvedMethod * getDefaultConstructor(TR_Memory *, TR_OpaqueClassBlock *);
@@ -798,7 +799,30 @@ public:
     *    VM access is not required
     */
    virtual TR_OpaqueMethodBlock* targetMethodFromMethodHandle(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
-
+   /*
+    * \brief
+    *    Return MemberName.vmindex, a J9JNIMethodID pointer containing vtable/itable offset for the MemberName method
+    *    Caller must acquire VM access
+    */
+   J9JNIMethodID* jniMethodIdFromMemberName(uintptr_t memberName);
+   /*
+    * \brief
+    *    Return MemberName.vmindex, a J9JNIMethodID pointer containing vtable/itable offset for the MemberName method
+    *    VM access is not required
+    */
+   J9JNIMethodID* jniMethodIdFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
+   /*
+    * \brief
+    *    Return vtable or itable index of a method represented by MemberName
+    *    Caller must acquire VM access
+    */
+   int32_t vTableOrITableIndexFromMemberName(uintptr_t memberName);
+   /*
+    * \brief
+    *    Return vtable or itable index of a method represented by MemberName
+    *    VM access is not required
+    */
+   int32_t vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
    /*
     * \brief
     *    Create and return a resolved method from member name index of an invoke cache array.

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1032,6 +1032,10 @@ public:
       return isMethodTracingEnabled((TR_OpaqueMethodBlock *)j9method);
       }
 
+   // Is method generated for LambdaForm
+   virtual bool isLambdaFormGeneratedMethod(TR_OpaqueMethodBlock *method);
+   virtual bool isLambdaFormGeneratedMethod(TR_ResolvedMethod *method);
+
    virtual bool isSelectiveMethodEnterExitEnabled();
 
    virtual bool canMethodEnterEventBeHooked();

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -370,7 +370,8 @@ public:
 
    virtual TR::Method * createMethod(TR_Memory *, TR_OpaqueClassBlock *, int32_t);
    virtual TR_ResolvedMethod * createResolvedMethod(TR_Memory *, TR_OpaqueMethodBlock *, TR_ResolvedMethod * = 0, TR_OpaqueClassBlock * = 0);
-   virtual TR_ResolvedMethod * createResolvedMethodWithSignature(TR_Memory *, TR_OpaqueMethodBlock *, TR_OpaqueClassBlock *, char *signature, int32_t signatureLength, TR_ResolvedMethod *);
+   virtual TR_ResolvedMethod * createResolvedMethodWithVTableSlot(TR_Memory *, uint32_t vTableSlot, TR_OpaqueMethodBlock * aMethod, TR_ResolvedMethod * owningMethod = 0, TR_OpaqueClassBlock * classForNewInstance = 0);
+   virtual TR_ResolvedMethod * createResolvedMethodWithSignature(TR_Memory *, TR_OpaqueMethodBlock *, TR_OpaqueClassBlock *, char *signature, int32_t signatureLength, TR_ResolvedMethod *, uint32_t = 0);
    virtual void * getStaticFieldAddress(TR_OpaqueClassBlock *, unsigned char *, uint32_t, unsigned char *, uint32_t);
    virtual int32_t getInterpreterVTableSlot(TR_OpaqueMethodBlock *, TR_OpaqueClassBlock *);
    virtual int32_t getVTableSlot(TR_OpaqueMethodBlock *, TR_OpaqueClassBlock *);

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -131,13 +131,13 @@ TR_J9ServerVM::createResolvedMethod(TR_Memory * trMemory, TR_OpaqueMethodBlock *
 
 TR_ResolvedMethod *
 TR_J9ServerVM::createResolvedMethodWithSignature(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_OpaqueClassBlock *classForNewInstance,
-                                                 char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod)
+                                                 char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod, uint32_t vTableSlot)
    {
    TR_ResolvedJ9Method *result = NULL;
    if (isAOT_DEPRECATED_DO_NOT_USE())
       {
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT)
-      result = new (trMemory->trHeapMemory()) TR_ResolvedRelocatableJ9JITServerMethod(aMethod, this, trMemory, owningMethod);
+      result = new (trMemory->trHeapMemory()) TR_ResolvedRelocatableJ9JITServerMethod(aMethod, this, trMemory, owningMethod, vTableSlot);
       TR::Compilation *comp = _compInfoPT->getCompilation();
       if (comp && comp->getOption(TR_UseSymbolValidationManager))
          {
@@ -149,7 +149,7 @@ TR_J9ServerVM::createResolvedMethodWithSignature(TR_Memory * trMemory, TR_Opaque
       }
    else
       {
-      result = new (trMemory->trHeapMemory()) TR_ResolvedJ9JITServerMethod(aMethod, this, trMemory, owningMethod);
+      result = new (trMemory->trHeapMemory()) TR_ResolvedJ9JITServerMethod(aMethod, this, trMemory, owningMethod, vTableSlot);
       if (classForNewInstance)
          {
          result->setClassForNewInstance((J9Class*)classForNewInstance);

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2936,3 +2936,16 @@ TR_J9SharedCacheServerVM::getResolvedInterfaceMethod(TR_OpaqueMethodBlock *inter
       }
    return ramMethod;
    }
+
+bool
+TR_J9ServerVM::isLambdaFormGeneratedMethod(TR_OpaqueMethodBlock *method)
+   {
+   return false;
+   }
+
+bool
+TR_J9ServerVM::isLambdaFormGeneratedMethod(TR_ResolvedMethod *method)
+   {
+   return false;
+   }
+

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -174,6 +174,11 @@ public:
    virtual bool needsInvokeExactJ2IThunk(TR::Node *node,  TR::Compilation *comp) override;
    virtual TR_ResolvedMethod *createMethodHandleArchetypeSpecimen(TR_Memory *trMemory, uintptr_t *methodHandleLocation, TR_ResolvedMethod *owningMethod = 0) override;
    virtual TR_ResolvedMethod *createMethodHandleArchetypeSpecimen(TR_Memory *trMemory, TR_OpaqueMethodBlock *archetype, uintptr_t *methodHandleLocation, TR_ResolvedMethod *owningMethod = 0) override;
+
+   // Is method generated for LambdaForm
+   virtual bool isLambdaFormGeneratedMethod(TR_OpaqueMethodBlock *method) override;
+   virtual bool isLambdaFormGeneratedMethod(TR_ResolvedMethod *method) override;
+
    virtual intptr_t getVFTEntry(TR_OpaqueClassBlock *clazz, int32_t offset) override;
    virtual bool isClassArray(TR_OpaqueClassBlock *klass) override;
    virtual uintptr_t getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRef, TR::SymbolReference* fieldRef) override { return 0; } // safe answer

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -63,7 +63,8 @@ public:
    virtual TR::Method * createMethod(TR_Memory *, TR_OpaqueClassBlock *, int32_t) override;
    virtual TR_ResolvedMethod * createResolvedMethod(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_ResolvedMethod * owningMethod, TR_OpaqueClassBlock *classForNewInstance) override;
    TR_ResolvedMethod * createResolvedMethod(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_ResolvedMethod * owningMethod, const TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_OpaqueClassBlock *classForNewInstance = NULL);
-   virtual TR_ResolvedMethod * createResolvedMethodWithSignature(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_OpaqueClassBlock *classForNewInstance, char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod) override;
+   virtual TR_ResolvedMethod * createResolvedMethodWithSignature(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_OpaqueClassBlock *classForNewInstance,
+                                                                 char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod, uint32_t = 0) override;
    TR_ResolvedMethod * createResolvedMethodWithSignature(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_OpaqueClassBlock *classForNewInstance, char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod, const TR_ResolvedJ9JITServerMethodInfo &methodInfo);
    virtual TR_YesNoMaybe isInstanceOf(TR_OpaqueClassBlock * a, TR_OpaqueClassBlock *b, bool objectTypeIsFixed, bool castTypeIsFixed = true, bool optimizeForAOT = false) override;
    virtual TR_OpaqueClassBlock * getSystemClassFromClassName(const char * name, int32_t length, bool isVettedForAOT = false) override;

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3960,6 +3960,14 @@ void TR_ResolvedJ9Method::construct()
       {  TR::unknownMethod}
       };
 
+   static X DirectMethodHandleMethods[] =
+      {
+      {x(TR::java_lang_invoke_DirectMethodHandle_internalMemberName,            "internalMemberName",                 "(Ljava/lang/Object;)Ljava/lang/Object;")},
+      {x(TR::java_lang_invoke_DirectMethodHandle_internalMemberNameEnsureInit,  "internalMemberNameEnsureInit",       "(Ljava/lang/Object;)Ljava/lang/Object;")},
+      {x(TR::java_lang_invoke_DirectMethodHandle_constructorMethod,             "constructorMethod",       "(Ljava/lang/Object;)Ljava/lang/Object;")},
+      {  TR::unknownMethod}
+      };
+
    static X PrimitiveHandleMethods[] =
       {
       {x(TR::java_lang_invoke_PrimitiveHandle_initializeClassIfRequired,  "initializeClassIfRequired",       "()V")},
@@ -4470,6 +4478,7 @@ void TR_ResolvedJ9Method::construct()
       {
       { "java/lang/invoke/ExplicitCastHandle", ExplicitCastHandleMethods },
       { "jdk/internal/loader/NativeLibraries", NativeLibrariesMethods },
+      { "java/lang/invoke/DirectMethodHandle", DirectMethodHandleMethods },
       { 0 }
       };
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -209,8 +209,15 @@ TR_J9VMBase::createResolvedMethod(TR_Memory * trMemory, TR_OpaqueMethodBlock * a
    }
 
 TR_ResolvedMethod *
+TR_J9VMBase::createResolvedMethodWithVTableSlot(TR_Memory * trMemory, uint32_t vTableSlot, TR_OpaqueMethodBlock * aMethod,
+                                  TR_ResolvedMethod * owningMethod, TR_OpaqueClassBlock *classForNewInstance)
+   {
+   return createResolvedMethodWithSignature(trMemory, aMethod, classForNewInstance, NULL, -1, owningMethod, vTableSlot);
+   }
+
+TR_ResolvedMethod *
 TR_J9VMBase::createResolvedMethodWithSignature(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_OpaqueClassBlock *classForNewInstance,
-                          char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod)
+                          char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod, uint32_t vTableSlot)
    {
    TR_ResolvedJ9Method *result = NULL;
    if (isAOT_DEPRECATED_DO_NOT_USE())
@@ -219,7 +226,7 @@ TR_J9VMBase::createResolvedMethodWithSignature(TR_Memory * trMemory, TR_OpaqueMe
 #if defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
       if (TR::Options::sharedClassCache())
          {
-         result = new (trMemory->trHeapMemory()) TR_ResolvedRelocatableJ9Method(aMethod, this, trMemory, owningMethod);
+         result = new (trMemory->trHeapMemory()) TR_ResolvedRelocatableJ9Method(aMethod, this, trMemory, owningMethod, vTableSlot);
          TR::Compilation *comp = TR::comp();
          if (comp && comp->getOption(TR_UseSymbolValidationManager))
             {
@@ -235,7 +242,7 @@ TR_J9VMBase::createResolvedMethodWithSignature(TR_Memory * trMemory, TR_OpaqueMe
       }
    else
       {
-      result = new (trMemory->trHeapMemory()) TR_ResolvedJ9Method(aMethod, this, trMemory, owningMethod);
+      result = new (trMemory->trHeapMemory()) TR_ResolvedJ9Method(aMethod, this, trMemory, owningMethod, vTableSlot);
       if (classForNewInstance)
          {
          result->setClassForNewInstance((J9Class*)classForNewInstance);

--- a/runtime/compiler/il/J9Symbol.cpp
+++ b/runtime/compiler/il/J9Symbol.cpp
@@ -151,6 +151,7 @@
        {r(TR::Symbol::Java_math_BigInteger_useLongRepresentation,     "java/math/BigInteger", "useLongRepresentation", "Z")},
        {r(TR::Symbol::Java_lang_ref_SoftReference_age,                "java/lang/ref/SoftReference", "age", "I")},
        {r(TR::Symbol::Java_lang_invoke_VarHandle_handleTable,         "java/lang/invoke/VarHandle", "handleTable", "[Ljava/lang/invoke/MethodHandle;")},
+       {r(TR::Symbol::Java_lang_invoke_MethodHandleImpl_LoopClauses_clauses,         "java/lang/invoke/MethodHandleImpl$LoopClauses", "clauses", "[[Ljava/lang/invoke/MethodHandle;")},
        {r(TR::Symbol::Java_lang_Integer_value,                        "java/lang/Integer", "value", "I")},
        {r(TR::Symbol::Java_lang_Long_value,                           "java/lang/Long", "value", "J")},
        {r(TR::Symbol::Java_lang_Float_value,                          "java/lang/Float", "value", "F")},

--- a/runtime/compiler/il/J9Symbol.hpp
+++ b/runtime/compiler/il/J9Symbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -160,6 +160,7 @@ public:
       Java_math_BigInteger_ZERO,
       Java_math_BigInteger_useLongRepresentation,
       Java_lang_invoke_VarHandle_handleTable,
+      Java_lang_invoke_MethodHandleImpl_LoopClauses_clauses,
       Java_lang_Integer_value,
       Java_lang_Long_value,
       Java_lang_Float_value,

--- a/runtime/compiler/optimizer/CMakeLists.txt
+++ b/runtime/compiler/optimizer/CMakeLists.txt
@@ -73,6 +73,7 @@ j9jit_files(
 	optimizer/StringPeepholes.cpp
 	optimizer/UnsafeFastPath.cpp
 	optimizer/VarHandleTransformer.cpp
+	optimizer/MethodHandleTransformer.cpp
 	optimizer/VPBCDConstraint.cpp
 	optimizer/TreeLowering.cpp
 )

--- a/runtime/compiler/optimizer/J9OptimizationManager.cpp
+++ b/runtime/compiler/optimizer/J9OptimizationManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -89,6 +89,9 @@ J9::OptimizationManager::OptimizationManager(TR::Optimizer *o, OptimizationFacto
          _flags.set(doesNotRequireAliasSets | supportsIlGenOptLevel);
          break;
       case OMR::varHandleTransformer:
+         _flags.set(doesNotRequireAliasSets | supportsIlGenOptLevel);
+         break;
+      case OMR::methodHandleTransformer:
          _flags.set(doesNotRequireAliasSets | supportsIlGenOptLevel);
          break;
       case OMR::unsafeFastPath:

--- a/runtime/compiler/optimizer/J9Optimizer.cpp
+++ b/runtime/compiler/optimizer/J9Optimizer.cpp
@@ -81,6 +81,7 @@
 #include "optimizer/VarHandleTransformer.hpp"
 #include "optimizer/StaticFinalFieldFolding.hpp"
 #include "optimizer/HandleRecompilationOps.hpp"
+#include "optimizer/MethodHandleTransformer.hpp"
 
 
 static const OptimizationStrategy J9EarlyGlobalOpts[] =
@@ -807,6 +808,8 @@ J9::Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *method
       new (comp->allocator()) TR::OptimizationManager(self(), TR::TreeLowering::create, OMR::treeLowering);
    _opts[OMR::varHandleTransformer] =
       new (comp->allocator()) TR::OptimizationManager(self(), TR_VarHandleTransformer::create, OMR::varHandleTransformer);
+   _opts[OMR::methodHandleTransformer] =
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_MethodHandleTransformer::create, OMR::methodHandleTransformer);
    _opts[OMR::unsafeFastPath] =
       new (comp->allocator()) TR::OptimizationManager(self(), TR_UnsafeFastPath::create, OMR::unsafeFastPath);
    _opts[OMR::idiomRecognition] =

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -198,6 +198,7 @@ static bool isArrayWithConstantElements(TR::SymbolReference *symRef, TR::Compila
          case TR::Symbol::Java_lang_invoke_BruteArgumentMoverHandle_extra:
          case TR::Symbol::Java_lang_invoke_MethodType_ptypes:
          case TR::Symbol::Java_lang_invoke_VarHandle_handleTable:
+         case TR::Symbol::Java_lang_invoke_MethodHandleImpl_LoopClauses_clauses:
          case TR::Symbol::Java_lang_String_value:
             return true;
          default:

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -203,6 +203,18 @@ public:
     *   \return True if specialization succeeds, false otherwise
     */
    static bool specializeInvokeExactSymbol(TR::Compilation *comp, TR::Node *callNode, uintptr_t *methodHandleLocation);
+
+   /*
+    * \brief
+    *    Refine `MethodHandle.invokeBasic` with a known receiver handle
+    */
+   static bool refineMethodHandleInvokeBasic(TR::Compilation* comp, TR::TreeTop* treetop, TR::Node* node, TR::KnownObjectTable::Index mhIndex, bool trace = false);
+   /*
+    * \brief
+    *    Refine `MethodHandle.linkTo*` with a known MemberName argument (the last argument)
+    *    Doesn't support `MethodHandle.linkToInterface` right now
+    */
+   static bool refineMethodHandleLinkTo(TR::Compilation* comp, TR::TreeTop* treetop, TR::Node* node, TR::KnownObjectTable::Index mnIndex, bool trace = false);
 protected:
    /**
     * \brief

--- a/runtime/compiler/optimizer/MethodHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/MethodHandleTransformer.cpp
@@ -1,0 +1,599 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "optimizer/MethodHandleTransformer.hpp"
+#include <stddef.h>
+#include <stdint.h>
+#include "codegen/CodeGenerator.hpp"
+#include "env/VMAccessCriticalSection.hpp"
+#include "env/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/ResolvedMethod.hpp"
+#include "compile/SymbolReferenceTable.hpp"
+#include "control/Options.hpp"
+#include "control/Options_inlines.hpp"
+#include "env/CompilerEnv.hpp"
+#include "env/IO.hpp"
+#include "env/VMJ9.h"
+#include "env/j9method.h"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/MethodSymbol.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/ResolvedMethodSymbol.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Checklist.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/Optimization_inlines.hpp"
+#include "optimizer/TransformUtil.hpp"
+#include "optimizer/PreExistence.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/ILWalk.hpp"
+#include "il/AutomaticSymbol.hpp"
+
+static void printObjectInfo(TR_MethodHandleTransformer::ObjectInfo *objectInfo, TR::Compilation *comp)
+   {
+   int localIndex = 0;
+   for (auto it = objectInfo->begin(); it != objectInfo->end(); it++)
+      {
+      if (*it != TR::KnownObjectTable::UNKNOWN)
+         {
+         traceMsg(comp, "(local #%2d: obj%d)  ", localIndex, *it);
+         }
+      localIndex++;
+      }
+   if (localIndex > 0)
+      traceMsg(comp, "\n");
+   }
+
+static bool isKnownObject(TR::KnownObjectTable::Index objectInfo)
+   {
+   if (objectInfo != TR::KnownObjectTable::UNKNOWN)
+      return true;
+   return false;
+   }
+
+int32_t TR_MethodHandleTransformer::perform()
+   {
+   // Only do the opt for MethodHandle methods
+   TR_ResolvedMethod* currentMethod = comp()->getCurrentMethod();
+   if (!comp()->fej9()->isLambdaFormGeneratedMethod(currentMethod))
+      return 0;
+
+   TR::StackMemoryRegion stackMemoryRegion(*trMemory());
+
+   if (trace())
+      traceMsg(comp(), "Start transforming LambdaForm generated method %s\n", currentMethod->signature(trMemory()));
+
+   // Assign local index to parms, autos and temps (including pending push temps)
+   assignLocalIndices();
+   if (_numLocals == 0)
+       return 0;
+
+   // For each block, compute an ObjectInfo array for all address typed parms or autos
+   _blockEndObjectInfos = new (comp()->trMemory()->currentStackRegion()) BlockResultMap(std::less<int32_t>(), comp()->trMemory()->currentStackRegion());
+
+   /*
+    * Do a reverse post-order traversal of the CFG as the best effort to figure out object info in one traverse.
+    * If there exist one or more unvisited predecessors, don't propagate object info from any predecessor
+    */
+
+   TR::ReversePostorderSnapshotBlockIterator blockIt(comp()->getFlowGraph(), comp());
+
+   // Set up object info for the first block
+   //
+   //Initialize type info for parms from prex arg for the entry block
+   TR::Block *firstBlock = blockIt.currentBlock();
+   ObjectInfo* firstBlockObjectInfo = getMethodEntryObjectInfo();
+   if (trace())
+      {
+      traceMsg(comp(), "Entry Block (block_%d) object Info:\n", firstBlock->getNumber());
+      printObjectInfo(firstBlockObjectInfo, comp());
+      }
+
+   processBlockAndUpdateObjectInfo(firstBlock, firstBlockObjectInfo);
+   (*_blockEndObjectInfos)[firstBlock->getNumber()] = firstBlockObjectInfo;
+   ++blockIt;
+
+   // Process the remaining blocks
+   //
+   while (blockIt.currentBlock())
+      {
+      TR::Block *block = blockIt.currentBlock();
+      int32_t blockNum = block->getNumber();
+      ObjectInfo* blockObjectInfo = blockStartObjectInfoFromPredecessors(block);
+      // Walk the trees in the block, update object info and optimize trees based on object info
+      processBlockAndUpdateObjectInfo(block, blockObjectInfo);
+      (*_blockEndObjectInfos)[blockNum] = blockObjectInfo;
+
+      ++blockIt;
+      }
+   return 0;
+   }
+
+// Walk treeteops, find stores to auto or temp
+void TR_MethodHandleTransformer::collectAutosFromTrees(List<TR::SymbolReference>& autoSymRefs)
+   {
+   TR_BitVector symRefBV(comp()->getSymRefTab()->getNumSymRefs(), comp()->trMemory()->currentStackRegion());
+
+   for (auto treetop = comp()->getMethodSymbol()->getFirstTreeTop(); treetop != NULL; treetop = treetop->getNextTreeTop())
+      {
+      auto ttNode = treetop->getNode();
+      auto storeNode = ttNode->getStoreNode();
+      if (storeNode &&
+          storeNode->getOpCode().isStoreDirect() &&
+          storeNode->getSymbol()->isAuto())
+         {
+         auto symRef = storeNode->getSymbolReference();
+         auto symRefNum = symRef->getReferenceNumber();
+         if (!symRefBV.isSet(symRefNum))
+            {
+            symRefBV.set(symRefNum);
+            }
+         }
+      }
+
+   // Add sym refs to list
+   TR_BitVectorIterator bvi(symRefBV);
+   while (bvi.hasMoreElements())
+      {
+      auto symRefNum = bvi.getNextElement();
+      auto symRef = comp()->getSymRefTab()->getSymRef(symRefNum);
+      autoSymRefs.add(symRef);
+      }
+   }
+
+void TR_MethodHandleTransformer::assignLocalIndices()
+   {
+   // Assign local index to parms
+   ListIterator<TR::ParameterSymbol> parms(&comp()->getMethodSymbol()->getParameterList());
+   for (TR::ParameterSymbol * p = parms.getFirst(); p; p = parms.getNext())
+      {
+      if (p->getDataType() == TR::Address)
+         {
+         if (trace())
+            traceMsg(comp(), "Local #%2d is symbol %p <parm %d>\n", _numLocals, p, p->getSlot());
+         p->setLocalIndex(_numLocals++);
+         }
+      }
+
+   // getAutoSymRefs from method symbol is missing some temp sym refs created during block splitting.
+   // Adding those sym refs to the list is causing test failures, as a workaround, walk the trees to
+   // find all autos (auto, temps and pending push temps) in the method
+   //
+   List<TR::SymbolReference> autoSymRefs(comp()->trMemory()->currentStackRegion());
+   collectAutosFromTrees(autoSymRefs);
+
+   ListIterator<TR::SymbolReference> autosIt(&autoSymRefs);
+   for (TR::SymbolReference* symRef = autosIt.getFirst(); symRef; symRef = autosIt.getNext())
+      {
+      TR::AutomaticSymbol *p = symRef->getSymbol()->getAutoSymbol();
+      if (p && p->getDataType() == TR::Address)
+         {
+         if (trace())
+            traceMsg(comp(), "Local #%2d is symbol %p [#%d]\n", _numLocals, p, symRef->getReferenceNumber());
+         p->setLocalIndex(_numLocals++);
+         }
+      }
+   }
+
+TR_MethodHandleTransformer::ObjectInfo*
+TR_MethodHandleTransformer::getMethodEntryObjectInfo()
+   {
+   TR_PrexArgInfo *argInfo = comp()->getCurrentInlinedCallArgInfo();
+   ObjectInfo* objectInfo = new (comp()->trMemory()->currentStackRegion()) ObjectInfo(_numLocals, static_cast<int>(TR::KnownObjectTable::UNKNOWN), comp()->trMemory()->currentStackRegion());
+   if (argInfo)
+      {
+      TR_ResolvedMethod* currentMethod = comp()->getCurrentMethod();
+      int32_t numArgs = currentMethod->numberOfParameters();
+
+      TR_ASSERT(argInfo->getNumArgs() == numArgs, "Number of prex arginfo %d doesn't match method parm number %d", argInfo->getNumArgs(), numArgs);
+
+      ListIterator<TR::ParameterSymbol> parms(&comp()->getMethodSymbol()->getParameterList());
+      for (TR::ParameterSymbol *p = parms.getFirst(); p != NULL; p = parms.getNext())
+         {
+         int32_t ordinal = p->getOrdinal();
+         TR_PrexArgument *arg = argInfo->get(ordinal);
+         if (arg && arg->getKnownObjectIndex() != TR::KnownObjectTable::UNKNOWN)
+            {
+            (*objectInfo)[p->getLocalIndex()] = arg->getKnownObjectIndex();
+            if (trace())
+               traceMsg(comp(), "Local #%2d is parm %d is obj%d\n", p->getLocalIndex(), ordinal, arg->getKnownObjectIndex());
+            }
+         }
+      }
+
+   return objectInfo;
+   }
+
+TR_MethodHandleTransformer::ObjectInfo*
+TR_MethodHandleTransformer::blockStartObjectInfoFromPredecessors(TR::Block* block)
+   {
+   auto blockNum = block->getNumber();
+   // If there exists one or more predecessor unvisited, the unvisited predecessor must be from a back edge.
+   // Don't propagate as we don't know what might happen from the predecessor.
+   //
+   TR_PredecessorIterator pi(block);
+   for (TR::CFGEdge *edge = pi.getFirst(); edge != NULL; edge = pi.getNext())
+      {
+      TR::Block *fromBlock = toBlock(edge->getFrom());
+      int32_t fromBlockNum = fromBlock->getNumber();
+      if (_blockEndObjectInfos->find(fromBlockNum) == _blockEndObjectInfos->end())
+         {
+         if (trace())
+            traceMsg(comp(), "Predecessor block_%d hasn't been visited yet, no object info is propagated for block_%d\n", fromBlockNum, blockNum);
+
+         return new (comp()->trMemory()->currentStackRegion()) ObjectInfo(_numLocals, static_cast<int>(TR::KnownObjectTable::UNKNOWN), comp()->trMemory()->currentStackRegion());
+         }
+      }
+
+   // Get block start object info by merging object info from predecessors
+   ObjectInfo* objectInfo = NULL;
+   for (TR::CFGEdge *edge = pi.getFirst(); edge != NULL; edge = pi.getNext())
+      {
+      TR::Block *fromBlock = toBlock(edge->getFrom());
+      int32_t fromBlockNum = fromBlock->getNumber();
+      ObjectInfo* fromBlockObjectInfo = (*_blockEndObjectInfos)[fromBlockNum];
+      if (!objectInfo)
+         objectInfo = new (comp()->trMemory()->currentStackRegion()) ObjectInfo(*fromBlockObjectInfo);
+      else
+         mergeObjectInfo(objectInfo, fromBlockObjectInfo);
+      }
+
+   if (trace())
+      {
+      traceMsg(comp(), "Block start object info for block_%d is\n", blockNum);
+      printObjectInfo(objectInfo, comp());
+      }
+
+   return objectInfo;
+   }
+
+// Merge second ObjectInfo into the first one
+// The merge does an intersect, only entries with the same value will be kept
+//
+void TR_MethodHandleTransformer::mergeObjectInfo(ObjectInfo *first, ObjectInfo *second)
+   {
+   if (trace())
+      {
+      traceMsg(comp(), "Object info before merging:\n");
+      printObjectInfo(first, comp());
+      }
+
+   bool changed = false;
+   for (int i = 0; i < _numLocals; i++)
+      {
+      TR::KnownObjectTable::Index firstObj = (*first)[i];
+      TR::KnownObjectTable::Index secondObj = (*second)[i];
+
+      if (firstObj != secondObj)
+         {
+         (*first)[i] = TR::KnownObjectTable::UNKNOWN;
+         }
+
+      if (firstObj != (*first)[i])
+         changed = true;
+      }
+
+   if (trace())
+      {
+      if (changed)
+         {
+         traceMsg(comp(), "Object info after merging:\n");
+         printObjectInfo(first, comp());
+         }
+      else
+         traceMsg(comp(), "Object info is not changed after merging\n");
+      }
+   }
+
+// Given a address type node, try to retrieve or compute its value
+//
+TR::KnownObjectTable::Index
+TR_MethodHandleTransformer::getObjectInfoOfNode(TR::Node* node)
+   {
+   TR_ASSERT(node->getType() == TR::Address, "Can't have object info on non-address type node n%dn %p", node->getGlobalIndex(), node);
+
+   if (trace())
+      {
+      traceMsg(comp(), "Looking for object info of n%dn\n", node->getGlobalIndex());
+      }
+
+   if (!node->getOpCode().hasSymbolReference())
+      return TR::KnownObjectTable::UNKNOWN;
+
+   auto symRef = node->getSymbolReference();
+   auto symbol = symRef->getSymbol();
+
+   if (symRef->isUnresolved())
+      return TR::KnownObjectTable::UNKNOWN;
+
+   if (symRef->hasKnownObjectIndex())
+      return symRef->getKnownObjectIndex();
+
+   if (node->getOpCode().isLoadDirect() &&
+       symbol->isAutoOrParm())
+      {
+      if (trace())
+         traceMsg(comp(), "getObjectInfoOfNode n%dn is load from auto or parm, local #%d\n", node->getGlobalIndex(), symbol->getLocalIndex());
+      return (*_currentObjectInfo)[symbol->getLocalIndex()];
+      }
+
+   auto knot = comp()->getKnownObjectTable();
+   if (knot &&
+       node->getOpCode().isCall() &&
+       !symbol->castToMethodSymbol()->isHelper())
+      {
+      auto rm = symbol->castToMethodSymbol()->getMandatoryRecognizedMethod();
+      switch (rm)
+        {
+        case TR::java_lang_invoke_DirectMethodHandle_internalMemberName:
+        case TR::java_lang_invoke_DirectMethodHandle_internalMemberNameEnsureInit:
+           {
+           auto mhIndex = getObjectInfoOfNode(node->getFirstArgument());
+           if (knot && isKnownObject(mhIndex) && !knot->isNull(mhIndex))
+              {
+              TR::VMAccessCriticalSection dereferenceKnownObjectField(comp()->fej9());
+              uintptr_t mhObject = knot->getPointer(mhIndex);
+              uintptr_t mnObject = comp()->fej9()->getReferenceField(mhObject, "member", "Ljava/lang/invoke/MemberName;");
+              auto mnIndex = knot->getOrCreateIndex(mnObject);
+              if (trace())
+                 traceMsg(comp(), "Get DirectMethodHandle.member known object %d\n", mnIndex);
+              return mnIndex;
+              }
+           }
+        case TR::java_lang_invoke_DirectMethodHandle_constructorMethod:
+           {
+           auto mhIndex = getObjectInfoOfNode(node->getFirstArgument());
+           if (knot && isKnownObject(mhIndex) && !knot->isNull(mhIndex))
+              {
+              TR::VMAccessCriticalSection dereferenceKnownObjectField(comp()->fej9());
+              uintptr_t mhObject = knot->getPointer(mhIndex);
+              uintptr_t mnObject = comp()->fej9()->getReferenceField(mhObject, "initMethod", "Ljava/lang/invoke/MemberName;");
+              auto mnIndex = knot->getOrCreateIndex(mnObject);
+              if (trace())
+                 traceMsg(comp(), "Get DirectMethodHandle.initMethod known object %d\n", mnIndex);
+              return mnIndex;
+              }
+           }
+        }
+      }
+
+   return TR::KnownObjectTable::UNKNOWN;
+   }
+
+// Store to local variable will change object info
+// Update _currentObjectInfo
+void
+TR_MethodHandleTransformer::visitStoreToLocalVariable(TR::TreeTop* tt, TR::Node* node)
+   {
+   TR::Node *rhs = node->getFirstChild();
+   TR::Symbol *local = node->getSymbolReference()->getSymbol();
+   if (rhs->getDataType().isAddress())
+      {
+      // Get object info of the rhs
+      TR::KnownObjectTable::Index newObject = getObjectInfoOfNode(rhs);
+      if (trace())
+         traceMsg(comp(), "rhs of store n%dn is obj%d\n", node->getGlobalIndex(), newObject);
+
+      TR::KnownObjectTable::Index oldObject = (*_currentObjectInfo)[local->getLocalIndex()];
+      if (newObject != oldObject && trace())
+         {
+         traceMsg(comp(), "Local #%2d obj%d -> obj%d at node n%dn\n", local->getLocalIndex(), oldObject, newObject,  node->getGlobalIndex());
+         }
+
+      (*_currentObjectInfo)[local->getLocalIndex()] = newObject;
+      }
+   }
+
+// Visit indirect load, discover known object by folding the load if applicable
+void TR_MethodHandleTransformer::visitIndirectLoad(TR::TreeTop* tt, TR::Node* node)
+   {
+   auto symRef = node->getSymbolReference();
+   if (symRef->hasKnownObjectIndex())
+      {
+      if (trace())
+         traceMsg(comp(), "Indirect load n%dn is obj%d\n", node->getGlobalIndex(), symRef->getKnownObjectIndex());
+      return;
+      }
+
+   auto symbol = node->getSymbol();
+   if (!symRef->isUnresolved() && symbol &&
+       (symbol->isFinal() || symbol->isArrayShadowSymbol()))
+      {
+      auto baseNode = symbol->isArrayShadowSymbol() ? node->getFirstChild()->getFirstChild() : node->getFirstChild();
+      auto baseSymRef = baseNode->getSymbolReference();
+      TR::KnownObjectTable::Index baseObj = getObjectInfoOfNode(baseNode);
+      if (trace())
+         traceMsg(comp(), "base object for indirect load n%dn is obj%d\n", node->getGlobalIndex(), baseObj);
+
+      auto knot = comp()->getKnownObjectTable();
+      if (knot && isKnownObject(baseObj) && !knot->isNull(baseObj))
+         {
+         // Since address node is not null, remove nullchk
+         // This step is needed before transforming indirect load, as the indirect load can be
+         // transformed into a const node, the base node will be removed
+         //
+         if (tt->getNode()->getOpCode().isNullCheck())
+            {
+            if (!performTransformation(comp(), "%sChange NULLCHK node n%dn to treetop\n", optDetailString(), tt->getNode()->getGlobalIndex()))
+               return;
+            TR::Node::recreate(tt->getNode(), TR::treetop);
+            }
+
+         // Have to improve the regular array-shadow to immutable-array-shadow in order to fold it
+         if (symbol->isArrayShadowSymbol() && knot->isArrayWithConstantElements(baseObj))
+            {
+            TR::SymbolReference* improvedSymRef = comp()->getSymRefTab()->findOrCreateImmutableArrayShadowSymbolRef(symbol->getDataType());
+            node->setSymbolReference(improvedSymRef);
+            if (trace())
+               traceMsg(comp(), "Improve regular array-shadow to immutable-array-shadow for n%dn\n", node->getGlobalIndex());
+            }
+
+         TR::Node* removedNode = NULL;
+         bool succeed = TR::TransformUtil::transformIndirectLoadChain(comp(), node, baseNode, baseObj, &removedNode);
+         if (!succeed && trace())
+            traceMsg(comp(), "Failed to fold indirect load n%dn from base object obj%d\n", node->getGlobalIndex(), baseObj);
+         else if (removedNode)
+            {
+            removedNode->recursivelyDecReferenceCount();
+            }
+         }
+      }
+   }
+
+// Visit a call node, compute its result or transform the call node with current object info
+//
+void TR_MethodHandleTransformer::visitCall(TR::TreeTop* tt, TR::Node* node)
+   {
+   auto knot = comp()->getKnownObjectTable();
+   TR::RecognizedMethod rm = node->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod();
+   switch (rm)
+      {
+      case TR::java_lang_invoke_MethodHandle_invokeBasic:
+         process_java_lang_invoke_MethodHandle_invokeBasic(tt, node);
+         break;
+      case TR::java_lang_invoke_MethodHandle_linkToSpecial:
+      case TR::java_lang_invoke_MethodHandle_linkToVirtual:
+      case TR::java_lang_invoke_MethodHandle_linkToStatic:
+         process_java_lang_invoke_MethodHandle_linkTo(tt, node);
+         break;
+      }
+   }
+
+// Visit a node may change the object info
+//
+void
+TR_MethodHandleTransformer::visitNode(TR::TreeTop* tt, TR::Node* node, TR::NodeChecklist &visitedNodes)
+   {
+   if (visitedNodes.contains(node))
+      return;
+
+   visitedNodes.add(node);
+
+   if (trace() && node == tt->getNode())
+      traceMsg(comp(), "Looking at treetop node n%dn\n", node->getGlobalIndex());
+
+   for (int32_t i = 0; i < node->getNumChildren(); i++)
+       visitNode(tt, node->getChild(i), visitedNodes);
+
+   if (node->getOpCode().isStoreDirect() && node->getSymbolReference()->getSymbol()->isAutoOrParm() && node->getType() == TR::Address)
+      {
+      visitStoreToLocalVariable(tt, node);
+      }
+   else if (node->getOpCode().isLoadIndirect() && node->getType() == TR::Address)
+      {
+      visitIndirectLoad(tt, node);
+      }
+   else if (node->getOpCode().isCall())
+      {
+      visitCall(tt, node);
+      }
+   }
+
+void
+TR_MethodHandleTransformer::processBlockAndUpdateObjectInfo(TR::Block *block, TR_MethodHandleTransformer::ObjectInfo *blockStartObjectInfo)
+   {
+   _currentObjectInfo = blockStartObjectInfo;
+   TR::NodeChecklist visitedNodes(comp());
+
+   if (trace())
+      {
+      traceMsg(comp(), "Start processing block_%d\n", block->getNumber());
+      printObjectInfo(_currentObjectInfo, comp());
+      }
+
+   // Find stores to auto, and calculate value of the auto after the store
+   // If the value is a load of final field, try fold the final field
+   // If the value is result of a call, try compute the call result
+   //
+   for (TR::TreeTop *tt = block->getEntry(); tt != block->getExit(); tt = tt->getNextTreeTop())
+      {
+      TR::Node *node = tt->getNode();
+      visitNode(tt, node, visitedNodes);
+      }
+
+   if (trace())
+      {
+      traceMsg(comp(), "End processing block_%d\n", block->getNumber());
+      printObjectInfo(_currentObjectInfo, comp());
+      }
+   }
+
+const char *
+TR_MethodHandleTransformer::optDetailString() const throw()
+   {
+   return "O^O METHODHANDLE TRANSFORMER: ";
+   }
+
+void
+TR_MethodHandleTransformer::process_java_lang_invoke_MethodHandle_invokeBasic(TR::TreeTop* tt, TR::Node* node)
+   {
+   auto mhNode = node->getFirstArgument();
+   TR::KnownObjectTable::Index objIndex = getObjectInfoOfNode(mhNode);
+   if (trace())
+      traceMsg(comp(), "MethodHandle is obj%d\n", objIndex);
+
+   auto knot = comp()->getKnownObjectTable();
+   bool transformed = false;
+   if (isKnownObject(objIndex) && knot && !knot->isNull(objIndex))
+      transformed = TR::TransformUtil::refineMethodHandleInvokeBasic(comp(), tt, node, objIndex, trace());
+
+   if (!transformed)
+      {
+      TR::DebugCounter::prependDebugCounter(comp(),
+                                            TR::DebugCounter::debugCounterName(comp(),
+                                                                               "MHUnknownObj/invokeBasic/(%s %s)",
+                                                                               comp()->signature(),
+                                                                               comp()->getHotnessName(comp()->getMethodHotness())),
+                                                                               tt);
+      }
+   }
+
+void
+TR_MethodHandleTransformer::process_java_lang_invoke_MethodHandle_linkTo(TR::TreeTop* tt, TR::Node* node)
+   {
+   auto mnNode = node->getLastChild();
+   TR::KnownObjectTable::Index objIndex = getObjectInfoOfNode(mnNode);
+   if (trace())
+      traceMsg(comp(), "MemberName is obj%d\n", objIndex);
+
+   auto knot = comp()->getKnownObjectTable();
+   bool transformed = false;
+   if (knot && isKnownObject(objIndex) && !knot->isNull(objIndex))
+      transformed = TR::TransformUtil::refineMethodHandleLinkTo(comp(), tt, node, objIndex, trace());
+
+   if (!transformed)
+      {
+      TR::DebugCounter::prependDebugCounter(comp(),
+                                            TR::DebugCounter::debugCounterName(comp(),
+                                                                               "MHUnknownObj/linkTo/(%s %s)",
+                                                                               comp()->signature(),
+                                                                               comp()->getHotnessName(comp()->getMethodHotness())),
+                                                                               tt);
+      }
+   }

--- a/runtime/compiler/optimizer/MethodHandleTransformer.hpp
+++ b/runtime/compiler/optimizer/MethodHandleTransformer.hpp
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef METHODHANDLETRANSFORMER_INCL
+#define METHODHANDLETRANSFORMER_INCL
+
+#include <set>
+#include <vector>
+#include "il/ParameterSymbol.hpp"
+#include "compile/Compilation.hpp"
+#include "infra/List.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
+#include "env/KnownObjectTable.hpp"
+
+/*
+ * This transformer is used to transform OpenJDK MethodHandle related methods,
+ * to make sure those methods are optimized for performance.
+ *
+ * Most of the transformation require knowledge of object-type node. Sources of
+ * object info include the following:
+ *  1. Prex arg info if under inlining
+ *  2. Nodes with known object index
+ *  3. Nodes whose value can be compile-time inferred and is a known object
+ *
+ * We'd like the object info be avaliable at places where we want to do transformation,
+ * however, the objects will be stored into autos and autos will be used instead of
+ * nodes with known object index. Thus we need to track the object info while walking
+ * the trees.
+ *
+ * Data flow analysis is expensive and we can't afford it especially in ilgen. Most of
+ * the methods we want to optimize should have only one store to an auto, i.e. most of
+ * the autos are not shared. So we can track the object info in autos with a reverse
+ * post-order traversal of CFG. Update object info while walking trees of a block, and
+ * propagate it to the block's successor. When visiting a block, if there exist a
+ * predecessor unvisited, simply clear the object info inherited from the successors.
+ *
+ * This opt will also try to discover as many known objects as possible.
+ */
+
+class TR_MethodHandleTransformer : public TR::Optimization
+   {
+   public:
+   TR_MethodHandleTransformer(TR::OptimizationManager *manager)
+      : TR::Optimization(manager),
+      _numLocals(0),
+      _currentObjectInfo(NULL),
+      _blockEndObjectInfos(NULL)
+      {}
+
+   static TR::Optimization *create(TR::OptimizationManager *manager)
+      {
+      return new (manager->allocator()) TR_MethodHandleTransformer(manager);
+      }
+
+   virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
+
+   typedef TR::typed_allocator<TR::KnownObjectTable::Index, TR::Region &> ObjectInfoAllocator;
+   typedef std::vector<TR::KnownObjectTable::Index, ObjectInfoAllocator> ObjectInfo;
+
+   // Walk through trees and nodes in block, update local object info
+   // Also discover new known objects through field folding
+   //
+   void processBlockAndUpdateObjectInfo(TR::Block *block, ObjectInfo *objectInfo);
+
+   // Merge ObjectInfo from second into first
+   //
+   void mergeObjectInfo(ObjectInfo *first, ObjectInfo *second);
+
+   // Obect info at method entry or first block of the method
+   // The object info comes from prex arg info
+   //
+   ObjectInfo* getMethodEntryObjectInfo();
+
+   // Object info of a block can be derived from its predecessors
+   //
+   ObjectInfo* blockStartObjectInfoFromPredecessors(TR::Block* block);
+
+   // Assign local index to autos
+   //
+   void assignLocalIndices();
+   // Walk trees and collect autos into a list
+   //
+   void collectAutosFromTrees(List<TR::SymbolReference> &autosList);
+
+   // Given an address-typed node, try to figure out it's object info
+   //
+   TR::KnownObjectTable::Index getObjectInfoOfNode(TR::Node* node);
+
+   // The folowing visit functions will visit different types of node, update object info,
+   // and/or do transformations
+   //
+   void visitIndirectLoad(TR::TreeTop* tt, TR::Node* node);
+   void visitStoreToLocalVariable(TR::TreeTop* tt, TR::Node* node);
+   void visitCall(TR::TreeTop* tt, TR::Node* node);
+   void visitNode(TR::TreeTop* tt, TR::Node* node, TR::NodeChecklist &visitedNodes);
+
+   // Refine MethodHandle.invokeBasic with known object info
+   //
+   void process_java_lang_invoke_MethodHandle_invokeBasic(TR::TreeTop* tt, TR::Node* node);
+
+   // Refine MethodHandle.linkTo* with known object info
+   //
+   void process_java_lang_invoke_MethodHandle_linkTo(TR::TreeTop* tt, TR::Node* node);
+
+   private:
+   int32_t _numLocals; // Number of parms, autos and temps
+   ObjectInfo * _currentObjectInfo;  // Object info for current block being processed
+
+   typedef TR::typed_allocator<std::pair<const int32_t, ObjectInfo *>, TR::Region &> ResultAllocator;
+   typedef std::map<int32_t, ObjectInfo *, std::less<int32_t>, ResultAllocator> BlockResultMap;
+
+   BlockResultMap* _blockEndObjectInfos; // A map of object info at the end of blocks
+   };
+
+#endif


### PR DESCRIPTION
This PR includes changes to transform OpenJDK MethodHandle methods such that the method is performant and inliner can inline the MethodHandle chain.

The main purpose of this PR is to transform the following VM INL with known object info such that inliner can match inline target with the actual call site and continue the MethodHandle chain inlining, which is critical to the performance
 - MethodHandle.invokeBasic
 - MethodHandle.linkToXXX

Notice that MethodHandle.linkToInterface is not transformed here due to current limitation of interface call representation, and it'll be addressed later

Depends on https://github.com/eclipse/omr/pull/5745