### PR TITLE
Ensure JitDump is always generated for compilation crashes

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -41,7 +41,6 @@
 #include "env/CompilerEnv.hpp"
 #include "env/J2IThunk.hpp"
 #include "env/StackMemoryRegion.hpp"
-#include "exceptions/JITShutDown.hpp"
 #include "il/Node_inlines.hpp"
 #include "il/ParameterSymbol.hpp"
 #include "il/ResolvedMethodSymbol.hpp"

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -722,6 +722,18 @@ public:
    bool initializeCompilationOnApplicationThread();
    bool  asynchronousCompilation();
    void stopCompilationThreads();
+
+   /**
+    * \brief
+    *    Stops a compilation thread by issuing an interruption request at the threads next yield point and by changing
+    *    its state to signal termination. Note that there can be a delay between making this request and the thread
+    *    state changing to `COMPTHREAD_STOPPED`.
+    * 
+    * \param compInfoPT
+    *    The thread to be stopped.
+    */
+   void stopCompilationThread(CompilationInfoPerThread* compInfoPT);
+   
    void suspendCompilationThread();
    void resumeCompilationThread();
    void purgeMethodQueue(TR_CompilationErrorCode errorCode);

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2645,32 +2645,11 @@ void TR::CompilationInfo::resumeCompilationThread()
          if (activate == TR_no)
             break;
 
-         if (curCompThreadInfoPT->getCompilationThreadState() == COMPTHREAD_SIGNAL_SUSPEND ||
-             curCompThreadInfoPT->getCompilationThreadState() == COMPTHREAD_SUSPENDED)
-            {
-            if (curCompThreadInfoPT->getCompilationThreadState() == COMPTHREAD_SUSPENDED)
-               {
-               curCompThreadInfoPT->setCompilationThreadState(COMPTHREAD_ACTIVE);
-               curCompThreadInfoPT->getCompThreadMonitor()->enter();
-               curCompThreadInfoPT->getCompThreadMonitor()->notifyAll(); // wake the suspended thread
-               curCompThreadInfoPT->getCompThreadMonitor()->exit();
-               }
-            else // COMPTHREAD_SIGNAL_SUSPEND
-               {
-               curCompThreadInfoPT->setCompilationThreadState(COMPTHREAD_ACTIVE);
-               }
-            incNumCompThreadsActive();
-            if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCompilationThreads))
-               {
-               TR_VerboseLog::writeLineLocked(TR_Vlog_INFO,"t=%6u Resume compThread %d Qweight=%d active=%d",
-                  (uint32_t)getPersistentInfo()->getElapsedTime(),
-                  curCompThreadInfoPT->getCompThreadId(),
-                  getQueueWeight(),
-                  getNumCompThreadsActive());
-               }
-            }
-         } // end for
-      TR_ASSERT(getNumCompThreadsActive() > 0, "We must have at least one compilation thread active");
+         curCompThreadInfoPT->resumeCompilationThread();
+         }
+
+      TR_ASSERT_FATAL(getNumCompThreadsActive() > 0, "We must have at least one compilation thread active");
+
       releaseCompMonitor(vmThread);
       }
    else // compilation on application thread

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -202,12 +202,12 @@ TR::CompilationInfoPerThreadBase::setCompilation(TR::Compilation *compiler)
 thread_local TR::CompilationInfoPerThread *TR::compInfoPT;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
