### PR TITLE
Use per-client persistent allocators on JITServer

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -185,6 +185,8 @@ J9::Compilation::Compilation(int32_t id,
    _remoteCompilation(false),
    _serializedRuntimeAssumptions(getTypedAllocator<SerializedRuntimeAssumption *>(self()->allocator())),
    _clientData(NULL),
+   _globalMemory(*::trPersistentMemory, heapMemoryRegion),
+   _perClientMemory(_trMemory),
 #endif /* defined(J9VM_OPT_JITSERVER) */
    _osrProhibitedOverRangeOfTrees(false),
    _useTracingBuffer(false),

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -347,6 +347,14 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    TR::list<SerializedRuntimeAssumption*>& getSerializedRuntimeAssumptions() { return _serializedRuntimeAssumptions; }
    ClientSessionData *getClientData() const { return _clientData; }
    void setClientData(ClientSessionData *clientData) { _clientData = clientData; }
+   void switchToPerClientMemory()
+      {
+      _trMemory = _perClientMemory;
+      }
+   void switchToGlobalMemory()
+      {
+      _trMemory = &_globalMemory;
+      }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    TR::SymbolValidationManager *getSymbolValidationManager() { return _symbolValidationManager; }
@@ -468,6 +476,9 @@ private:
    // Client session data for the client that requested this out-of-process
    // compilation (at the JITServer); unused (always NULL) at the client side
    ClientSessionData *_clientData;
+
+   TR_Memory *_perClientMemory;
+   TR_Memory _globalMemory;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    TR::SymbolValidationManager *_symbolValidationManager;

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -315,6 +315,21 @@ class CompilationInfoPerThreadBase
 
    void                     setClientStream(JITServer::ClientStream *stream) { _clientStream = stream; }
    JITServer::ClientStream *getClientStream() const { return _clientStream; }
+
+   /**
+      @brief After this method runs, all subsequent persistent allocations
+      on the current thread for a given client will use a per-client allocator,
+      instead of the global one.
+    */
+   void                     enterPerClientAllocationRegion();
+
+   /**
+      @brief Ends per-client allocation on this thread. After this method returns,
+      all allocations will use the global persistent allocator.
+   */
+   void                     exitPerClientAllocationRegion();
+   TR_PersistentMemory *getPerClientPersistentMemory() { return _perClientPersistentMemory; }
+
    /**
       @brief Heuristic that returns true if compiling a method of given size
              and at given optimization level less is likely to consume little
@@ -370,6 +385,7 @@ class CompilationInfoPerThreadBase
 #if defined(J9VM_OPT_JITSERVER)
    ClientSessionData * _cachedClientDataPtr;
    JITServer::ClientStream * _clientStream;
+   TR_PersistentMemory * _perClientPersistentMemory;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 private:

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1995,7 +1995,7 @@ J9::Options::fePreProcess(void * base)
       JITServerAlreadyParsed = true;
       if (vm->internalVMFunctions->isJITServerEnabled(vm))
          {
-         compInfo->getPersistentInfo()->setRemoteCompilationMode(JITServer::SERVER);
+         J9::PersistentInfo::_remoteCompilationMode = JITServer::SERVER;
          // Increase the default timeout value for JITServer.
          // It can be overridden with -XX:JITServerTimeout= option in JITServerParseCommonOptions().
          compInfo->getPersistentInfo()->setSocketTimeout(30000);
@@ -2013,7 +2013,7 @@ J9::Options::fePreProcess(void * base)
          // Check if option is at all specified
          if (xxUseJITServerArgIndex > xxDisableUseJITServerArgIndex)
             {
-            compInfo->getPersistentInfo()->setRemoteCompilationMode(JITServer::CLIENT);
+            J9::PersistentInfo::_remoteCompilationMode = JITServer::CLIENT;
 
             // Check if the technology preview message should be displayed.
             const char *xxJITServerTechPreviewMessageOption = "-XX:+JITServerTechPreviewMessage";

--- a/runtime/compiler/control/MethodToBeCompiled.cpp
+++ b/runtime/compiler/control/MethodToBeCompiled.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -157,7 +157,7 @@ TR_MethodToBeCompiled::freeJITServerAllocations()
    {
    if (_clientOptions)
       {
-      _compInfoPT->getCompilationInfo()->persistentMemory()->freePersistentMemory((void *)_clientOptions);
+      TR::Compiler->persistentMemory()->freePersistentMemory((void *)_clientOptions);
       _clientOptions = NULL;
       }
    }

--- a/runtime/compiler/env/J9CompilerEnv.cpp
+++ b/runtime/compiler/env/J9CompilerEnv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,6 +25,9 @@
 #include "env/defines.h"
 #include "env/CPU.hpp"
 #include "j9.h"
+#if defined(J9VM_OPT_JITSERVER)
+#include "control/CompilationRuntime.hpp"
+#endif /* defined(J9VM_OPT_JITSERVER) */
 
 J9::CompilerEnv::CompilerEnv(J9JavaVM *vm, TR::RawAllocator raw, const TR::PersistentAllocatorKit &persistentAllocatorKit) :
 #if defined(TR_HOST_ARM) || defined(TR_HOST_ARM64)
@@ -66,3 +69,45 @@ J9::CompilerEnv::isCodeTossed()
 
    return false;
    }
