### PR TITLE
Add conditional relo tracing mechanism 

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -186,7 +186,12 @@ J9::Compilation::Compilation(int32_t id,
    _serializedRuntimeAssumptions(getTypedAllocator<SerializedRuntimeAssumption *>(self()->allocator())),
    _clientData(NULL),
 #endif /* defined(J9VM_OPT_JITSERVER) */
-   _osrProhibitedOverRangeOfTrees(false)
+   _osrProhibitedOverRangeOfTrees(false),
+   _useTracingBuffer(false),
+   _tracingBufferStart(NULL),
+   _tracingBufferCursor(NULL),
+   _tracingBufferSize(0),
+   _tracingBufferFreeSpace(0)
    {
    _symbolValidationManager = new (self()->region()) TR::SymbolValidationManager(self()->region(), compilee);
 
@@ -228,6 +233,14 @@ J9::Compilation::Compilation(int32_t id,
 J9::Compilation::~Compilation()
    {
    _profileInfo->~TR_AccessedProfileInfo();
+   }
+
+void
+J9::Compilation::allocateTracingBuffer()
+   {
+   const int32_t size = TRACING_BUFFER_CAPACITY;
+   _tracingBufferStart = (char *)self()->region().allocate(size);
+   _tracingBufferSize = size;
    }
 
 TR_J9VMBase *

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -75,6 +75,22 @@ class ClientSessionData;
 #define COMPILATION_RESERVE_NTRAMPOLINES_ERROR_INBINARYENCODING -19
 #define COMPILATION_AOT_RELOCATION_FAILED -20
 
+#define TRACING_BUFFER_CAPACITY 10*1024
+#define TRACING_BUFFER_SEGMENT_SIZE 128
+#define ADD_TRACING_BUFFER_MESSAGE(comp, fmt, ...) \
+   do \
+      { \
+      if (comp->useTracingBuffer()) \
+         { \
+         char *buffer = comp->getTracingBufferCursor(); \
+         if (comp->getTracingBufferFreeSpace() >= TRACING_BUFFER_SEGMENT_SIZE) \
+            { \
+            snprintf(buffer, TRACING_BUFFER_SEGMENT_SIZE, fmt, ##__VA_ARGS__); \
+            comp->incTracingBuffer(TRACING_BUFFER_SEGMENT_SIZE); \
+            } \
+         } \
+      } while (false)
+
 
 
 namespace J9
@@ -339,6 +355,23 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    void setOSRProhibitedOverRangeOfTrees() { _osrProhibitedOverRangeOfTrees = true; }
    bool isOSRProhibitedOverRangeOfTrees() { return _osrProhibitedOverRangeOfTrees; }
 
+   void setUseTracingBuffer(bool use) { _useTracingBuffer = use; }
+   bool useTracingBuffer() { return _useTracingBuffer; }
+   char *getTracingBufferStart() { return _tracingBufferStart; }
+   char *getTracingBufferCursor() { return _tracingBufferCursor; }
+   void incTracingBuffer(size_t size)
+      {
+      _tracingBufferCursor += size;
+      _tracingBufferFreeSpace -= size;
+      }
+   void allocateTracingBuffer();
+   void resetTracingBuffer()
+      {
+      _tracingBufferCursor = _tracingBufferStart;
+      _tracingBufferFreeSpace = _tracingBufferSize;
+      }
+   int32_t getTracingBufferFreeSpace() { return _tracingBufferFreeSpace; }
+
 private:
    enum CachedClassPointerId
       {
@@ -439,6 +472,12 @@ private:
 
    TR::SymbolValidationManager *_symbolValidationManager;
    bool _osrProhibitedOverRangeOfTrees;
+
+   bool _useTracingBuffer;
+   char *_tracingBufferStart;
+   char *_tracingBufferCursor;
+   int32_t _tracingBufferSize;
+   int32_t _tracingBufferFreeSpace;
    };
 
 }

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -843,6 +843,14 @@ J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * ow
    TR_ResolvedJ9Method * owningMethod =
       static_cast<TR_ResolvedJ9Method*>(owningMethodSymbol->getResolvedMethod());
 
+   if (comp()->compileRelocatableCode())
+      {
+      comp()->setUseTracingBuffer(true);
+      if (comp()->getTracingBufferStart() == NULL)
+         comp()->allocateTracingBuffer();
+      comp()->resetTracingBuffer();
+      }
+
    bool isVolatile = true, isFinal = false, isPrivate = false, isUnresolvedInCP;
    TR::DataType type = TR::NoType;
    uint32_t offset = 0;
@@ -868,6 +876,22 @@ J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * ow
 
       if (comp()->compileRelocatableCode())
          {
+         if (comp()->useTracingBuffer())
+            {
+            if (containingClass == NULL)
+               {
+               const char *bufferPtr = comp()->getTracingBufferCursor();
+               for (char *cursor = comp()->getTracingBufferStart(); cursor < bufferPtr; cursor += TRACING_BUFFER_SEGMENT_SIZE)
+                  {
+                  J9VMThread *vmThread = comp()->fej9()->getCurrentVMThread();
+                  // each subsection *should* be NULL terminated
+                  fprintf(stderr, "%p: %s", vmThread, cursor);
+                  }
+               fprintf(stderr, "End (%d)\n", comp()->getTracingBufferFreeSpace());
+               }
+            comp()->setUseTracingBuffer(false);
+            }
+
          TR_ASSERT_FATAL(
             containingClass != NULL,
             "failed to get defining class of field ref cpIndex=%d in owning method J9Method=%p\n"
@@ -895,8 +919,13 @@ J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * ow
          findResolvedFieldShadow(key, isVolatile, isPrivate, isFinal);
 
       if (symRef != NULL)
+         {
+         comp()->setUseTracingBuffer(false);
          return symRef;
+         }
       }
+
+   comp()->setUseTracingBuffer(false);
 
    TR::Symbol * sym = 0;
 

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -863,6 +863,12 @@ TR_J9SharedCache::createClassKey(UDATA classOffsetInCache, char *key, uint32_t &
 UDATA *
 TR_J9SharedCache::rememberClass(J9Class *clazz, bool create)
    {
+   return rememberClass(create, NULL, clazz);
+   }
+
+UDATA *
+TR_J9SharedCache::rememberClass(bool create, TR::Compilation *comp, J9Class *clazz)
+   {
    UDATA *chainData = NULL;
 #if defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
@@ -875,6 +881,10 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, bool create)
    if (!isROMClassInSharedCache(romClass, &classOffsetInCache))
       {
       LOG(1,"\trom class not in shared cache, returning\n");
+      if (comp)
+         {
+         ADD_TRACING_BUFFER_MESSAGE(comp, "rememberClass (%p): rom class %p not in shared cache, returning\n", clazz, romClass);
+         }
       return NULL;
       }
 
@@ -884,10 +894,14 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, bool create)
 
    LOG(3, "\tkey created: %.*s\n", keyLength, key);
 
-   chainData = findChainForClass(clazz, key, keyLength);
+   chainData = findChainForClass(clazz, key, keyLength, comp, romClass);
    if (chainData != NULL)
       {
       LOG(1, "\tchain exists (%p) so nothing to store\n", chainData);
+      if (comp)
+         {
+         ADD_TRACING_BUFFER_MESSAGE(comp, "rememberClass: chain exists (%p) so nothing to store, %p, %p\n", chainData, clazz, romClass);
+         }
       return chainData;
       }
 
@@ -902,18 +916,30 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, bool create)
    if (chainLength > maxChainLength*sizeof(UDATA))
       {
       LOG(1, "\t\t > %d so bailing\n", maxChainLength);
+      if (comp)
+         {
+         ADD_TRACING_BUFFER_MESSAGE(comp, "rememberClass: chainLength larger than maxChainLength; bailing, %p %p\n", clazz, romClass);
+         }
       return NULL;
       }
 
    if (!fillInClassChain(clazz, chainData, chainLength, numSuperclasses, numInterfaces))
       {
       LOG(1, "\tfillInClassChain failed, bailing\n");
+      if (comp)
+         {
+         ADD_TRACING_BUFFER_MESSAGE(comp, "rememberClass: failed to fill in class chain; bailing, %p, %p\n", clazz, romClass);
+         }
       return NULL;
       }
 
    if (!create)
       {
-      LOG(1, "\tnot asked to create but could create, returning non-null\n");
+      LOG(1, "\tnot asked to create but could create, returning non-null, %p %p\n", clazz, romClass);
+      if (comp)
+         {
+         ADD_TRACING_BUFFER_MESSAGE(comp, "rememberClass: not asked to create but could create ; bailing, %p %p\n", clazz, romClass);
+         }
       return (UDATA *) 0x1;
       }
 
@@ -936,10 +962,18 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, bool create)
    if (chainData)
       {
       LOG(1, "\tstored data, chain at %p\n", chainData);
+      if (comp)
+         {
+         ADD_TRACING_BUFFER_MESSAGE(comp, "rememberClass: stored data, chain at %p, %p, %p\n", chainData, clazz, romClass);
+         }
       }
    else
       {
       LOG(1, "\tunable to store chain\n");
+      if (comp)
+         {
+         ADD_TRACING_BUFFER_MESSAGE(comp, "rememberClass: unable to store chain %p, %p\n", vmThread, romClass);
+         }
       TR::Options::getAOTCmdLineOptions()->setOption(TR_NoStoreAOT);
 
       setSharedCacheDisabledReason(SHARED_CACHE_CLASS_CHAIN_STORE_FAILED);
@@ -1085,7 +1119,7 @@ TR_J9SharedCache::romclassMatchesCachedVersion(J9ROMClass *romClass, UDATA * & c
    }
 
 UDATA *
-TR_J9SharedCache::findChainForClass(J9Class *clazz, const char *key, uint32_t keyLength)
+TR_J9SharedCache::findChainForClass(J9Class *clazz, const char *key, uint32_t keyLength, TR::Compilation *comp, J9ROMClass *romClass)
    {
    UDATA * chainForClass = NULL;
 #if defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
@@ -1105,6 +1139,12 @@ TR_J9SharedCache::findChainForClass(J9Class *clazz, const char *key, uint32_t ke
    //fprintf(stderr,"findChainForClass: key %.*s chain %p\n", keyLength, key, dataDescriptor.address);
    chainForClass = (UDATA *) dataDescriptor.address;
 #endif
+
+   if (comp)
+      {
+      ADD_TRACING_BUFFER_MESSAGE(comp, "findChainForClass %p, %p, %p, %p\n", vmThread, clazz, romClass, chainForClass);
+      }
+
    return chainForClass;
    }
 

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -182,6 +182,7 @@ public:
       }
 
    virtual UDATA *rememberClass(J9Class *clazz, bool create=true);
+   virtual UDATA *rememberClass(bool create, TR::Compilation *comp, J9Class *clazz);
 
    virtual UDATA rememberDebugCounterName(const char *name);
    virtual const char *getDebugCounterName(UDATA offset);
@@ -392,7 +393,7 @@ private:
                          uint32_t numSuperclasses, uint32_t numInterfaces);
 
    bool romclassMatchesCachedVersion(J9ROMClass *romClass, UDATA * & chainPtr, UDATA *chainEnd);
-   UDATA *findChainForClass(J9Class *clazz, const char *key, uint32_t keyLength);
+   UDATA *findChainForClass(J9Class *clazz, const char *key, uint32_t keyLength, TR::Compilation *comp=NULL, J9ROMClass *romClass=NULL);
 
    /**
     * \brief Helper Method; Converts an offset into the ROMClass section into a pointer.

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1721,6 +1721,9 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
       {
       if (aotStats)
          aotStats->numDefiningClassNotFound++;
+
+      ADD_TRACING_BUFFER_MESSAGE(comp, "relo::storeValRecordIfNec, definingClass NULL, %p, %d, %p\n", constantPool, cpIndex, ramMethod);
+
       return false;
       }
 
@@ -1732,7 +1735,10 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
    // all kinds of validations may need to rely on the entire class chain, so make sure we can build one first
    classChain = fej9->sharedCache()->rememberClass(definingClass);
    if (!classChain)
+      {
+      ADD_TRACING_BUFFER_MESSAGE(comp, "relo::storeValRecordIfNec, classChain NULL, %p, %p, %d, %p\n", definingClass, constantPool, cpIndex, ramMethod);
       return false;
+      }
 
    bool inLocalList = false;
    TR::list<TR::AOTClassInfo*>* aotClassInfo = comp->_aotClassInfo;
@@ -1764,6 +1770,7 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
    if (inLocalList)
       {
       traceMsg(comp, "\tFound in local list, nothing to do\n");
+      ADD_TRACING_BUFFER_MESSAGE(comp, "relo::storeValRecordIfNec, Found in local list, nothing to do (%p, %d, %p)\n", constantPool, cpIndex, ramMethod);
       if (aotStats)
          {
          if (isStatic)
@@ -1787,10 +1794,13 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
             aotStats->numNewCHEntriesInLocalList++;
          }
 
+      ADD_TRACING_BUFFER_MESSAGE(comp, "relo::storeValRecordIfNec, Created new AOT class info %p\n", classInfo);
+
       return true;
       }
 
    // should only be a native OOM that gets us here...
+   ADD_TRACING_BUFFER_MESSAGE(comp, "relo::storeValRecordIfNec, native OOM?\n");
    return false;
    }
 
@@ -1843,6 +1853,7 @@ TR_ResolvedRelocatableJ9Method::fieldAttributes(TR::Compilation * comp, int32_t 
                }
             else
                {
+               ADD_TRACING_BUFFER_MESSAGE(comp, "relo::fieldAttrib, %d, %p, %p\n", cpIndex, constantPool, ramMethod());
                fieldInfoCanBeUsed = storeValidationRecordIfNecessary(comp, constantPool, cpIndex, TR_ValidateInstanceField, ramMethod());
                }
             }
@@ -1895,6 +1906,8 @@ TR_ResolvedRelocatableJ9Method::fieldAttributes(TR::Compilation * comp, int32_t 
 #if defined(DEBUG_LOCAL_CLASS_OPT)
       unresolvedCtr++;
 #endif
+
+      ADD_TRACING_BUFFER_MESSAGE(comp, "relo::fieldAttrib, theFieldIsFromLocalClass will be false (%p, %d, %p)\n", constantPool, cpIndex, ramMethod());
       }
 
    if (unresolvedInCP)
@@ -2039,7 +2052,10 @@ TR_ResolvedRelocatableJ9Method::definingClassFromCPFieldRef(
       valid = storeValidationRecordIfNecessary(comp, cp(), cpIndex, isStatic ? TR_ValidateStaticField : TR_ValidateInstanceField, ramMethod());
 
    if (!valid)
+      {
+      ADD_TRACING_BUFFER_MESSAGE(comp, "relo::definingClassFromCPFieldRef !valid, %p, %d, %p\n", cp(), cpIndex, ramMethod());
       clazz = NULL;
+      }
 
    return clazz;
    }


### PR DESCRIPTION
To help debug #9416, this commit adds some tracing that is only enabled
on the path leading up to the failing assert. If the assert fails, the
traced messages are printed to stderr. Once the underlying issue is
resolved, this commit should be reverted.

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>