### PR TITLE
Remove vm.cmprssptrs in platformRequirements

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-	Copyright (c) 2016, 2020 IBM Corp. and others
+	Copyright (c) 2016, 2021 IBM Corp. and others
 
 	This program and the accompanying materials are made available under
 	the terms of the Eclipse Public License 2.0 which accompanies this
@@ -494,7 +494,7 @@
 	<test>
 		<testCaseName>jit_hwWarm</testCaseName>
 		<variations>
-			<variation>-Xdump:java -Xjit:optlevel=warm,count=0</variation>
+			<variation>Mode110 -Xdump:java -Xjit:optlevel=warm,count=0</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
@@ -504,7 +504,7 @@
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
-		<platformRequirements>os.linux,^vm.cmprssptrs,^arch.arm</platformRequirements>
+		<platformRequirements>os.linux,^arch.arm</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -625,8 +625,8 @@
 		<testCaseName>testJITServer</testCaseName>
 		<!-- Variations are passed to the client via the CLIENT_PROGRAM property from $JVM_OPTIONS; neither the test harness nor the server care about these. -->
 		<variations>
-			<variation>NoOptions</variation>
-			<variation>-Xshareclasses:none -Xjit:optLevel=hot</variation>
+			<variation>Mode610</variation>
+			<variation>Mode610 -Xshareclasses:none -Xjit:optLevel=hot</variation>
 		</variations>
 		<!-- Check if the JITServer launcher exists and if so start the test and
 			 - specify the executables for the client and server via the CLIENT_EXE and SERVER_EXE properties respectively,
@@ -650,7 +650,7 @@
 		echo $(Q)$(TEST_JDK_BIN)$(D)jitserver doesn't exist; assuming this JDK does not support JITServer and trivially passing the test.$(Q); \
 	fi; \
 	$(TEST_STATUS)</command>
-		<platformRequirements>os.linux,arch.x86,bits.64,vm.cmprssptrs</platformRequirements>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/functional/cmdLineTests/libpathTest/playlist.xml
+++ b/test/functional/cmdLineTests/libpathTest/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2020 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,9 @@
 	<!-- LIBPATH tests intended for PMR56610 (CMVC 201272) -->
 	<test>
 		<testCaseName>cmdLineTester_libpathTestRtf</testCaseName>
+		<variations>
+			<variation>Mode610</variation>
+		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJAVA_EXE=$(JAVA_COMMAND) -DJAVA_HOME=$(Q)$(JAVA_HOME)$(Q) -DJAVATEST_ROOT=$(JAVATEST_ROOT) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) \
 	-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)libpathTest.jar$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) -jar $(CMDLINETESTER_JAR) \
@@ -34,7 +37,7 @@
 	-nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
 		<!-- temporarily disable this test on osx; https://github.com/eclipse/openj9/issues/3787 -->
-		<platformRequirements>bits.64,vm.cmprssptrs,^os.osx,^os.zos</platformRequirements>
+		<platformRequirements>bits.64,^os.osx,^os.zos</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/functional/cmdLineTests/xxargtest/playlist.xml
+++ b/test/functional/cmdLineTests/xxargtest/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,12 +26,11 @@
 	<test>
 		<testCaseName>testXXArgumentTesting</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)XXArgumentTesting.xml$(Q); \
 	$(TEST_STATUS)</command>
-		<platformRequirements>vm.cmprssptrs</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
vm.cmprssptrs does not apply to mixref SDK.
Remove vm.cmprssptrs and use Mode110/610 or Mode150/650 instead

[ci skip]
Related:https://github.com/eclipse/openj9/issues/9231

Signed-off-by: lanxia <lan_xia@ca.ibm.com>