### PR TITLE
Set loadType of Unsafe classes and LOAD_LOCATION_UNKNOWN classes

### DIFF
--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -543,12 +543,18 @@ ROMClassBuilder::prepareAndLaydown( BufferManager *bufferManager, ClassFileParse
 #if defined(J9VM_OPT_SHARED_CLASSES)
 	if (context->isROMClassShareable()) {
 		UDATA loadType = J9SHR_LOADTYPE_NORMAL;
-		if (context->isClassHidden()) {
-			loadType = J9SHR_LOADTYPE_NOT_FROM_PATH;
-		} else if (context->isRedefining()) {
+		if (context->isRedefining()) {
 			loadType = J9SHR_LOADTYPE_REDEFINED;
 		} else if (context->isRetransforming()) {
 			loadType = J9SHR_LOADTYPE_RETRANSFORMED;
+		} else if (context->isClassUnsafe()
+			|| context->isClassHidden()
+			|| (LOAD_LOCATION_UNKNOWN == context->loadLocation())
+		) {
+			/* For redefining/transforming, we still want loadType to be J9SHR_LOADTYPE_REDEFINED/J9SHR_LOADTYPE_RETRANSFORMED,
+			 * so put these checks after the redefining/transforming checks.
+			 */ 
+			loadType = J9SHR_LOADTYPE_NOT_FROM_PATH;
 		}
 
 		SCStoreTransaction sharedStoreClassTransaction =

--- a/runtime/shared_common/SCImplementedAPI.cpp
+++ b/runtime/shared_common/SCImplementedAPI.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -478,7 +478,7 @@ j9shr_classStoreTransaction_start(void * tobj, J9VMThread* currentThread, J9Clas
 	modContext = sconfig->modContext;
 
 	if ((classloader != NULL)
-		&& (J9SHR_LOADTYPE_NOT_FROM_PATH != loadType) /* no need to set classpath if loadType is J9SHR_LOADTYPE_NOT_FROM_PATH */
+		&& (J9SHR_LOADTYPE_NORMAL == loadType) /* no need to set classpath if loadType is not J9SHR_LOADTYPE_NORMAL */
 	) {
 		/* default values for bootstrap: */
 		IDATA helperID = 0;


### PR DESCRIPTION
For Unsafe classes and LOAD_LOCATION_UNKNOWN classes, set load
type to J9SHR_LOADTYPE_NOT_FROM_PATH so that they are stored as orphan.

Fixes #10073

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>