### PR TITLE
Remove mention of AdoptOpenJDK downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2020 IBM Corp. and others
+Copyright (c) 2017, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,7 +33,6 @@ Welcome to the Eclipse OpenJ9 repository
 We're not sure which route you might have taken on your way here, but we're really pleased to see you! If you came directly from our website, you've probably already learned a lot about Eclipse OpenJ9 and how it fits in to the OpenJDK ecosystem. If you came via some other route, here are a few key links to get you started:
 
 - [Eclipse OpenJ9 website](http://www.eclipse.org/openj9) - Learn about this high performance, enterprise-grade Java Virtual Machine (JVM) and why we think you want to get involved in its development.
-- [AdoptOpenJDK website](https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=openj9) - Grab pre-built OpenJDK binaries that embed OpenJ9 and try it out.
 - Build instructions for [JDK8](https://github.com/eclipse/openj9/blob/master/doc/build-instructions/Build_Instructions_V8.md), [JDK11](https://github.com/eclipse/openj9/blob/master/doc/build-instructions/Build_Instructions_V11.md), and [More](https://github.com/eclipse/openj9/blob/master/doc/build-instructions) - Here's how you can build an OpenJDK with OpenJ9 yourself.
 
 If you're looking for ways to help out at the project (thanks!), we have:
@@ -60,11 +59,11 @@ License 2.0 or Eclipse Public License 2.0 with a secondary compatibility license
 GPLv2 license) that is designed to allow OpenJDK to be built with the OpenJ9 JVM.  Please see our
 [LICENSE file](https://github.com/eclipse/openj9/blob/master/LICENSE) for more details.
 
-Eclipse OpenJ9 is a source code project that can be built alongside Java class libraries.  Cross platform
-nightly and release binaries and docker containers for OpenJDK with OpenJ9, targeting several JDK levels
-(JDK8, JDK11, and the latest versions) are built by the [AdoptOpenJDK organization](https://github.com/adoptopenjdk)
-and can be downloaded from the [AdoptOpenJDK download site](https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=openj9)
-or on [DockerHub](https://hub.docker.com/search/?isAutomated=0&isOfficial=0&page=1&pullCount=0&q=openj9&starCount=0).
+Eclipse OpenJ9 is a source code project that can be built alongside Java class libraries. See the
+[build instructions](https://github.com/eclipse/openj9/blob/master/doc/build-instructions). Eclipse
+Foundation projects are not permitted to distribute, market or promote JDK binaries unless they have
+passed a Java SE Technology Compatibility Kit licensed from Oracle, to which the OpenJ9 project does
+not currently have access. See the [Eclipse Adoptium Project Charter](https://projects.eclipse.org/projects/adoptium/charter).
 
 What is the goal of the project?
 ================================

--- a/doc/processes/release_process.md
+++ b/doc/processes/release_process.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2018, 2020 IBM Corp. and others
+Copyright (c) 2018, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,8 +41,6 @@ extensions repos:
 * JDK14 https://github.com/ibmruntimes/openj9-openjdk-jdk14
 * JDK.next https://github.com/ibmruntimes/openj9-openjdk-jdk
 
-OpenJ9 binaries are built by the AdoptOpenJDK community.  
-
 An OpenJ9 release should:
 
 * Use a single code base to support the various JDK-levels.
@@ -50,8 +48,7 @@ An OpenJ9 release should:
 * Use a consistent set of tags across OpenJ9 & extensions repos to 
 ensure that releases can be rebuilt or branched later.
 * OpenJ9 releases should be high quality and pass a common quality bar. 
-* Communicate the tags for a release to AdoptOpenJDK to ensure that
-binaries at the correct levels have been created. 
+* Communicate the tags for a release to downstream projects. 
 * Clearly define the supported platforms
 * Should not regress performance from release to release.
 * Use Github releases to identify releases and link to the relevant
@@ -133,7 +130,7 @@ determination can be made to either:
 will be `openj9-0.8.0`.
 1. Create the [github release](https://help.github.com/articles/creating-releases/)
 corresponding to the tagged level.  The release should link to the Eclipse Release 
-document, the release issue, and the AdoptOpenJDK download links.
+document, and the release issue.
 1. Open an Eclipse Bugzilla requesting the branch be marked `protected` to prevent 
 commits after the release is complete.
 1. Remove the `doc:releasenote` tag from items that were included in the release 

--- a/doc/release-notes/0.24/0.24.md
+++ b/doc/release-notes/0.24/0.24.md
@@ -26,17 +26,11 @@
 
 These release notes support the [Eclipse OpenJ9 0.24.0 release plan](https://projects.eclipse.org/projects/technology.openj9/releases/0.24.0/plan).
 
-## Binaries and supported environments
+## Supported environments
 
 OpenJ9 release 0.24.0 supports OpenJDK 8, OpenJDK 11, and OpenJDK 15.
 
-Binaries are available at the AdoptOpenJDK project:
-
-- [OpenJDK 8 with OpenJ9](https://adoptopenjdk.net/archive.html?variant=openjdk8&jvmVariant=openj9)
-- [OpenJDK 11 with OpenJ9](https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=openj9)
-- [OpenJDK 15 with OpenJ9](https://adoptopenjdk.net/archive.html?variant=openjdk15&jvmVariant=openj9)
-
-All builds are tested against the OpenJ9 functional verification (FV) test suite, the OpenJDK test suites, and additional tests at AdoptOpenJDK.
+All releases are tested against the OpenJ9 functional verification (FV) test suite, the OpenJDK test suites, and additional tests at AdoptOpenJDK.
 
 To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](https://eclipse.org/openj9/docs/openj9_support/index.html).
 


### PR DESCRIPTION
The Eclipse foundation has entered into an agreement with Oracle,
Eclipse projects can only distribute, market or promote open source Java
SE implementations that are licensed for and have passed a Java SE
Technology Compatibility Kit licensed from Oracle.

See https://www.eclipse.org/lists/openj9-dev/msg00085.html

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>