### PR TITLE
Store a single copy of each distinct ROMClass at JITServer

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -406,6 +406,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/runtime/JITClientSession.cpp \
     compiler/runtime/JITServerIProfiler.cpp \
     compiler/runtime/JITServerROMClassHash.cpp \
+    compiler/runtime/JITServerSharedROMClassCache.cpp \
     compiler/runtime/JITServerStatisticsThread.cpp \
     compiler/runtime/Listener.cpp
 endif

--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -405,6 +405,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/runtime/CompileService.cpp \
     compiler/runtime/JITClientSession.cpp \
     compiler/runtime/JITServerIProfiler.cpp \
+    compiler/runtime/JITServerROMClassHash.cpp \
     compiler/runtime/JITServerStatisticsThread.cpp \
     compiler/runtime/Listener.cpp
 endif

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -77,6 +77,7 @@ template <typename T> class TR_PersistentArray;
 typedef J9JITExceptionTable TR_MethodMetaData;
 #if defined(J9VM_OPT_JITSERVER)
 class ClientSessionHT;
+class JITServerSharedROMClassCache;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 struct TR_SignatureCountPair
@@ -1067,6 +1068,9 @@ public:
    void setCompThreadActivationPolicy(JITServer::CompThreadActivationPolicy newPolicy) { _activationPolicy = newPolicy; }
    JITServer::CompThreadActivationPolicy getCompThreadActivationPolicy() const { return _activationPolicy; }
    uint64_t getCachedFreePhysicalMemoryB() const { return _cachedFreePhysicalMemoryB; }
+
+   JITServerSharedROMClassCache *getJITServerSharedROMClassCache() const { return _sharedROMClassCache; }
+   void setJITServerSharedROMClassCache(JITServerSharedROMClassCache *cache) { _sharedROMClassCache = cache; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    static void replenishInvocationCount(J9Method* method, TR::Compilation* comp);
@@ -1286,6 +1290,7 @@ private:
    PersistentVector<std::string> _sslKeys;
    PersistentVector<std::string> _sslCerts;
    JITServer::CompThreadActivationPolicy _activationPolicy;
+   JITServerSharedROMClassCache *_sharedROMClassCache;
 #endif /* defined(J9VM_OPT_JITSERVER) */
    }; // CompilationInfo
 }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1193,6 +1193,7 @@ TR::CompilationInfo::CompilationInfo(J9JITConfig *jitConfig) :
    _chTableUpdateFlags = 0;
    _localGCCounter = 0;
    _activationPolicy = JITServer::CompThreadActivationPolicy::AGGRESSIVE;
+   _sharedROMClassCache = NULL;
 #endif /* defined(J9VM_OPT_JITSERVER) */
    }
 

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -127,6 +127,7 @@ int64_t J9::Options::_oldAge = 1000*60*1000; // 1000 minutes
 int64_t J9::Options::_oldAgeUnderLowMemory = 1000*60*5; // 5 minute
 int64_t J9::Options::_timeBetweenPurges = 1000*60*1; // 1 minute
 bool J9::Options::_shareROMClasses = false;
+int32_t J9::Options::_sharedROMClassCacheNumPartitions = 16;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 int32_t J9::Options::_interpreterSamplingThreshold = 300;
@@ -961,6 +962,8 @@ TR::OptionTable OMR::Options::_feOptions[] = {
    {"seriousCompFailureThreshold=",     "M<nnn>\tnumber of srious compilation failures after which we write a trace point in the snap file",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_seriousCompFailureThreshold, 0, "F%d", NOT_IN_SUBSET},
 #if defined(J9VM_OPT_JITSERVER)
+   {"sharedROMClassCacheNumPartitions=", " \tnumber of JITServer ROMClass cache partitions (each has its own monitor)",
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_sharedROMClassCacheNumPartitions, 0, "F%d", NOT_IN_SUBSET},
    {"shareROMClasses", " \tstore a single copy of each distinct ROMClass shared by all clients at JITServer",
         TR::Options::setStaticBool, (intptr_t)&TR::Options::_shareROMClasses, 1, "F", NOT_IN_SUBSET},
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -126,6 +126,7 @@ uintptr_t J9::Options::_compThreadAffinityMask = 0;
 int64_t J9::Options::_oldAge = 1000*60*1000; // 1000 minutes
 int64_t J9::Options::_oldAgeUnderLowMemory = 1000*60*5; // 5 minute
 int64_t J9::Options::_timeBetweenPurges = 1000*60*1; // 1 minute
+bool J9::Options::_shareROMClasses = false;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 int32_t J9::Options::_interpreterSamplingThreshold = 300;
@@ -959,6 +960,10 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_secondaryClassLoadingPhaseThreshold, 0, "F%d", NOT_IN_SUBSET},
    {"seriousCompFailureThreshold=",     "M<nnn>\tnumber of srious compilation failures after which we write a trace point in the snap file",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_seriousCompFailureThreshold, 0, "F%d", NOT_IN_SUBSET},
