### PR TITLE
Exempt BCV_SPECIAL_INIT from being set with top in mergeStacks

### DIFF
--- a/runtime/bcverify/bcverify.c
+++ b/runtime/bcverify/bcverify.c
@@ -956,13 +956,12 @@ mergeStacks (J9BytecodeVerificationData * verifyData, UDATA target)
 					if ((sourceItem | targetItem) & (BCV_BASE_OR_SPECIAL)) {
 
 						/* Mismatch results in undefined local - rewalk if modified stack
-						 * Note: BCV_SPECIAL (specifically BCV_SPECIAL_INIT) must be reserved
-						 * to flag the uninitialized_this object existing in the stackmap frame
-						 * when invoking setInitializedThisStatus() after the stackmaps is
-						 * successfully built.
+						 * Note: BCV_SPECIAL_INIT must be reserved to flag the uninitialized_this object
+						 * existing in the stackmap frame when invoking setInitializedThisStatus() after
+						 * the stackmaps are successfully built.
 						 */
-						if ((targetItem != (UDATA) (BCV_BASE_TYPE_TOP))
-						&& ((targetItem & BCV_SPECIAL) == 0)
+						if (((UDATA)(BCV_BASE_TYPE_TOP) != targetItem)
+						&& (0 == (targetItem & BCV_SPECIAL_INIT))
 						) {
 							*targetStackPtr = (UDATA) (BCV_BASE_TYPE_TOP);
 							rewalk = TRUE;

--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -347,8 +347,8 @@ matchStack(J9BytecodeVerificationData * verifyData, J9BranchTargetStack *liveSta
 					}
 				}
 			} else if (*targetPtr != BCV_BASE_TYPE_TOP) {
-				if ((*targetPtr & BCV_SPECIAL) && verifyData->createdStackMap) {
-					/* Generated stackmaps can skip the check on the target slot with BCV_SPECIAL
+				if ((*targetPtr & BCV_SPECIAL_INIT) && verifyData->createdStackMap) {
+					/* Generated stackmaps can skip the check on the target slot with BCV_SPECIAL_INIT
 					 * as this slot is set up based on the bytecode itself rather than decompressed stackmaps.
 					 */
 				} else {


### PR DESCRIPTION
The change is to reinforce the initial intention that only
a target slot with BCV_SPECIAL_INIT is exempted from being
set with top given setInitializedThisStatus() needs to check
BCV_SPECIAL_INIT to flag the uninitialized_this object.

Fixes: #11683,#11684,#11685

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>