### PR TITLE
Capture more files for diagnostics

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corp. and others
+ * Copyright (c) 2017, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -469,10 +469,8 @@ def archive_diagnostics() {
         }
         // Note: to preserve the files ACLs set _OS390_USTAR=Y env variable (see variable files)
         sh "find . -name 'core.*.dmp' -o -name 'javacore.*.txt' -o -name 'Snap.*.trc' -o -name 'jitdump.*.dmp' | sed 's#^./##' | pax -wzf ${diagnosticsFilename}"
-    } else if (SPEC.endsWith("_cm")) {
-        sh "find . -name 'core.*.dmp' -o -name 'javacore.*.txt' -o -name 'Snap.*.trc' -o -name 'jitdump.*.dmp' -o -name ddr_info -o -name superset.dat -o -name j9ddr.dat -o -name '*.stub.h' -o -name '*.annt.h' | sed 's#^./##' | tar -zcvf ${diagnosticsFilename} -T -"
     } else {
-        sh "find . -name 'core.*.dmp' -o -name 'javacore.*.txt' -o -name 'Snap.*.trc' -o -name 'jitdump.*.dmp' | sed 's#^./##' | tar -zcvf ${diagnosticsFilename} -T -"
+        sh "find . -name 'core.*.dmp' -o -name 'javacore.*.txt' -o -name 'Snap.*.trc' -o -name 'jitdump.*.dmp' -o -name ddr_info -o -name j9ddr.dat -o -name superset.dat -o -name '*.annt.h' -o -name '*.stub.h' -o -name '*.dSYM' | sed 's#^./##' | tar -zcvf ${diagnosticsFilename} -T -"
     }
     if (ARTIFACTORY_CONFIG) {
         def uploadSpec = """{


### PR DESCRIPTION
Remove special case for `*_cm` specs: it's not a problem if patterns don't match any files and it doesn't recognize that some builds use `cmake` by default.

See #11834.