### PR TITLE
Fix sending server memory state at compilation failure

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -3385,17 +3385,11 @@ remoteCompile(
       else
          {
          TR_ASSERT(JITServer::MessageType::compilationFailure == response, "Received %u but expect JITServer::MessageType::compilationFailure message type", response);
-         if (JITServer::MessageType::compilationCode == compilationLowPhysicalMemory)
-            {
-            auto recv = client->getRecvData<uint32_t, JITServer::ServerMemoryState>();
-            statusCode = std::get<0>(recv);
-            updateCompThreadActivationPolicy(compInfoPT, std::get<1>(recv)); 
-            }
-         else
-            {
-            auto recv = client->getRecvData<uint32_t>();
-            statusCode = std::get<0>(recv);
-            }
+         auto recv = client->getRecvData<uint32_t, uint64_t>();
+         statusCode = std::get<0>(recv);
+         uint64_t otherData = std::get<1>(recv);
+         if (statusCode == compilationLowPhysicalMemory && otherData != -1) // if failed due to low memory, should've received an updated memory state
+            updateCompThreadActivationPolicy(compInfoPT, (JITServer::ServerMemoryState) otherData); 
          if (TR::Options::getVerboseOption(TR_VerboseJITServer))
             TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "remoteCompile: compilationFailure statusCode %u\n", statusCode);
 

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -770,7 +770,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       {
       if (TR::Options::getVerboseOption(TR_VerboseJITServer))
          TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Server out of memory in processEntry: %s", e.what());
-      stream->writeError(compilationLowPhysicalMemory, computeServerMemoryState(getCompilationInfo()));
+      stream->writeError(compilationLowPhysicalMemory, (uint64_t) computeServerMemoryState(getCompilationInfo()));
       abortCompilation = true;
       }
 

--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -217,15 +217,14 @@ public:
    /**
       @brief Function invoked by server when compilation is aborted
    */
-   template <typename ...T>
-   void writeError(uint32_t statusCode, T... args)
+   void writeError(uint32_t statusCode, uint64_t otherData = -1)
       {
       try
          {
          if (TR::Options::getVerboseOption(TR_VerboseJITServer))
             TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d MessageType::compilationFailure: statusCode %u",
                   TR::compInfoPT->getCompThreadId(), statusCode);
-         write(MessageType::compilationFailure, statusCode, args...);
+         write(MessageType::compilationFailure, statusCode, otherData);
          }
       catch (std::exception &e)
          {

--- a/runtime/compiler/runtime/CompileService.cpp
+++ b/runtime/compiler/runtime/CompileService.cpp
@@ -46,5 +46,5 @@ void J9CompileDispatcher::compile(JITServer::ServerStream *stream)
          }
       } // end critical section
    // If we reached this point there was a memory allocation failure
-   stream->writeError(compilationLowPhysicalMemory, JITServer::ServerMemoryState::VERY_LOW);
+   stream->writeError(compilationLowPhysicalMemory, (uint64_t) JITServer::ServerMemoryState::VERY_LOW);
    }


### PR DESCRIPTION
PR #11628 introduced a bug where it was assumed that message type
is the same as compilation failures status code, as described in #11711.

This commit fixes it by adding a new message type to send memory state
updates to the client.
Also reverted changes to `ServerStream::writeError`, since there is no
need to write variable number of arguments anymore.