### PR TITLE
Deprecate isSingleRefUnevaluated

### DIFF
--- a/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
@@ -2629,8 +2629,9 @@ J9::Z::TreeEvaluator::BCDCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Node* callParamRoot = isVariableParam ? pdopNode : node;
    for (uint32_t i = firstCallParamIndex; i < callParamRoot->getNumChildren(); ++i)
       {
-      if (!callParamRoot->getChild(i)->isSingleRefUnevaluated())
-         cg->evaluate(callParamRoot->getChild(i));
+      TR::Node* callArg = callParamRoot->getChild(i);
+      if (callArg->getReferenceCount() != 1 || callArg->getRegister() != NULL)
+         cg->evaluate(callArg);
       }
 
    /*
@@ -7519,7 +7520,8 @@ J9::Z::TreeEvaluator::pdshlVectorEvaluatorHelper(TR::Node *node, TR::CodeGenerat
             firstChild->getOpCodeValue() == TR::pdmul ||
             firstChild->getOpCodeValue() == TR::pddiv ||
             firstChild->getOpCodeValue() == TR::pdrem) &&
-           firstChild->isSingleRefUnevaluated();
+            firstChild->getReferenceCount() == 1 &&
+            firstChild->getRegister() == NULL;
 
    int32_t shiftAmount = (int32_t)shiftAmountNode->get64bitIntegralValue();
    uint8_t decimalPrecision = node->getDecimalPrecision();

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -3351,7 +3351,8 @@ J9::Z::TreeEvaluator::BNDCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    bool skipArrayLengthReg = false;
    bool skipArrayIndexReg = false;
    if (firstChild->getOpCodeValue() == TR::l2i &&
-           firstChild->isSingleRefUnevaluated() &&
+           firstChild->getReferenceCount() == 1 &&
+           firstChild->getRegister() == NULL &&
            firstChild->getFirstChild() &&
            firstChild->getFirstChild()->getRegister())
       {
@@ -3364,7 +3365,8 @@ J9::Z::TreeEvaluator::BNDCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       }
 
    if (secondChild->getOpCodeValue() == TR::l2i &&
-           secondChild->isSingleRefUnevaluated() &&
+           secondChild->getReferenceCount() == 1 &&
+           secondChild->getRegister() == NULL &&
            secondChild->getFirstChild() &&
            secondChild->getFirstChild()->getRegister())
       {
@@ -3538,8 +3540,12 @@ J9::Z::TreeEvaluator::BNDCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          return NULL;
          }
       else if (useS390CompareAndTrap &&
-              (  (firstChild->getOpCode().isLoadVar() && firstChild->isSingleRefUnevaluated()) ||
-                 (secondChild->getOpCode().isLoadVar() && secondChild->isSingleRefUnevaluated())) &&
+              ((firstChild->getOpCode().isLoadVar() &&
+               firstChild->getReferenceCount() == 1 &&
+               firstChild->getRegister() == NULL) ||
+               (secondChild->getOpCode().isLoadVar() && 
+               secondChild->getReferenceCount() == 1 &&
+               secondChild->getRegister() == NULL)) &&
               cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_ZEC12))
          {
          // Assume 1st child is the memory operand.
@@ -3548,7 +3554,9 @@ J9::Z::TreeEvaluator::BNDCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          TR::InstOpCode::S390BranchCondition compareCondition = TR::InstOpCode::COND_BNL;
 
          // Check if first child is really the memory operand
-         if (!(firstChild->getOpCode().isLoadVar() && firstChild->isSingleRefUnevaluated()))
+         if (!(firstChild->getOpCode().isLoadVar() && 
+               firstChild->getReferenceCount() == 1 &&
+               firstChild->getRegister() == NULL))
             {
             // Nope... the second child is!
             memChild = secondChild;


### PR DESCRIPTION
See eclipse/omr#5648 for discussion. It was decided during the OMR
architecture meeting that this API is not very clear and that inlining
it's uses is more understandable as it is very explicit as to what is
being checked.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>