+
+TR::PersistentAllocator &
+J9::CompilerEnv::persistentAllocator()
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (J9::PersistentInfo::_remoteCompilationMode == JITServer::SERVER)
+      {
+      auto compInfoPT = TR::compInfoPT;
+      if (compInfoPT && compInfoPT->getPerClientPersistentMemory())
+         {
+         // Returns per-client allocator after enterPerClientPersistentAllocator() is called
+         return compInfoPT->getPerClientPersistentMemory()->_persistentAllocator.get();
+         }
+      }
+#endif
+   return OMR::CompilerEnv::persistentAllocator();
+   }
+
+TR_PersistentMemory *
+J9::CompilerEnv::persistentMemory()
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (J9::PersistentInfo::_remoteCompilationMode == JITServer::SERVER)
+      {
+      auto compInfoPT = TR::compInfoPT;
+      if (compInfoPT && compInfoPT->getPerClientPersistentMemory())
+         {
+         // Returns per-client persistent memory after enterPerClientPersistentAllocator() is called
+         return compInfoPT->getPerClientPersistentMemory();
+         }
+      }
+#endif
+   return OMR::CompilerEnv::persistentMemory();
+   }
+
+#if defined(J9VM_OPT_JITSERVER)
+TR::PersistentAllocator &
+J9::CompilerEnv::persistentGlobalAllocator()
+   {
+   return OMR::CompilerEnv::persistentAllocator();
+   }
+#endif

--- a/runtime/compiler/env/J9CompilerEnv.hpp
+++ b/runtime/compiler/env/J9CompilerEnv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,6 +54,13 @@ public:
    void initializeTargetEnvironment();
 
    bool isCodeTossed();
+
+   TR::PersistentAllocator &persistentAllocator();
+
+   TR_PersistentMemory *persistentMemory();
+#if defined(J9VM_OPT_JITSERVER)
+   TR::PersistentAllocator &persistentGlobalAllocator();
+#endif
    };
 
 }

--- a/runtime/compiler/env/J9PersistentInfo.cpp
+++ b/runtime/compiler/env/J9PersistentInfo.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,6 +24,9 @@
 #if defined(J9VM_OPT_JITSERVER)
 #include "control/CompilationThread.hpp"
 #include "runtime/JITClientSession.hpp"
+
+
+JITServer::RemoteCompilationModes J9::PersistentInfo::_remoteCompilationMode = JITServer::NONE;
 #endif
 
 TR_PersistentCHTable *

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -154,7 +154,6 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _runtimeInstrumentationEnabled(false),
          _runtimeInstrumentationRecompilationEnabled(false),
 #if defined(J9VM_OPT_JITSERVER)
-         _remoteCompilationMode(JITServer::NONE),
          _JITServerAddress("localhost"),
          _JITServerPort(38400),
          _socketTimeoutMs(2000),
@@ -321,8 +320,9 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    int32_t _countForRecompile;
 
 #if defined(J9VM_OPT_JITSERVER)
