### PR TITLE
ClassIteratorClassSlots now returns address of class instead of slots

### DIFF
--- a/runtime/gc_api/HeapRootScanner.cpp
+++ b/runtime/gc_api/HeapRootScanner.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -141,9 +141,9 @@ MM_HeapRootScanner::doStringTableSlot(J9Object **slotPtr, GC_StringTableIterator
  * @todo Provide function documentation
  */
 void
-MM_HeapRootScanner::doVMClassSlot(J9Class **slotPtr, GC_VMClassSlotIterator *vmClassSlotIterator)
+MM_HeapRootScanner::doVMClassSlot(J9Class *classPtr)
 {
-	doClassSlot(slotPtr);
+	doClassSlot(classPtr);
 }
 
 #if defined(J9VM_OPT_JVMTI)
@@ -213,7 +213,7 @@ MM_HeapRootScanner::scanVMClassSlots()
 	J9Class **slotPtr;
 	
 	while((slotPtr = classSlotIterator.nextSlot()) != NULL) {
-		doVMClassSlot(slotPtr, &classSlotIterator);
+		doVMClassSlot(*slotPtr);
 	}
 	
 	reportScanningEnded(RootScannerEntity_VMClassSlots);	
@@ -224,9 +224,9 @@ MM_HeapRootScanner::scanVMClassSlots()
  * This handler is called for every reference to a J9Class. 
  */
 void 
-MM_HeapRootScanner::doClassSlot(J9Class** slotPtr)
+MM_HeapRootScanner::doClassSlot(J9Class *classPtr)
 {
-	doClass(*slotPtr);
+	doClass(classPtr);
 }
 
 /**

--- a/runtime/gc_api/HeapRootScanner.hpp
+++ b/runtime/gc_api/HeapRootScanner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -155,7 +155,7 @@ public:
 	virtual void doSlot(J9Object** slotPtr) = 0;
 
 	/** General class slot handler to be reimplemented by specializing class. This handler is called for every reference to a J9Class. */
-	virtual void doClassSlot(J9Class** slotPtr);
+	virtual void doClassSlot(J9Class *classPtr);
 
 	/** General class handler to be reimplemented by specializing class. This handler is called once per class. */
 	virtual void doClass(J9Class *clazz) = 0;
@@ -224,7 +224,7 @@ public:
 #endif /* J9VM_OPT_JVMTI */
 
 	virtual void doStringTableSlot(J9Object **slotPtr, GC_StringTableIterator *stringTableIterator);
-	virtual void doVMClassSlot(J9Class **slotPtr, GC_VMClassSlotIterator *vmClassSlotIterator);
+	virtual void doVMClassSlot(J9Class *classPtr);
 	virtual void doVMThreadSlot(J9Object **slotPtr, GC_VMThreadIterator *vmThreadIterator);
 };
 

--- a/runtime/gc_base/ReferenceChainWalker.hpp
+++ b/runtime/gc_base/ReferenceChainWalker.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -115,14 +115,14 @@ private:
 
 	virtual void doMonitorReference(J9ObjectMonitor *objectMonitor, GC_HashTableIterator *monitorReferenceIterator);
 	virtual void doStringTableSlot(J9Object **slotPtr, GC_StringTableIterator *stringTableIterator);
-	virtual void doVMClassSlot(J9Class **slotPtr, GC_VMClassSlotIterator *vmClassSlotIterator);
+	virtual void doVMClassSlot(J9Class *classPtr);
 	virtual void doVMThreadSlot(J9Object **slotPtr, GC_VMThreadIterator *vmThreadIterator);
 	virtual void doStackSlot(J9Object **slotPtr, void *walkState, const void* stackLocation);
 	virtual void doSlot(J9Object **slotPtr);
-	virtual void doClassSlot(J9Class **slotPtr);
+	virtual void doClassSlot(J9Class *classPtr);
 	virtual void doClass(J9Class *clazz);
 	virtual void doSlot(J9Object **slotPtr, IDATA type, IDATA index, J9Object *sourceObj);
-	virtual void doClassSlot(J9Class **slotPtr, IDATA type, IDATA index, J9Object *sourceObj);
+	virtual void doClassSlot(J9Class *classPtr, IDATA type, IDATA index, J9Object *sourceObj);
 	using MM_RootScanner::doFieldSlot;
 	virtual void doFieldSlot(GC_SlotObject *slotObject, IDATA type, IDATA index, J9Object *sourceObj);
 	

--- a/runtime/gc_base/RootScanner.cpp
+++ b/runtime/gc_base/RootScanner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -245,9 +245,9 @@ MM_RootScanner::doStringCacheTableSlot(J9Object **slotPtr)
  * @todo Provide function documentation
  */
 void
