### PR TITLE
Eliminate vm.heapBaseAddress()

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -484,20 +484,12 @@ J9::ARM64::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::CodeGenerator *c
       if (translatedNode->getOpCode().isRightShift()) // optional
          translatedNode = translatedNode->getFirstChild();
 
-      bool usingLowMemHeap = false;
-      if (TR::Compiler->vm.heapBaseAddress() == 0 || secondChild->isNull())
-         usingLowMemHeap = true;
+      usingCompressedPointers = true;
 
-      if (translatedNode->getOpCode().isSub() || usingLowMemHeap)
-         usingCompressedPointers = true;
-
-      if (usingCompressedPointers)
-         {
-         while (secondChild->getNumChildren() && secondChild->getOpCodeValue() != TR::a2l)
-            secondChild = secondChild->getFirstChild();
-         if (secondChild->getNumChildren())
-            secondChild = secondChild->getFirstChild();
-         }
+      while (secondChild->getNumChildren() && secondChild->getOpCodeValue() != TR::a2l)
+         secondChild = secondChild->getFirstChild();
+      if (secondChild->getNumChildren())
+         secondChild = secondChild->getFirstChild();
       }
 
    if (secondChild->getReferenceCount() > 1 && secondChild->getRegister() != NULL)
@@ -2645,20 +2637,12 @@ J9::ARM64::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR::CodeGenerat
       if (translatedNode->getOpCode().isRightShift()) // optional
          translatedNode = translatedNode->getFirstChild();
 
-      bool usingLowMemHeap = false;
-      if (TR::Compiler->vm.heapBaseAddress() == 0 || sourceChild->isNull())
-         usingLowMemHeap = true;
+      usingCompressedPointers = true;
 
