### PR TITLE
Set domainCombiner from closest frame in result AccessControlContext

### DIFF
--- a/jcl/src/java.base/share/classes/java/security/AccessController.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessController.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -510,6 +510,10 @@ private static AccessControlContext getContextHelper(boolean forDoPrivilegedWith
 		}
 		if (null != acc && null != acc.domainCombiner) {
 			accTmp.domainCombiner = acc.domainCombiner;
+			if (activeDC == null) {
+				// This activeDC will be set to accContext.domainCombiner.
+				activeDC = acc.domainCombiner;
+			}
 		}
 		if (null != domains[j * OBJS_ARRAY_SIZE + OBJS_INDEX_PERMS_OR_CACHECHECKED]) {
 			// this is frame with limited permissions


### PR DESCRIPTION
Set `domainCombiner` from closest frame in result `AccessControlContext` of `j.s.AccessController.getContextHelper()` if the `activeDC` is `null`.

This is part of fix https://github.com/eclipse/openj9/pull/3051 lost when fixing https://github.com/eclipse/openj9/pull/6492.
Note: https://github.com/eclipse/openj9/pull/6492 has its own automated test which still passes with PR in a personal build (`s390x_linux 8/11/15 sanity.functional`). The test for this PR is `jdk_security4` - `test/jdk/sun/security/krb5/auto/HttpNegotiateServer.java`.

closes https://github.com/eclipse/openj9/issues/11268

Signed-off-by: Jason Feng <fengj@ca.ibm.com>