### PR TITLE
Update SCC CML test cases for unsafe classes

### DIFF
--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
@@ -46,8 +46,10 @@
  	<variable name="PROGRAM_LAMBDA" value="org.openj9.test.lambdatests.Test1" />
 	<variable name="PROGRAM_UNSAFE" value="org.openj9.test.classtests.ClassTest" />
  	<variable name="BOOTSTRAP_CLASS" value="java/lang/Object" />
- 	
+
 	<variable name="EXPORTS" value="--add-exports java.base/jdk.internal.misc=ALL-UNNAMED" />
+	<!-- set variable EXPORTS to an empty string on Java 8. JDK version is passed in before bits -->
+	<exec command="echo " capture="EXPORTS" platforms="8_bits.*" />
 	
  	<variable name="AGENT_NOCLASSMODIFICATION" value="-agentlib:jvmtitest=test:ecflh001,args:noModify" />
  	<variable name="AGENT_RETRANSFORM" value="-agentlib:jvmtitest=test:rtc001" />
@@ -62,7 +64,7 @@
 	<variable name="NON_64BIT_PLATFORMS" value=".*bits\.3[12]" />
 	<variable name="64BIT_PLATFORMS" value=".*bits\.64" />
 
-		
+
 	<if testVariable="SCMODE" testValue="204" resultVariable="currentMode" resultValue="$mode204$"/>
 	
 	<echo value=" "/>
@@ -1068,10 +1070,11 @@
 	</test>
 
 	<test id="Test 57-b: Make sure that lambda classes are stored in the cache as orphans" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$,printstats=orphan</command>
+		<command>$JAVA_EXE$ $currentMode$,printstats=orphan+romclass</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0x00000000|0x0000000000000000) at</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0x00000000|0x0000000000000000) at</output>
 	    
+	    <output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">ROMCLASS: org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0x00000000|0x0000000000000000) at</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1211,10 +1214,10 @@
 	</test>
 	
 	<test id="Test 61-b: Make sure that no lambda classes are in the cache" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$,printstats=orphan</command>
+		<command>$JAVA_EXE$ $currentMode$,printstats=orphan+romclass</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1 at</output>
 
-		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0x00000000|0x0000000000000000) at</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(0x00000000|0x0000000000000000) at</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1235,11 +1238,12 @@
 		<output type="failure" caseSensitive="yes" regex="no">JVM requested Snap dump</output>
 	</test>
 
-	<test id="Test 62-a: Store the Anonymous Class and the Unsafe Class in the cache" timeout="600" runPath=".">
+	<test id="Test 62-a: Store the Anonymous Class and the Unsafe Classes (via app classloader and bootstrap classloader) in the cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$ $EXPORTS$ $CP_HANOI$ $PROGRAM_UNSAFE$</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">test done!</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Test</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Hello</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">running UnsafeBootClass.bar()</output>
 
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
@@ -1248,11 +1252,15 @@
 	</test>
 
 	<test id="Test 62-b: Check whether they have been stored correctly" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$,printstats=orphan</command>
+		<command>$JAVA_EXE$ $currentMode$,printstats=orphan+romclass</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/ClassTest at</output>		
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0x00000000|0x0000000000000000) at</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest at</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/UnsafeBootClass at</output>
 	    
+	    <output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ROMCLASS: org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0x00000000|0x0000000000000000) at</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ROMCLASS: org/openj9/test/classtests/AnonClassAndUnsafeClassTest at</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ROMCLASS: org/openj9/test/classtests/UnsafeBootClass at</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1264,11 +1272,15 @@
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">test done!</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Test</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Hello</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">running UnsafeBootClass.bar()</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/classtests/AnonClassAndUnsafeClassTest'</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0x00000000|0x0000000000000000)'</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/classtests/UnsafeBootClass'</output>
+		
 		
 		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/classtests/AnonClassAndUnsafeClassTest </output>
 		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0x00000000|0x0000000000000000) </output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/classtests/UnsafeBootClass </output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1311,6 +1323,7 @@
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">test done!</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Test</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Hello</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">running UnsafeBootClass.bar()</output>
 
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
@@ -1319,11 +1332,13 @@
 	</test>
 
 	<test id="Test 63-b: Check whether the Anonymous Class has been stored correctly" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$,printstats=orphan</command>
