### PR TITLE
Limited the native test loadLegacyLibrary to IBM and openj9 only.

### DIFF
--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -2624,6 +2624,10 @@
 		<types>
 			<type>native</type>
 		</types>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
[ci skip]

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>