-      if ((translatedNode->getOpCode().isSub()) || usingLowMemHeap)
-         usingCompressedPointers = true;
-
-      if (usingCompressedPointers)
-         {
-         while ((sourceChild->getNumChildren() > 0) && (sourceChild->getOpCodeValue() != TR::a2l))
-            sourceChild = sourceChild->getFirstChild();
-         if (sourceChild->getOpCodeValue() == TR::a2l)
-            sourceChild = sourceChild->getFirstChild();
-         }
+      while ((sourceChild->getNumChildren() > 0) && (sourceChild->getOpCodeValue() != TR::a2l))
+         sourceChild = sourceChild->getFirstChild();
+      if (sourceChild->getOpCodeValue() == TR::a2l)
+         sourceChild = sourceChild->getFirstChild();
       }
 
    TR::Register *srcReg;

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -462,7 +462,6 @@ J9::CodeGenerator::lowerCompressedRefs(
       vcount_t visitCount,
       TR_BitVector *childrenToBeLowered)
    {
-   bool isLowMem = true;
    if (node->getOpCode().isCall() && childrenToBeLowered)
       {
       TR_BitVectorIterator bvi(*childrenToBeLowered);
@@ -633,9 +632,7 @@ J9::CodeGenerator::lowerCompressedRefs(
    if (TR::Compiler->om.compressedReferenceShiftOffset() > 0)
       shftOffset = TR::Node::create(loadOrStoreNode, TR::iconst, 0, TR::Compiler->om.compressedReferenceShiftOffset());
 
-   static char *pEnv = feGetEnv("TR_disableLowHeapMem");
-   if (pEnv)
-      isLowMem = false;
+   bool isLowMem = feGetEnv("TR_disableLowHeapMem") ? false : true;
 
    if (isLoad)
       {

--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -618,7 +618,7 @@ J9::ObjectModel::getArrayLengthInElements(TR::Compilation* comp, uintptr_t objec
 uintptr_t
 J9::ObjectModel::decompressReference(TR::Compilation* comp, uintptr_t compressedReference)
    {
-   return (compressedReference << TR::Compiler->om.compressedReferenceShift()) + TR::Compiler->vm.heapBaseAddress();
+   return (compressedReference << TR::Compiler->om.compressedReferenceShift());
    }
 
 bool

--- a/runtime/compiler/env/J9VMEnv.cpp
+++ b/runtime/compiler/env/J9VMEnv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,14 +60,6 @@ J9::VMEnv::maxHeapSizeInBytes()
    J9MemoryManagerFunctions * mmf = jvm->memoryManagerFunctions;
    return (int64_t) mmf->j9gc_get_maximum_heap_size(jvm);
    }
-
-
-UDATA
-J9::VMEnv::heapBaseAddress()
-   {
-   return 0;
-   }
-
 
 bool
 J9::VMEnv::hasAccess(OMR_VMThread *omrVMThread)

--- a/runtime/compiler/env/J9VMEnv.hpp
+++ b/runtime/compiler/env/J9VMEnv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,8 +50,6 @@ class OMR_EXTENSIBLE VMEnv : public OMR::VMEnvConnector
 public:
 
    int64_t maxHeapSizeInBytes();
-
-   uintptr_t heapBaseAddress();
 
    uintptr_t thisThreadGetPendingExceptionOffset();
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1141,7 +1141,7 @@ TR_J9VMBase::getReferenceFieldAtAddress(uintptr_t fieldAddress)
    if (TR::Compiler->om.compressObjectReferences())
       {
       uintptr_t compressedResult = *(uint32_t*)fieldAddress;
-      return (compressedResult << TR::Compiler->om.compressedReferenceShift()) + TR::Compiler->vm.heapBaseAddress();
+      return (compressedResult << TR::Compiler->om.compressedReferenceShift());
       }
    return *(uintptr_t*)fieldAddress;
    }

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -1474,30 +1474,6 @@ TR::Register *J9::Power::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::Co
 
    if (comp->useCompressedPointers() && (node->getSymbolReference()->getSymbol()->getDataType() == TR::Address) && (node->getSecondChild()->getDataType() != TR::Address))
       {
-      // pattern match the sequence
-      //     iwrtbar f     iwrtbar f         <- node
-      //       aload O       aload O
-      //     value           l2i
-      //                       lshr         <- translatedNode
-      //                         lsub
-      //                           a2l
-      //                             value   <- secondChild
-      //                           lconst HB
-      //                         iconst shftKonst
-      //
-      // -or- if the field is known to be null or usingLowMemHeap
-      // iwrtbar f
-      //    aload O
-      //    l2i
-      //      a2l
-      //        value  <- secondChild
-      //
-      TR::Node *translatedNode = secondChild;
-      if (translatedNode->getOpCode().isConversion())
-         translatedNode = translatedNode->getFirstChild();
-      if (translatedNode->getOpCode().isRightShift()) // optional
-         translatedNode = translatedNode->getFirstChild();
-
       usingCompressedPointers = true;
       while (secondChild->getNumChildren() && secondChild->getOpCodeValue() != TR::a2l)
          secondChild = secondChild->getFirstChild();
@@ -3382,30 +3358,6 @@ TR::Register *J9::Power::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, T
 
    if (comp->useCompressedPointers() && firstChild->getOpCode().isIndirect())
       {
-      // pattern match the sequence
-      //     iistore f     iistore f         <- node
-      //       aload O       aload O
-      //     value           l2i
-      //                       lshr
-      //                         lsub
-      //                           a2l
-      //                             value   <- sourceChild
-      //                           lconst HB
-      //                         iconst shftKonst
-      //
-      // -or- if the field is known to be null
-      // iistore f
-      //    aload O
-      //    l2i
-      //      a2l
-      //        value  <- valueChild
-      //
-      TR::Node *translatedNode = sourceChild;
-      if (translatedNode->getOpCode().isConversion())
-         translatedNode = translatedNode->getFirstChild();
-      if (translatedNode->getOpCode().isRightShift()) // optional
-         translatedNode = translatedNode->getFirstChild();
-
       while ((sourceChild->getNumChildren() > 0) && (sourceChild->getOpCodeValue() != TR::a2l))
          sourceChild = sourceChild->getFirstChild();
       if (sourceChild->getOpCodeValue() == TR::a2l)

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -353,14 +353,10 @@ static TR_OutlinedInstructions *generateArrayletReference(
    generateRegMemInstruction(op, node, scratchReg, spineMR, cg);
 
    // Decompress the arraylet pointer from the spine.
-   //
-   bool isHB0 = false;
    int32_t shiftOffset = 0;
 
    if (comp->target().is64Bit() && comp->useCompressedPointers())
       {
-      isHB0 = true;
-
       shiftOffset = TR::Compiler->om.compressedReferenceShiftOffset();
       if (shiftOffset > 0)
          {
@@ -458,17 +454,13 @@ static TR_OutlinedInstructions *generateArrayletReference(
       //
       if (loadNeedsDecompression)
          {
-         if (isHB0)
-            {
+		 if (comp->target().is64Bit() && comp->useCompressedPointers())
+		    {
             if (shiftOffset > 0)
                {
                generateRegImmInstruction(SHL8RegImm1, node, loadOrStoreReg, shiftOffset, cg);
                }
-            }
-         else
-            {
-            TR_ASSERT(0, "!HB0 not supported yet");
-            }
+			}
          }
       }
    else

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -5167,30 +5167,6 @@ J9::Z::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node * node, TR::CodeGenerator 
    bool usingCompressedPointers = false;
    if (comp->useCompressedPointers() && firstChild->getOpCode().isIndirect())
       {
-       // pattern match the sequence
-       //     iistore f     iistore f         <- node
-       //       aload O       aload O
-       //     value           l2i
-       //                       lshr
-       //                         lsub
-       //                           a2l
-       //                             value   <- sourceChild
-       //                           lconst HB
-       //                         iconst shftKonst
-       //
-       // -or- if the field is known to be null
-       // iistore f
-       //    aload O
-       //    l2i
-       //      a2l
-       //        value  <- valueChild
-       //
-      TR::Node *translatedNode = sourceChild;
-      if (translatedNode->getOpCode().isConversion())
-         translatedNode = translatedNode->getFirstChild();
-      if (translatedNode->getOpCode().isRightShift()) // optional
-         translatedNode = translatedNode->getFirstChild();
-
       usingCompressedPointers = true;
 
       if (usingCompressedPointers)


### PR DESCRIPTION
This commit removes `J9::VMEnv::heapBaseAddress()` as this routine always returns 0. It was introduced in the codebase early on in the codebase and has since been superseded by a shift-based solution. Hence this is no longer needed. See eclipse/openj9#11263 for original issue and discussion.

Fixes: #11263

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>