### PR TITLE
Fix ScavengerForwardedHeader compatibilty issue

### DIFF
--- a/runtime/gc_base/GCObjectEvents.cpp
+++ b/runtime/gc_base/GCObjectEvents.cpp
@@ -82,6 +82,7 @@ localGCReportObjectEvents(MM_EnvironmentBase *env, MM_MemorySubSpaceSemiSpace *m
 	/* Find the region associated with the evacuate allocate profile */
 	GC_MemorySubSpaceRegionIterator regionIterator(memorySubSpaceNew);
 	MM_HeapRegionDescriptor *evacuateRegion = NULL;
+	bool const compressed = extensions->compressObjectReferences();
 	while ((evacuateRegion = regionIterator.nextRegion()) != NULL) {
 		J9Object *objectPtr = (J9Object *)evacuateRegion->getLowAddress();
 		/* skip survivor regions */
@@ -94,7 +95,7 @@ localGCReportObjectEvents(MM_EnvironmentBase *env, MM_MemorySubSpaceSemiSpace *m
 				if (extensions->objectModel.isDeadObject(objectPtr)) {
 					objectPtr = (J9Object *)((U_8 *)objectPtr + extensions->objectModel.getSizeInBytesDeadObject(objectPtr));
 				} else {
-					MM_ForwardedHeader forwardHeader(objectPtr, extensions);
+					MM_ForwardedHeader forwardHeader(objectPtr, compressed);
 					if (forwardHeader.isForwardedPointer()) {
 						J9Object *forwardPtr = forwardHeader.getForwardedObject();
 						Assert_MM_true(NULL != forwardPtr);

--- a/runtime/gc_base/ScavengerForwardedHeader.hpp
+++ b/runtime/gc_base/ScavengerForwardedHeader.hpp
@@ -51,7 +51,7 @@ protected:
 	omrobjectptr_t _objectPtr; /**< the object on which to act */
 	uintptr_t _preserved; /**< a backup copy of the header fields which may be modified by this class */
 #if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
-	bool const _compressObjectReferences;
+	bool _compressObjectReferences;
 #endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
 private:
 };

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -1855,7 +1855,7 @@ MM_CopyForwardScheme::updateForwardedPointer(J9Object *objectPtr)
 	J9Object *forwardPtr;
 
 	if(isObjectInEvacuateMemory(objectPtr)) {
-		MM_ForwardedHeader forwardedHeader(objectPtr, _extensions);
+		MM_ForwardedHeader forwardedHeader(objectPtr, _extensions->compressObjectReferences());
 		forwardPtr = forwardedHeader.getForwardedObject();
 		if(forwardPtr != NULL) {
 			return forwardPtr;


### PR DESCRIPTION
Remove `const` keyword from  ScavengerForwardedHeader and fix MM_ForwardedHeader in GCObjectEvents

Fixes JDK8_x86-64_windows and JDK11_x86-64_mac_mixed builds

Signed-off-by: Igor Braga <higorb1@gmail.com>