-   JITServer::RemoteCompilationModes getRemoteCompilationMode() const { return _remoteCompilationMode; }
-   void setRemoteCompilationMode(JITServer::RemoteCompilationModes m) { _remoteCompilationMode = m; }
+   static JITServer::RemoteCompilationModes _remoteCompilationMode; // JITServer::NONE, JITServer::CLIENT, JITServer::SERVER
+
+   static JITServer::RemoteCompilationModes getRemoteCompilationMode() { return _remoteCompilationMode; }
    const std::string &getJITServerAddress() const { return _JITServerAddress; }
    void setJITServerAddress(char *addr) { _JITServerAddress = addr; }
    uint32_t getSocketTimeout() const { return _socketTimeoutMs; }
@@ -416,7 +416,6 @@ class PersistentInfo : public OMR::PersistentInfoConnector
 
    int32_t _numLoadedClasses; ///< always increasing
 #if defined(J9VM_OPT_JITSERVER)
-   JITServer::RemoteCompilationModes _remoteCompilationMode; // JITServer::NONE, JITServer::CLIENT, JITServer::SERVER
    std::string _JITServerAddress;
    uint32_t    _JITServerPort;
    uint32_t    _socketTimeoutMs; // timeout for communication sockets used in out-of-process JIT compilation

--- a/runtime/compiler/env/JITServerPersistentCHTable.hpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -157,7 +157,7 @@ class FlatPersistentClassInfo
    {
 public:
    static std::string serializeHierarchy(const JITClientPersistentCHTable *chTable);
-   static std::vector<TR_PersistentClassInfo*> deserializeHierarchy(const std::string& data);
+   static std::vector<TR_PersistentClassInfo*> deserializeHierarchy(const std::string& data, TR_PersistentMemory *persistentMemory);
    static size_t classSize(TR_PersistentClassInfo *clazz);
    static size_t serializeClass(TR_PersistentClassInfo *clazz, FlatPersistentClassInfo* info);
    static size_t deserializeClassSimple(TR_PersistentClassInfo *clazz, FlatPersistentClassInfo *info);
@@ -204,7 +204,7 @@ public:
    virtual void setFirstSubClass(TR_SubClass *sc) override;
    virtual void setFieldInfo(TR_PersistentClassInfoForFields *i) override;
    virtual TR_SubClass *addSubClass(TR_PersistentClassInfo *subClass) override;
-   virtual void removeSubClasses() override;
+   virtual void removeSubClasses(TR_PersistentMemory *persistentMemory = ::trPersistentMemory) override;
    virtual void removeASubClass(TR_PersistentClassInfo *subClass) override;
    virtual void removeUnloadedSubClasses() override;
    virtual void setUnloaded() override;

--- a/runtime/compiler/env/PersistentCHTable.hpp
+++ b/runtime/compiler/env/PersistentCHTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -220,6 +220,8 @@ class TR_PersistentCHTable
 
    uint8_t _buffer[sizeof(TR_LinkHead<TR_PersistentClassInfo>) * (CLASSHASHTABLE_SIZE + 1)];
    TR_LinkHead<TR_PersistentClassInfo> *_classes;
+
+   protected:
    TR_PersistentMemory *_trPersistentMemory;
    };
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -764,7 +764,7 @@ TR_J9VMBase::TR_J9VMBase(
 #if defined(J9VM_OPT_JITSERVER)
       if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
          {
-         _sharedCache = new (PERSISTENT_NEW) TR_J9JITServerSharedCache(this);
+         _sharedCache = new (compInfo->persistentMemory()) TR_J9JITServerSharedCache(this);
          }
       else
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/net/MessageBuffer.hpp
+++ b/runtime/compiler/net/MessageBuffer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
 #include "env/jittypes.h"
 #include "env/TRMemory.hpp"
 #include "OMR/Bytes.hpp" // for alignNoCheck
+#include "env/CompilerEnv.hpp"
 
 namespace JITServer
 {
@@ -52,7 +53,7 @@ public:
 
    ~MessageBuffer()
       {
-      TR_Memory::jitPersistentFree(_storage);
+      freeMemory(_storage);
       }
 
 
@@ -203,10 +204,13 @@ public:
 private:
    static const size_t INITIAL_BUFFER_SIZE = 18000;
    uint32_t offset(char *addr) const { return addr - _storage; }
+   char *allocateMemory(uint32_t capacity) { return static_cast<char *>(_allocator.allocate(capacity)); }
+   void freeMemory(char *storage) { _allocator.deallocate(storage); }
 
    uint32_t _capacity;
    char *_storage;
    char *_curPtr;
+   TR::PersistentAllocator &_allocator;
    };
 };
 #endif

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1033,6 +1033,12 @@ TR_CISCGraph::makePreparedCISCGraphs(TR::Compilation *c)
    else
       graphsInitialized = true;
 
