### PR TITLE
Remove JVM_DTrace*, JVM_GetInterfaceVersion from Java 17+

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2019, 2020 IBM Corp. and others
+# Copyright (c) 2019, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -83,7 +83,6 @@ jvm_add_exports(jvm
 	_JVM_GetClassLoader@8
 	_JVM_GetClassSignature@8
 	_JVM_GetEnclosingMethodInfo@8
-	_JVM_GetInterfaceVersion@0
 	_JVM_GetLastErrorString@8
 	_JVM_GetManagement@4
 	_JVM_GetPortLibrary@0
@@ -212,11 +211,6 @@ jvm_add_exports(jvm
 	_JVM_GetSockOpt@20
 	_JVM_ExtendBootClassPath@8
 	_JVM_Bind@12
-	_JVM_DTraceActivate@20
-	_JVM_DTraceDispose@12
-	_JVM_DTraceGetVersion@4
-	_JVM_DTraceIsProbeEnabled@8
-	_JVM_DTraceIsSupported@4
 	_JVM_DefineClass@24
 	_JVM_DefineClassWithSourceCond@32
 	_JVM_EnqueueOperation@20
@@ -375,6 +369,17 @@ elseif(NOT JAVA_SPEC_VERSION LESS 16)
 		JVM_IsSharingEnabled
 		JVM_LogLambdaFormInvoker
 		JVM_IsDumpingClassList
+	)
+endif()
+
+if(JAVA_SPEC_VERSION LESS 17)
+	jvm_add_exports(jvm
+		_JVM_DTraceActivate@20
+		_JVM_DTraceDispose@12
+		_JVM_DTraceGetVersion@4
+		_JVM_DTraceIsProbeEnabled@8
+		_JVM_DTraceIsSupported@4
+		_JVM_GetInterfaceVersion@0
 	)
 endif()
 

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2020 IBM Corp. and others
+ * Copyright (c) 2002, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2686,6 +2686,8 @@ JVM_Bind(jint arg0, jint arg1, jint arg2)
 	return NULL;
 }
 
+#if JAVA_SPEC_VERSION < 17
+
 jobject JNICALL
 JVM_DTraceActivate(jint arg0, jint arg1, jint arg2, jint arg3, jint arg4)
 {
@@ -2720,6 +2722,8 @@ JVM_DTraceIsSupported(jint arg0)
 	assert(!"JVM_DTraceIsSupported() stubbed!");
 	return NULL;
 }
+
+#endif /* JAVA_SPEC_VERSION < 17 */
 
 jobject JNICALL
 JVM_DefineClass(jint arg0, jint arg1, jint arg2, jint arg3, jint arg4, jint arg5)

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2007, 2020 IBM Corp. and others
+Copyright (c) 2007, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -83,7 +83,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</export>
 		<export name="_JVM_GetClassSignature@8" />
 		<export name="_JVM_GetEnclosingMethodInfo@8" />
-		<export name="_JVM_GetInterfaceVersion@0" />
+		<export name="_JVM_GetInterfaceVersion@0">
+			<exclude-if condition="spec.java17"/>
+		</export>
 		<export name="_JVM_GetLastErrorString@8" />
 		<export name="_JVM_GetManagement@4" />
 		<export name="_JVM_GetPortLibrary@0" />
@@ -213,11 +215,21 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="_JVM_GetSockOpt@20"/>
 		<export name="_JVM_ExtendBootClassPath@8" />
 		<export name="_JVM_Bind@12"/>
-		<export name="_JVM_DTraceActivate@20"/>
-		<export name="_JVM_DTraceDispose@12"/>
-		<export name="_JVM_DTraceGetVersion@4"/>
-		<export name="_JVM_DTraceIsProbeEnabled@8"/>
-		<export name="_JVM_DTraceIsSupported@4"/>
+		<export name="_JVM_DTraceActivate@20">
+			<exclude-if condition="spec.java17"/>
+		</export>
+		<export name="_JVM_DTraceDispose@12">
+			<exclude-if condition="spec.java17"/>
+		</export>
+		<export name="_JVM_DTraceGetVersion@4">
+			<exclude-if condition="spec.java17"/>
+		</export>
+		<export name="_JVM_DTraceIsProbeEnabled@8">
+			<exclude-if condition="spec.java17"/>
+		</export>
+		<export name="_JVM_DTraceIsSupported@4">
+			<exclude-if condition="spec.java17"/>
+		</export>
 		<export name="_JVM_DefineClass@24"/>
 		<export name="_JVM_DefineClassWithSourceCond@32"/>
 		<export name="_JVM_EnqueueOperation@20"/>

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -5477,6 +5477,7 @@ JVM_InitClassName
 }
 
 
