### PR TITLE
Fix invokedynamic in DDR bytecode dumper

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ByteCodeDumper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ByteCodeDumper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -434,7 +434,7 @@ public class ByteCodeDumper {
 				out.append(J9UTF8Helper.stringValue(nameAndSig.signature())); /* dump signature */
 				out.append(nl);
 
-				pc = pc.add(4);
+				pc = pc.add(2);
 			} else if (bcIntVal == JBinvokeinterface2) {
 				incIndex();
 				pc = pc.add(1);


### PR DESCRIPTION
Found in #11582

In the class file, invokedynamic is 5 bytes. OpenJ9 rewrites it as a
3-byte invoke followed by two nop.

The dumper maintains two separate bytecode indices and invokedynamic did
not keep them in sync (2 bytes are consumed from the stream, but the
bytecode index was incremented by 4). Change the increment to 2 to be
consistent.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>