-static UDATA
-jitSignalHandler(struct J9PortLibrary *portLibrary, U_32 gpType, void *gpInfo, void *arg)
+static uintptr_t
+jitSignalHandler(struct J9PortLibrary *portLibrary, uint32_t gpType, void *gpInfo, void *handler_arg)
    {
    static int32_t numCrashes = 0;
    bool recoverable = true;
-   J9VMThread *vmThread = (J9VMThread *)arg;
+   J9VMThread *vmThread = (J9VMThread *)handler_arg;
 
    // Try to find the compilation object
    TR::Compilation * comp = 0;
@@ -7909,14 +7909,14 @@ TR::CompilationInfoPerThreadBase::compile(J9VMThread * vmThread,
             UDATA protectedResult;
             if (entry->getMethodDetails().isJitDumpMethod())
                {
-               protectedResult = j9sig_protect(static_cast<j9sig_protected_fn>(wrappedCompile), static_cast<void*>(&compParam),
-                                                  static_cast<j9sig_handler_fn>(jitDumpSignalHandler), 
+               protectedResult = j9sig_protect(wrappedCompile, static_cast<void*>(&compParam),
+                                                  jitDumpSignalHandler, 
                                                   vmThread, flags, &result);
                }
             else
                {
-               protectedResult = j9sig_protect(static_cast<j9sig_protected_fn>(wrappedCompile), static_cast<void*>(&compParam),
-                                                  static_cast<j9sig_handler_fn>(jitSignalHandler), 
+               protectedResult = j9sig_protect(wrappedCompile, static_cast<void*>(&compParam),
+                                                  jitSignalHandler, 
                                                   vmThread, flags, &result);
                }
 

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7894,7 +7894,7 @@ TR::CompilationInfoPerThreadBase::compile(J9VMThread * vmThread,
 #if defined(J9VM_PORT_SIGNAL_SUPPORT)
          U_32 flags = J9PORT_SIG_FLAG_MAY_RETURN |
                       J9PORT_SIG_FLAG_SIGSEGV | J9PORT_SIG_FLAG_SIGFPE |
-                      J9PORT_SIG_FLAG_SIGILL  | J9PORT_SIG_FLAG_SIGBUS;
+                      J9PORT_SIG_FLAG_SIGILL  | J9PORT_SIG_FLAG_SIGBUS | J9PORT_SIG_FLAG_SIGTRAP;
 
          static char *noSignalWrapper = feGetEnv("TR_NoSignalWrapper");
 
@@ -7908,18 +7908,15 @@ TR::CompilationInfoPerThreadBase::compile(J9VMThread * vmThread,
             UDATA protectedResult;
             if (entry->getMethodDetails().isJitDumpMethod())
                {
-               // NOTE:
-               //       for intentional crashes, intentional traps cause the dump, and we
-               //       are not protected against them (flag: J9PORT_SIG_FLAG_SIGTRAP)
-               protectedResult = j9sig_protect((j9sig_protected_fn)wrappedCompile, static_cast<void *>(&compParam),
-                                                  (j9sig_handler_fn)  jitDumpSignalHandler, vmThread,
-                                                  flags, &result);
+               protectedResult = j9sig_protect(static_cast<j9sig_protected_fn>(wrappedCompile), static_cast<void*>(&compParam),
+                                                  static_cast<j9sig_handler_fn>(jitDumpSignalHandler), 
+                                                  vmThread, flags, &result);
                }
             else
                {
-               protectedResult = j9sig_protect((j9sig_protected_fn)wrappedCompile, static_cast<void*>(&compParam),
-                                                  (j9sig_handler_fn)  jitSignalHandler, vmThread,
-                                                  flags, &result);
+               protectedResult = j9sig_protect(static_cast<j9sig_protected_fn>(wrappedCompile), static_cast<void*>(&compParam),
+                                                  static_cast<j9sig_handler_fn>(jitSignalHandler), 
+                                                  vmThread, flags, &result);
                }
 
             if (protectedResult == 0) // successful completion of wrappedCompile

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2649,7 +2649,10 @@ void TR::CompilationInfo::resumeCompilationThread()
          curCompThreadInfoPT->resumeCompilationThread();
          }
 
-      TR_ASSERT_FATAL(getNumCompThreadsActive() > 0, "We must have at least one compilation thread active");
+      if (getNumCompThreadsActive() == 0)
+         {
+         TR_VerboseLog::writeLineLocked(TR_Vlog_INFO, "No threads were activated following a resume all compilation threads call");
+         }
 
       releaseCompMonitor(vmThread);
       }
@@ -3456,7 +3459,7 @@ void TR::CompilationInfo::stopCompilationThreads()
 
    addCompilationTraceEntry(vmThread, OP_WillStopCompilationThreads);
 
-   // Cycle though all non-diagnostic threads and stop them
+   // Cycle through all non-diagnostic threads and stop them
    for (uint8_t i = 0; i < getNumTotalCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -982,6 +982,7 @@ TR::CompilationInfoPerThreadBase::CompilationInfoPerThreadBase(TR::CompilationIn
    _numJITCompilations(),
    _qszWhenCompStarted(),
    _compilationCanBeInterrupted(false),
+   _uninterruptableOperationDepth(0),
    _compilationThreadState(COMPTHREAD_UNINITIALIZED),
    _compilationShouldBeInterrupted(false),
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -3527,7 +3527,9 @@ void TR::CompilationInfo::stopCompilationThreads()
             TR_ASSERT(false, "No other comp thread state possible here\n");
          } // end switch
       }
-   TR_ASSERT(getNumCompThreadsActive()==0, "All threads must be inactive at this point\n");
+
+   TR_ASSERT_FATAL(getNumCompThreadsActive() == 0, "All threads must be inactive at this point\n");
+
    purgeMethodQueue(compilationSuspended);
 
    for (uint8_t i = 0; i < getNumTotalCompilationThreads(); i++)

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -5807,15 +5807,11 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread * vmThread, TR::Il
       return startPC;
       }
 
-   // Check to see if compilation threads are available to perform the compilation
-   if (
-         (getNumCompThreadsActive() == 0) ||
-         (
-            getPersistentInfo()->getDisableFurtherCompilation() &&
-            oldStartPC == 0 &&
-            !details.isJitDumpMethod()
-         )
-      )
+   // If there are no active threads ready to perform the compilation or further compilations are disabled we will
+   // end this compilation request. The only exception to this case is if we are performing a JitDump compilation,
+   // in which case we always want to proceed with the compilation since it will be performed on the diagnostic
+   // thread. Note that the diagnostic thread is not counted towards `getNumCompThreadsActive` count.
+   if ((getNumCompThreadsActive() == 0 || getPersistentInfo()->getDisableFurtherCompilation()) && !details.isJitDumpMethod())
       {
       bool shouldReturn = true;
 

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -204,8 +204,6 @@ class CompilationInfoPerThreadBase
    bool methodCanBeCompiled(TR_Memory *trMemory, TR_FrontEnd *fe, TR_ResolvedMethod *compilee, TR_FilterBST *&filter);
    int32_t                getCompThreadId() const { return _compThreadId; }
 
-   bool compilationCanBeInterrupted() const { return _compilationCanBeInterrupted; }
-
    class InterruptibleOperation
       {
       friend class TR::CompilationInfoPerThreadBase;
@@ -257,7 +255,11 @@ class CompilationInfoPerThreadBase
       bool _originalValue;
       };
 
-   uint8_t                compilationShouldBeInterrupted() const { return _compilationShouldBeInterrupted; }
+   uint8_t compilationShouldBeInterrupted() const
+      {
+      return _compilationCanBeInterrupted ? _compilationShouldBeInterrupted : 0;
+      }
+
    void                   setCompilationShouldBeInterrupted(uint8_t reason) { _compilationShouldBeInterrupted = reason; }
    TR_DataCache*          reservedDataCache() { return _reservedDataCache; }
    void                   setReservedDataCache(TR_DataCache *dataCache) { _reservedDataCache = dataCache; }

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -928,7 +928,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
 
    // We can suspend this thread if too many are active
    if (
-      !(isDiagnosticThread()) // Must not be reserved for log
+      !isDiagnosticThread() // Must not be reserved for log
       && compInfo->getNumCompThreadsActive() > 1 // we should have at least one active besides this one
       && compilationThreadIsActive() // We haven't already been signaled to suspend or terminate
       && (compInfo->getRampDownMCT() || compInfo->getSuspendThreadDueToLowPhysicalMemory())

--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -38,10 +38,10 @@
 #include "runtime/Listener.hpp"
 #endif
 
-UDATA
-jitDumpSignalHandler(struct J9PortLibrary *portLibrary, U_32 gpType, void *gpInfo, void *arg)
+uintptr_t
+jitDumpSignalHandler(struct J9PortLibrary *portLibrary, uint32_t gpType, void *gpInfo, void *handler_arg)
    {
-   TR_VerboseLog::writeLineLocked(TR_Vlog_JITDUMP, "vmThread = %p Recursive crash occurred. Aborting JIT dump.", reinterpret_cast<J9VMThread*>(arg));
+   TR_VerboseLog::writeLineLocked(TR_Vlog_JITDUMP, "vmThread = %p Recursive crash occurred. Aborting JIT dump.", reinterpret_cast<J9VMThread*>(handler_arg));
 
    // Returning J9PORT_SIG_EXCEPTION_RETURN will make us come back to the same crashing instruction over and over
    //
@@ -69,9 +69,9 @@ typedef struct DumpCurrentILParamenters
    } DumpCurrentILParamenters;
 
 static UDATA
-blankDumpCurrentILSignalHandler(struct J9PortLibrary *portLibrary, U_32 gpType, void *gpInfo, void *arg)
+blankDumpCurrentILSignalHandler(struct J9PortLibrary *portLibrary, U_32 gpType, void *gpInfo, void *handler_arg)
    {
-   J9VMThread *vmThread = (J9VMThread *) arg;
+   J9VMThread *vmThread = (J9VMThread *) handler_arg;
    TR_VerboseLog::writeLineLocked(TR_Vlog_JITDUMP, "vmThread=%p Crashed while printing out current IL.", vmThread);
    return J9PORT_SIG_EXCEPTION_RETURN;
    }

--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -638,6 +638,13 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
          // get current compilation
          TR::Compilation *comp = threadCompInfo->getCompilation();
 
+         // Printing the crashed thread trees or any similar operation on the crashed thread may result in having to
+         // acquire VM access (ex. to get a class signature). Other VM events, such as VM shutdown or the GC unloading
+         // classes may cause compilations to be interrupted. Because the crashed thread is not a diagnostic thread,
+         // the call to print the crashed thread IL may get interrupted and the jitdump will be incomplete. We prevent
+         // this from occuring by disallowing interruptions until we are done generating the jitdump.
+         TR::CompilationInfoPerThreadBase::UninterruptibleOperation generateJitDumpForCrashedThread(*threadCompInfo);
+
          // if the compilation is in progress, dump interesting things from it and then recompile
          if (comp)
             {

--- a/runtime/compiler/control/JitDump.hpp
+++ b/runtime/compiler/control/JitDump.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/control/JitDump.hpp
+++ b/runtime/compiler/control/JitDump.hpp
@@ -27,8 +27,8 @@
 #include "j9dump.h"
 #include "j9nonbuilder.h"
 
-extern J9_CFUNC UDATA
-jitDumpSignalHandler(struct J9PortLibrary *portLibrary, U_32 gpType, void *gpInfo, void *arg);
+extern J9_CFUNC uintptr_t
+jitDumpSignalHandler(struct J9PortLibrary *portLibrary, uint32_t gpType, void *gpInfo, void *handler_arg);
 
 extern J9_CFUNC omr_error_t
 runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent);

--- a/runtime/compiler/env/J9VMEnv.cpp
+++ b/runtime/compiler/env/J9VMEnv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/env/J9VMEnv.cpp
+++ b/runtime/compiler/env/J9VMEnv.cpp
@@ -220,7 +220,7 @@ acquireVMaccessIfNeededInner(J9VMThread *vmThread, TR_YesNoMaybe isCompThread)
     * At shutdown time the compilation thread executes Java code and it may receive a sample (see D174900)
     * Only abort the compilation if we're explicitly prepared to handle it.
     */
-   if (compInfoPT->compilationCanBeInterrupted() && compInfoPT->compilationShouldBeInterrupted())
+   if (compInfoPT->compilationShouldBeInterrupted())
       {
       TR_ASSERT(compInfoPT->compilationShouldBeInterrupted() != GC_COMP_INTERRUPT, "GC should not have cut in _compInfoPT=%p\n", compInfoPT);
 

--- a/runtime/compiler/env/ProcessorDetection.cpp
+++ b/runtime/compiler/env/ProcessorDetection.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/env/ProcessorDetection.cpp
+++ b/runtime/compiler/env/ProcessorDetection.cpp
@@ -59,7 +59,6 @@
 #include "control/CompilationController.hpp"
 #include "env/StackMemoryRegion.hpp"
 #include "compile/CompilationException.hpp"
-#include "exceptions/JITShutDown.hpp"
 #include "env/exports.h"
 #include "env/CompilerEnv.hpp"
 #include "env/CHTable.hpp"

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -384,7 +384,7 @@ bool acquireVMaccessIfNeeded(J9VMThread *vmThread, TR_YesNoMaybe isCompThread)
        * At shutdown time the compilation thread executes Java code and it may receive a sample (see D174900)
        * Only abort the compilation if we're explicitly prepared to handle it.
        */
-      if (compInfoPT->compilationCanBeInterrupted() && compInfoPT->compilationShouldBeInterrupted())
+      if (compInfoPT->compilationShouldBeInterrupted())
          {
          TR_ASSERT(compInfoPT->compilationShouldBeInterrupted() != GC_COMP_INTERRUPT, "GC should not have cut in _compInfoPT=%p\n", compInfoPT);
          // in prod builds take some corrective action

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1332,7 +1332,6 @@ extern J9_CFUNC void  jitExclusiveVMShutdownPending (J9VMThread *vmThread);
 extern J9_CFUNC void*  getNextInlinedCallSite (J9JITExceptionTable * metaData, void * inlinedCallSite);
 extern J9_CFUNC void*  jitGetStackMapFromPC (J9JavaVM * javaVM, struct J9JITExceptionTable * exceptionTable, UDATA jitPC);
 extern J9_CFUNC void  jitAddPicToPatchOnClassUnload (void *classPointer, void *addressToBePatched);
-extern J9_CFUNC UDATA  jitSignalHandler (J9VMThread *vmStruct, U_32 gpType, void* gpInfo);
 #endif /* J9VM_INTERP_NATIVE_SUPPORT */
 #endif /* _J9VMNATIVEHELPERSLARGE_ */
 


### PR DESCRIPTION
This PR is a sequence of commits fixing a variety of problems found when stress testing the JitDump process. The issues encountered are fully documented in the issues which are being fixed below. Each commit has a full description of why the change is being made and under which circumstances the observed problem can occur. There were also a lot of comments added in the code because the logic following such situations is definitely non-trivial and we want future readers to understand the importance of some of the code delivered by this PR.

In my stress testing, following this sequence of fixes, I have yet to encounter a situation in which the JitDump process does not both print out the current IL of the crashed thread and then generate a proper trace log with full information in a recompilation step.

Fixes: #9522
Fixes: #11765
Fixes: #11770
Fixes: #11772