### PR TITLE
Implement TR_J9VM::ensureOSRBufferSize for JITServer

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -470,6 +470,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             vmInfo._helperAddresses[i] = runtimeHelperValue((TR_RuntimeHelper) i);
 #endif
          vmInfo._isHotReferenceFieldRequired = TR::Compiler->om.isHotReferenceFieldRequired();
+         vmInfo._osrGlobalBufferSize = javaVM->osrGlobalBufferSize;
 
          client->write(response, vmInfo, listOfCacheDescriptors);
          }
@@ -1019,6 +1020,13 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             fields.push_back(field);
             }
          client->write(response, declaringClasses, fields);
+         }
+         break;
+      case MessageType::VM_increaseOSRGlobalBufferSize:
+         {
+         auto recv = client->getRecvData<uintptr_t, uintptr_t, uintptr_t>();
+         bool result = fe->ensureOSRBufferSize(comp, std::get<0>(recv), std::get<1>(recv), std::get<2>(recv));
+         client->write(response, result, jitConfig->javaVM->osrGlobalBufferSize);
          }
          break;
       case MessageType::mirrorResolvedJ9Method:

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -89,6 +89,7 @@ public:
    virtual int32_t printTruncatedSignature(char *sigBuf, int32_t bufLen, TR_OpaqueMethodBlock *method) override;
    virtual bool isClassInitialized(TR_OpaqueClassBlock * clazz) override;
    virtual UDATA getOSRFrameSizeInBytes(TR_OpaqueMethodBlock * method) override;
+   virtual bool ensureOSRBufferSize(TR::Compilation *comp, uintptr_t osrFrameSizeInBytes, uintptr_t osrScratchBufferSizeInBytes, uintptr_t osrStackFrameSizeInBytes) override;
    virtual int32_t getByteOffsetToLockword(TR_OpaqueClassBlock * clazz) override;
    virtual int32_t getInitialLockword(TR_OpaqueClassBlock* clazzPointer) override;
    virtual bool isEnableGlobalLockReservationSet() override;
@@ -306,6 +307,7 @@ public:
    virtual void * persistThunk(char *signatureChars, uint32_t signatureLength, uint8_t *thunkStart, uint32_t totalSize) { TR_ASSERT_FATAL(0, "persistThunk should not be called on the server"); return NULL; }
    virtual void *findPersistentThunk(char *signatureChars, uint32_t signatureLength) override { TR_ASSERT_FATAL(0, "findPersistentThunk should not be called on the server"); return NULL; }
    virtual J9Class * getClassForAllocationInlining(TR::Compilation *comp, TR::SymbolReference *classSymRef) override;
+   virtual bool ensureOSRBufferSize(TR::Compilation *comp, uintptr_t osrFrameSizeInBytes, uintptr_t osrScratchBufferSizeInBytes, uintptr_t osrStackFrameSizeInBytes) override;
    virtual TR_OpaqueMethodBlock *getMethodFromName(char *className, char *methodName, char *signature) override;
    virtual TR_OpaqueMethodBlock *getResolvedVirtualMethod(TR_OpaqueClassBlock * classObject, int32_t cpIndex, bool ignoreReResolve = true) override;
    virtual TR_OpaqueMethodBlock *getResolvedInterfaceMethod(TR_OpaqueMethodBlock *ownerMethod, TR_OpaqueClassBlock * classObject, int32_t cpIndex) override;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -102,7 +102,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 21;
+   static const uint16_t MINOR_NUMBER = 22;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -181,6 +181,7 @@ enum MessageType : uint16_t
    VM_getObjectSizeClass,
    VM_stackWalkerMaySkipFramesSVM,
    VM_getFields,
+   VM_increaseOSRGlobalBufferSize,
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled,
@@ -417,6 +418,7 @@ static const char *messageNames[] =
    "VM_getObjectSizeClass",
    "VM_stackWalkerMaySkipFramesSVM",
    "VM_getFields",
+   "VM_increaseOSRGlobalBufferSize",
    "CompInfo_isCompiled",
    "CompInfo_getPCIfCompiled",
    "CompInfo_getInvocationCount",

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -274,6 +274,7 @@ class ClientSessionData
    /**
       @class VMInfo
       @brief Struct which contains information about VM that does not change during its lifetime
+      or changes infrequently
    */
    struct VMInfo
       {
@@ -322,6 +323,7 @@ class ClientSessionData
       void *_helperAddresses[TR_numRuntimeHelpers];
 #endif
       bool _isHotReferenceFieldRequired;
+      UDATA _osrGlobalBufferSize;
       }; // struct VMInfo
 
    /**

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -755,11 +755,6 @@ TR_RelocationRuntime::relocateMethodMetaData(UDATA codeRelocationAmount, UDATA d
       _exceptionTable->osrInfo = (void *) (((U_8 *)_exceptionTable->osrInfo) + dataRelocationAmount);
       }
 
-#if defined(J9VM_OPT_JITSERVER)
-   if (_exceptionTable->osrInfo)
-      _exceptionTable->osrInfo = (void *) (((U_8 *)_exceptionTable->osrInfo) + dataRelocationAmount);
-#endif /* defined(J9VM_OPT_JITSERVER) */
-
    // Reset the uninitialized bit
    _exceptionTable->flags &= ~JIT_METADATA_NOT_INITIALIZED;
    }


### PR DESCRIPTION
The method needs to compute the usage of VM's buffer and
reallocate it to a bigger size if necessary.
Since the buffer is stored on the client, this PR overrides
`ensureOSRBufferSize` and sends a message to the client
to expand the buffer when it detects that it's needed

Fixes: #11893