### PR TITLE
Make MethodHandles.classData public for JDK16

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -5528,6 +5528,9 @@ public class MethodHandles {
 	 * @return the classData casted to the appropriate type.
 	 * @throws IllegalAccessException in the absence of full privilege access.
 	 */
+	/*[IF JAVA_SPEC_VERSION >= 16]*/
+	public
+	/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 	static <T> T classData(Lookup caller, String unused, Class<T> type) throws IllegalAccessException {
 		if (caller.hasFullPrivilegeAccess()) {
 			Object classData = MethodHandleNatives.classData(caller.accessClass);


### PR DESCRIPTION
Related: https://github.com/eclipse/openj9/issues/11135
Related: https://github.com/eclipse/openj9/issues/11359

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>