+#if defined(J9VM_OPT_JITSERVER)
+   // Prepared CISC graphs are static, i.e. initialized only once.
+   // Need to use the global allocator here.
+   if (c->isOutOfProcessCompilation())
+      c->fej9()->_compInfoPT->exitPerClientAllocationRegion();
+#endif
    int32_t num = 0;
    bool genTRxx = c->cg()->getSupportsArrayTranslateTRxx();
    bool genSIMD = c->cg()->getSupportsVectorRegisters() && !c->getOption(TR_DisableSIMDArrayTranslate);
@@ -1205,6 +1211,12 @@ TR_CISCGraph::makePreparedCISCGraphs(TR::Compilation *c)
       if (minimumHotnessPrepared > hotness)
          minimumHotnessPrepared = hotness;
       }
+
+#if defined(J9VM_OPT_JITSERVER)
+   // Return to per-client allocation
+   if (c->isOutOfProcessCompilation())
+      c->fej9()->_compInfoPT->enterPerClientAllocationRegion();
+#endif
    }
 
 void

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -110,14 +110,14 @@ TR_PersistentClassInfo::removeASubClass(TR_PersistentClassInfo *subClassToRemove
 
 
 void
-TR_PersistentClassInfo::removeSubClasses()
+TR_PersistentClassInfo::removeSubClasses(TR_PersistentMemory *persistentMemory)
    {
    TR_SubClass *scl = _subClasses.getFirst();
    _subClasses.setFirst(0);
    while (scl)
       {
       TR_SubClass *nextScl = scl->getNext();
-      jitPersistentFree(scl);
+      persistentMemory->freePersistentMemory(scl);
       scl = nextScl;
       }
    }
@@ -1284,9 +1284,9 @@ J9::PersistentInfo::addUnloadedClass(
    }
 
 #if defined(J9VM_OPT_JITSERVER)
-void TR_AddressSet::destroy()
+void TR_AddressSet::destroy(TR_PersistentMemory *persistentMemory)
    {
-   jitPersistentFree(_addressRanges);
+   persistentMemory->freePersistentMemory(_addressRanges);
    }
 
 void TR_AddressSet::getRanges(std::vector<TR_AddressRange> &ranges)

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -212,7 +212,7 @@ class ClientSessionData
    struct ClassInfo
       {
       ClassInfo();
-      void freeClassInfo(); // this method is in place of a destructor. We can't have destructor
+      void freeClassInfo(TR_PersistentMemory *persistentMemory); // this method is in place of a destructor. We can't have destructor
       // because it would be called after inserting ClassInfo into the ROM map, freeing romClass
 
       J9ROMClass *_romClass; // romClass content exists in persistentMemory at the server
@@ -337,10 +337,12 @@ class ClientSessionData
       };
 
    TR_PERSISTENT_ALLOC(TR_Memory::ClientSessionData)
-   ClientSessionData(uint64_t clientUID, uint32_t seqNo);
+   ClientSessionData(uint64_t clientUID, uint32_t seqNo, TR_PersistentMemory *persistentMemory, bool usesPerClientMemory);
    ~ClientSessionData();
    static void destroy(ClientSessionData *clientSession);
 
+   TR_PersistentMemory *persistentMemory() { return _persistentMemory; }
+   bool usesPerClientMemory() { return _usesPerClientMemory; }
    void setJavaLangClassPtr(TR_OpaqueClassBlock* j9clazz) { _javaLangClassPtr = j9clazz; }
    TR_OpaqueClassBlock * getJavaLangClassPtr() const { return _javaLangClassPtr; }
    TR_PersistentCHTable *getCHTable();
@@ -437,6 +439,8 @@ class ClientSessionData
    private:
    const uint64_t _clientUID;
    int64_t  _timeOfLastAccess; // in ms
+   TR_PersistentMemory *_persistentMemory;
+   bool _usesPerClientMemory;
    TR_OpaqueClassBlock *_javaLangClassPtr; // NULL means not set
    // Server side CHTable
    JITServerPersistentCHTable *_chTable;
@@ -525,7 +529,7 @@ class ClientSessionHT
    ClientSessionHT();
    ~ClientSessionHT();
    static ClientSessionHT* allocate(); // allocates a new instance of this class
-   ClientSessionData * findOrCreateClientSession(uint64_t clientUID, uint32_t seqNo, bool *newSessionWasCreated);
+   ClientSessionData * findOrCreateClientSession(uint64_t clientUID, uint32_t seqNo, bool *newSessionWasCreated, J9JITConfig *jitConfig);
    bool deleteClientSession(uint64_t clientUID, bool forDeletion);
    ClientSessionData * findClientSession(uint64_t clientUID);
    void purgeOldDataIfNeeded();

--- a/runtime/compiler/runtime/Listener.cpp
+++ b/runtime/compiler/runtime/Listener.cpp
@@ -309,7 +309,7 @@ TR_Listener::serveRemoteCompilationRequests(BaseCompileDispatcher *compiler)
             if (sslCtx && !acceptOpenSSLConnection(sslCtx, connfd, bio))
                continue;
 
-            JITServer::ServerStream *stream = new (PERSISTENT_NEW) JITServer::ServerStream(connfd, bio);
+            JITServer::ServerStream *stream = new (TR::Compiler->persistentGlobalAllocator()) JITServer::ServerStream(connfd, bio);
             compiler->compile(stream);
             }
          } while ((-1 != connfd) && !getListenerThreadExitFlag());

