### PR TITLE
Add a CML test suite for JEP390

### DIFF
--- a/test/functional/cmdLineTests/ValueBasedClassTest/build.xml
+++ b/test/functional/cmdLineTests/ValueBasedClassTest/build.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2021, 2021 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="cmdLineTests" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTester_ValueBasedClassTest
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/ValueBasedClassTest" />
+	<property name="src" location="./src"/>
+	<property name="build" location="./bin"/>
+	<property name="addExports" value="--add-exports java.base/jdk.internal=ALL-UNNAMED" />
+
+	<target name="init">
+		<mkdir dir="${DEST}" />
+		<mkdir dir="${build}" />
+	</target>
+
+	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+			<compilerarg line='${addExports}' />
+		</javac>
+	</target>
+
+	<target name="dist" depends="compile" description="generate the distribution">
+		<jar jarfile="${DEST}/ValueBasedClassTest.jar" filesonly="true">
+			<fileset dir="${build}" />
+			<fileset dir="${src}" />
+		</jar>
+		<copy todir="${DEST}">
+			<fileset dir="${src}/../" includes="*.xml" />
+			<fileset dir="${src}/../" includes="*.mk" />
+		</copy>
+	</target>
+
+	<target name="clean" depends="dist" description="clean up">
+		<!-- Delete the ${build} directory trees -->
+		<delete dir="${build}" />
+	</target>
+
+	<target name="build" >
+		<if>
+			<or>
+				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
+				<equals arg1="${JDK_IMPL}" arg2="openj9" />
+			</or>
+			<then>
+				<if>
+					<not>
+						<!--Only need this test for Java 16 and up-->
+						<matches string="${JDK_VERSION}" pattern="^(8|11)$$" />
+					</not>
+					<then>
+						<antcall target="clean" inheritall="true" />
+					</then>
+				</if>
+			</then>
+		</if>
+	</target>
+</project>

--- a/test/functional/cmdLineTests/ValueBasedClassTest/jep390.xml
+++ b/test/functional/cmdLineTests/ValueBasedClassTest/jep390.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2021, 2021 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="Value based class tests" timeout="300">
+<!--   
+	This test is for the new command line options added in Java 16 and up by JEP390: Warnings for Value-Based Classes.
+	-XX:DiagnoseSyncOnValuedBasedClasses=1 triggers a VirtualMachineError when synchronizing on a object that is value-based.
+	-XX:DiagnoseSyncOnValuedBasedClasses=1 triggers a warning message when synchronizing on a object that is value-based.
+	This JEP is to prepare users for the upcoming value-types.
+ -->
+ 	<test id="Test 1-a Test no error warning or VirtualMachineError if neither of the new CML options is used when calling syncOnValueBasedClass()">
+		<command>$JAVA_EXE$ -cp $Q$$JARPATH$$Q$ org.openj9.test.JEP390Test.ValueBasedClassTest VB</command>
+		<output regex="no" type="success">ValueBasedClassTest Exit</output> 
+		<output regex="no" type="required">Calling method syncOnValueBasedClass()</output>
+		<output type="failure" caseSensitive="no" regex="no">object that is synchronized is value-based</output>
+		<output type="failure" caseSensitive="no" regex="no">VirtualMachineError</output>
+		<output type="failure" caseSensitive="no" regex="no">ValueBasedClassTest.java</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test 1-b Test no error warning or VirtualMachineError if neither of the new CML options is used when calling syncOnObject()">
+		<command>$JAVA_EXE$ -cp $Q$$JARPATH$$Q$ org.openj9.test.JEP390Test.ValueBasedClassTest OBJ</command>
+		<output regex="no" type="success">ValueBasedClassTest Exit</output> 
+		<output regex="no" type="required">Calling method syncOnObject()</output>
+		<output type="failure" caseSensitive="no" regex="no">object that is synchronized is value-based</output>
+		<output type="failure" caseSensitive="no" regex="no">VirtualMachineError</output>
+		<output type="failure" caseSensitive="no" regex="no">ValueBasedClassTest.java</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+ 
+	<test id="Test 2-a Test error message when calling syncOnValueBasedClass()">
+		<command>$JAVA_EXE$ -XX:DiagnoseSyncOnValuedBasedClasses=1 -cp $Q$$JARPATH$$Q$ org.openj9.test.JEP390Test.ValueBasedClassTest VB</command>
+		<output regex="no" type="success">Calling method syncOnValueBasedClass()</output> 
+		<output regex="no" type="required">VirtualMachineError: bad object type org/openj9/test/JEP390Test/ValueBasedClass: object that is synchronized is value-based</output>
+		<output regex="no" type="required">at org.openj9.test.JEP390Test.ValueBasedClassTest.syncOnValueBasedClass(ValueBasedClassTest.java:48)</output> 
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Test 2-b Test error message when calling syncOnObject()">
+		<command>$JAVA_EXE$ -XX:DiagnoseSyncOnValuedBasedClasses=1 -cp $Q$$JARPATH$$Q$ org.openj9.test.JEP390Test.ValueBasedClassTest OBJ</command>
+		<output regex="no" type="success">Calling method syncOnObject()</output> 
+		<output regex="no" type="required">VirtualMachineError: bad object type org/openj9/test/JEP390Test/ValueBasedClass: object that is synchronized is value-based</output>
+		<output regex="no" type="required">at org.openj9.test.JEP390Test.ValueBasedClassTest.syncOnObject(ValueBasedClassTest.java:54)</output> 
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test 3-a Test warning message when calling syncOnValueBasedClass()">
+		<command>$JAVA_EXE$ -XX:DiagnoseSyncOnValuedBasedClasses=2 -cp $Q$$JARPATH$$Q$ org.openj9.test.JEP390Test.ValueBasedClassTest VB</command>
+		<output regex="no" type="success">ValueBasedClassTest Exit</output> 
+		<output regex="no" type="required">Calling method syncOnValueBasedClass()</output>
+		<output regex="no" type="required">JVMJ9VM200W bad object type org/openj9/test/JEP390Test/ValueBasedClass: object that is synchronized is value-based</output>
+		<output type="failure" caseSensitive="no" regex="no">VirtualMachineError</output>
+		<output type="failure" caseSensitive="no" regex="no">ValueBasedClassTest.java</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Test 3-b Test warning message when calling syncOnObject()">
+		<command>$JAVA_EXE$ -XX:DiagnoseSyncOnValuedBasedClasses=2 -cp $Q$$JARPATH$$Q$ org.openj9.test.JEP390Test.ValueBasedClassTest OBJ</command>
+		<output regex="no" type="success">ValueBasedClassTest Exit</output> 
+		<output regex="no" type="required">Calling method syncOnObject()</output>
+		<output regex="no" type="required">JVMJ9VM200W bad object type org/openj9/test/JEP390Test/ValueBasedClass: object that is synchronized is value-based</output>
+		<output type="failure" caseSensitive="no" regex="no">VirtualMachineError</output>
+		<output type="failure" caseSensitive="no" regex="no">ValueBasedClassTest.java</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+</suite>