-MM_RootScanner::doVMClassSlot(J9Class **slotPtr, GC_VMClassSlotIterator *vmClassSlotIterator)
+MM_RootScanner::doVMClassSlot(J9Class *classPtr)
 {
-	doClassSlot(slotPtr);
+	doClassSlot(classPtr);
 }
 
 /**
@@ -317,7 +317,7 @@ MM_RootScanner::scanVMClassSlots(MM_EnvironmentBase *env)
 		J9Class **slotPtr;
 
 		while((slotPtr = classSlotIterator.nextSlot()) != NULL) {
-			doVMClassSlot(slotPtr, &classSlotIterator);
+			doVMClassSlot(*slotPtr);
 		}
 
 		reportScanningEnded(RootScannerEntity_VMClassSlots);
@@ -329,7 +329,7 @@ MM_RootScanner::scanVMClassSlots(MM_EnvironmentBase *env)
  * This handler is called for every reference to a J9Class.
  */
 void
-MM_RootScanner::doClassSlot(J9Class** slotPtr)
+MM_RootScanner::doClassSlot(J9Class *classPtr)
 {
 	/* ignore class slots by default */
 }

--- a/runtime/gc_base/RootScanner.hpp
+++ b/runtime/gc_base/RootScanner.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,7 +60,7 @@ class MM_CollectorLanguageInterfaceImpl;
  * should be done rarely and in only extreme circumstances.  Handling of elements can be specialized for all
  * elements as well as for specific types of structures.
  * 
- * The core routines to be reimplemented are doSlot(J9Object **), doClassSlot(J9Class **) and doClass(J9Class *).
+ * The core routines to be reimplemented are doSlot(J9Object **), doClassSlot(J9Class *) and doClass(J9Class *).
  * All other slot types are forwarded by default to these routines for processing.  To handle structure slots in 
  * specific ways, the slot handler for that type should be overridden.
  * 
@@ -382,7 +382,7 @@ public:
 	virtual void doSlot(J9Object** slotPtr) = 0;
 
 	/** General class slot handler to be reimplemented by specializing class. This handler is called for every reference to a J9Class. */
-	virtual void doClassSlot(J9Class** slotPtr);
+	virtual void doClassSlot(J9Class *classPtr);
 
 	/** General class handler to be reimplemented by specializing class. This handler is called once per class. */
 	virtual void doClass(J9Class *clazz) = 0;
@@ -504,7 +504,7 @@ public:
 
 	virtual void doStringTableSlot(J9Object **slotPtr, GC_StringTableIterator *stringTableIterator);
 	virtual void doStringCacheTableSlot(J9Object **slotPtr);
-	virtual void doVMClassSlot(J9Class **slotPtr, GC_VMClassSlotIterator *vmClassSlotIterator);
+	virtual void doVMClassSlot(J9Class *classPtr);
 	virtual void doVMThreadSlot(J9Object **slotPtr, GC_VMThreadIterator *vmThreadIterator);
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 	/**

--- a/runtime/gc_realtime/RealtimeRootScanner.cpp
+++ b/runtime/gc_realtime/RealtimeRootScanner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,7 +59,7 @@ MM_RealtimeRootScanner::doClass(J9Class *clazz)
 	GC_ClassIteratorClassSlots classSlotIterator(clazz);
 	J9Class **classSlotPtr;
 	while((classSlotPtr = classSlotIterator.nextSlot()) != NULL) {
-		doClassSlot(classSlotPtr);
+		doClassSlot(*classSlotPtr);
 	}
 }
 
@@ -67,9 +67,9 @@ MM_RealtimeRootScanner::doClass(J9Class *clazz)
  * 
  */
 void
-MM_RealtimeRootScanner::doClassSlot(J9Class **clazzPtr)
+MM_RealtimeRootScanner::doClassSlot(J9Class *classPtr)
 {
-	_realtimeGC->getRealtimeDelegate()->markClass(_env, *clazzPtr);
+	_realtimeGC->getRealtimeDelegate()->markClass(_env, classPtr);
 }
 
 MM_RootScanner::CompletePhaseCode

--- a/runtime/gc_realtime/RealtimeRootScanner.hpp
+++ b/runtime/gc_realtime/RealtimeRootScanner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -96,7 +96,7 @@ public:
 
 	virtual const char* scannerName() = 0;
 	
-	virtual void doClassSlot(J9Class **clazzPtr);
+	virtual void doClassSlot(J9Class *classPtr);
 
 	virtual void scanMonitorLookupCaches(MM_EnvironmentBase *env);
 


### PR DESCRIPTION
- Changing the nextSlot method to return the pointer to the object in
the next slot instead of the pointer to the next slot with an object
reference in it.
- Added new method getClassSlotAddress method to ClassIteratorClassSlots
 which returns the address of the most recently returned slot.
- Modified calls to nextSlot to fit new implementation, reducing the need to
dereference slot addresses.

Signed-off-by: Oussama Saoudi <oussama.saoudi@ibm.com>