### PR TITLE
Update options for UMA configurations

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -139,7 +139,7 @@ cmake:
 #========================================#
 uma:
   extra_configure_options:
-    all: '--without-cmake'
+    all: '--with-cmake=no --with-mixedrefs=no'
 #========================================#
 # JITServer
 #========================================#


### PR DESCRIPTION
This will be significant for versions where the default is (or will be) `--with-mixedrefs=static`.

This probably should be merged before ibmruntimes/openj9-openjdk-jdk11#382.