### PR TITLE
Prevent hang when running with AOT & FSD & Sync Compilation

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7268,6 +7268,10 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
             && !details.isMethodHandleThunk()
             && !TR::CompilationInfo::isCompiled(method)
 
+            // If using a loadLimit/loadLimitFile, don't do an AOT compilation
+            // for a method body that's already in the SCC
+            && entry->_methodIsInSharedCache != TR_yes
+
             // See eclipse/openj9#11879 for details
             && (!TR::Options::getCmdLineOptions()->getOption(TR_FullSpeedDebug)
                 || !entry->_oldStartPC)

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -5982,7 +5982,7 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread * vmThread, TR::Il
 
    if (TR::Options::sharedClassCache() && !TR::Options::getAOTCmdLineOptions()->getOption(TR_NoLoadAOT) && details.isOrdinaryMethod())
       {
-      if (!isJNINative(method) && !oldStartPC)
+      if (!isJNINative(method) && !isCompiled(method))
          {
          // If the method is in shared cache but we decide not to take it from there
          // we must bump the count, because this is a method whose count was decreased to scount
@@ -7248,10 +7248,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
                entry->_priority = CP_ASYNC_NORMAL;
             }
          }
-      }
 
-   if (!entry->isAotLoad())
-      {
       // Determine if we need to perform an AOT compilation
       //
       if (entry->isOutOfProcessCompReq())
@@ -7265,18 +7262,23 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
          {
          TR::IlGeneratorMethodDetails & details = entry->getMethodDetails();
          eligibleForRelocatableCompile =
-            TR::Options::sharedClassCache() &&
-            !details.isNewInstanceThunk() &&
-            !entry->isJNINative() &&
-            !details.isMethodHandleThunk() &&
-            !TR::CompilationInfo::isCompiled(method) &&
-            !entry->isDLTCompile() &&
-            !entry->_doNotUseAotCodeFromSharedCache &&
-            fe->sharedCache()->isROMClassInSharedCache(J9_CLASS_FROM_METHOD(method)->romClass) &&
-            !isMethodIneligibleForAot(method) &&
-            (!TR::Options::getAOTCmdLineOptions()->getOption(TR_AOTCompileOnlyFromBootstrap) ||
-               fe->isClassLibraryMethod((TR_OpaqueMethodBlock *)method), true) &&
-            (NULL != fe->sharedCache()->rememberClass(J9_CLASS_FROM_METHOD(method)));
+            TR::Options::sharedClassCache()
+            && !details.isNewInstanceThunk()
+            && !entry->isJNINative()
+            && !details.isMethodHandleThunk()
+            && !TR::CompilationInfo::isCompiled(method)
+
+            // See eclipse/openj9#11879 for details
+            && (!TR::Options::getCmdLineOptions()->getOption(TR_FullSpeedDebug)
+                || !entry->_oldStartPC)
+
+            && !entry->isDLTCompile()
+            && !entry->_doNotUseAotCodeFromSharedCache
+            && fe->sharedCache()->isROMClassInSharedCache(J9_CLASS_FROM_METHOD(method)->romClass)
+            && !isMethodIneligibleForAot(method)
+            && (!TR::Options::getAOTCmdLineOptions()->getOption(TR_AOTCompileOnlyFromBootstrap)
+                || fe->isClassLibraryMethod((TR_OpaqueMethodBlock *)method), true)
+            && (NULL != fe->sharedCache()->rememberClass(J9_CLASS_FROM_METHOD(method)));
          }
 
       bool sharedClassTest = eligibleForRelocatableCompile &&


### PR DESCRIPTION
There is hang possible when running with AOT, FSD, and Sync Compilation.

1. JIT sampling results in `TR::Recompilation::induceRecompilation` patching the startPC of old body to trigger sync compile
2. App thread issues synchronous recompilation reques
3. Comp thread starts recompilation
4. Classes (unrelated to the method being compiled) get redefined
5. All compilations are aborted and the method queue is purged; additionally, all compiled methods are discarded and the extra field of all J9Methods are reset to indicate that they are not compiled. Therefore, the recompilation is aborted and the App thread is woken up
6. App thread returns and re-executes (patched) startPC, thus issuing another **recompilation** request
7. Although `oldStartPC` (from the entry) is not NULL, `isCompiled(method)` will return false; the code to set `_methodIsInSharedCache` never gets executed.
8. If `_methodIsInSharedCache` is false, an AOT load does not happen; however an AOT compilation occurs instead. This is because the check to see if a method is eligible for an AOT compilation uses the `isCompiled` query
9. The AOT compilation succeeds, but `method->extra` is not updated with the startPC because of the heuristic to delay AOT loads.
10. The old startPC is patched to call the helper to patch the callee.
11. The App thread is woken up; it returns and re-executes the patched startPC, which jumps to a helper. The helper checks if the method has been previously compiled, which based on the extra shows that it has not.
12. Helper jumps to another helper which issues another **recompilation** request.
13. Go to 7 above.

 I was going to put this commit along with https://github.com/eclipse/openj9/pull/11554 but given the amount of text needed to describe the hang, as well as the discussion needed regarding the proposed fix, I figured it's best done as a separate PR. FSD isn't currently enabled on AOT but this PR will facilitate that.

There are two main changes here:

1. In the place where we check if the method is in the SCC ~, if in FSD and sync compilation mode,~ use `isCompiled` instead.
2. When determining whether a compile is eligible for relocatable compilation, add a condition that if in FSD mode the `entry->_oldStartPC == NULL`

The hang happens only when class redefinition occurs in the middle of a **recompilation**. To give context for this, this issue was seen when running `_cmdLineTester_jvmtitests_hcr_OSRG_nongold_2`. This test, which runs with `disableAsyncCompilation`, redefines some classes over and over again. In FSD mode, involuntary OSR is used to transition to the interpreter, and **ALL** existing compiled bodies are discarded. This results in the JIT compiling those methods again. Without AOT the JIT will just do regular JIT compilations. With AOT, if a method is in the SCC it will perform an AOT Load - note that an AOT load will still perform all the validations; a load will fail if the redefinition changed something to make the body in the SCC invalid for the current JVM instance.

Without AOT, steps 1-7 happen but because we don't do an AOT compilation, the method->extra field is updated immediately; thus when the startPC is patched to call the helper (that patches the callee and jumps to the new body), it succeeds in jumping to the new body because the method->extra field shows a valid JIT startPC. Additionally, even if the method whose recompilation was interrupted was the one that gets redefined, `samplingRecompileMethod` (which is what the startPC is originally patched to) determines the method->extra by grabbing the J9Method pointer from the `TR_PersistentMethodInfo` object which gets patched via runtime assumptions.

With that background:
Change 1 ensures that in FSD mode, the compiler uses j9method->extra to determine whether this is a "first time compile" for the purposes of determining whether to do an AOT load.
Change 2 ensures that if the method being recompiled was the one that got redefined, we don't do an AOT warm compilation for the new J9Method we pull out from the `TR_PersistentMethodInfo` object. Alternatively I suppose we could just disable delaying relocation. Both approaches ensure that the j9method->extra field contains a valid JIT address at the end of compilation, which is necessary to ensure we jump to the new body from the oldStartPC.

Now a further subtlety is that we can't just replace all uses of `entry->_oldStartPC` with calls to `TR::Compilationinfo::isCompiled`/`TR::CompilationInfo::getPCIfCompiled` because in the sync case, we do need to patch the oldStartPC; the App thread is not going to be able to OSR out anymore. This also means that in the sync case, we **cannot** recycle the code cache even though all methods are invalid specifically because the App thread needs to return to the oldStartPC in order to jump to the new body. As it turns out we don't recycle the code cache right now, but it's something to be aware of if we do so in the future.

EDIT:
I've added another change which is tangentially related; it ensures that we don't do an AOT Warm compilation of a method that's already in the SCC if we've specified a loadLimit/loadLimitFile.