### PR TITLE
Fix PGC calibration issue

### DIFF
--- a/runtime/gc_vlhgc/SchedulingDelegate.cpp
+++ b/runtime/gc_vlhgc/SchedulingDelegate.cpp
@@ -412,16 +412,25 @@ void
 MM_SchedulingDelegate::measureScanRate(MM_EnvironmentVLHGC *env, double historicWeight)
 {
 	Trc_MM_SchedulingDelegate_measureScanRate_Entry(env->getLanguageVMThread(), env->_cycleState->_collectionType);
-	MM_MarkVLHGCStats *markStats = &static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._markStats;
-	
-	UDATA currentBytesScanned = markStats->_bytesScanned + markStats->_bytesCardClean;
+	UDATA currentBytesScanned = 0;
+	U_64 scantime = 0;
+	if (env->_cycleState->_collectionType == MM_CycleState::CT_PARTIAL_GARBAGE_COLLECTION) {
+		/* mark/compact PGC has been replaced with CopyForwardHybrid collector, so retrieve scan stats from  */
+		MM_CopyForwardStats *copyforwardStats = &static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._copyForwardStats;
+		currentBytesScanned = copyforwardStats->_scanBytesTotal + copyforwardStats->_bytesCardClean;
+		scantime = copyforwardStats->_endTime - copyforwardStats->_startTime;
+	} else {
+		MM_MarkVLHGCStats *markStats = &static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._markStats;
+		currentBytesScanned = markStats->_bytesScanned + markStats->_bytesCardClean;
+		scantime = markStats->getScanTime();
+	}
 
 	if (0 != currentBytesScanned) {
 		PORT_ACCESS_FROM_ENVIRONMENT(env);
 		UDATA historicalBytesScanned = _scanRateStats.historicalBytesScanned;
 		U_64 historicalScanMicroseconds = _scanRateStats.historicalScanMicroseconds;
 		/* NOTE: scan time is the total time all threads spent scanning */
-		U_64 currentScanMicroseconds = j9time_hires_delta(0, markStats->getScanTime(), J9PORT_TIME_DELTA_IN_MICROSECONDS);
+		U_64 currentScanMicroseconds = j9time_hires_delta(0, scantime, J9PORT_TIME_DELTA_IN_MICROSECONDS);
 
 		if (0 != historicalBytesScanned) {
 			/* Keep a historical count of bytes scanned and scan times and re-derive microsecondsperBytes every time we receive new data */


### PR DESCRIPTION
In order to run copyforward PGC, the first PGC might need to run
mark/compact mode for generating scan rate statistics, currently
measureScanRate() only collect data from markStats, which are used
by Mark/Compact PGC, GMP and global collector, but recently we
replace Mark/Compact PGC with Copyforward Hybrid collector, it could
cause performance impact at the beginning of jvm runtime(until first
GMP), update measureScanRate() to retrieve data from copyforward stats
for the case.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>