### PR TITLE
Fix failures in identifying invokeBasic

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -6348,7 +6348,7 @@ TR_ResolvedJ9Method::getClassNameFromConstantPool(uint32_t cpIndex, uint32_t &le
    }
 
 char *
-TR_ResolvedJ9Method::getMethodNameAndSignatureFromConstantPool(I_32 cpIndex, int32_t & len)
+TR_ResolvedJ9Method::getMethodSignatureFromConstantPool(I_32 cpIndex, int32_t & len)
    {
    I_32 realCPIndex = jitGetRealCPIndex(_fe->vmThread(), romClassPtr(), cpIndex);
    if (realCPIndex == -1)
@@ -6716,7 +6716,7 @@ bool
 TR_ResolvedJ9Method::shouldCompileTimeResolveMethod(I_32 cpIndex)
    {
    int32_t methodNameLength;
-   char *methodName = getMethodNameAndSignatureFromConstantPool(cpIndex, methodNameLength);
+   char *methodName = getMethodSignatureFromConstantPool(cpIndex, methodNameLength);
 
    I_32 classCPIndex = classCPIndexOfMethod(cpIndex);
    uint32_t classNameLength;

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6358,6 +6358,17 @@ TR_ResolvedJ9Method::getMethodSignatureFromConstantPool(I_32 cpIndex, int32_t & 
    return utf8Data(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSig), len);
    }
 
+char *
+TR_ResolvedJ9Method::getMethodNameFromConstantPool(int32_t cpIndex, int32_t & len)
+   {
+   I_32 realCPIndex = jitGetRealCPIndex(_fe->vmThread(), romClassPtr(), cpIndex);
+   if (realCPIndex == -1)
+      return 0;
+   J9ROMMethodRef *romMethodRef = (J9ROMMethodRef *) (&romCPBase()[realCPIndex]);
+   J9ROMNameAndSignature *nameAndSig = J9ROMMETHODREF_NAMEANDSIGNATURE(romMethodRef);
+   return utf8Data(J9ROMNAMEANDSIGNATURE_NAME(nameAndSig), len);
+   }
+
 const char *
 TR_ResolvedJ9Method::newInstancePrototypeSignature(TR_Memory * m, TR_AllocationKind allocKind)
    {
@@ -6716,7 +6727,7 @@ bool
 TR_ResolvedJ9Method::shouldCompileTimeResolveMethod(I_32 cpIndex)
    {
    int32_t methodNameLength;
-   char *methodName = getMethodSignatureFromConstantPool(cpIndex, methodNameLength);
+   char *methodName = getMethodNameFromConstantPool(cpIndex, methodNameLength);
 
    I_32 classCPIndex = classCPIndexOfMethod(cpIndex);
    uint32_t classNameLength;

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -352,6 +352,7 @@ public:
 
    virtual char *                  getClassNameFromConstantPool(uint32_t cpIndex, uint32_t &length);
    virtual char *                  getMethodSignatureFromConstantPool(int32_t cpIndex, int32_t & len);
+   virtual char *                  getMethodNameFromConstantPool(int32_t cpIndex, int32_t & len);
    virtual TR::DataType            getLDCType(int32_t cpIndex);
    virtual bool                    isClassConstant(int32_t cpIndex);
    virtual bool                    isStringConstant(int32_t cpIndex);

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -351,7 +351,7 @@ public:
    virtual bool                    validateArbitraryClass( TR::Compilation *comp, J9Class *clazz);
 
    virtual char *                  getClassNameFromConstantPool(uint32_t cpIndex, uint32_t &length);
-   virtual char *                  getMethodNameAndSignatureFromConstantPool(int32_t cpIndex, int32_t & len);
+   virtual char *                  getMethodSignatureFromConstantPool(int32_t cpIndex, int32_t & len);
    virtual TR::DataType            getLDCType(int32_t cpIndex);
    virtual bool                    isClassConstant(int32_t cpIndex);
    virtual bool                    isStringConstant(int32_t cpIndex);

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -758,7 +758,7 @@ TR_ResolvedJ9JITServerMethod::createResolvedMethodFromJ9Method( TR::Compilation 
       {
       // Signature polymorphic method's signature varies at different call sites and will be different than its declared signature
       int32_t signatureLength;
-      char   *signature = getMethodNameAndSignatureFromConstantPool(cpIndex, signatureLength);
+      char   *signature = getMethodSignatureFromConstantPool(cpIndex, signatureLength);
       ((TR_ResolvedJ9Method *)m)->setSignature(signature, signatureLength, comp->trMemory());
       }
    return m;
@@ -772,7 +772,7 @@ TR_ResolvedJ9JITServerMethod::createResolvedMethodFromJ9Method( TR::Compilation 
       {
       // Signature polymorphic method's signature varies at different call sites and will be different than its declared signature
       int32_t signatureLength;
-      char   *signature = getMethodNameAndSignatureFromConstantPool(cpIndex, signatureLength);
+      char   *signature = getMethodSignatureFromConstantPool(cpIndex, signatureLength);
       ((TR_ResolvedJ9Method *)m)->setSignature(signature, signatureLength, comp->trMemory());
       }
    return m;
@@ -1142,7 +1142,7 @@ TR_ResolvedJ9JITServerMethod::classSignatureOfFieldOrStatic(I_32 cpIndex, int32_
    }
 
 char *
-TR_ResolvedJ9JITServerMethod::getMethodNameAndSignatureFromConstantPool(I_32 cpIndex, int32_t & len)
+TR_ResolvedJ9JITServerMethod::getMethodSignatureFromConstantPool(I_32 cpIndex, int32_t & len)
    {
    I_32 realCPIndex = jitGetRealCPIndex(_fe->vmThread(), romClassPtr(), cpIndex);
    if (realCPIndex == -1)
@@ -2389,7 +2389,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::createResolvedMethodFromJ9Method(TR::Co
       {
       // Signature polymorphic method's signature varies at different call sites and will be different than its declared signature
       int32_t signatureLength;
-      char   *signature = getMethodNameAndSignatureFromConstantPool(cpIndex, signatureLength);
+      char   *signature = getMethodSignatureFromConstantPool(cpIndex, signatureLength);
       ((TR_ResolvedJ9Method *)resolvedMethod)->setSignature(signature, signatureLength, comp->trMemory());
       }
 
@@ -2410,7 +2410,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::createResolvedMethodFromJ9Method( TR::C
       {
       // Signature polymorphic method's signature varies at different call sites and will be different than its declared signature
       int32_t signatureLength;
-      char   *signature = getMethodNameAndSignatureFromConstantPool(cpIndex, signatureLength);
+      char   *signature = getMethodSignatureFromConstantPool(cpIndex, signatureLength);
       ((TR_ResolvedJ9Method *)resolvedMethod)->setSignature(signature, signatureLength, comp->trMemory());
       }
 
@@ -2894,4 +2894,3 @@ TR_J9ServerMethod::TR_J9ServerMethod(TR_FrontEnd * fe, TR_Memory * trMemory, J9C
    parseSignature(trMemory);
    _fullSignature = NULL;
    }
-

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1156,6 +1156,20 @@ TR_ResolvedJ9JITServerMethod::getMethodSignatureFromConstantPool(I_32 cpIndex, i
    }
 
 char *
+TR_ResolvedJ9JITServerMethod::getMethodNameFromConstantPool(I_32 cpIndex, int32_t & len)
+   {
+   I_32 realCPIndex = jitGetRealCPIndex(_fe->vmThread(), romClassPtr(), cpIndex);
+   if (realCPIndex == -1)
+      return 0;
+   char *name = getROMString(len, &romCPBase()[realCPIndex],
+                        {
+                        offsetof(J9ROMMethodRef, nameAndSignature),
+                        offsetof(J9ROMNameAndSignature, name)
+                        });
+   return name;
+   }
+
+char *
 TR_ResolvedJ9JITServerMethod::fieldOrStaticNameChars(I_32 cpIndex, int32_t & len)
    {
    if (cpIndex < 0)

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -193,7 +193,7 @@ public:
    virtual char * getClassNameFromConstantPool(uint32_t cpIndex, uint32_t &length) override;
    virtual char * classNameOfFieldOrStatic(int32_t cpIndex, int32_t & len) override;
    virtual char * classSignatureOfFieldOrStatic(int32_t cpIndex, int32_t & len) override;
-   virtual char * getMethodNameAndSignatureFromConstantPool(int32_t cpIndex, int32_t & len) override;
+   virtual char * getMethodSignatureFromConstantPool(int32_t cpIndex, int32_t & len) override;
    virtual char * fieldOrStaticNameChars(int32_t cpIndex, int32_t & len) override;
    virtual bool isSubjectToPhaseChange(TR::Compilation *comp) override;
    virtual void * stringConstant(int32_t cpIndex) override;

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -194,6 +194,7 @@ public:
    virtual char * classNameOfFieldOrStatic(int32_t cpIndex, int32_t & len) override;
    virtual char * classSignatureOfFieldOrStatic(int32_t cpIndex, int32_t & len) override;
    virtual char * getMethodSignatureFromConstantPool(int32_t cpIndex, int32_t & len) override;
+   virtual char * getMethodNameFromConstantPool(int32_t cpIndex, int32_t & len) override;
    virtual char * fieldOrStaticNameChars(int32_t cpIndex, int32_t & len) override;
    virtual bool isSubjectToPhaseChange(TR::Compilation *comp) override;
    virtual void * stringConstant(int32_t cpIndex) override;


### PR DESCRIPTION
An issue identifying invokeBasic resulted in invokeBasic not getting resolved at compile time when `rtResolve` option is set.