+		<command>$JAVA_EXE$ $currentMode$,printstats=orphan+romclass</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/ClassTest at</output>	
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0x00000000|0x0000000000000000) at</output>
-	    
-		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest at</output>
+
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">org/openj9/test/classtests/UnsafeBootClass at</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">org/openj9/test/classtests/AnonClassAndUnsafeClassTest at</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ROMCLASS: org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0x00000000|0x0000000000000000) at</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1349,6 +1364,7 @@
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">test done!</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Test</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Hello</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">running UnsafeBootClass.bar()</output>
 
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
@@ -1357,11 +1373,14 @@
 	</test>
 
 	<test id="Test 64-b: Check whether the Unsafe class has been stored correctly" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$,printstats=orphan</command>
+		<command>$JAVA_EXE$ $currentMode$,printstats=orphan+romclass</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/ClassTest at</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest at</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/UnsafeBootClass at</output>
 
-		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0x00000000|0x0000000000000000) at</output>	    
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ROMCLASS: org/openj9/test/classtests/AnonClassAndUnsafeClassTest at</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0x00000000|0x0000000000000000) at</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ROMCLASS: org/openj9/test/classtests/UnsafeBootClass at</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1387,6 +1406,7 @@
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">test done!</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Test</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Hello</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">running UnsafeBootClass.bar()</output>
 		
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
@@ -1395,11 +1415,12 @@
 	</test>
 
 	<test id="Test 65-b: Make sure none of the classes has been stored in the cache" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$,printstats=orphan</command>
+		<command>$JAVA_EXE$ $currentMode$,printstats=orphan+romclass</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/ClassTest at</output>
 	    
-		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0x00000000|0x0000000000000000) at</output>
-		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/classtests/AnonClassAndUnsafeClassTest at</output>		
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">org/openj9/test/classtests/AnonClassAndUnsafeClassTest/(0x00000000|0x0000000000000000) at</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">org/openj9/test/classtests/AnonClassAndUnsafeClassTest at</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">org/openj9/test/classtests/UnsafeBootClass at</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1407,7 +1428,7 @@
 	</test>
 
 	<test id="Test 66: Processor Features PrintStats Test : Ensure -Xshareclasses:printStats cache contains processor feature info" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$,printStats -version</command>
+		<command>$JAVA_EXE$ $currentMode$,printStats</command>
 		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes" platforms=".*x86.*,.*ppc.*,.*390.*">Processor Features[\s]*= null</output>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes" platforms=".*x86.*,.*ppc.*,.*390.*">Processor Features[\s]*= .*</output>
 		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes" platforms=".*aarch64.*">Processor Features[\s]*= .*</output>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/exclude.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/exclude.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2010, 2020 IBM Corp. and others
+  Copyright (c) 2010, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -218,48 +218,6 @@
 	</exclude>
 	<exclude id="Test 55 Check default cache size on Java 9 and up" platform="8">
 		<reason>This test should not be run on Java 8</reason>
-	</exclude>
-	<exclude id="Test 61 clean-up" platform="8">
-		<reason>Exclude the extra clean-up since tests are not run in jdk8</reason>
-	</exclude>
-	<exclude id="Test 62-a: Store the Anonymous Class and the Unsafe Class in the cache" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe </reason>
-	</exclude>
-	<exclude id="Test 62-b: Check whether they have been stored correctly" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
-	</exclude>
-	<exclude id="Test 62-c: Make sure the classes are loaded from the cache and work properly" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
-	</exclude>
-	<exclude id="Test 62-d: Check whether the classes are loaded correctly and work properly after the implementation has been modified" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
-	</exclude>
-	<exclude id="Test 62 clean-up" platform="8">
-		<reason>Exclude the extra clean-up since tests are not run in jdk8</reason>
-	</exclude>
-	<exclude id="Test 63-a: Only store the Anonymous Class in the cache" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
-	</exclude>
-	<exclude id="Test 63-b: Check whether the Anonymous Class has been stored correctly" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
-	</exclude>
-	<exclude id="Test 63 clean-up" platform="8">
-		<reason>Exclude the extra clean-up since tests are not run in jdk8</reason>
-	</exclude>
-	<exclude id="Test 64-a: Only store the Unsafe Class in the cache" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
-	</exclude>
-	<exclude id="Test 64-b: Check whether the Unsafe class has been stored correctly" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
-	</exclude>
-	<exclude id="Test 64 clean-up" platform="8">
-		<reason>Exclude the extra clean-up since tests are not run in jdk8</reason>
-	</exclude>
-	<exclude id="Test 65-a: Do not store the Anonymous Class and the Unsafe Class in the cache" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
-	</exclude>
-	<exclude id="Test 65-b: Make sure none of the classes has been stored in the cache" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
 	</exclude>
 	<exclude id="Test 180: Setup for Tests from 181 - 196. Create the layer 0 cache" platform=".*-3[12].*">
 		<reason> The multi-layer cache feature is only supported on 64-bit platforms </reason>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/exclude_openj9.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/exclude_openj9.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2010, 2020 IBM Corp. and others
