### PR TITLE
Prevent non-diagnostic threads from picking up JitDump compiles

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -5252,7 +5252,9 @@ TR::CompilationInfo::getNextMethodToBeCompiled(TR::CompilationInfoPerThread *com
       {
       *compThreadAction = PROCESS_ENTRY;
 
-      if (_methodQueue)
+      // Due to the above mentioned timing hole, a non-diagnostic compilation thread may still be trying to process
+      // entries. We prevent it from processing JitDump compilation requests here.
+      if (_methodQueue != NULL && !_methodQueue->getMethodDetails().isJitDumpMethod())
          {
          // If the request is sync or AOT load, take it now
          if (_methodQueue->_priority >= CP_SYNC_MIN // sync comp


### PR DESCRIPTION
Address the fact that a non-diagnostic compilation thread may still be
trying to process entries before the diagnostic thread has reached the
processing loop.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>