### PR TITLE
Update pointer offset addition for dbf Scan Ordering

### DIFF
--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -2130,11 +2130,12 @@ MM_CopyForwardScheme::depthCopyHotFields(MM_EnvironmentVLHGC *env, J9Class *claz
 
 MMINLINE void
 MM_CopyForwardScheme::copyHotField(MM_EnvironmentVLHGC *env, J9Object *destinationObjectPtr, U_8 offset, MM_AllocationContextTarok *reservingContext) {
-	GC_SlotObject hotFieldObject(_javaVM->omrVM, (fomrobject_t*)(destinationObjectPtr + offset));
+	bool const compressed = _extensions->compressObjectReferences();
+	GC_SlotObject hotFieldObject(_javaVM->omrVM, GC_SlotObject::addToSlotAddress((fomrobject_t*)((uintptr_t)destinationObjectPtr), offset, compressed));
 	omrobjectptr_t objectPtr = hotFieldObject.readReferenceFromSlot();							
 	if (isObjectInEvacuateMemory(objectPtr)) {
 		/* Hot field needs to be copy and forwarded.  Check if the work has already been done */
-		MM_ForwardedHeader forwardHeaderHotField(objectPtr, _extensions->compressObjectReferences());
+		MM_ForwardedHeader forwardHeaderHotField(objectPtr, compressed);
 		if (!forwardHeaderHotField.isForwardedPointer()) {
 			env->_hotFieldCopyDepthCount += 1;
 			copy(env, reservingContext, &forwardHeaderHotField);


### PR DESCRIPTION
Update pointer offset addition for adding a hot field
offset to an object pointer in order to copy the hot
field of the object for dbf Scan Ordering in balanced GC.

Issue: #11819 
Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>