### PR TITLE
JDK8 getMethod returns any matching method for an interface

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
  * Copyright (c) 1998, 2021 IBM Corp. and others
  *
@@ -1677,8 +1677,19 @@ private Method getMostSpecificMethodFromAllInterfacesOfCurrentClass(HashMap<Clas
 		} else {
 			for (Method m: mi.jlrMethods) {
 				bestMethod = getMostSpecificInterfaceMethod(name, parameterTypes, bestMethod, m);
+				/*[IF JAVA_SPEC_VERSION == 8]*/
+				// Java 8 returns any matching method found
+				if (bestMethod != null) {
+					break;
+				}
+				/*[ENDIF] JAVA_SPEC_VERSION == 8 */
 			}
 		}
+		/*[IF JAVA_SPEC_VERSION == 8]*/
+		if (bestMethod != null) {
+			break;
+		}
+		/*[ENDIF] JAVA_SPEC_VERSION == 8 */
 	}
 
 	return bestMethod;

--- a/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_Class.java
@@ -422,6 +422,36 @@ public void test_getMethods_subtest5() {
 	}
 }
 
+abstract class ClzParent {}
+class ClzChild extends ClzParent {}
+class ClzImpl implements InterFaceLayerOne {
+	@Override
+	public ClzChild getType() {
+		return null;
+	}
+}
+interface InterFaceLayerOne extends InterfaceLayerTwoA<ClzChild>, InterfaceLayerTwoB {}
+interface InterfaceLayerTwoA<S> extends InterfaceLayerThreeA<ClzChild>, InterfaceLayerThreeB {}
+interface InterfaceLayerTwoB {
+	ClzParent getType();
+}
+interface InterfaceLayerThreeA<S> {
+	S getType();
+}
+interface InterfaceLayerThreeB {
+	ClzParent getType();
+}
+@Test
+public void test_getMethods_subtest6() throws Exception {
+	ClzImpl clzImpl = new ClzImpl();
+	for (Method method : clzImpl.getClass().getMethods()) {
+		for (Class<?> anInterface : method.getDeclaringClass().getInterfaces()) {
+			Method intfMethod = anInterface.getMethod(method.getName(), method.getParameterTypes());
+			Assert.assertEquals(intfMethod.toString(), "public abstract org.openj9.test.java.lang.Test_Class$ClzParent org.openj9.test.java.lang.Test_Class$InterfaceLayerThreeB.getType()");
+		}
+	}
+}
+
 static String[] concatenateObjectMethods(String methodList[]) {
 	final String[] jlobjectMethods = new String[] {
 			objectClass+".equals(java.lang.Object)boolean",
@@ -818,7 +848,7 @@ public void test_getConstructors() {
  */
 @Test
 public void test_getDeclaredClasses() {
-	int len = 65;
+	int len = 73;
 	// Test for method java.lang.Class [] java.lang.Class.getDeclaredClasses()
 	Class[] declaredClasses = Test_Class.class.getDeclaredClasses();
 	if (declaredClasses.length != len) {

--- a/test/functional/Java8andUp/src_80/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java8andUp/src_80/org/openj9/test/java/lang/Test_Class.java
@@ -458,6 +458,35 @@ public class Test_Class {
 		Assert.assertEquals(java.util.List.class, specificMethod.getReturnType(), 
 			"Expected method return type: " + java.util.List.class + " but got: " + specificMethod.getReturnType());
 	}
+	abstract class ClzParent {}
+	class ClzChild extends ClzParent {}
+	class ClzImpl implements InterFaceLayerOne {
+		@Override
+		public ClzChild getType() {
+			return null;
+		}
+	}
+	interface InterFaceLayerOne extends InterfaceLayerTwoA<ClzChild>, InterfaceLayerTwoB {}
+	interface InterfaceLayerTwoA<S> extends InterfaceLayerThreeA<ClzChild>, InterfaceLayerThreeB {}
+	interface InterfaceLayerTwoB {
+		ClzParent getType();
+	}
+	interface InterfaceLayerThreeA<S> {
+		S getType();
+	}
+	interface InterfaceLayerThreeB {
+		ClzParent getType();
+	}
+	@Test
+	public void test_getMethods_subtest8() throws Exception {
+		ClzImpl clzImpl = new ClzImpl();
+		for (Method method : clzImpl.getClass().getMethods()) {
+			for (Class<?> anInterface : method.getDeclaringClass().getInterfaces()) {
+				Method intfMethod = anInterface.getMethod(method.getName(), method.getParameterTypes());
+				Assert.assertEquals(intfMethod.toString(), "public abstract java.lang.Object org.openj9.test.java.lang.Test_Class$InterfaceLayerThreeA.getType()");
+			}
+		}
+	}
 	
 	class TestSpecificMethodsCL extends ClassLoader {
 		public Class<?> findClass(String name) throws ClassNotFoundException {
@@ -904,7 +933,7 @@ public class Test_Class {
 	 */
 	@Test
 	public void test_getDeclaredClasses() {
-		int len = 66;
+		int len = 74;
 		// Test for method java.lang.Class [] java.lang.Class.getDeclaredClasses()
 		Class[] declaredClasses = Test_Class.class.getDeclaredClasses();
 		if (declaredClasses.length != len) {


### PR DESCRIPTION
As per `Java 8` spec, if `C` is an interface, then the `superinterfaces` of `C` (if any) are searched for a matching method. If any such method is found, it is reflected.
Added tests for `Java 8` & `11+`.

Note: https://github.com/eclipse/openj9/pull/8230 resolved https://github.com/eclipse/openj9/issues/7623, the change was applied to Java 8 as well and didn't match `Java 8` spec and RI behaviours.
Also created https://github.com/AdoptOpenJDK/openjdk-tests/pull/2230 to enabled JTReg Test: `java/lang/reflect/DefaultMethodMembers/FilterNotMostSpecific.java`

Signed-off-by: Jason Feng <fengj@ca.ibm.com>