### PR TITLE
Exclude cmdLineTester_jep178_staticLinking_SE80 on plinux

### DIFF
--- a/test/functional/cmdLineTests/jep178staticLinkingTest/playlist.xml
+++ b/test/functional/cmdLineTests/jep178staticLinkingTest/playlist.xml
@@ -27,6 +27,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<comment>https://github.com/eclipse/openj9/issues/3212</comment>
 			<plat>.*windows.*</plat>
 		</disabled>
+		<disabled>
+			<comment>https://github.com/eclipse/openj9/issues/11854</comment>
+			<plat>ppc64le.*</plat>
+		</disabled>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DJAVATEST_ROOT=$(Q)$(JAVATEST_ROOT)$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) \


### PR DESCRIPTION
Issue https://github.com/eclipse/openj9/issues/11854