### PR TITLE
Update override-vm for romclass changes

### DIFF
--- a/runtime/ddr/overrides-vm
+++ b/runtime/ddr/overrides-vm
@@ -155,6 +155,8 @@ typeoverride.J9ROMNameAndSignature.signature=J9SRP(J9UTF8)
 
 typeoverride.J9ROMMethodTypeRef.signature=J9SRP(J9UTF8)
 
+typeoverride.J9ROMConstantDynamicRef.nameAndSignature=J9SRP(J9ROMNameAndSignature)
+
 # AVL leftChild and rightChild pointers aren't regular wide pointers.
 # They have AVL balance data encoded in them - so treat
 # them as IDATAs and handle them in the DDR AVL code.


### PR DESCRIPTION
Update override-vm for romclass changes

vmddrstructs.properties was updated as a result of
https://github.com/eclipse/openj9/pull/11619 missing the constant
dynamic cp entries. The equivalent change was missed in override-vm.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>