### PR TITLE
Change to use Reflection.getClassAccessFlags in MHs.checkClassAccess

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import jdk.internal.reflect.CallerSensitive;
+import jdk.internal.reflect.Reflection;
 import java.lang.invoke.VarHandle.AccessMode;
 import java.lang.reflect.Array;
 /*[IF Sidecar19-SE-OpenJ9]*/
@@ -70,6 +71,7 @@ import java.lang.reflect.Module;
 /*[ENDIF] Sidecar19-SE-OpenJ9*/
 /*[ELSE] Sidecar19-SE*/
 import sun.reflect.CallerSensitive;
+import sun.reflect.Reflection;
 /*[ENDIF] Sidecar19-SE*/
 
 /*[IF JAVA_SPEC_VERSION >= 15]*/
@@ -602,7 +604,7 @@ public class MethodHandles {
 				 * the protected flag of this class doesn't exist on the VM level (there is no 
 				 * access flag in the binary form representing 'protected')
 				 */
-				int targetClassModifiers = targetClass.getModifiers();
+				int targetClassModifiers = Reflection.getClassAccessFlags(targetClass);
 				final boolean targetClassIsPublic = (Modifier.isPublic(targetClassModifiers) || Modifier.isProtected(targetClassModifiers));
 
 				/*[IF JAVA_SPEC_VERSION >= 14]*/

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -349,6 +349,20 @@ public class MethodHandles {
 		static final VMLangAccess getVMLangAccess() {
 			return VMLangAccessGetter.vma;
 		}
+
+		private static int getClassModifiers(Class<?> cls) {
+			int modifiers = 0;
+			/* Use Reflection.getClassAccessFlags to get the actual ROM Class modifiers
+			 * instead of the attribute flags for innerclasses
+			 */
+			if (cls.isPrimitive() || cls.isArray()) {
+				modifiers = cls.getModifiers();
+			} else {
+				modifiers = Reflection.getClassAccessFlags(cls);
+			}
+
+			return modifiers;
+		}
 		
 		/* Verify two classes share the same package in a way to avoid Class.getPackage()
 		 * and the security checks that go with it.
@@ -604,8 +618,8 @@ public class MethodHandles {
 				 * the protected flag of this class doesn't exist on the VM level (there is no 
 				 * access flag in the binary form representing 'protected')
 				 */
-				int targetClassModifiers = Reflection.getClassAccessFlags(targetClass);
-				final boolean targetClassIsPublic = (Modifier.isPublic(targetClassModifiers) || Modifier.isProtected(targetClassModifiers));
+				int targetClassModifiers = getClassModifiers(targetClass);
+				final boolean targetClassIsPublic = Modifier.isPublic(targetClassModifiers);
 
 				/*[IF JAVA_SPEC_VERSION >= 14]*/
 				Module accessModule = accessClass.getModule();
@@ -1324,9 +1338,8 @@ public class MethodHandles {
 			 * the protected flag of this class doesn't exist on the VM level (there is no 
 			 * access flag in the binary form representing 'protected')
 			 */
-			int lookupClassModifiers = lookupClass.getModifiers();
-			final boolean lookupClassIsPublic = (Modifier.isPublic(lookupClassModifiers) || Modifier.isProtected(lookupClassModifiers));
-			if(!lookupClassIsPublic) {
+			int lookupClassModifiers = getClassModifiers(lookupClass);
+			if(!Modifier.isPublic(lookupClassModifiers)) {
 				if(isSamePackage(accessClass, lookupClass)) {
 					if (0 == (accessMode & PACKAGE)) {
 						newAccessMode = NO_ACCESS;
@@ -2036,7 +2049,7 @@ public class MethodHandles {
 		 */
 		public Class<?> accessClass(Class<?> targetClass) throws IllegalAccessException {
 			targetClass.getClass(); /* implicit null checks */
-			int targetClassModifiers = targetClass.getModifiers();
+			int targetClassModifiers = getClassModifiers(targetClass);
 			checkAccess(targetClass);
 			checkSecurity(targetClass, targetClass, targetClassModifiers);
 			return targetClass;


### PR DESCRIPTION
Using class.getModifiers() for an innerclass will return the source code
level modifiers from the innerclass attribute, which may be different
from the runtime class header.

Change to use Reflection.getClassAccessFlags will ensure the actual
JVM ROMClass modifiers are used for access checks.

Fixes: #11538 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>