+  Copyright (c) 2010, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -220,48 +220,6 @@
 	</exclude>
 	<exclude id="Test 55 Check default cache size on Java 9 and up" platform="8">
 		<reason>This test should not be run on Java 8</reason>
-	</exclude>
-	<exclude id="Test 61 clean-up" platform="8">
-		<reason>Exclude the extra clean-up since tests are not run in jdk8</reason>
-	</exclude>
-	<exclude id="Test 62-a: Store the Anonymous Class and the Unsafe Class in the cache" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe </reason>
-	</exclude>
-	<exclude id="Test 62-b: Check whether they have been stored correctly" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
-	</exclude>
-	<exclude id="Test 62-c: Make sure the classes are loaded from the cache and work properly" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
-	</exclude>
-	<exclude id="Test 62-d: Check whether the classes are loaded correctly and work properly after the implementation has been modified" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
-	</exclude>
-	<exclude id="Test 62 clean-up" platform="8">
-		<reason>Exclude the extra clean-up since tests are not run in jdk8</reason>
-	</exclude>
-	<exclude id="Test 63-a: Only store the Anonymous Class in the cache" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
-	</exclude>
-	<exclude id="Test 63-b: Check whether the Anonymous Class has been stored correctly" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
-	</exclude>
-	<exclude id="Test 63 clean-up" platform="8">
-		<reason>Exclude the extra clean-up since tests are not run in jdk8</reason>
-	</exclude>
-	<exclude id="Test 64-a: Only store the Unsafe Class in the cache" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
-	</exclude>
-	<exclude id="Test 64-b: Check whether the Unsafe class has been stored correctly" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
-	</exclude>
-	<exclude id="Test 64 clean-up" platform="8">
-		<reason>Exclude the extra clean-up since tests are not run in jdk8</reason>
-	</exclude>
-	<exclude id="Test 65-a: Do not store the Anonymous Class and the Unsafe Class in the cache" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
-	</exclude>
-	<exclude id="Test 65-b: Make sure none of the classes has been stored in the cache" platform="8">
-		<reason>Only Java 11 and up use jdk.internal.misc.Unsafe  </reason>
 	</exclude>
 	<exclude id="Test 180: Setup for Tests from 181 - 196. Create the layer 0 cache" platform=".*-3[12].*">
 		<reason> The multi-layer cache feature is only supported on 64-bit platforms </reason>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
@@ -38,7 +38,7 @@
 	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-DUTILSJAR_2=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils2$(D)utils2.jar$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
-	-config $(Q)$(TEST_RESROOT)$(D)ShareClassesCMLTests-1.xml$(Q) -xids all,$(PLATFORM),$(VARIATION),$(JDK_VERSION) -plats all,$(PLATFORM),$(VARIATION),$(BITS) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
+	-config $(Q)$(TEST_RESROOT)$(D)ShareClassesCMLTests-1.xml$(Q) -xids all,$(PLATFORM),$(VARIATION),$(JDK_VERSION) -plats all,$(PLATFORM),$(VARIATION),$(JDK_VERSION)_$(BITS) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
 	-nonZeroExitWhenError \
 	-outputLimit 300; \
 	$(TEST_STATUS)</command>

--- a/test/functional/cmdLineTests/utils/build.xml
+++ b/test/functional/cmdLineTests/utils/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,10 +31,10 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/utils" />
 	<property name="src" location="./src"/>
