### PR TITLE
(v0.24.0-release) Set domainCombiner from closest frame in result AccessControlContext

### DIFF
--- a/jcl/src/java.base/share/classes/java/security/AccessController.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessController.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -510,6 +510,10 @@ private static AccessControlContext getContextHelper(boolean forDoPrivilegedWith
 		}
 		if (null != acc && null != acc.domainCombiner) {
 			accTmp.domainCombiner = acc.domainCombiner;
+			if (activeDC == null) {
+				// This activeDC will be set to accContext.domainCombiner.
+				activeDC = acc.domainCombiner;
+			}
 		}
 		if (null != domains[j * OBJS_ARRAY_SIZE + OBJS_INDEX_PERMS_OR_CACHECHECKED]) {
 			// this is frame with limited permissions


### PR DESCRIPTION
Set `domainCombiner` from closest frame in result `AccessControlContext` of `j.s.AccessController.getContextHelper()` if the `activeDC` is `null`.

Cherry-pick from https://github.com/eclipse/openj9/pull/11664

Signed-off-by: Jason Feng <fengj@ca.ibm.com>