--- a/runtime/compiler/runtime/RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -121,7 +121,7 @@ class TR_PersistentClassInfo : public TR_Link0<TR_PersistentClassInfo>
    int32_t getSubClassesCount() { return _subClasses.getSize(); }
 
    virtual TR_SubClass *addSubClass(TR_PersistentClassInfo *subClass);
-   virtual void removeSubClasses();
+   virtual void removeSubClasses(TR_PersistentMemory *persistentMemory = ::trPersistentMemory);
    virtual void removeASubClass(TR_PersistentClassInfo *subClass);
    virtual void removeUnloadedSubClasses();
    virtual void setUnloaded(){_visitedStatus |= 0x2;}
@@ -251,7 +251,7 @@ class TR_AddressSet
       {}
 
 #if defined(J9VM_OPT_JITSERVER)
-   void destroy();
+   void destroy(TR_PersistentMemory *persistentMemory);
    void getRanges(std::vector<TR_AddressRange> &ranges); // copies the address ranges stored in the current object into a vector
    void setRanges(const std::vector<TR_AddressRange> &ranges); // loads the address ranges from the vector given as parameter
    int32_t getNumberOfRanges() const { return _numAddressRanges; }


### PR DESCRIPTION
As described in eclipse#11162, a regular persistent allocator doesn't
release freed memory back to the system, which causes the memory
occupied by persistent allocator to remain unavailable for other
allocation types, even if all the clients have disconnected.
If the available memory is low, this leads to memory
exhaustion once a large enough number of  clients have cycled through.

This commit enables the server to create a new persistent allocator
for each client. When a client disconnects and its client data is
cleaned, its corresponding persistent allocator will also be destroyed.
This releases all memory reserved by that allocator back into the system.
We modify the persistent allocator to use virtual memory allocation,
instead of simple malloc, because memory allocated with malloc is not
guaranteed to be released back into the system and could also be
retained internally.

The main interface for using per-client allocation is inside
`TR::CompilationInfoPerThreadBase` and contains the following methods:
- `enterPerClientAllocationRegion(clientUID)`: begins per-client
persistent allocation on the current thread for a client with a given UID.
All allocations/frees that would normally be done globally, are now
rerouted to be done by a per-client allocator, e.g. `PERSISTENT_NEW`,
`TR::Compiler->persistentAllocator()`, `jitPersistentAlloc/Free`, etc.
- `exitPerClientAllocationRegion()`: end per-client allocation on the
current thread. All allocations/frees after this call will be done by
the default global allocator.

While the vast majority of persistent allocations can be strictly
divided into per-client/global allocations, there may be some rare
cases when a data structure is allocated globally but can be freed or
reallocated in the middle of a compilation. These cases need to be
handled manually by exiting the allocation region, performing the
required
memory operation and re-entering the region.