### PR TITLE
Remove Windows Configuration text from test suite id

### DIFF
--- a/test/functional/cmdLineTests/URLClassLoaderTests/URLClassLoaderTests.xml
+++ b/test/functional/cmdLineTests/URLClassLoaderTests/URLClassLoaderTests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2001, 2018 IBM Corp. and others
+  Copyright (c) 2001, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <!-- #### RUN URLClassLoaderTests SUITE #### -->
-<suite id="Shared Classes URLClassLoaderTests Suite - Windows Configuration">
+<suite id="Shared Classes URLClassLoaderTests Suite">
 
 	<!-- Used to set which mode the test cases are run in -->
 	<variable name="currentMode" value=" "/>

--- a/test/functional/cmdLineTests/URLClassLoaderTests/URLClassLoaderTests_Java8.xml
+++ b/test/functional/cmdLineTests/URLClassLoaderTests/URLClassLoaderTests_Java8.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2001, 2018 IBM Corp. and others
+  Copyright (c) 2001, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <!-- #### RUN URLClassLoaderTests SUITE #### -->
-<suite id="Shared Classes URLClassLoaderTests Suite - Windows Configuration">
+<suite id="Shared Classes URLClassLoaderTests Suite">
 
 	<!-- Used to set which mode the test cases are run in -->
 	<variable name="currentMode" value=" "/>

--- a/test/functional/cmdLineTests/shareClassTests/ListAllCachesTests/expireAndListAllCachesTests.xml
+++ b/test/functional/cmdLineTests/shareClassTests/ListAllCachesTests/expireAndListAllCachesTests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2010, 2018 IBM Corp. and others
+  Copyright (c) 2010, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <!-- #### RUN TokenHelperTests SUITE #### -->
-<suite id="Shared Classes CommandLineOptionTests Suite - Windows Configuration">
+<suite id="Shared Classes CommandLineOptionTests Suite">
 
 	<!-- Our test modes for this suite -->
 	<variable name="mode204" value="-Xshareclasses:name=ShareClassesCMLTests"/>

--- a/test/functional/cmdLineTests/shareClassTests/ListAllCachesTests/listAllCachesTests.xml
+++ b/test/functional/cmdLineTests/shareClassTests/ListAllCachesTests/listAllCachesTests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2010, 2018 IBM Corp. and others
+  Copyright (c) 2010, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,7 @@
 
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
-<suite id="Shared Classes CommandLineOptionTests Suite - Windows Configuration">
+<suite id="Shared Classes CommandLineOptionTests Suite">
 
 	<!-- Our test modes for this suite -->
 	<variable name="mode204" value="-Xshareclasses:name=listAllCacheName"/>

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/CommandLineOptionTests.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/CommandLineOptionTests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2004, 2019 IBM Corp. and others
+  Copyright (c) 2004, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <!-- #### RUN TokenHelperTests SUITE #### -->
-<suite id="Shared Classes CommandLineOptionTests Suite - Windows Configuration">
+<suite id="Shared Classes CommandLineOptionTests Suite">
 
 	<!-- Set variables up -->
 	<variable name="JAVA_DIR" value="$TEST_JDK_HOME$/bin"/>

--- a/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/HelperCompatibilityTests.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/HelperCompatibilityTests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <!-- #### RUN TokenHelperTests SUITE #### -->
-<suite id="Shared Classes HelperCompatibilityTests Suite - Windows Configuration">
+<suite id="Shared Classes HelperCompatibilityTests Suite">
 
 	<!-- Used to set which mode the test cases are run in -->
 	<variable name="currentMode" value=" "/>

--- a/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/HelperCompatibilityTests_8.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/HelperCompatibilityTests_8.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2006, 2019 IBM Corp. and others
+  Copyright (c) 2006, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <!-- #### RUN TokenHelperTests SUITE #### -->
-<suite id="Shared Classes HelperCompatibilityTests Suite - Windows Configuration">
+<suite id="Shared Classes HelperCompatibilityTests Suite">
 
 	<!-- Used to set which mode the test cases are run in -->
 	<variable name="currentMode" value=" "/>

--- a/test/functional/cmdLineTests/shareClassTests/ShareClassesSimpleSanity/ShareClassesSimpleSanity.xml
+++ b/test/functional/cmdLineTests/shareClassTests/ShareClassesSimpleSanity/ShareClassesSimpleSanity.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2008, 2019 IBM Corp. and others
+  Copyright (c) 2008, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <!-- #### RUN TokenHelperTests SUITE #### -->
-<suite id="Shared Classes CommandLineOptionTests Suite - Windows Configuration">
+<suite id="Shared Classes CommandLineOptionTests Suite">
 
 	<!-- Our test modes for this suite -->
 	<variable name="mode204" value="-Xshareclasses:name=HelloWorldSanity"/>

--- a/test/functional/cmdLineTests/shareClassTests/StoreFilterTests/StoreFilterTests.xml
+++ b/test/functional/cmdLineTests/shareClassTests/StoreFilterTests/StoreFilterTests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <!-- #### RUN StoreFilterTests SUITE #### -->
-<suite id="Shared Classes StoreFilterTests Suite - Windows Configuration">
+<suite id="Shared Classes StoreFilterTests Suite">
 
 	<variable name="currentMode" value=" "/>
 	<variable name="TESTCACHENAME" value="storeFilterCache"/>

--- a/test/functional/cmdLineTests/shareClassTests/StoreFilterTests/StoreFilterTests_8.xml
+++ b/test/functional/cmdLineTests/shareClassTests/StoreFilterTests/StoreFilterTests_8.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2011, 2019 IBM Corp. and others
+  Copyright (c) 2011, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <!-- #### RUN StoreFilterTests SUITE #### -->
-<suite id="Shared Classes StoreFilterTests Suite - Windows Configuration">
+<suite id="Shared Classes StoreFilterTests Suite">
 
 	<variable name="currentMode" value=" "/>
 	<variable name="TESTCACHENAME" value="storeFilterCache"/>

--- a/test/functional/cmdLineTests/shareClassTests/URLHelperTests/URLHelperTests.xml
+++ b/test/functional/cmdLineTests/shareClassTests/URLHelperTests/URLHelperTests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2006, 2020 IBM Corp. and others
+  Copyright (c) 2006, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <!-- #### RUN URLHelperTests SUITE #### -->
-<suite id="Shared Classes URLHelperTests Suite - Windows Configuration">
+<suite id="Shared Classes URLHelperTests Suite">
 
 	<!-- Used to set which mode the test cases are run in -->
 	<variable name="currentMode" value=" "/>

--- a/test/functional/cmdLineTests/shareClassTests/URLHelperTests/URLHelperTests_80.xml
+++ b/test/functional/cmdLineTests/shareClassTests/URLHelperTests/URLHelperTests_80.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2016, 2020 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <!-- #### RUN URLHelperTests SUITE #### -->
-<suite id="Shared Classes URLHelperTests Suite - Windows Configuration">
+<suite id="Shared Classes URLHelperTests Suite">
 
 	<!-- Used to set which mode the test cases are run in -->
 	<variable name="currentMode" value=" "/>


### PR DESCRIPTION
"Windows Configuration" is included in the test suite id of several tests, but those tests are not specific to Windows, so this text should be removed.

Some more discussion: https://github.com/eclipse/openj9/issues/11801#issuecomment-768624138