### PR TITLE
Fix bug in SerializedRuntimeAssumption list allocation

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -182,7 +182,7 @@ J9::Compilation::Compilation(int32_t id,
    _reloRuntime(reloRuntime),
 #if defined(J9VM_OPT_JITSERVER)
    _remoteCompilation(false),
-   _serializedRuntimeAssumptions(getTypedAllocator<SerializedRuntimeAssumption>(self()->allocator())),
+   _serializedRuntimeAssumptions(getTypedAllocator<SerializedRuntimeAssumption *>(self()->allocator())),
    _clientData(NULL),
 #endif /* defined(J9VM_OPT_JITSERVER) */
    _osrProhibitedOverRangeOfTrees(false)


### PR DESCRIPTION
We were using the typed allocator for the `SerializedRuntimeAssumption`
object itself, when the list actually stores pointers.