### PR TITLE
Modify romClassLoadFromCookie entry trace point

### DIFF
--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -575,7 +575,7 @@ TraceEvent=Trc_VM_sendTclinit_forClass Overhead=1 Level=3 Template="sendTclinit 
 
 TraceAssert=Assert_VM_true_Level9 noEnv Overhead=1 Level=9 Assert="(P1)"
 
-TraceEntry=Trc_VM_romClassLoadFromCookie_Entry1 Overhead=1 Level=3 Template="romClassLoadFromCookie vmStruct=%p clsName=%p clsNameLength=%d romClassBytes=%p romClassLength=%d"
+TraceEntry=Trc_VM_romClassLoadFromCookie_Entry1 Obsolete Overhead=1 Level=3 Template="romClassLoadFromCookie vmStruct=%p clsName=%p clsNameLength=%d romClassBytes=%p romClassLength=%d"
 
 TraceEvent=Trc_VM_resolveKnownClass_SkipResolveOfStringBytesFieldRef Overhead=1 Level=1 Template="Skipping resolve of char[] java.lang.String#value. String compression is enabled. Instance field ref %u for known class %zu (%p)"
 TraceEvent=Trc_VM_resolveKnownClass_SkipResolveOfStringBytesCompressedFieldRef Overhead=1 Level=1 Template="Skipping resolve of Object java.lang.String#value. String compression is disabled. Instance field ref %u for known class %zu (%p)"
@@ -873,3 +873,4 @@ TraceExit=Trc_VM_resolveInvokeDynamic_Exit Overhead=1 Level=3 Template="resolveI
 
 TraceEntry=Trc_VM_sendResolveOpenJDKInvokeHandle_Entry Overhead=1 Level=2 Template="sendResolveOpenJDKInvokeHandle"
 TraceExit=Trc_VM_sendResolveOpenJDKInvokeHandle_Exit Overhead=1 Level=2 Template="sendResolveOpenJDKInvokeHandle"
+TraceEntry=Trc_VM_romClassLoadFromCookie_Entry2 Overhead=1 Level=3 Template="romClassLoadFromCookie vmStruct=%p clsNamePtr=%p clsName=%.*s romClassBytes=%p romClassLength=%d"

--- a/runtime/vm/romutil.c
+++ b/runtime/vm/romutil.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -126,7 +126,7 @@ romClassLoadFromCookie (J9VMThread *vmStruct, U_8 *clsName, UDATA clsNameLength,
 		return NULL;
 	}
 
-	Trc_VM_romClassLoadFromCookie_Entry1(vmStruct, vmStruct, clsName, clsNameLength, romClassBytes, romClassLength);
+	Trc_VM_romClassLoadFromCookie_Entry2(vmStruct, vmStruct, clsName, clsNameLength, clsName , romClassBytes, romClassLength);
 
 	if ( cookie->version != J9_ROM_CLASS_COOKIE_VERSION ) {
 		return NULL;


### PR DESCRIPTION
It is more helpful to include the class name string in the
romClassLoadFromCookie entry trace point. Modify it to print class name
string.

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>