### PR TITLE
Fix error introduced by #11635

### DIFF
--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1379,7 +1379,7 @@ done:
 			} else {
 				/* Final field - ensure the running method is allowed to store */
 				if (J9_UNEXPECTED(!J9ROMMETHOD_ALLOW_FINAL_FIELD_WRITES(J9_ROM_METHOD_FROM_RAM_METHOD(method), J9AccStatic))) {
-					if (J9_UNEXPECTED(VM_VMHelpers::ramClassChecksFinalStores(ramConstantPool->ramClass))) {
+					if (J9_UNEXPECTED(ramClassChecksFinalStores(ramConstantPool->ramClass))) {
 						/* Store not allowed - run the resolve code to throw the exception */
 						resolved = false;
 					}
@@ -1594,7 +1594,7 @@ exit:
 				|| (method == vm->jliMethodHandleInvokeWithArgs)
 				|| (method == vm->jliMethodHandleInvokeWithArgsList)
 				|| (vm->srMethodAccessor
-						&& VM_VMHelpers::isSameOrSuperclass(
+						&& isSameOrSuperclass(
 								J9VM_J9CLASS_FROM_JCLASS(currentThread,
 										vm->srMethodAccessor), currentClass)));
 	}

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -6401,9 +6401,10 @@ done:
 			VM_VMHelpers::resolvedStaticFieldRefIsPutResolved(flagsAndClass, _literals, ramConstantPool)
 		))) {
 			/* Unresolved */
+			J9Method *method = _literals; /* Record the running method before building the special frame */
 			buildGenericSpecialStackFrame(REGISTER_ARGS, 0);
 			updateVMStruct(REGISTER_ARGS);
-			resolveResult = resolveStaticFieldRef(_currentThread, _literals, ramConstantPool, index, J9_RESOLVE_FLAG_RUNTIME_RESOLVE | J9_RESOLVE_FLAG_FIELD_SETTER | J9_RESOLVE_FLAG_CHECK_CLINIT, NULL);
+			resolveResult = resolveStaticFieldRef(_currentThread, method, ramConstantPool, index, J9_RESOLVE_FLAG_RUNTIME_RESOLVE | J9_RESOLVE_FLAG_FIELD_SETTER | J9_RESOLVE_FLAG_CHECK_CLINIT, NULL);
 			VMStructHasBeenUpdated(REGISTER_ARGS);
 			restoreGenericSpecialStackFrame(REGISTER_ARGS);
 			if (immediateAsyncPending()) {


### PR DESCRIPTION
Removal of a seemingly unneeded local variable caused NULL to be passed
as the method to the static field resolve code, resulting in the final
field check being omitted.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>