### PR TITLE
Add optimization to ClassIteratorClassSlots

### DIFF
--- a/runtime/gc_base/ClassLoaderManager.cpp
+++ b/runtime/gc_base/ClassLoaderManager.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -312,6 +312,13 @@ MM_ClassLoaderManager::cleanUpClassLoadersStart(MM_EnvironmentBase *env, J9Class
 	
 	Trc_MM_cleanUpClassLoadersStart_Entry(env->getLanguageVMThread());
 	
+	/*
+	 * Verify that boolean array class has been marked. Assertion is done to ensure correctness
+	 * of an optimization in ClassIteratorClassSlots that only checks booleanArrayClass Interfaces
+	 * since all array claseses share the same ITable.
+	 */
+	Assert_MM_true(markMap->isBitSet(_javaVM->booleanArrayClass->classObject));
+
 	/*
 	 * Walk anonymous classes and set unmarked as dying
 	 *

--- a/runtime/gc_base/ReferenceChainWalker.cpp
+++ b/runtime/gc_base/ReferenceChainWalker.cpp
@@ -429,7 +429,7 @@ MM_ReferenceChainWalker::scanClass(J9Class *clazz)
 		doSlot((j9object_t*)slot, refType, index, referrer);
 	}
 
-	GC_ClassIteratorClassSlots classIteratorClassSlots(clazz);
+	GC_ClassIteratorClassSlots classIteratorClassSlots(static_cast<J9JavaVM*>(_omrVM->_language_vm), clazz);
 	while(J9Class **slot = classIteratorClassSlots.nextSlot()) {
 		switch (classIteratorClassSlots.getState()) {
 		case classiteratorclassslots_state_constant_pool:

--- a/runtime/gc_check/CheckEngine.cpp
+++ b/runtime/gc_check/CheckEngine.cpp
@@ -762,7 +762,7 @@ GC_CheckEngine::checkClassHeap(J9JavaVM *javaVM, J9Class *clazz, J9MemorySegment
 	/*
 	 * Process class slots in the class
 	 */
-	GC_ClassIteratorClassSlots classIteratorClassSlots(clazz);
+	GC_ClassIteratorClassSlots classIteratorClassSlots(javaVM, clazz);
 	J9Class** classSlotPtr;
 	while((classSlotPtr = classIteratorClassSlots.nextSlot()) != NULL) {
 		int state = classIteratorClassSlots.getState();

--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -412,6 +412,13 @@ MM_MetronomeDelegate::processDyingClasses(MM_EnvironmentRealtime *env, UDATA* cl
 	J9ClassLoader *unloadLink = NULL;
 	J9Class *classUnloadList = NULL;
 	J9Class *anonymousClassUnloadList = NULL;
+
+	/*
+	 * Verify that boolean array class has been marked. Assertion is done to ensure correctness
+	 * of an optimization in ClassIteratorClassSlots that only checks booleanArrayClass Interfaces
+	 * since all array claseses share the same ITable.
+	 */
+	Assert_MM_true(_markingScheme->isMarked(_javaVM->booleanArrayClass->classObject));
 
 	/*
 	 * Walk anonymous classes and set unmarked as dying
@@ -916,7 +923,7 @@ MM_MetronomeDelegate::doClassTracing(MM_EnvironmentRealtime *env)
 								didWork |= _markingScheme->markObject(env, *objectSlotPtr);
 							}
 
-							GC_ClassIteratorClassSlots classSlotIterator(clazz);
+							GC_ClassIteratorClassSlots classSlotIterator(_javaVM, clazz);
 							J9Class **classSlotPtr;
 							while((classSlotPtr = classSlotIterator.nextSlot()) != NULL) {
 								didWork |= markClass(env, *classSlotPtr);
@@ -945,7 +952,7 @@ MM_MetronomeDelegate::doClassTracing(MM_EnvironmentRealtime *env)
 								didWork |= _markingScheme->markObject(env, *objectSlotPtr);
 							}
 
-							GC_ClassIteratorClassSlots classSlotIterator(clazz);
+							GC_ClassIteratorClassSlots classSlotIterator(_javaVM, clazz);
 							J9Class **classSlotPtr;
 							while((classSlotPtr = classSlotIterator.nextSlot()) != NULL) {
 								didWork |= markClass(env, *classSlotPtr);

--- a/runtime/gc_realtime/RealtimeRootScanner.cpp
+++ b/runtime/gc_realtime/RealtimeRootScanner.cpp
@@ -56,7 +56,7 @@ MM_RealtimeRootScanner::doClass(J9Class *clazz)
 		/* discard volatile since we must be in stop-the-world mode */
 		doSlot((j9object_t*)objectSlotPtr);
 	}
-	GC_ClassIteratorClassSlots classSlotIterator(clazz);
+	GC_ClassIteratorClassSlots classSlotIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm), clazz);
 	J9Class **classSlotPtr;
 	while((classSlotPtr = classSlotIterator.nextSlot()) != NULL) {
 		doClassSlot(*classSlotPtr);

--- a/runtime/gc_structs/ClassIteratorClassSlots.cpp
+++ b/runtime/gc_structs/ClassIteratorClassSlots.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,28 +46,34 @@ GC_ClassIteratorClassSlots::nextSlot()
 
 	case classiteratorclassslots_state_constant_pool:
 		slotPtr = _constantPoolClassSlotIterator.nextSlot();
-		if(NULL != slotPtr) {
+		if (NULL != slotPtr) {
 			return slotPtr;
 		}
 		_state += 1;
 
 	case classiteratorclassslots_state_superclasses:
 		slotPtr = _classSuperclassesIterator.nextSlot();
-		if(NULL != slotPtr) {
+		if (NULL != slotPtr) {
 			return slotPtr;
 		}
 		_state += 1;
 
 	case classiteratorclassslots_state_interfaces:
-		slotPtr = _classLocalInterfaceIterator.nextSlot();
-		if(NULL != slotPtr) {
-			return slotPtr;
+		/*
+		 * Checking sharedITable is an optimization that only checks booleanArrayClass Interfaces
+		 * since all array claseses share the same ITable.
+		 */
+		if (_shouldScanInterfaces) {
+			slotPtr = _classLocalInterfaceIterator.nextSlot();
+			if (NULL != slotPtr) {
+				return slotPtr;
+			}
 		}
 		_state += 1;
 
 	case classiteratorclassslots_state_array_class_slots:
 		slotPtr = _classArrayClassSlotIterator.nextSlot();
-		if(NULL != slotPtr) {
+		if (NULL != slotPtr) {
 			return slotPtr;
 		}
 		_state += 1;

--- a/runtime/gc_structs/ClassIteratorClassSlots.hpp
+++ b/runtime/gc_structs/ClassIteratorClassSlots.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,6 +37,7 @@
 #include "ClassSuperclassesIterator.hpp"
 #include "ClassLocalInterfaceIterator.hpp"
 #include "ClassArrayClassSlotIterator.hpp"
+#include "ClassModel.hpp"
 
 /**
  * State constants representing the current stage of the iteration process
@@ -62,6 +63,7 @@ enum {
 class GC_ClassIteratorClassSlots
 {
 protected:
+	const bool _shouldScanInterfaces;
 	J9Class *_clazzPtr;
 	int _state;
 
@@ -72,7 +74,8 @@ protected:
 
 public:
 
-	GC_ClassIteratorClassSlots(J9Class *clazz) :
+	GC_ClassIteratorClassSlots(J9JavaVM *vm, J9Class *clazz) :
+		_shouldScanInterfaces(!GC_ClassModel::usesSharedITable(vm, clazz)),
 		_clazzPtr(clazz),
 		_state(classiteratorclassslots_state_start),
 		_constantPoolClassSlotIterator(clazz),

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -2543,7 +2543,7 @@ MM_CopyForwardScheme::scanClassObjectSlots(MM_EnvironmentVLHGC *env, MM_Allocati
 			 * However we need to scan them for case of Anonymous classes. Its are unloaded on individual basis so it is important to reach each one
 			 */
 			if (J9_ARE_ANY_BITS_SET(J9CLASS_EXTENDED_FLAGS(classPtr), J9ClassIsAnonymous)) {
-				GC_ClassIteratorClassSlots classSlotIterator(classPtr);
+				GC_ClassIteratorClassSlots classSlotIterator(_javaVM, classPtr);
 				J9Class **classSlotPtr;
 				while (success && (NULL != (classSlotPtr = classSlotIterator.nextSlot()))) {
 					/* GC_ClassIteratorClassSlots can return NULL in *classSlotPtr so it should to be filtered out */

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -774,7 +774,7 @@ MM_GlobalMarkingScheme::scanClassObject(MM_EnvironmentVLHGC *env, J9Object *clas
 			 * However we need to scan them for case of Anonymous classes. Its are unloaded on individual basis so it is important to reach each one
 			 */
 			if (J9_ARE_ANY_BITS_SET(J9CLASS_EXTENDED_FLAGS(classPtr), J9ClassIsAnonymous)) {
-				GC_ClassIteratorClassSlots classSlotIterator(classPtr);
+				GC_ClassIteratorClassSlots classSlotIterator(_javaVM, classPtr);
 				J9Class **classSlotPtr;
 				while(NULL != (classSlotPtr = classSlotIterator.nextSlot())) {
 					/* GC_ClassIteratorClassSlots can return NULL in *classSlotPtr so it should to be filtered out */


### PR DESCRIPTION
- Optimization walks the ITable of array classes only once since all
array classes share the same ITable. The array class that is walked
is the booleanArrayClass.
- Assertion that booleanArrayClass has been marked added to
MetronomeDelegate and the ClassLoaderManager to ensure correctness
of the optimization.

Signed-off-by: Oussama Saoudi <oussama.saoudi@ibm.com>