### PR TITLE
Add a missing null check in defineHiddenClassWithClassData

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2316,6 +2316,8 @@ public class MethodHandles {
 		 * @throws IllegalAccessException if this Lookup does not have full privilege access.
 		 */
 		public Lookup defineHiddenClassWithClassData(byte[] bytes, Object classData, boolean initOption, ClassOption... classOptions) throws IllegalAccessException {
+			/* Only classData requires an explicit null check. */
+			Objects.requireNonNull(classData);
 			ClassDefiner definer = classDefiner(bytes, classOptions);
 			return new Lookup(definer.defineClass(initOption, classData));
 		}
@@ -2332,6 +2334,8 @@ public class MethodHandles {
 		 * @throws IllegalAccessException if this Lookup does not have full privilege access.
 		 */
 		Lookup defineHiddenClassWithClassData(byte[] bytes, Object classData, ClassOption... classOptions) throws IllegalAccessException {
+			/* Only classData requires an explicit null check. */
+			Objects.requireNonNull(classData);
 			ClassDefiner definer = classDefiner(bytes, classOptions);
 			return new Lookup(definer.defineClass(true, classData));
 		}


### PR DESCRIPTION
As per the doc for [Lookup.defineHiddenClassWithClassData](https://download.java.net/java/early_access/jdk16/docs/api/java.base/java/lang/invoke/MethodHandles.Lookup.html#defineHiddenClassWithClassData(byte%5B%5D,java.lang.Object,boolean,java.lang.invoke.MethodHandles.Lookup.ClassOption...)),
`NullPointerException` must be thrown `if any parameter is null`.

All input parameters have an implicit null check except `classData`. So,
an explicit null check has been added for `classData`.

Related: https://github.com/eclipse/openj9/issues/11366 (fixes one of the errors)

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>