--- a/test/functional/cmdLineTests/ValueBasedClassTest/playlist.xml
+++ b/test/functional/cmdLineTests/ValueBasedClassTest/playlist.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2021, 2021 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+	<test>
+		<testCaseName>cmdLineTester_ValueBasedClassTest</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		-DJARPATH=$(Q)$(TEST_RESROOT)$(D)ValueBasedClassTest.jar$(Q) \
+		-DJAVA_EXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(SQ) \
+		-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)jep390.xml$(Q) \
+		-nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+		<!-- run for Java 16 and up -->
+			<subset>16+</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+</playlist>

--- a/test/functional/cmdLineTests/ValueBasedClassTest/src/org/openj9/test/JEP390Test/ValueBasedClass.java
+++ b/test/functional/cmdLineTests/ValueBasedClassTest/src/org/openj9/test/JEP390Test/ValueBasedClass.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.JEP390Test;
+
+@jdk.internal.ValueBased
+public class ValueBasedClass
+{
+	private int year;
+	ValueBasedClass(int y) {
+		year = y;
+	}
+}

--- a/test/functional/cmdLineTests/ValueBasedClassTest/src/org/openj9/test/JEP390Test/ValueBasedClassTest.java
+++ b/test/functional/cmdLineTests/ValueBasedClassTest/src/org/openj9/test/JEP390Test/ValueBasedClassTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.JEP390Test;
+/**
+ * This class is used by test cases in jep390.xml. jep390.xml has test cases checking for line numbers in the stack trace, 
+ * so jep390.xml may need to be updated accordingly if this file is modified. 
+ */
+public class ValueBasedClassTest
+{
+	public static void main(String[] args) {
+		ValueBasedClass vb = new ValueBasedClass(2021);
+		String input1 = "VB";
+		String input2 = "OBJ";
+		if (args.length != 1) {
+			System.out.println("Pass in either " + '"' + input1 + '"' + " or " + '"' + input2 + '"' + " as parameter");
+		} else {
+			if (args[0].equals(input1)) {
+				syncOnValueBasedClass(vb);
+			} else if (args[0].equals(input2)) {
+				syncOnObject(vb);
+			} else {
+				System.out.println("Pass in either " + '"' + input1 + '"' + " or " + '"' + input2 + '"' + " as parameter");
+			}
+		}
+		System.out.println("ValueBasedClassTest Exit");
+	}
+	private static void syncOnValueBasedClass(ValueBasedClass vb) {
+		System.out.println("Calling method syncOnValueBasedClass()");
+		synchronized (vb) {
+			System.out.println("synchronizing on ValueBasedClass");
+		}
+	}
+	private static void syncOnObject(Object o) {
+		System.out.println("Calling method syncOnObject()");
+		synchronized (o) {
+			System.out.println("synchronizing on Object");
+		}
+	}
+}


### PR DESCRIPTION
1. Add source code, build.xml and playlist.xml
2. Enable this test on Java 16 and up.

issue #10620

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>