+#if defined(J9VM_OPT_JITSERVER)
+   {"shareROMClasses", " \tstore a single copy of each distinct ROMClass shared by all clients at JITServer",
+        TR::Options::setStaticBool, (intptr_t)&TR::Options::_shareROMClasses, 1, "F", NOT_IN_SUBSET},
+#endif /* defined(J9VM_OPT_JITSERVER) */
    {"singleCache", "C\tallow only one code cache and one data cache to be allocated", RESET_JITCONFIG_RUNTIME_FLAG(J9JIT_GROW_CACHES) },
    {"smallMethodBytecodeSizeThreshold=", "O<nnn> Threshold for determining small methods\t "
                                          "(measured in number of bytecodes)",

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -262,6 +262,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int64_t _oldAgeUnderLowMemory;
    static int64_t _timeBetweenPurges;
    static bool _shareROMClasses;
+   static int32_t _sharedROMClassCacheNumPartitions;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    static int32_t _waitTimeToEnterIdleMode;

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -261,6 +261,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int64_t _oldAge;
    static int64_t _oldAgeUnderLowMemory;
    static int64_t _timeBetweenPurges;
+   static bool _shareROMClasses;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    static int32_t _waitTimeToEnterIdleMode;

--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -30,6 +30,7 @@
 #include "infra/Statistics.hpp"
 #include "net/CommunicationStream.hpp"
 #include "OMR/Bytes.hpp"// for OMR::alignNoCheck()
+#include "runtime/JITServerSharedROMClassCache.hpp"
 #include "romclasswalk.h"
 #include "util_api.h"// for allSlotsInROMClassDo()
 
@@ -602,10 +603,13 @@ JITServerHelpers::packRemoteROMClassInfo(J9Class *clazz, J9VMThread *vmThread, T
 J9ROMClass *
 JITServerHelpers::romClassFromString(const std::string &romClassStr, TR_PersistentMemory *trMemory)
    {
+   if (auto cache = TR::CompilationInfo::get()->getJITServerSharedROMClassCache())
+      return cache->getOrCreate((const J9ROMClass *)romClassStr.data());
+
    auto romClass = (J9ROMClass *)(trMemory->allocatePersistentMemory(romClassStr.size(), TR_Memory::ROMClass));
    if (!romClass)
       throw std::bad_alloc();
-   memcpy(romClass, &romClassStr[0], romClassStr.size());
+   memcpy(romClass, romClassStr.data(), romClassStr.size());
    return romClass;
    }
 

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1688,6 +1688,17 @@ onLoadInternal(
       if (!JITServer::loadLibsslAndFindSymbols())
          return -1;
       }
+   else if ((compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER) &&
+            TR::Options::_shareROMClasses)
+      {
+      // ROMClass sharing uses a hash implementation from SSL. Disable it if we can't load the library.
+      if (!JITServer::loadLibsslAndFindSymbols())
+         {
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Failed to load SSL library, disabling ROMClass sharing");
+         TR::Options::_shareROMClasses = false;
+         }
+      }
 
    if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
       {

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1733,7 +1733,8 @@ onLoadInternal(
       //NOTE: This must be done only after the SSL library has been successfully loaded
       if (TR::Options::_shareROMClasses)
          {
-         auto cache = new (PERSISTENT_NEW) JITServerSharedROMClassCache();
+         size_t numPartitions = std::max(1, TR::Options::_sharedROMClassCacheNumPartitions);
+         auto cache = new (PERSISTENT_NEW) JITServerSharedROMClassCache(numPartitions);
          if (!cache)
             return -1;
          compInfo->setJITServerSharedROMClassCache(cache);

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -114,9 +114,10 @@
 #include "net/LoadSSLLibs.hpp"
 #include "runtime/JITClientSession.hpp"
 #include "runtime/Listener.hpp"
+#include "runtime/JITServerSharedROMClassCache.hpp"
 #include "runtime/JITServerStatisticsThread.hpp"
 #include "runtime/JITServerIProfiler.hpp"
-#endif
+#endif /* defined(J9VM_OPT_JITSERVER) */
 
 extern "C" int32_t encodeCount(int32_t count);
 
@@ -1728,6 +1729,16 @@ onLoadInternal(
          {
          ((TR_JitPrivateConfig*)(jitConfig->privateConfig))->statisticsThreadObject = NULL;
          }
+
+      //NOTE: This must be done only after the SSL library has been successfully loaded
+      if (TR::Options::_shareROMClasses)
+         {
+         auto cache = new (PERSISTENT_NEW) JITServerSharedROMClassCache();
+         if (!cache)
+            return -1;
+         compInfo->setJITServerSharedROMClassCache(cache);
+         }
+
       }
    else if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
       {

--- a/runtime/compiler/env/J9CompilerEnv.cpp
+++ b/runtime/compiler/env/J9CompilerEnv.cpp
@@ -105,9 +105,17 @@ J9::CompilerEnv::persistentMemory()
    }
 
 #if defined(J9VM_OPT_JITSERVER)
+
 TR::PersistentAllocator &
 J9::CompilerEnv::persistentGlobalAllocator()
    {
    return OMR::CompilerEnv::persistentAllocator();
    }
-#endif
+
+TR_PersistentMemory *
+J9::CompilerEnv::persistentGlobalMemory()
+   {
+   return OMR::CompilerEnv::persistentMemory();
+   }
+
+#endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/env/J9CompilerEnv.hpp
+++ b/runtime/compiler/env/J9CompilerEnv.hpp
@@ -58,9 +58,11 @@ public:
    TR::PersistentAllocator &persistentAllocator();
 
    TR_PersistentMemory *persistentMemory();
+
 #if defined(J9VM_OPT_JITSERVER)
    TR::PersistentAllocator &persistentGlobalAllocator();
-#endif
+   TR_PersistentMemory *persistentGlobalMemory();
+#endif /* defined(J9VM_OPT_JITSERVER) */
    };
 
 }

--- a/runtime/compiler/net/LoadSSLLibs.cpp
+++ b/runtime/compiler/net/LoadSSLLibs.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -93,6 +93,13 @@ OX509_INFO_free_t * OX509_INFO_free = NULL;
 OX509_STORE_add_cert_t * OX509_STORE_add_cert = NULL;
 OX509_STORE_add_crl_t * OX509_STORE_add_crl = NULL;
 OX509_free_t * OX509_free = NULL;
+
+OEVP_MD_CTX_new_t * OEVP_MD_CTX_new = NULL;
+OEVP_MD_CTX_free_t * OEVP_MD_CTX_free = NULL;
+OEVP_DigestInit_ex_t * OEVP_DigestInit_ex = NULL;
+OEVP_DigestUpdate_t * OEVP_DigestUpdate = NULL;
+OEVP_DigestFinal_ex_t * OEVP_DigestFinal_ex = NULL;
+OEVP_sha256_t * OEVP_sha256 = NULL;
 
 OERR_print_errors_fp_t * OERR_print_errors_fp = NULL;
 
@@ -334,6 +341,13 @@ void dbgPrintSymbols()
    printf(" X509_STORE_add_crl %p\n", OX509_STORE_add_crl);
    printf(" X509_free %p\n", OX509_free);
 
+   printf(" EVP_MD_CTX_new %p\n", OEVP_MD_CTX_new);
+   printf(" EVP_MD_CTX_free %p\n", OEVP_MD_CTX_free);
+   printf(" EVP_DigestInit_ex %p\n", OEVP_DigestInit_ex);
+   printf(" EVP_DigestUpdate %p\n", OEVP_DigestUpdate);
+   printf(" EVP_DigestFinal_ex %p\n", OEVP_DigestFinal_ex);
+   printf(" EVP_sha256 %p\n", OEVP_sha256);
+
    printf(" ERR_print_errors_fp %p\n", OERR_print_errors_fp);
 
    printf("=============================================================\n\n");
@@ -448,6 +462,15 @@ bool loadLibsslAndFindSymbols()
    OX509_STORE_add_crl = (OX509_STORE_add_crl_t *)findLibsslSymbol(handle, "X509_STORE_add_crl");
    OX509_free = (OX509_free_t *)findLibsslSymbol(handle, "X509_free");
 
+   OEVP_MD_CTX_new = (OEVP_MD_CTX_new_t *)findLibsslSymbol(handle, (ossl_ver == 0) ? "EVP_MD_CTX_create"
+                                                                                   : "EVP_MD_CTX_new");
+   OEVP_MD_CTX_free = (OEVP_MD_CTX_free_t *)findLibsslSymbol(handle, (ossl_ver == 0) ? "EVP_MD_CTX_destroy"
+                                                                                     : "EVP_MD_CTX_free");
+   OEVP_DigestInit_ex = (OEVP_DigestInit_ex_t *)findLibsslSymbol(handle, "EVP_DigestInit_ex");
+   OEVP_DigestUpdate = (OEVP_DigestUpdate_t *)findLibsslSymbol(handle, "EVP_DigestUpdate");
+   OEVP_DigestFinal_ex = (OEVP_DigestFinal_ex_t *)findLibsslSymbol(handle, "EVP_DigestFinal_ex");
+   OEVP_sha256 = (OEVP_sha256_t *)findLibsslSymbol(handle, "EVP_sha256");
+
    OERR_print_errors_fp = (OERR_print_errors_fp_t *)findLibsslSymbol(handle, "ERR_print_errors_fp");
 
    if (
@@ -506,6 +529,13 @@ bool loadLibsslAndFindSymbols()
        (OX509_STORE_add_cert == NULL) ||
        (OX509_STORE_add_crl == NULL) ||
        (OX509_free == NULL) ||
+
+       (OEVP_MD_CTX_new == NULL) ||
+       (OEVP_MD_CTX_free == NULL) ||
+       (OEVP_DigestInit_ex == NULL) ||
+       (OEVP_DigestUpdate == NULL) ||
+       (OEVP_DigestFinal_ex == NULL) ||
+       (OEVP_sha256 == NULL) ||
 
        (OERR_print_errors_fp == NULL)
       )

--- a/runtime/compiler/net/LoadSSLLibs.hpp
+++ b/runtime/compiler/net/LoadSSLLibs.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,6 +24,7 @@
 
 #include <stdint.h>
 #include <openssl/ssl.h>
+#include <openssl/evp.h>
 
 typedef const char * OOpenSSL_version_t(int);
 
@@ -88,6 +89,13 @@ typedef int OX509_STORE_add_cert_t(X509_STORE *ctx, X509 *x);
 typedef int OX509_STORE_add_crl_t(X509_STORE *ctx, X509_CRL *x);
 typedef void OX509_free_t(X509 *a);
 
+typedef EVP_MD_CTX * OEVP_MD_CTX_new_t(void);
+typedef void OEVP_MD_CTX_free_t(EVP_MD_CTX *ctx);
+typedef int OEVP_DigestInit_ex_t(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl);
+typedef int OEVP_DigestUpdate_t(EVP_MD_CTX *ctx, const void *d, size_t cnt);
+typedef int OEVP_DigestFinal_ex_t(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s);
+typedef const EVP_MD * OEVP_sha256_t(void);
+
 typedef void OERR_print_errors_fp_t(FILE *fp);
 
 extern "C" OOpenSSL_version_t * OOpenSSL_version;
@@ -148,7 +156,12 @@ extern "C" OX509_STORE_add_cert_t * OX509_STORE_add_cert;
 extern "C" OX509_STORE_add_crl_t * OX509_STORE_add_crl;
 extern "C" OX509_free_t * OX509_free;
 
-extern "C" OEVP_cleanup_t * OEVP_cleanup;
+extern "C" OEVP_MD_CTX_new_t * OEVP_MD_CTX_new;
+extern "C" OEVP_MD_CTX_free_t * OEVP_MD_CTX_free;
+extern "C" OEVP_DigestInit_ex_t * OEVP_DigestInit_ex;
+extern "C" OEVP_DigestUpdate_t * OEVP_DigestUpdate;
+extern "C" OEVP_DigestFinal_ex_t * OEVP_DigestFinal_ex;
+extern "C" OEVP_sha256_t * OEVP_sha256;
 
 extern "C" OERR_print_errors_fp_t * OERR_print_errors_fp;
 

--- a/runtime/compiler/runtime/CMakeLists.txt
+++ b/runtime/compiler/runtime/CMakeLists.txt
@@ -65,6 +65,7 @@ if(J9VM_OPT_JITSERVER)
 		runtime/JITClientSession.cpp
 		runtime/JITServerIProfiler.cpp
 		runtime/JITServerROMClassHash.cpp
+		runtime/JITServerSharedROMClassCache.cpp
 		runtime/JITServerStatisticsThread.cpp
 		runtime/Listener.cpp
 	)

--- a/runtime/compiler/runtime/CMakeLists.txt
+++ b/runtime/compiler/runtime/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,6 +64,7 @@ if(J9VM_OPT_JITSERVER)
 		runtime/CompileService.cpp
 		runtime/JITClientSession.cpp
 		runtime/JITServerIProfiler.cpp
+		runtime/JITServerROMClassHash.cpp
 		runtime/JITServerStatisticsThread.cpp
 		runtime/Listener.cpp
 	)

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -28,6 +28,7 @@
 #include "env/ut_j9jit.h"
 #include "net/ServerStream.hpp" // for JITServer::ServerStream
 #include "runtime/RuntimeAssumptions.hpp" // for TR_AddressSet
+#include "runtime/JITServerSharedROMClassCache.hpp"
 #include "env/JITServerPersistentCHTable.hpp"
 #include "env/VerboseLog.hpp"
 #include "runtime/SymbolValidationManager.hpp"
@@ -402,7 +403,10 @@ ClientSessionData::ClassInfo::ClassInfo() :
 void
 ClientSessionData::ClassInfo::freeClassInfo(TR_PersistentMemory *persistentMemory)
    {
-   persistentMemory->freePersistentMemory(_romClass);
+   if (auto cache = TR::CompilationInfo::get()->getJITServerSharedROMClassCache())
+      cache->release(_romClass);
+   else
+      persistentMemory->freePersistentMemory(_romClass);
 
    // free cached _interfaces
    _interfaces->~PersistentVector<TR_OpaqueClassBlock *>();

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -720,7 +720,7 @@ ClientSessionHT::~ClientSessionHT()
 // Must have compilation monitor in hand when calling this function.
 // Side effects: _inUse is incremented on the ClientSessionData
 //               _lastProcessedCriticalSeqNo is populated if a new ClientSessionData is created
-//                timeOflastAccess is updated with curent time.
+//                timeOflastAccess is updated with current time.
 ClientSessionData *
 ClientSessionHT::findOrCreateClientSession(uint64_t clientUID, uint32_t seqNo, bool *newSessionWasCreated, J9JITConfig *jitConfig)
    {
@@ -733,22 +733,28 @@ ClientSessionHT::findOrCreateClientSession(uint64_t clientUID, uint32_t seqNo, b
       static const char* disablePerClientPersistentAllocation = feGetEnv("TR_DisablePerClientPersistentAllocation");
       if (!disablePerClientPersistentAllocation)
          {
-         // allocate new persistent allocator and memory and store them inside a client session
-         TR::PersistentAllocator *newAllocator = new (TR::Compiler->rawAllocator) TR::PersistentAllocator(TR::PersistentAllocatorKit( 1 << 20, *TR::Compiler->javaVM));
-
-         sessionMemory = new (TR::Compiler->rawAllocator) TR_PersistentMemory(
-            jitConfig,
-            *newAllocator
-            );
+         // allocate new persistent allocator and memory and store them inside the client session
+         TR::PersistentAllocatorKit kit(1 << 20/*1 MB*/, *TR::Compiler->javaVM);
+         auto allocator = new (TR::Compiler->rawAllocator) TR::PersistentAllocator(kit);
+         try
+            {
+            sessionMemory = new (TR::Compiler->rawAllocator) TR_PersistentMemory(jitConfig, *allocator);
+            }
+         catch (...)
+            {
+            allocator->~PersistentAllocator();
+            TR::Compiler->rawAllocator.deallocate(allocator);
+            throw;
+            }
          }
       else
          {
          // passed env variable to disable per-client allocation, always use the global allocator
          usesPerClientMemory = false;
-         sessionMemory = TR::Compiler->persistentMemory();
+         sessionMemory = TR::Compiler->persistentGlobalMemory();
          }
 
-      // alocate a new ClientSessionData object and create a clientUID mapping
+      // allocate a new ClientSessionData object and create a clientUID mapping
       clientData = new (sessionMemory) ClientSessionData(clientUID, seqNo, sessionMemory, usesPerClientMemory);
       if (clientData)
          {
@@ -761,7 +767,6 @@ ClientSessionHT::findOrCreateClientSession(uint64_t clientUID, uint32_t seqNo, b
          {
          if (TR::Options::getVerboseOption(TR_VerboseJITServer))
             TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "ERROR: Server could not allocate client session data");
-         // should we throw bad_alloc here?
          }
       }
    return clientData;

--- a/runtime/compiler/runtime/JITServerROMClassHash.cpp
+++ b/runtime/compiler/runtime/JITServerROMClassHash.cpp
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#include "j9.h"
+#include "net/LoadSSLLibs.hpp"
+#include "runtime/JITServerROMClassHash.hpp"
+
+
+JITServerROMClassHash::JITServerROMClassHash(const J9ROMClass *romClass)
+   {
+   EVP_MD_CTX *ctx = OEVP_MD_CTX_new();
+   if (!ctx)
+      throw std::bad_alloc();//The only possible error is memory allocation failure
+   if (!OEVP_DigestInit_ex(ctx, OEVP_sha256(), NULL))
+      throw std::bad_alloc();//The only possible error is memory allocation failure
+
+   int success = OEVP_DigestUpdate(ctx, romClass, romClass->romSize);
+   TR_ASSERT(success, "EVP_DigestUpdate() failed");
+   unsigned int hashSize = 0;
+   success = OEVP_DigestFinal_ex(ctx, (uint8_t *)_data, &hashSize);
+   TR_ASSERT(success, "EVP_DigestFinal() failed");
+   TR_ASSERT(hashSize == sizeof(_data), "Invalid hash size");
+
+   OEVP_MD_CTX_free(ctx);
+   }
+
+const char *
+JITServerROMClassHash::toString(char *buffer, size_t size) const
+   {
+   TR_ASSERT(size > sizeof(_data) * 2, "Buffer too small");
+
+   char *s = buffer;
+   for (size_t i = 0; i < sizeof(_data); ++i)
+      s += sprintf(s, "%02x", ((uint8_t *)_data)[i]);
+   return buffer;
+   }

--- a/runtime/compiler/runtime/JITServerROMClassHash.hpp
+++ b/runtime/compiler/runtime/JITServerROMClassHash.hpp
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#ifndef JITSERVER_ROMCLASS_HASH_H
+#define JITSERVER_ROMCLASS_HASH_H
+
+#include <functional>
+#include <limits.h>
+#include <string.h>
+
+#include "infra/Assert.hpp"
+
+struct J9ROMClass;
+
+
+// Assuming a 256-bit hash such as SHA-256
+#define ROMCLASS_HASH_BITS 256
+
+static_assert(ROMCLASS_HASH_BITS % (CHAR_BIT * sizeof(size_t)) == 0,
+              "Invalid number of ROMClass hash bits");
+
+#define ROMCLASS_HASH_BYTES (ROMCLASS_HASH_BITS / CHAR_BIT)
+#define ROMCLASS_HASH_WORDS (ROMCLASS_HASH_BYTES / sizeof(size_t))
+
+
+struct JITServerROMClassHash
+   {
+public:
+   JITServerROMClassHash() { memset(_data, 0, sizeof(_data)); }
+   JITServerROMClassHash(const J9ROMClass *romClass);
+
+   bool operator==(const JITServerROMClassHash &h) const
+      {
+      return memcmp(_data, h._data, sizeof(_data)) == 0;
+      }
+
+   bool operator!=(const JITServerROMClassHash &h) const { return !(*this == h); }
+
+   size_t getWord(size_t idx) const
+      {
+      TR_ASSERT(idx < sizeof(_data) / sizeof(_data[0]), "Out of bounds");
+      return _data[idx];
+      }
+
+   const char *toString(char *buffer, size_t size) const;
+
+private:
+   size_t _data[ROMCLASS_HASH_WORDS];
+   };
+
+
+// std::hash specialization for using JITServerROMClassHash as unordered map key
+namespace std
+   {
+   template<> struct hash<JITServerROMClassHash>
+      {
+      size_t operator()(const JITServerROMClassHash &k) const noexcept
+         {
+         // Simply truncate the hash and use its first sizeof(size_t) bytes
+         return k.getWord(0);
+         }
+      };
+   }
+
+
+#endif /* JITSERVER_ROMCLASS_HASH_H */

--- a/runtime/compiler/runtime/JITServerSharedROMClassCache.cpp
+++ b/runtime/compiler/runtime/JITServerSharedROMClassCache.cpp
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#include "AtomicSupport.hpp"
+#include "env/CompilerEnv.hpp"
+#include "infra/CriticalSection.hpp"
+#include "runtime/JITServerSharedROMClassCache.hpp"
+
+
+#define JITSERVER_SHARED_ROMCLASS_EYECATCHER 0xC1A55E7E
+
+struct JITServerSharedROMClassCache::Entry
+   {
+   Entry(const J9ROMClass *romClass) :
+      _refCount(1), _hash(NULL), _eyeCatcher(JITSERVER_SHARED_ROMCLASS_EYECATCHER)
+      {
+      memcpy(_data, romClass, romClass->romSize);
+      }
+
+   // The ROMClass is embedded in this structure in order to avoid exposing it in the API
+   static Entry *get(J9ROMClass *romClass)
+      {
+      auto entry = (Entry *)((uint8_t *)romClass - offsetof(Entry, _data));
+      TR_ASSERT_FATAL(entry->_eyeCatcher == JITSERVER_SHARED_ROMCLASS_EYECATCHER,
+                      "ROMClass not embedded in cache entry");
+      return entry;
+      }
+
+   J9ROMClass *acquire()
+      {
+      VM_AtomicSupport::add(&_refCount, 1);
+      return (J9ROMClass *)_data;
+      }
+
+   // Returns new reference count
+   size_t release() { return VM_AtomicSupport::subtract(&_refCount, 1); }
+
+   volatile size_t _refCount;
+   // Store the pointer to this entry's key so that we don't have to
+   // recompute it when deleting the entry from the map.
+   //NOTE: The entity pointed to by _hash is not owned by this Entry,
+   //      and must not be deleted when the Entry is destroyed.
+   const JITServerROMClassHash *_hash;
+   const size_t _eyeCatcher;
+   uint8_t _data[];// embedded J9ROMClass
+   };
+
+
+JITServerSharedROMClassCache::JITServerSharedROMClassCache() :
+   _persistentMemory(TR::Compiler->persistentGlobalMemory()),
+   _map(decltype(_map)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _monitor(TR::Monitor::create("JIT-JITServerSharedROMClassCacheMonitor"))
+   {
+   if (!_monitor)
+      throw std::bad_alloc();
+   }
+
+JITServerSharedROMClassCache::~JITServerSharedROMClassCache()
+   {
+   for (const auto &kv : _map)
+      _persistentMemory->freePersistentMemory(kv.second);
+   _monitor->destroy();
+   }
+
+
+J9ROMClass *
+JITServerSharedROMClassCache::getOrCreate(const J9ROMClass *packedROMClass)
+   {
+   JITServerROMClassHash hash(packedROMClass);
+
+      {
+      OMR::CriticalSection sharedROMClassCache(_monitor);
+      auto it = _map.find(hash);
+      if (it != _map.end())
+         return it->second->acquire();// Reuse existing entry, incrementing its reference count
+      }
+
+   // Create new entry outside of the critical section to reduce lock contention
+   size_t size = sizeof(Entry) + packedROMClass->romSize;
+   void *ptr = _persistentMemory->allocatePersistentMemory(size, TR_Memory::ROMClass);
+   if (!ptr)
+      throw std::bad_alloc();
+   auto entry = new (ptr) Entry(packedROMClass);
+   auto romClass = (J9ROMClass *)entry->_data;
+
+   try
+      {
+      OMR::CriticalSection sharedROMClassCache(_monitor);
+      auto it = _map.insert({ hash, entry });
+      if (it.second)
+         entry->_hash = &it.first->first;
+      else
+         romClass = it.first->second->acquire();// Another thread already created this entry; reuse it
+      }
+   catch (...)
+      {
+      // Prevent memory leak if map insertion failed
+      _persistentMemory->freePersistentMemory(entry);
+      throw;
+      }
+
+   // Free the newly allocated entry if it won't be used
+   if (romClass != (J9ROMClass *)entry->_data)
+      _persistentMemory->freePersistentMemory(entry);
+   return romClass;
+   }
+
+void
+JITServerSharedROMClassCache::release(J9ROMClass *romClass)
+   {
+   auto entry = Entry::get(romClass);
+   // To reduce lock contention, we synchronize access to the reference count
+   // using atomic operations. Releasing a ROMClass doesn't require the monitor
+   // unless it's the last reference. This should help in the scenario when a
+   // client session is destroyed and all its cached ROMClasses are released.
+   if (entry->release() != 0)
+      return;
+
+      {
+      OMR::CriticalSection sharedROMClassCache(_monitor);
+      // Another thread could have looked up and acquired this entry while its reference
+      // count was 0, need to check again if it's still 0. The value is guaranteed to be
+      // fresh since the field is declared volatile (so that the compiler will generate
+      // a memory read), and the monitor acquisition above implies a memory barrier.
+      if (entry->_refCount != 0)
+         return;
+
+      auto it = _map.find(*entry->_hash);
+      TR_ASSERT(it != _map.end(), "Entry to be removed not found");
+      TR_ASSERT(it->second == entry, "Duplicate entry");
+      _map.erase(it);
+      }
+
+   _persistentMemory->freePersistentMemory(entry);
+   }

--- a/runtime/compiler/runtime/JITServerSharedROMClassCache.hpp
+++ b/runtime/compiler/runtime/JITServerSharedROMClassCache.hpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#ifndef JITSERVER_ROMCLASS_CACHE_H
+#define JITSERVER_ROMCLASS_CACHE_H
+
+#include "env/TRMemory.hpp"
+#include "env/PersistentCollections.hpp"
+#include "infra/Monitor.hpp"
+#include "runtime/JITServerROMClassHash.hpp"
+
+
+// Stores a single copy of each distinct ROMClass that is shared by multiple
+// client sessions in order to reduce JITServer memory usage.
+class JITServerSharedROMClassCache
+   {
+public:
+   TR_PERSISTENT_ALLOC(TR_Memory::ROMClass)
+
+   JITServerSharedROMClassCache();
+   ~JITServerSharedROMClassCache();
+
+   J9ROMClass *getOrCreate(const J9ROMClass *packedROMClass);
+   void release(J9ROMClass *romClass);
+
+private:
+   struct Entry;
+
+   TR_PersistentMemory *const _persistentMemory;
+   // To avoid comparing the ROMClass contents inside a critical section when
+   // inserting a new entry (which would increase lock contention), we instead
+   // use a hash of the contents as the key. The hash is computed outside of
+   // the critical section, and key hashing and comparison are very quick.
+   PersistentUnorderedMap<JITServerROMClassHash, Entry *> _map;
+   TR::Monitor *const _monitor;
+   };
+
+
+#endif /* JITSERVER_ROMCLASS_CACHE_H */

--- a/runtime/compiler/runtime/JITServerSharedROMClassCache.hpp
+++ b/runtime/compiler/runtime/JITServerSharedROMClassCache.hpp
@@ -35,8 +35,14 @@ class JITServerSharedROMClassCache
 public:
    TR_PERSISTENT_ALLOC(TR_Memory::ROMClass)
 
+   //NOTE: The cache is not usable until initialize() is called
    JITServerSharedROMClassCache(size_t numPartitions);
    ~JITServerSharedROMClassCache();
+
+   // Initializes the cache. Must be called when the first client session is created.
+   void initialize(J9JITConfig *jitConfig);
+   // Releases memory used by the cache. Must be called when the last client session is destroyed.
+   void shutdown(bool lastClient = true);
 
    J9ROMClass *getOrCreate(const J9ROMClass *packedROMClass);
    void release(J9ROMClass *romClass);
@@ -49,8 +55,15 @@ private:
    // partitions, each synchronized with a separate monitor
    Partition &getPartition(const JITServerROMClassHash &hash);
 
+   void createPartitions();
+   void destroyPartitions();
+
+   bool isInitialized() const { return _persistentMemory != NULL; }
+
    const size_t _numPartitions;
+   TR_PersistentMemory *_persistentMemory;
    Partition *const _partitions;
+   TR::Monitor **const _monitors;
 };
 
 


### PR DESCRIPTION
This PR adds an option `-Xjit:shareROMClasses` to store a single copy of each distinct ROMClass at the JITServer that can be shared by all the clients. The feature is disabled by default.

The shared ROMClass cache stores distinct serialized ROMClasses in an unordered map using a SHA-512/256 hash of the ROMClass contents as the key and the ROMClass along with a reference count as the value. This design helps reduce the time spent in the critical section when inserting a new ROMClass into the map. Access to reference counts is synchronized using atomic operations in order to reduce lock contention by not having to acquire the monitor that protects the map when releasing a ROMClass that still has references.

In order to reduce lock contention, the shared ROMClass cache is divided into a number of partitions (controlled by the `-Xjit:sharedROMClassCacheNumPartitions=` option, 16 by default), each synchronized with a separate monitor.

Closes: #11776