### PR TITLE
Set up AIX XLClang flags for JDK 16+ CMake builds

### DIFF
--- a/runtime/cmake/platform/toolcfg/xlc.cmake
+++ b/runtime/cmake/platform/toolcfg/xlc.cmake
@@ -39,7 +39,8 @@ if(CMAKE_C_COMPILER_IS_XLCLANG)
 	# OMR_PLATFORM_COMPILE_OPTIONS gets applied to the jit (which doesn't compile with -g),
 	# so we put -g in the CMAKE_C_FLAGS and CMAKE_CXX_FLAGS instead
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions -g")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -g")
+	list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -fno-rtti)
 else()
 	# xlc/xlc++ options
 	list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -g)

--- a/runtime/cmake/platform/toolcfg/xlc.cmake
+++ b/runtime/cmake/platform/toolcfg/xlc.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020, 2020 IBM Corp. and others
+# Copyright (c) 2020, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -O3 -g)
+list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -O3)
 
 list(APPEND OMR_PLATFORM_CXX_COMPILE_OPTIONS -qnortti)
 
@@ -33,3 +33,14 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -qnoeh")
 
 set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -qpic=large")
+
+if(CMAKE_C_COMPILER_IS_XLCLANG)
+	# xlclang/xlclang++ options
+	# OMR_PLATFORM_COMPILE_OPTIONS gets applied to the jit (which doesn't compile with -g),
+	# so we put -g in the CMAKE_C_FLAGS and CMAKE_CXX_FLAGS instead
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions -g")
+else()
+	# xlc/xlc++ options
+	list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -g)
+endif()

--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -277,13 +277,8 @@ elseif(OMR_OS_AIX)
 
 			if(CMAKE_C_COMPILER_IS_XLCLANG)
 				# xlclang/xlclang++ options
-				list(APPEND J9_SHAREDFLAGS -qxlcompatmacros)
 				list(APPEND SPP_FLAGS -qlanglvl=extc99)
-				list(APPEND J9_CXXFLAGS -fno-rtti)
 				set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lc++")
-			else()
-				# xlc/xlc++ options
-				list(APPEND J9_SHAREDFLAGS -qnotempinc -qmbcs)
 			endif()
 		endif()
 	else()

--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -274,6 +274,17 @@ elseif(OMR_OS_AIX)
 			# Modify the arch tuning value we inherit from omr
 			list(REMOVE_ITEM TR_COMPILE_OPTIONS "-qarch=pwr7")
 			list(APPEND TR_COMPILE_OPTIONS "-qarch=ppc64grsq")
+
+			if(CMAKE_C_COMPILER_IS_XLCLANG)
+				# xlclang/xlclang++ options
+				list(APPEND J9_SHAREDFLAGS -qxlcompatmacros)
+				list(APPEND SPP_FLAGS -qlanglvl=extc99)
+				list(APPEND J9_CXXFLAGS -fno-rtti)
+				set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lc++")
+			else()
+				# xlc/xlc++ options
+				list(APPEND J9_SHAREDFLAGS -qnotempinc -qmbcs)
+			endif()
 		endif()
 	else()
 		list(APPEND J9_SHAREDFLAGS -q32)


### PR DESCRIPTION
This allows AIX XLClang CMake builds to work for JDK16.

Existing xlc/xlclang files for reference
- [runtime/makelib/targets.mk.aix.inc.ftl](https://github.com/eclipse/openj9/blob/master/runtime/makelib/targets.mk.aix.inc.ftl)
- [runtime/compiler/build/toolcfg/aix-xlc/common.mk](https://github.com/eclipse/openj9/blob/master/runtime/compiler/build/toolcfg/aix-xlc/common.mk)

Depends on OMR changes: https://github.com/eclipse/omr/pull/5794

Successfully ran personal builds `JDK16_ppc64_aix_cm` and `JDK16_ppc64_aix_mixed` with these changes + corresponding OMR changes.