-	<property name="src_110" location="./src_110"/>
 	<property name="build" location="./bin"/>
 	<property name="addExports" value="--add-exports java.base/jdk.internal.misc=ALL-UNNAMED" />
 	<property name="TestUtilities" location="../utilshelper/src" />
+	<property name="TestUtilities_110" location="../utilshelper/src_110" />
 
 	<target name="init">
 		<mkdir dir="${DEST}" />
@@ -48,17 +48,19 @@
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" />
 		<if>
-			<not>
-				<equals arg1="${JDK_VERSION}" arg2="8" />
-			</not>
+			<equals arg1="${JDK_VERSION}" arg2="8"/>
 			<then>
-				<javac srcdir="${src_110}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" >
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" >
 					<src path="${TestUtilities}" />
-					<compilerarg line='${addExports}' />
 				</javac>
 			</then>
+			<else>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" >
+					<src path="${TestUtilities_110}" />
+					<compilerarg line='${addExports}' />
+				</javac>
+			</else>
 		</if>
 	</target>
 

--- a/test/functional/cmdLineTests/utils/src/org/openj9/test/classtests/AnonClassAndUnsafeClassTest.java
+++ b/test/functional/cmdLineTests/utils/src/org/openj9/test/classtests/AnonClassAndUnsafeClassTest.java
@@ -22,20 +22,13 @@
 
 package org.openj9.test.classtests;
 
-import java.io.*;
-import org.openj9.test.classtests.ClassTestHelper;
+/* The AnonClassAndUnsafeClassTest.class will be used to create the Anonyomus Class and the Unsafe Class */
 
