### PR TITLE
Add error handling in NonUpgradeableModules and make it final

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/Util.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/Util.java
@@ -422,17 +422,15 @@ private static boolean includeModuleVersion(StackTraceElement element) {
  * non-upgradeable module. Non-upgradeable modules should not have their module
  * version displayed in a stack trace if the calling class is Throwable or StackFrame.
  */
-private static class NonUpgradeableModules {
-	static Set<String> moduleNames;
+private static final class NonUpgradeableModules {
+	static final Set<String> moduleNames;
 
 	static {
-		Optional<ResolvedModule> javaBaseModule = ModuleLayer.boot().configuration().findModule("java.base"); //$NON-NLS-1$
+		ResolvedModule resolvedJavaBaseModule = ModuleLayer.boot().configuration().findModule("java.base") //$NON-NLS-1$
+				.orElseThrow(() -> new InternalError("java.base module could not be found")); //$NON-NLS-1$
+		ModuleReferenceImpl javaBaseModuleRef = (ModuleReferenceImpl) resolvedJavaBaseModule.reference();
 
-		if (javaBaseModule.isPresent()) {
-			ResolvedModule resolvedJavaBaseModule = javaBaseModule.get();
-			ModuleReferenceImpl javaBaseModuleRef = (ModuleReferenceImpl) resolvedJavaBaseModule.reference();
-			moduleNames = javaBaseModuleRef.recordedHashes().names();
-		}
+		moduleNames = javaBaseModuleRef.recordedHashes().names();
 	}
 }
 /*[ENDIF] JAVA_SPEC_VERSION >= 11*/


### PR DESCRIPTION
Although we don't expect `java.base` to not be present, the existing code does not handle the case where the `java.base` module is somehow not found.

Changes in this PR:
- Add error handling to the Util `NonUpgradeableModules` class per: https://github.com/eclipse/openj9/pull/11601#discussion_r565649150.
- Make the class and its `moduleNames` field final, since the class is just a utility for determining if a module is a non-upgradeable module.