### PR TITLE
Simplify isMonitorValueBasedOrValueType

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -5447,20 +5447,22 @@ J9::CodeGenerator::isMonitorValueType(TR::Node* monNode)
 TR_YesNoMaybe
 J9::CodeGenerator::isMonitorValueBasedOrValueType(TR::Node* monNode)
    {
-   TR_OpaqueClassBlock *clazz = self()->getMonClass(monNode);
+   if (TR::Compiler->om.areValueTypesEnabled() || TR::Compiler->om.areValueBasedMonitorChecksEnabled())
+      {
+      TR_OpaqueClassBlock *clazz = self()->getMonClass(monNode);
 
-   if (!clazz)
-      return TR_maybe;
+      if (!clazz)
+         return TR_maybe;
 
-   //java.lang.Object class is only set when monitor is java.lang.Object but not its subclass
-   if (clazz == self()->comp()->getObjectClassPointer())
-      return TR_no;
+      //java.lang.Object class is only set when monitor is java.lang.Object but not its subclass
+      if (clazz == self()->comp()->getObjectClassPointer())
+         return TR_no;
 
-   if (!TR::Compiler->cls.isConcreteClass(self()->comp(), clazz))
-      return TR_maybe;
+      if (!TR::Compiler->cls.isConcreteClass(self()->comp(), clazz))
+         return TR_maybe;
 
-   if (TR::Compiler->cls.isValueBasedOrValueTypeClass(clazz))
-      return TR_yes;
-
+      if (TR::Compiler->cls.isValueBasedOrValueTypeClass(clazz))
+         return TR_yes;
+      }
    return TR_no;
    }

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -334,7 +334,8 @@ public:
    TR_YesNoMaybe isMonitorValueType(TR::Node* monNode);
    /*
     * \brief
-    *    Whether a monitor object is of value based class type or value type
+    *    Whether a monitor object is of value based class type or value type.
+    *    This API checks if value based or value type is enabled first.
     *
     * \return
     *    TR_yes The monitor object is definitely value based class type or value type

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -7249,8 +7249,7 @@ J9::Z::TreeEvaluator::VMmonentEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
    int32_t lwOffset = fej9->getByteOffsetToLockword((TR_OpaqueClassBlock *) cg->getMonClass(node));
    J9::Z::CHelperLinkage *helperLink =  static_cast<J9::Z::CHelperLinkage*>(cg->getLinkage(TR_CHelper));
-   bool isValueTypeOrValueBasedEnabled = (TR::Compiler->om.areValueTypesEnabled() || TR::Compiler->om.areValueBasedMonitorChecksEnabled());
-   TR_YesNoMaybe isMonitorValueBasedOrValueType = isValueTypeOrValueBasedEnabled ? cg->isMonitorValueBasedOrValueType(node) : TR_no;
+   TR_YesNoMaybe isMonitorValueBasedOrValueType = cg->isMonitorValueBasedOrValueType(node);
 
    if (comp->getOption(TR_OptimizeForSpace) ||
        (isMonitorValueBasedOrValueType == TR_yes) ||
@@ -7699,8 +7698,7 @@ J9::Z::TreeEvaluator::VMmonexitEvaluator(TR::Node * node, TR::CodeGenerator * cg
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
    int32_t lwOffset = fej9->getByteOffsetToLockword((TR_OpaqueClassBlock *) cg->getMonClass(node));
    J9::Z::CHelperLinkage *helperLink =  static_cast<J9::Z::CHelperLinkage*>(cg->getLinkage(TR_CHelper));
-   bool isValueTypeOrValueBasedEnabled = (TR::Compiler->om.areValueTypesEnabled() || TR::Compiler->om.areValueBasedMonitorChecksEnabled());
-   TR_YesNoMaybe isMonitorValueBasedOrValueType = isValueTypeOrValueBasedEnabled ? cg->isMonitorValueBasedOrValueType(node) : TR_no;
+   TR_YesNoMaybe isMonitorValueBasedOrValueType = cg->isMonitorValueBasedOrValueType(node);
 
    if (comp->getOption(TR_OptimizeForSpace) ||
        (isMonitorValueBasedOrValueType == TR_yes) ||


### PR DESCRIPTION
As per discussion in code review https://github.com/eclipse/openj9/pull/11677#discussion_r559693247, update `isMonitorValueBasedOrValueType` to check if value based or value type is enabled so that the caller does not need to do so.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>