### PR TITLE
[MethodHandles] Update classData and add classDataAt for JDK16

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -424,6 +424,8 @@ K0683=Target class '{0}' cannot be an array class
 K0684=Target class '{0}' cannot be a primitive class
 K0685=Target class '{0}' cannot be accessed from Lookup class '{1}'
 K0686=Unknown reference kind: '{0}'
+K0687=Name does not match. Expected: '{0}', but found: '{1}'
+K0688=Lookup does not have the ORIGINAL access bit
 
 #java.lang.StackWalker
 K0639="Stack walker not configured with RETAIN_CLASS_REFERENCE"


### PR DESCRIPTION
Update `classData` and add `classDataAt` as per the JDK16 Java doc:
- [MethodHandles.html#classData](https://download.java.net/java/early_access/jdk16/docs/api/java.base/java/lang/invoke/MethodHandles.html#classData(java.lang.invoke.MethodHandles.Lookup,java.lang.String,java.lang.Class))
- [MethodHandles.html#classDataAt](https://download.java.net/java/early_access/jdk16/docs/api/java.base/java/lang/invoke/MethodHandles.html#classDataAt(java.lang.invoke.MethodHandles.Lookup,java.lang.String,java.lang.Class,int))

This fixes few failures in `ClassDataTest.java`.

Related: https://github.com/eclipse/openj9/issues/11366

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>