### PR TITLE
Zero out unused fields in TR_AOTHeader

### DIFF
--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1168,10 +1168,10 @@ TR_SharedCacheRelocationRuntime::createAOTHeader(TR_FrontEnd *fe)
 
    if (aotHeader)
       {
+      memset(aotHeader, 0, sizeof(TR_AOTHeader));
       aotHeader->eyeCatcher = TR_AOTHeaderEyeCatcher;
 
       TR_Version *aotHeaderVersion = &aotHeader->version;
-      memset(aotHeaderVersion, 0, sizeof(TR_Version));
       aotHeaderVersion->structSize = sizeof(TR_Version);
       aotHeaderVersion->majorVersion = TR_AOTHeaderMajorVersion;
       aotHeaderVersion->minorVersion = TR_AOTHeaderMinorVersion;


### PR DESCRIPTION
This PR fixes `TR_AOTHeader` initialization in `TR_SharedCacheRelocationRuntime::createAOTHeader()`: the whole structure is zeroed out so that any unused fields are initialized to zeros instead of arbitrary values. This fix is required for caching AOT methods at JITServer.