### PR TITLE
Allow zero subclass in the PermittedSubclasses attribute

### DIFF
--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -2397,15 +2397,6 @@ checkAttributes(J9PortLibrary* portLib, J9CfrClassFile* classfile, J9CfrAttribut
 				break;
 			}
 
-			value = ((J9CfrAttributePermittedSubclasses*)attrib)->numberOfClasses;
-			if (0 >= value) {
-				if (enablePermittedSubclassErrors) {
-					errorCode = J9NLS_CFR_ERR_SEALED_CLASS_HAS_INVALID_NUMBER_SUBCLASSES__ID;
-					goto _errorFound;
-				}
-				break;
-			}
-
 			for (j = 0; j < ((J9CfrAttributePermittedSubclasses*)attrib)->numberOfClasses; j++) {
 				value = ((J9CfrAttributePermittedSubclasses*)attrib)->classes[j];
 				if ((0 == value) || (value >= cpCount)) {
@@ -2534,7 +2525,7 @@ checkClassVersion(J9CfrClassFile* classfile, U_8* segment, U_32 vmVersionShifted
 		if (0xffff == minorVersion) {
 			errorCode = J9NLS_CFR_ERR_PREVIEW_VERSION__ID;
 			/* Allow cfdump to dump preview classes from other releases */
-			if (J9_ARE_ANY_BITS_SET(flags, BCT_AnyPreviewVersion)) {
+			if (J9_ARE_ANY_BITS_SET(flags, BCT_AnyPreviewVersion | BCT_EnablePreview)) {
 				return 0;
 			}
 		}

--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1551,9 +1551,4 @@ J9NLS_CFR_ERR_PERMITTEDSUBCLASSES_CLASS_ENTRY_NOT_CLASS_TYPE.system_action=The J
 J9NLS_CFR_ERR_PERMITTEDSUBCLASSES_CLASS_ENTRY_NOT_CLASS_TYPE.user_response=Contact the provider of the classfile for a corrected version.
 # END NON-TRANSLATABLE
 
-J9NLS_CFR_ERR_SEALED_CLASS_HAS_INVALID_NUMBER_SUBCLASSES=Sealed classes must have at least one permitted subclass
-# START NON-TRANSLATABLE
-J9NLS_CFR_ERR_SEALED_CLASS_HAS_INVALID_NUMBER_SUBCLASSES.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
-J9NLS_CFR_ERR_SEALED_CLASS_HAS_INVALID_NUMBER_SUBCLASSES.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
-J9NLS_CFR_ERR_SEALED_CLASS_HAS_INVALID_NUMBER_SUBCLASSES.user_response=Contact the provider of the classfile for a corrected version.
-# END NON-TRANSLATABLE
+J9NLS_CFR_ERR_SEALED_CLASS_HAS_INVALID_NUMBER_SUBCLASSES=

--- a/test/functional/Java15andUp/playlist.xml
+++ b/test/functional/Java15andUp/playlist.xml
@@ -43,8 +43,7 @@
             <group>functional</group>
         </groups>
         <subsets>
-            <!-- run for Java 15 only since this is a preview feature. -->
-            <subset>15</subset>
+            <subset>15+</subset>
         </subsets>
     </test>
     <test>


### PR DESCRIPTION
The change is to remove the check of the subclasses's number
in the case that there is no subclass in the PermittedSubclasses
attribute given the latest VM Spec doesn't require that the
subclasses's number must be greater than 0.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>