-/* 
- * Calls the helper class ClassTestHelper to generate the Anonymous class and the Unsafe class. 
- * A duplicate file is in the utils/src/org/openj9/classtests folder, please also modify that file if this one is modified.
- * */
-
-public class ClassTest {
-    public static void main(String[] args) throws Throwable {
-        ClassTest ct = new ClassTest();
-        ClassTestHelper ch = new ClassTestHelper();
-        InputStream anonUnsafeClassStream = ct.getClass().getResourceAsStream("AnonClassAndUnsafeClassTest.class");
-        InputStream unsafeBootClassStream = ct.getClass().getResourceAsStream("UnsafeBootClass.class");
-        ch.func(ct.getClass(), anonUnsafeClassStream, unsafeBootClassStream);
+public class AnonClassAndUnsafeClassTest {
+    public void func() {
+        System.out.println("Test");
+    }
+    public void funcunsafe() {
+        System.out.println("Hello");
     }
 }

--- a/test/functional/cmdLineTests/utils/src/org/openj9/test/classtests/ClassTest.java
+++ b/test/functional/cmdLineTests/utils/src/org/openj9/test/classtests/ClassTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,8 @@ public class ClassTest {
     public static void main(String[] args) throws Throwable {
         ClassTest ct = new ClassTest();
         ClassTestHelper ch = new ClassTestHelper();
-        InputStream is = ct.getClass().getResourceAsStream("AnonClassAndUnsafeClassTest.class");
-        ch.func(ct.getClass(), is);
+        InputStream anonUnsafeClassStream = ct.getClass().getResourceAsStream("AnonClassAndUnsafeClassTest.class");
+        InputStream unsafeBootClassStream = ct.getClass().getResourceAsStream("UnsafeBootClass.class");
+        ch.func(ct.getClass(), anonUnsafeClassStream, unsafeBootClassStream);
     }
 }

--- a/test/functional/cmdLineTests/utils/src/org/openj9/test/classtests/UnsafeBootClass.java
+++ b/test/functional/cmdLineTests/utils/src/org/openj9/test/classtests/UnsafeBootClass.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2021, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,13 +22,14 @@
 
 package org.openj9.test.classtests;
 
-/* The AnonClassAndUnsafeClassTest.class will be used to create the Anonyomus Class and the Unsafe Class */
+/* The UnsafeBootClass.class will be used to create an unsafe bootstrap class */
 
-public class AnonClassAndUnsafeClassTest {
-    public void func() {
-        System.out.println("Test");
-    }
-    public void funcunsafe() {
-        System.out.println("Hello");
-    }
+public class UnsafeBootClass {
+	private String str = "This class is used to create an unsafe bootstrap class";
+	public void foo() {
+		System.out.println(str);
+	}
+	public void bar() {
+		System.out.println("running UnsafeBootClass.bar()");
+	}
 }

--- a/test/functional/cmdLineTests/utils2/build.xml
+++ b/test/functional/cmdLineTests/utils2/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2019, 2019 IBM Corp. and others
+  Copyright (c) 2019, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,7 @@
 	<property name="build" location="./bin"/>
 	<property name="addExports" value="--add-exports java.base/jdk.internal.misc=ALL-UNNAMED" />
 	<property name="TestUtilities" location="../utilshelper/src" />
+	<property name="TestUtilities_110" location="../utilshelper/src_110" />
 
 	<target name="init">
 		<mkdir dir="${DEST}" />
@@ -48,15 +49,18 @@
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
 		<if>
-			<not>
-				<equals arg1="${JDK_VERSION}" arg2="8" />
-			</not>
+			<equals arg1="${JDK_VERSION}" arg2="8"/>
 			<then>
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" >
 					<src path="${TestUtilities}" />
-					<compilerarg line='${addExports}' />
 				</javac>
 			</then>
+			<else>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" >
+					<src path="${TestUtilities_110}" />
+					<compilerarg line='${addExports}' />
+				</javac>
+			</else>
 		</if>
 	</target>
 

--- a/test/functional/cmdLineTests/utilshelper/src_110/org/openj9/test/classtests/ClassTestHelper.java
+++ b/test/functional/cmdLineTests/utilshelper/src_110/org/openj9/test/classtests/ClassTestHelper.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.test.classtests;
+
+import java.io.*;
+import java.util.*;
+import java.lang.reflect.Field;
+
+import jdk.internal.misc.Unsafe;
+
+/* Generates the Anonymous class and the Unsafe class */
+
+public class ClassTestHelper {
+	private static Unsafe unsafe = Unsafe.getUnsafe();
+	public byte[] getContent(InputStream is) throws Throwable {
+		if (null == is) {
+			return null;
+		}
+		int read;
+		byte[] data = new byte[4096];
+		ByteArrayOutputStream isbuffer = new ByteArrayOutputStream();
+		while (-1 != (read = is.read(data, 0, data.length))) {
+			isbuffer.write(data, 0, read);
+		}
+		return isbuffer.toByteArray();
+	}
+
+	public void func(Class hostclass, InputStream anonUnsafeClassStream, InputStream unsafeBootClassStream) throws Throwable {
+		byte[] content = getContent(anonUnsafeClassStream);
+		ClassLoader extLoader = hostclass.getClassLoader();
+		if (null != content) {
+			Class<?> anonclass = unsafe.defineAnonymousClass(hostclass, content, null);
+			Class unsafeclass = unsafe.defineClass(null, content, 0, content.length, extLoader, hostclass.getProtectionDomain());
+			anonclass.getMethod("func").invoke(anonclass.getDeclaredConstructor().newInstance());
+			unsafeclass.getMethod("funcunsafe").invoke(unsafeclass.getDeclaredConstructor().newInstance());
+		}
+		content = getContent(unsafeBootClassStream);
+		if (null != content) {
+			Class<?> unsafeclass = unsafe.defineClass(null, content, 0, content.length, null, null);
+			unsafeclass.getMethod("bar").invoke(unsafeclass.getDeclaredConstructor().newInstance());
+		}
+		System.out.println("test done!");
+	}
+}


### PR DESCRIPTION
1. Improve the existing unsafe Class tests in SCCMLTests1.
  1.1 Enable anon and unsafe Class tests in Java 8.
  1.2 When checking for a stored orphan class, we should also make sure
it is not stored as romclass. Update the test cases to print romclasses. 
  1.3 org.openj9.test.classtests does not need to be under
/utils/src_110 as they will be used in java 8 as well. Move them to
utils/src
  1.4 Put ClassTestHelper.java in /utilshelper/src_110 for java 11+
and another version in /utilshelper/src for java 8
  1.5 Modify build.xml

2. Add a test case for #10073
  2.1 Update ClassTestHelper to define an unsafe class via bootstrap
class loader.
  2.2 Add a CML test case to ensure unsafe bootstrap class is stored as
orphan in the SCC.

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>