### PR TITLE
Remove unnecessary dependence on bash

### DIFF
--- a/runtime/compiler/build/scripts/guess-platform.sh
+++ b/runtime/compiler/build/scripts/guess-platform.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,16 +35,16 @@ error() {
 
 # chooseplatform 32bit_platform 64bit_platform
 chooseplatform() {
-    if [[ $thirty_two_bit -eq 1 ]] ; then
+    if [ $thirty_two_bit -eq 1 ] ; then
         platform=$1
     else
         platform=$2
     fi
 }
 
-if [ $# -eq 0 ]; then
+if [ $# -eq 0 ] ; then
     arg="--64"
-elif [ $# -eq 1 ]; then
+elif [ $# -eq 1 ] ; then
     arg=$1
 else
     usage


### PR DESCRIPTION
Don't use `[[` when `[` will suffice.

See https://github.com/eclipse/openj9/pull/11648#issuecomment-762401859.