### PR TITLE
Compute NPE message for JBinvokestatic

### DIFF
--- a/runtime/vm/extendedMessageNPE.cpp
+++ b/runtime/vm/extendedMessageNPE.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -512,6 +512,7 @@ getCompleteNPEMessage(J9VMThread *vmThread, U_8 *bcCurrentPtr, J9ROMClass *romCl
 		case JBinvokeinterface2: /* FALLTHROUGH */
 		case JBinvokeinterface: /* FALLTHROUGH */
 		case JBinvokespecial: /* FALLTHROUGH */
+		case JBinvokestatic: /* FALLTHROUGH */
 		case JBinvokevirtual: {
 			U_16 index = 0;
 			J9ROMConstantPoolItem *constantPool = J9_ROM_CP_FROM_ROM_CLASS(romClass);


### PR DESCRIPTION
`invokestatic` was not expected to cause `NPE`.
`OpenJ9` with `OpenJDK` `MethodHandles` throws `NPE` internally without modifying the stack and it appears to be coming from the `invokestatic`.

Note: there is no testcase to exercise this change in `master` branch.
A separated PR will be targeted to https://github.com/babsingh/openj9/commits/ojdk_jsr292_final for test message modification.
With this PR, a NPE message for `test_MHinvoke` looks like
```
java.lang.NullPointerException: Cannot invoke "java.lang.invoke.MethodHandle.linkToVirtual(java.lang.Object, java.lang.invoke.MemberName)" because "<parameter1>" is null
	at java.base/java.lang.invoke.LambdaForm$DMH/0x0000000000000000.invokeVirtual(LambdaForm$DMH)
	at java.base/java.lang.invoke.LambdaForm$MH/0x0000000000000000.invoke(LambdaForm$MH)
	at java.base/java.lang.invoke.LambdaForm$MH/0x0000000000000000.invoke_MT(LambdaForm$MH)
	at a.se.java_lang_npe.TestMHNPE.testAll(TestMHNPE.java:18)
```
RI output is:
```
java.lang.NullPointerException
	at a.se.java_lang_npe.TestMHNPE.testAll(TestMHNPE.java:18)
```
It was decided to provide the actual message instead of matching RI behaviours. The extra stracktrace output is mentioned at https://github.com/eclipse/openj9/issues/11458#issuecomment-759525175.

Related to : https://github.com/eclipse/openj9/issues/11458

Signed-off-by: Jason Feng <fengj@ca.ibm.com>