### PR TITLE
Fixup varHandleMethodTypes in HCR

### DIFF
--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2400,6 +2400,8 @@ swapClassesForFastHCR(J9Class *originalClass, J9Class *obsoleteClass)
 	SWAP_MEMBER(specialSplitMethodTable, J9Method **, originalClass, obsoleteClass);
 	/* Force invokedynamics to be re-resolved as we can't map from the old callsite index to the new one */
 	SWAP_MEMBER(callSites, j9object_t*, originalClass, obsoleteClass);
+	/* Force varhanles to be re-resolved as we can't map from the old varhandle MTs index to the new one */
+	SWAP_MEMBER(varHandleMethodTypes, j9object_t*, originalClass, obsoleteClass);
 	/* Force methodTypes to be re-resolved as indexes are assigned in CP order, no mapping from old to new. */
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 	SWAP_MEMBER(invokeCache, j9object_t*, originalClass, obsoleteClass);


### PR DESCRIPTION
Fixup varHandleMethodTypes in HCR

based on https://github.com/eclipse/openj9/pull/11905

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>