+#if JAVA_SPEC_VERSION < 17
 /**
  * Return the JVM_INTERFACE_VERSION. This function should not lock, gc or throw exception.
  * @return JVM_INTERFACE_VERSION, JDK8 - 4, JDK11+ - 6.
@@ -5494,7 +5495,7 @@ JVM_GetInterfaceVersion(void)
 
 	return result;
 }
-
+#endif /* JAVA_SPEC_VERSION < 17 */
 
 
 /* jclass parameter 2 is apparently not used */

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 2001, 2020 IBM Corp. and others
+dnl Copyright (c) 2001, 2021 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,7 +73,8 @@ _IF([JAVA_SPEC_VERSION >= 11],
 	[_X(JVM_InitClassName,JNICALL,true,jstring, JNIEnv *env, jclass theClass)])
 _X(JVM_GetClassSignature,JNICALL,true,jstring,JNIEnv *env, jclass target)
 _X(JVM_GetEnclosingMethodInfo,JNICALL,true,jobjectArray,JNIEnv *env, jclass theClass)
-_X(JVM_GetInterfaceVersion,JNICALL,true,jint,void)
+_IF([JAVA_SPEC_VERSION < 17],
+	[_X(JVM_GetInterfaceVersion,JNICALL,true,jint,void)])
 _X(JVM_GetLastErrorString,JNICALL,true,jint,char *buffer, jint length)
 _X(JVM_GetManagement,JNICALL,true,void *,jint version)
 _X(JVM_GetPortLibrary,JNICALL,true,struct J9PortLibrary *,void)
@@ -235,11 +236,16 @@ _X(GetStringPlatform,,false,jint,JNIEnv *env, jstring instr, char *outstr, jint 
 _X(GetStringPlatformLength,,false,jint,JNIEnv *env, jstring instr, jint *outlen, const char *encoding)
 _X(JVM_ExtendBootClassPath,JNICALL,true,void,JNIEnv *env, const char *path)
 _X(JVM_Bind,JNICALL,true,jobject,jint arg0, jint arg1, jint arg2)
-_X(JVM_DTraceActivate,JNICALL,true,jobject,jint arg0, jint arg1, jint arg2, jint arg3, jint arg4)
-_X(JVM_DTraceDispose,JNICALL,true,jobject,jint arg0, jint arg1, jint arg2)
-_X(JVM_DTraceGetVersion,JNICALL,true,jobject,jint arg0)
-_X(JVM_DTraceIsProbeEnabled,JNICALL,true,jobject,jint arg0, jint arg1)
-_X(JVM_DTraceIsSupported,JNICALL,true,jobject,jint arg0)
+_IF([JAVA_SPEC_VERSION < 17],
+	[_X(JVM_DTraceActivate,JNICALL,true,jobject,jint arg0, jint arg1, jint arg2, jint arg3, jint arg4)])
+_IF([JAVA_SPEC_VERSION < 17],
+	[_X(JVM_DTraceDispose,JNICALL,true,jobject,jint arg0, jint arg1, jint arg2)])
+_IF([JAVA_SPEC_VERSION < 17],
+	[_X(JVM_DTraceGetVersion,JNICALL,true,jobject,jint arg0)])
+_IF([JAVA_SPEC_VERSION < 17],
+	[_X(JVM_DTraceIsProbeEnabled,JNICALL,true,jobject,jint arg0, jint arg1)])
+_IF([JAVA_SPEC_VERSION < 17],
+	[_X(JVM_DTraceIsSupported,JNICALL,true,jobject,jint arg0)])
 _X(JVM_DefineClass,JNICALL,true,jobject,jint arg0, jint arg1, jint arg2, jint arg3, jint arg4, jint arg5)
 _X(JVM_DefineClassWithSourceCond,JNICALL,true,jobject,jint arg0, jint arg1, jint arg2, jint arg3, jint arg4, jint arg5, jint arg6, jint arg7)
 _X(JVM_EnqueueOperation,JNICALL,true,jobject,jint arg0, jint arg1, jint arg2, jint arg3, jint arg4)


### PR DESCRIPTION
Removed by openjdk:
* 8260193: Remove JVM_GetInterfaceVersion() and JVM_DTraceXXX