### PR TITLE
Update the CML option of JEP390

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -392,9 +392,9 @@ enum INIT_STAGE {
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 /* Option to turn on exception on synchronization on instances of value-based classes */
-#define VMOPT_XXDIAGNOSE_SYNC_ON_VALUEBASED_CLASSES_EQUALS1 "-XX:DiagnoseSyncOnValuedBasedClasses=1"
+#define VMOPT_XXDIAGNOSE_SYNC_ON_VALUEBASED_CLASSES_EQUALS1 "-XX:DiagnoseSyncOnValueBasedClasses=1"
 /* Option to turn on warning on synchronization on instances of value-based classes */
-#define VMOPT_XXDIAGNOSE_SYNC_ON_VALUEBASED_CLASSES_EQUALS2 "-XX:DiagnoseSyncOnValuedBasedClasses=2"
+#define VMOPT_XXDIAGNOSE_SYNC_ON_VALUEBASED_CLASSES_EQUALS2 "-XX:DiagnoseSyncOnValueBasedClasses=2"
 
 #define VMOPT_XX_NOSUBALLOC32BITMEM "-XXnosuballoc32bitmem"
 

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -1489,9 +1489,9 @@ areValueTypesEnabled(J9JavaVM *vm);
 
 
 /**
- * @brief Queries if -XX:DiagnoseSyncOnValuedBasedClasses=1 or -XX:DiagnoseSyncOnValuedBasedClasses=2 are found in the CML
+ * @brief Queries if -XX:DiagnoseSyncOnValueBasedClasses=1 or -XX:DiagnoseSyncOnValueBasedClasses=2 are found in the CML
  * @param[in] vm pointer to the J9JavaVM
- * @return FALSE if neither of -XX:DiagnoseSyncOnValuedBasedClasses=1/-XX:DiagnoseSyncOnValuedBasedClasses=2 are found in the CML.
+ * @return FALSE if neither of -XX:DiagnoseSyncOnValueBasedClasses=1/-XX:DiagnoseSyncOnValueBasedClasses=2 are found in the CML.
  * 			(i.e. neither J9_EXTENDED_RUNTIME2_VALUE_BASED_EXCEPTION/J9_EXTENDED_RUNTIME2_VALUE_BASED_WARNING are set in 
  * 			vm->extendedRuntimeFlags2)
  * 			Otherwise, return TRUE.

--- a/test/functional/cmdLineTests/ValueBasedClassTest/jep390.xml
+++ b/test/functional/cmdLineTests/ValueBasedClassTest/jep390.xml
@@ -27,8 +27,8 @@
 <suite id="Value based class tests" timeout="300">
 <!--   
 	This test is for the new command line options added in Java 16 and up by JEP390: Warnings for Value-Based Classes.
-	-XX:DiagnoseSyncOnValuedBasedClasses=1 triggers a VirtualMachineError when synchronizing on a object that is value-based.
-	-XX:DiagnoseSyncOnValuedBasedClasses=1 triggers a warning message when synchronizing on a object that is value-based.
+	-XX:DiagnoseSyncOnValueBasedClasses=1 triggers a VirtualMachineError when synchronizing on a object that is value-based.
+	-XX:DiagnoseSyncOnValueBasedClasses=1 triggers a warning message when synchronizing on a object that is value-based.
 	This JEP is to prepare users for the upcoming value-types.
  -->
  	<test id="Test 1-a Test no error warning or VirtualMachineError if neither of the new CML options is used when calling syncOnValueBasedClass()">
@@ -56,7 +56,7 @@
 	</test>
  
 	<test id="Test 2-a Test error message when calling syncOnValueBasedClass()">
-		<command>$JAVA_EXE$ -XX:DiagnoseSyncOnValuedBasedClasses=1 -cp $Q$$JARPATH$$Q$ org.openj9.test.JEP390Test.ValueBasedClassTest VB</command>
+		<command>$JAVA_EXE$ -XX:DiagnoseSyncOnValueBasedClasses=1 -cp $Q$$JARPATH$$Q$ org.openj9.test.JEP390Test.ValueBasedClassTest VB</command>
 		<output regex="no" type="success">Calling method syncOnValueBasedClass()</output> 
 		<output regex="no" type="required">VirtualMachineError: bad object type org/openj9/test/JEP390Test/ValueBasedClass: object that is synchronized is value-based</output>
 		<output regex="no" type="required">at org.openj9.test.JEP390Test.ValueBasedClassTest.syncOnValueBasedClass(ValueBasedClassTest.java:48)</output> 
@@ -66,7 +66,7 @@
 	</test>
 
 	<test id="Test 2-b Test error message when calling syncOnObject()">
-		<command>$JAVA_EXE$ -XX:DiagnoseSyncOnValuedBasedClasses=1 -cp $Q$$JARPATH$$Q$ org.openj9.test.JEP390Test.ValueBasedClassTest OBJ</command>
+		<command>$JAVA_EXE$ -XX:DiagnoseSyncOnValueBasedClasses=1 -cp $Q$$JARPATH$$Q$ org.openj9.test.JEP390Test.ValueBasedClassTest OBJ</command>
 		<output regex="no" type="success">Calling method syncOnObject()</output> 
 		<output regex="no" type="required">VirtualMachineError: bad object type org/openj9/test/JEP390Test/ValueBasedClass: object that is synchronized is value-based</output>
 		<output regex="no" type="required">at org.openj9.test.JEP390Test.ValueBasedClassTest.syncOnObject(ValueBasedClassTest.java:54)</output> 
@@ -76,7 +76,7 @@
 	</test>
 	
 	<test id="Test 3-a Test warning message when calling syncOnValueBasedClass()">
-		<command>$JAVA_EXE$ -XX:DiagnoseSyncOnValuedBasedClasses=2 -cp $Q$$JARPATH$$Q$ org.openj9.test.JEP390Test.ValueBasedClassTest VB</command>
+		<command>$JAVA_EXE$ -XX:DiagnoseSyncOnValueBasedClasses=2 -cp $Q$$JARPATH$$Q$ org.openj9.test.JEP390Test.ValueBasedClassTest VB</command>
 		<output regex="no" type="success">ValueBasedClassTest Exit</output> 
 		<output regex="no" type="required">Calling method syncOnValueBasedClass()</output>
 		<output regex="no" type="required">JVMJ9VM200W bad object type org/openj9/test/JEP390Test/ValueBasedClass: object that is synchronized is value-based</output>
@@ -88,7 +88,7 @@
 	</test>
 
 	<test id="Test 3-b Test warning message when calling syncOnObject()">
-		<command>$JAVA_EXE$ -XX:DiagnoseSyncOnValuedBasedClasses=2 -cp $Q$$JARPATH$$Q$ org.openj9.test.JEP390Test.ValueBasedClassTest OBJ</command>
+		<command>$JAVA_EXE$ -XX:DiagnoseSyncOnValueBasedClasses=2 -cp $Q$$JARPATH$$Q$ org.openj9.test.JEP390Test.ValueBasedClassTest OBJ</command>
 		<output regex="no" type="success">ValueBasedClassTest Exit</output> 
 		<output regex="no" type="required">Calling method syncOnObject()</output>
 		<output regex="no" type="required">JVMJ9VM200W bad object type org/openj9/test/JEP390Test/ValueBasedClass: object that is synchronized is value-based</output>


### PR DESCRIPTION
Change `-XX:DiagnoseSyncOnValuedBasedClasses` to `-XX:DiagnoseSyncOnValueBasedClasses`

issue #10620

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>