### PR TITLE
Disable VAR_HANDLE_GUARDS optimization in OpenJ9

### DIFF
--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -959,6 +959,15 @@ initializeSystemProperties(J9JavaVM * vm)
 		goto fail;
 	}
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	if (j2seVersion >= J2SE_V11) {
+		rc = addSystemProperty(vm, "java.lang.invoke.VarHandle.VAR_HANDLE_GUARDS", "false", J9SYSPROP_FLAG_WRITEABLE);
+		if (J9SYSPROP_ERROR_NONE != rc) {
+			goto fail;
+		}
+	}
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
+
 	/* If we get here all is good */
 	rc = J9SYSPROP_ERROR_NONE;
 


### PR DESCRIPTION
The `VAR_HANDLE_GUARDS` optimization is disabled in OpenJ9. Refer to
https://github.com/eclipse/openj9/issues/11582 for more details on why this optimization needs to be disabled.

`VarHandles` are only enabled in JDK11+ so the `VAR_HANDLE_GUARDS` system
property only needs to be disabled in JDK11+.

Related: https://github.com/eclipse/openj9/issues/11582, https://github.com/eclipse/openj9/issues/7352

Co-authored-by: Jack Lu <Jack.S.Lu@ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>