### PR TITLE
VarHandle withInvoke[Exact]Behavior methods should be abstract

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/ArrayVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ArrayVarHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2020 IBM Corp. and others
+ * Copyright (c) 2016, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -118,6 +118,16 @@ final class ArrayVarHandle extends VarHandle {
 		return Optional.ofNullable(result);
 	}
 /*[ENDIF] JAVA_SPEC_VERSION >= 12 */
+
+/*[IF JAVA_SPEC_VERSION >= 16]*/
+	public VarHandle withInvokeExactBehavior() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	public VarHandle withInvokeBehavior() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 
 	/**
 	 * Type specific methods used by array element VarHandle methods.

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2020 IBM Corp. and others
+ * Copyright (c) 2016, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -176,4 +176,14 @@ abstract class FieldVarHandle extends VarHandle {
 	final String getFieldName() {
 		return fieldName;
 	}
+
+/*[IF JAVA_SPEC_VERSION >= 16]*/
+	public VarHandle withInvokeExactBehavior() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	public VarHandle withInvokeBehavior() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -1673,13 +1673,9 @@ public abstract class VarHandle extends VarHandleInternal
 		return accessModeTypeUncached(AccessType.values()[index]);
 	}
 
-	public VarHandle withInvokeExactBehavior() {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-	}
+	public abstract VarHandle withInvokeExactBehavior();
 
-	public VarHandle withInvokeBehavior() {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-	}
+	public abstract VarHandle withInvokeBehavior();
 
 	public boolean hasInvokeExactBehavior() {
 		return exact;

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ViewVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ViewVarHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE & !OPENJDK_METHODHANDLES]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2020 IBM Corp. and others
+ * Copyright (c) 2016, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,6 +68,16 @@ abstract class ViewVarHandle extends VarHandle {
 			throw new InternalError("Invalid AccessMode"); //$NON-NLS-1$
 		}
 	}
+
+/*[IF JAVA_SPEC_VERSION >= 16]*/
+	public VarHandle withInvokeExactBehavior() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	public VarHandle withInvokeBehavior() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+/*[ENDIF] JAVA_SPEC_VERSION >= 16 */
 
 	static class ViewVarHandleOperations extends VarHandleOperations {
 		static final char convertEndian(char value) {


### PR DESCRIPTION
As per the [JDK16 doc for VarHandle](https://download.java.net/java/early_access/jdk16/docs/api/java.base/java/lang/invoke/VarHandle.html), `withInvokeBehavior` and
`withInvokeExactBehavior` methods should be declared as `abstract` within
the `VarHandle` class.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>