### PR TITLE
(0.25.0) CMake:  Update java handling for windows jdk16+

### DIFF
--- a/sourcetools/CMakeLists.txt
+++ b/sourcetools/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,13 @@ include(UseJava)
 project(j9_sourcetools VERSION 1.0)
 
 set(CMAKE_JAVA_TARGET_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
+# Due to the way cmake generates the java class path, it will generate a leading path separator.
+# This prevents fixpath from JDKs after JDK11 from properly translating the path.
+# To work around the issue we tack on a dummy path at the beginning of the output classpath.
+if((WIN32 AND NOT CMAKE_HOST_WIN32) AND (JAVA_SPEC_VERSION GREATER 11))
+	set(CMAKE_JAVA_INCLUDE_PATH_FINAL "${CMAKE_CURRENT_SOURCE_DIR}")
+endif()
 
 # TODO this needs to be named and handled better
 set(SPEC_LEVEL 7 CACHE STRING "")

--- a/sourcetools/j9constantpool/CMakeLists.txt
+++ b/sourcetools/j9constantpool/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,9 +23,10 @@
 # CMake doesn't properly handle directory separators when building in cygwin
 # but using a windows java binary. IE it uses ':' as a directory separator,
 # rather than required ';'
+# Note: this isn't required for JDKs after JDK11 as fixpath will convert the path separators for us.
 
 # WIN32 will be true when the build is targeting windows, but CMAKE_HOST_WIN32 is false on cygwin
-if(WIN32 AND NOT CMAKE_HOST_WIN32)
+if((WIN32 AND NOT CMAKE_HOST_WIN32) AND (NOT JAVA_SPEC_VERSION GREATER 11))
 	# put  "-cp <Path_to_objectmodel_jar>" into a text file we will pass in with '@file'
 	file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cygwin_classpath" CONTENT "-cp\n$<TARGET_PROPERTY:objectmodel,JAR_FILE>\n")
 	set(CYGWIN_CP "@${CMAKE_CURRENT_BINARY_DIR}/cygwin_classpath")


### PR DESCRIPTION
Cherry pick https://github.com/eclipse/openj9/pull/11892 for the 0.25 release.