### PR TITLE
Refactor ClassIteratorClassSlots and VMClassSlotIterator

### DIFF
--- a/runtime/gc_api/HeapRootScanner.cpp
+++ b/runtime/gc_api/HeapRootScanner.cpp
@@ -210,10 +210,10 @@ MM_HeapRootScanner::scanVMClassSlots()
 	setReachability(RootScannerEntityReachability_Strong);
 
 	GC_VMClassSlotIterator classSlotIterator(_javaVM);
-	J9Class **slotPtr;
+	J9Class *classPtr;
 	
-	while((slotPtr = classSlotIterator.nextSlot()) != NULL) {
-		doVMClassSlot(*slotPtr);
+	while (NULL != (classPtr = classSlotIterator.nextSlot())) {
+		doVMClassSlot(classPtr);
 	}
 	
 	reportScanningEnded(RootScannerEntity_VMClassSlots);	

--- a/runtime/gc_base/ReferenceChainWalker.cpp
+++ b/runtime/gc_base/ReferenceChainWalker.cpp
@@ -430,22 +430,22 @@ MM_ReferenceChainWalker::scanClass(J9Class *clazz)
 	}
 
 	GC_ClassIteratorClassSlots classIteratorClassSlots(static_cast<J9JavaVM*>(_omrVM->_language_vm), clazz);
-	while(J9Class **slot = classIteratorClassSlots.nextSlot()) {
+	while (J9Class *classPtr = classIteratorClassSlots.nextSlot()) {
 		switch (classIteratorClassSlots.getState()) {
 		case classiteratorclassslots_state_constant_pool:
-			doClassSlot(*slot, J9GC_REFERENCE_TYPE_CONSTANT_POOL, classIteratorClassSlots.getIndex(), referrer);
+			doClassSlot(classPtr, J9GC_REFERENCE_TYPE_CONSTANT_POOL, classIteratorClassSlots.getIndex(), referrer);
 			break;
 		case classiteratorclassslots_state_superclasses:
-			doClassSlot(*slot, J9GC_REFERENCE_TYPE_SUPERCLASS, classIteratorClassSlots.getIndex(), referrer);
+			doClassSlot(classPtr, J9GC_REFERENCE_TYPE_SUPERCLASS, classIteratorClassSlots.getIndex(), referrer);
 			break;
 		case classiteratorclassslots_state_interfaces:
-			doClassSlot(*slot, J9GC_REFERENCE_TYPE_INTERFACE, classIteratorClassSlots.getIndex(), referrer);
+			doClassSlot(classPtr, J9GC_REFERENCE_TYPE_INTERFACE, classIteratorClassSlots.getIndex(), referrer);
 			break;
 		case classiteratorclassslots_state_array_class_slots:
-			doClassSlot(*slot, J9GC_REFERENCE_TYPE_CLASS_ARRAY_CLASS, classIteratorClassSlots.getIndex(), referrer);
+			doClassSlot(classPtr, J9GC_REFERENCE_TYPE_CLASS_ARRAY_CLASS, classIteratorClassSlots.getIndex(), referrer);
 			break;
 		default:
-			doClassSlot(*slot, J9GC_REFERENCE_TYPE_UNKNOWN, classIteratorClassSlots.getIndex(), referrer);
+			doClassSlot(classPtr, J9GC_REFERENCE_TYPE_UNKNOWN, classIteratorClassSlots.getIndex(), referrer);
 			break;
 		}
 	}

--- a/runtime/gc_base/RootScanner.cpp
+++ b/runtime/gc_base/RootScanner.cpp
@@ -314,10 +314,10 @@ MM_RootScanner::scanVMClassSlots(MM_EnvironmentBase *env)
 		reportScanningStarted(RootScannerEntity_VMClassSlots);
 
 		GC_VMClassSlotIterator classSlotIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm));
-		J9Class **slotPtr;
+		J9Class *classPtr;
 
-		while((slotPtr = classSlotIterator.nextSlot()) != NULL) {
-			doVMClassSlot(*slotPtr);
+		while (NULL != (classPtr = classSlotIterator.nextSlot())) {
+			doVMClassSlot(classPtr);
 		}
 
 		reportScanningEnded(RootScannerEntity_VMClassSlots);

--- a/runtime/gc_check/CheckEngine.cpp
+++ b/runtime/gc_check/CheckEngine.cpp
@@ -763,43 +763,34 @@ GC_CheckEngine::checkClassHeap(J9JavaVM *javaVM, J9Class *clazz, J9MemorySegment
 	 * Process class slots in the class
 	 */
 	GC_ClassIteratorClassSlots classIteratorClassSlots(javaVM, clazz);
-	J9Class** classSlotPtr;
-	while((classSlotPtr = classIteratorClassSlots.nextSlot()) != NULL) {
+	J9Class *classPtr;
+	while (NULL != (classPtr = classIteratorClassSlots.nextSlot())) {
 		int state = classIteratorClassSlots.getState();
 		const char *elementName = "";
-		J9Class *clazzPtr = *classSlotPtr;
 
 		result = J9MODRON_GCCHK_RC_OK;
 
 		switch (state) {
 			case classiteratorclassslots_state_constant_pool:
-				/* may be NULL */
-				if (clazzPtr != NULL) {
-					result = checkJ9ClassPointer(javaVM, clazzPtr);
-				}
+				result = checkJ9ClassPointer(javaVM, classPtr);
 				elementName = "constant ";
 				break;
 			case classiteratorclassslots_state_superclasses:
-				/* must not be NULL */
-				result = checkJ9ClassPointer(javaVM, clazzPtr);
+				result = checkJ9ClassPointer(javaVM, classPtr);
 				elementName = "superclass ";
 				break;
 			case classiteratorclassslots_state_interfaces:
-				/* must not be NULL */
-				result = checkJ9ClassPointer(javaVM, clazzPtr);
+				result = checkJ9ClassPointer(javaVM, classPtr);
 				elementName = "interface ";
 				break;
 			case classiteratorclassslots_state_array_class_slots:
-				/* may be NULL */
-				if (clazzPtr != NULL) {
-					result = checkJ9ClassPointer(javaVM, clazzPtr);
-				}
+				result = checkJ9ClassPointer(javaVM, classPtr);
 				elementName = "array class ";
 				break;
 		}
 
 		if (J9MODRON_GCCHK_RC_OK != result) {
-			GC_CheckError error( clazz, classSlotPtr, _cycle, _currentCheck, elementName, result, _cycle->nextErrorCount());
+			GC_CheckError error(clazz, &classPtr, _cycle, _currentCheck, elementName, result, _cycle->nextErrorCount());
 			_reporter->report(&error);
 			return J9MODRON_SLOT_ITERATOR_OK;
 		}

--- a/runtime/gc_check/CheckVMClassSlots.cpp
+++ b/runtime/gc_check/CheckVMClassSlots.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,14 +48,11 @@ void
 GC_CheckVMClassSlots::check()
 {
 	GC_VMClassSlotIterator classSlotIterator(_javaVM);
-	J9Class **slotPtr;
+	J9Class *classPtr;
 
-	while((slotPtr = classSlotIterator.nextSlot()) != NULL) {
-		J9Class *theClazz = *slotPtr;
-		if (theClazz != NULL) {
-			if (_engine->checkJ9ClassPointer(_javaVM, theClazz) != J9MODRON_GCCHK_RC_OK) {
-				return;
-			}
+	while (NULL != (classPtr = classSlotIterator.nextSlot())) {
+		if (J9MODRON_GCCHK_RC_OK != _engine->checkJ9ClassPointer(_javaVM, classPtr)) {
+			return;
 		}
 	}
 }
@@ -64,11 +61,11 @@ void
 GC_CheckVMClassSlots::print()
 {
 	GC_VMClassSlotIterator classSlotIterator(_javaVM);
-	J9Class **slotPtr;
+	J9Class *classPtr;
 
 	GC_ScanFormatter formatter(_portLibrary, "VMClass Slot");
-	while((slotPtr = classSlotIterator.nextSlot()) != NULL) {
-		formatter.entry((void *)*slotPtr);
+	while (NULL != (classPtr = classSlotIterator.nextSlot())) {
+		formatter.entry((void *)classPtr);
 	}
 	formatter.end("VMClass Slot");
 }

--- a/runtime/gc_glue_java/MarkingDelegate.cpp
+++ b/runtime/gc_glue_java/MarkingDelegate.cpp
@@ -387,11 +387,9 @@ MM_MarkingDelegate::scanClass(MM_EnvironmentBase *env, J9Class *clazz)
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 	if (isDynamicClassUnloadingEnabled()) {
 		GC_ClassIteratorClassSlots classSlotIterator((J9JavaVM*)env->getLanguageVM(), clazz);
-		J9Class **slotPtr;
-		while (NULL != (slotPtr = classSlotIterator.nextSlot())) {
-			if (NULL != *slotPtr) {
-				_markingScheme->markObject(env, (*slotPtr)->classObject);
-			}
+		J9Class *classPtr;
+		while (NULL != (classPtr = classSlotIterator.nextSlot())) {
+			_markingScheme->markObject(env, classPtr->classObject);
 		}
 	}
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */

--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -924,9 +924,9 @@ MM_MetronomeDelegate::doClassTracing(MM_EnvironmentRealtime *env)
 							}
 
 							GC_ClassIteratorClassSlots classSlotIterator(_javaVM, clazz);
-							J9Class **classSlotPtr;
-							while((classSlotPtr = classSlotIterator.nextSlot()) != NULL) {
-								didWork |= markClass(env, *classSlotPtr);
+							J9Class *classPtr;
+							while (NULL != (classPtr = classSlotIterator.nextSlot())) {
+								didWork |= markClass(env, classPtr);
 							}
 						}
 					}
@@ -953,9 +953,9 @@ MM_MetronomeDelegate::doClassTracing(MM_EnvironmentRealtime *env)
 							}
 
 							GC_ClassIteratorClassSlots classSlotIterator(_javaVM, clazz);
-							J9Class **classSlotPtr;
-							while((classSlotPtr = classSlotIterator.nextSlot()) != NULL) {
-								didWork |= markClass(env, *classSlotPtr);
+							J9Class *classPtr;
+							while (NULL != (classPtr = classSlotIterator.nextSlot())) {
+								didWork |= markClass(env, classPtr);
 							}
 						}
 						_realtimeGC->condYield(env, 0);

--- a/runtime/gc_realtime/RealtimeRootScanner.cpp
+++ b/runtime/gc_realtime/RealtimeRootScanner.cpp
@@ -57,9 +57,9 @@ MM_RealtimeRootScanner::doClass(J9Class *clazz)
 		doSlot((j9object_t*)objectSlotPtr);
 	}
 	GC_ClassIteratorClassSlots classSlotIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm), clazz);
-	J9Class **classSlotPtr;
-	while((classSlotPtr = classSlotIterator.nextSlot()) != NULL) {
-		doClassSlot(*classSlotPtr);
+	J9Class *classPtr;
+	while (NULL != (classPtr = classSlotIterator.nextSlot())) {
+		doClassSlot(classPtr);
 	}
 }
 

--- a/runtime/gc_structs/ClassArrayClassSlotIterator.cpp
+++ b/runtime/gc_structs/ClassArrayClassSlotIterator.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,32 +36,36 @@
  * @return the next slot containing an object reference
  * @return NULL if there are no more such slots
  */
-J9Class **
+J9Class *
 GC_ClassArrayClassSlotIterator::nextSlot() 
 {
-	J9Class **slotPtr;
-
-	switch(_state) {
-	case classArrayClassSlotIterator_state_arrayClass:
-		slotPtr = (J9Class **)&_iterateClazz->arrayClass;
-		if(!_isArrayClass) {
-			_state = classArrayClassSlotIterator_state_done;
-		} else {
+	J9Class *classPtr = NULL;
+	while (_state != classArrayClassSlotIterator_state_done) {
+		switch (_state) {
+		case classArrayClassSlotIterator_state_arrayClass:
+			classPtr = (J9Class *)_iterateClazz->arrayClass;
+			if (!_isArrayClass) {
+				_state = classArrayClassSlotIterator_state_done;
+			} else {
+				_state += 1;
+			}
+			break;
+		case classArrayClassSlotIterator_state_componentType:
+			classPtr = ((J9ArrayClass *)_iterateClazz)->componentType;
 			_state += 1;
+			break;
+		case classArrayClassSlotIterator_state_leafComponentType:
+			classPtr = ((J9ArrayClass *)_iterateClazz)->leafComponentType;
+			_state += 1;
+			break;
+		case classArrayClassSlotIterator_state_done:
+		default:
+			break;
 		}
-		break;
-	case classArrayClassSlotIterator_state_componentType:
-		slotPtr = &((J9ArrayClass *)_iterateClazz)->componentType;
-		_state += 1;
-		break;
-	case classArrayClassSlotIterator_state_leafComponentType:
-		slotPtr = &((J9ArrayClass *)_iterateClazz)->leafComponentType;
-		_state += 1;
-		break;
-	default:
-		return NULL;
-		break;
+		if (NULL != classPtr) {
+			break;
+		}
 	}
-	return slotPtr;
+	return classPtr;
 }
 

--- a/runtime/gc_structs/ClassArrayClassSlotIterator.hpp
+++ b/runtime/gc_structs/ClassArrayClassSlotIterator.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,7 +58,7 @@ public:
 		_state(classArrayClassSlotIterator_state_arrayClass)
 	{};
 
-	J9Class **nextSlot();
+	J9Class *nextSlot();
 	
 	/**
 	 * Gets the current slot's "index".

--- a/runtime/gc_structs/ClassIteratorClassSlots.cpp
+++ b/runtime/gc_structs/ClassIteratorClassSlots.cpp
@@ -32,29 +32,29 @@
 #include "ClassIteratorClassSlots.hpp"
 
 /**
- * @return the next slot in the class containing an object reference
- * @return NULL if there are no more such slots
+ * @return the next non-NULL class reference
+ * @return NULL if there are no more such references
  */
-J9Class **
+J9Class *
 GC_ClassIteratorClassSlots::nextSlot()
 {
-	J9Class **slotPtr;
+	J9Class *classPtr;
 
 	switch(_state) {
 	case classiteratorclassslots_state_start:
 		_state += 1;
 
 	case classiteratorclassslots_state_constant_pool:
-		slotPtr = _constantPoolClassSlotIterator.nextSlot();
-		if (NULL != slotPtr) {
-			return slotPtr;
+		classPtr = _constantPoolClassSlotIterator.nextSlot();
+		if (NULL != classPtr) {
+			return classPtr;
 		}
 		_state += 1;
 
 	case classiteratorclassslots_state_superclasses:
-		slotPtr = _classSuperclassesIterator.nextSlot();
-		if (NULL != slotPtr) {
-			return slotPtr;
+		classPtr = _classSuperclassesIterator.nextSlot();
+		if (NULL != classPtr) {
+			return classPtr;
 		}
 		_state += 1;
 
@@ -64,17 +64,17 @@ GC_ClassIteratorClassSlots::nextSlot()
 		 * since all array claseses share the same ITable.
 		 */
 		if (_shouldScanInterfaces) {
-			slotPtr = _classLocalInterfaceIterator.nextSlot();
-			if (NULL != slotPtr) {
-				return slotPtr;
+			classPtr = _classLocalInterfaceIterator.nextSlot();
+			if (NULL != classPtr) {
+				return classPtr;
 			}
 		}
 		_state += 1;
 
 	case classiteratorclassslots_state_array_class_slots:
-		slotPtr = _classArrayClassSlotIterator.nextSlot();
-		if (NULL != slotPtr) {
-			return slotPtr;
+		classPtr = _classArrayClassSlotIterator.nextSlot();
+		if (NULL != classPtr) {
+			return classPtr;
 		}
 		_state += 1;
 		

--- a/runtime/gc_structs/ClassIteratorClassSlots.hpp
+++ b/runtime/gc_structs/ClassIteratorClassSlots.hpp
@@ -116,7 +116,7 @@ public:
 		}			
 	}
 	
-	J9Class **nextSlot();
+	J9Class *nextSlot();
 
 };
 

--- a/runtime/gc_structs/ClassLoaderClassesIterator.cpp
+++ b/runtime/gc_structs/ClassLoaderClassesIterator.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,15 +47,7 @@ GC_ClassLoaderClassesIterator::GC_ClassLoaderClassesIterator(MM_GCExtensionsBase
 J9Class *
 GC_ClassLoaderClassesIterator::nextSystemClass() 
 {
-	J9Class * result = NULL;
-	J9Class ** slot = NULL;
-	while (NULL != (slot = _vmClassSlotIterator.nextSlot())) {
-		result = *slot;
-		if (NULL != result) {
-			break;
-		}
-	}
-	return result;
+	return _vmClassSlotIterator.nextSlot();
 }
 
 J9Class *

--- a/runtime/gc_structs/ClassLocalInterfaceIterator.cpp
+++ b/runtime/gc_structs/ClassLocalInterfaceIterator.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,17 +36,17 @@
  * @return the next interface reference slot in the class
  * @return NULL if the class has no more interface references
  */
-J9Class **
+J9Class *
 GC_ClassLocalInterfaceIterator::nextSlot()
 {
-	J9Class **slotPtr;
-
-	if(_iTable == _superclassITable) {
-		return NULL;
+	J9Class *classPtr = NULL;
+	while (_iTable != _superclassITable) {
+		classPtr = _iTable->interfaceClass;
+		_iTable = _iTable->next;
+		if (NULL != classPtr) {
+			break;
+		}
 	}
-
-	slotPtr = &_iTable->interfaceClass;
-	_iTable = _iTable->next;
-	return slotPtr;
+	return classPtr;
 }
 

--- a/runtime/gc_structs/ClassLocalInterfaceIterator.hpp
+++ b/runtime/gc_structs/ClassLocalInterfaceIterator.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,7 +56,7 @@ public:
 		}
 	};
 
-	J9Class **nextSlot();
+	J9Class *nextSlot();
 };
 
 #endif /* CLASSLOCALINTERFACEITERATOR_HPP_ */

--- a/runtime/gc_structs/ClassSuperclassesIterator.cpp
+++ b/runtime/gc_structs/ClassSuperclassesIterator.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,20 +36,19 @@
  * @return a reference to the next superclass
  * @return NULL if the class has no more superclass references
  */
-J9Class **
+J9Class *
 GC_ClassSuperclassesIterator::nextSlot()
 {
-	J9Class **slotPtr;
-
-	if(0 == _classDepth) {
-		return NULL;
+	J9Class *classPtr = NULL;
+	while (0 != _classDepth) {
+		_index += 1;
+		_classDepth -= 1;
+		classPtr = *_superclassPtr++;
+		if (NULL != classPtr) {
+			break;
+		}
 	}
-
-	_index += 1;
-	_classDepth -= 1;
-	slotPtr = _superclassPtr++;
-
-	return slotPtr;	
+	return classPtr;
 }
 
 

--- a/runtime/gc_structs/ClassSuperclassesIterator.hpp
+++ b/runtime/gc_structs/ClassSuperclassesIterator.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,7 +51,7 @@ public:
 		_superclassPtr(clazz->superclasses)
 	{};
 
-	J9Class **nextSlot();
+	J9Class *nextSlot();
 	
 	/**
 	 * Gets the current superclass index.

--- a/runtime/gc_structs/ConstantPoolClassSlotIterator.cpp
+++ b/runtime/gc_structs/ConstantPoolClassSlotIterator.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,21 +36,19 @@
  * @return the next Class reference from the constant pool
  * @return NULL if there are no more references
  */
-J9Class **
+J9Class *
 GC_ConstantPoolClassSlotIterator::nextSlot()
 {
-	U_32 slotType;
-	J9Object **slotPtr;
-
-	while(_cpEntryCount) {
-		if(0 == _cpDescriptionIndex) {
+	J9Class *classPtr = NULL;
+	while (_cpEntryCount) {
+		if (0 == _cpDescriptionIndex) {
 			_cpDescription = *_cpDescriptionSlots;
 			_cpDescriptionSlots += 1;
 			_cpDescriptionIndex = J9_CP_DESCRIPTIONS_PER_U32;
 		}
 
-		slotType = _cpDescription & J9_CP_DESCRIPTION_MASK;
-		slotPtr = _cpEntry;
+		U_32 slotType = _cpDescription & J9_CP_DESCRIPTION_MASK;
+		J9Object **slotPtr = _cpEntry;
 
 		/* Adjust the CP slot and description information */
 		_cpEntry = (J9Object **)( ((U_8 *)_cpEntry) + sizeof(J9RAMConstantPoolItem) );
@@ -60,9 +58,12 @@ GC_ConstantPoolClassSlotIterator::nextSlot()
 		_cpDescriptionIndex -= 1;
 
 		/* Determine if the slot should be processed */
-		if(slotType == J9CPTYPE_CLASS) {
-			return &(((J9RAMClassRef *) slotPtr)->value);
+		if (slotType == J9CPTYPE_CLASS) {
+			classPtr = ((J9RAMClassRef *) slotPtr)->value;
+			if (NULL != classPtr) {
+				break;
+			}
 		}
 	}
-	return NULL;
+	return classPtr;
 }

--- a/runtime/gc_structs/ConstantPoolClassSlotIterator.hpp
+++ b/runtime/gc_structs/ConstantPoolClassSlotIterator.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,7 +72,7 @@ public:
 		return _cpEntryTotal - _cpEntryCount - 1;
 	}
 
-	J9Class **nextSlot();
+	J9Class *nextSlot();
 };
 
 #endif /* CONSTANTPOOLCLASSSLOTITERATOR_HPP_ */

--- a/runtime/gc_structs/VMClassSlotIterator.cpp
+++ b/runtime/gc_structs/VMClassSlotIterator.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,11 +36,15 @@
  * @return the next slot containing an object reference
  * @return NULL if there are no more such slots
  */
-J9Class **
+J9Class *
 GC_VMClassSlotIterator::nextSlot()
 {
-	if(_scanPtr < _endPtr) {
-		return _scanPtr++;
+	J9Class *classPtr = NULL;
+	while (_scanPtr < _endPtr) {
+		classPtr = *_scanPtr++;
+		if (NULL != classPtr) {
+			break;
+		}
 	}
-	return NULL;
+	return classPtr;
 }

--- a/runtime/gc_structs/VMClassSlotIterator.hpp
+++ b/runtime/gc_structs/VMClassSlotIterator.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,7 +48,7 @@ public:
 		_endPtr( &javaVM->longArrayClass + 1 )
 	{};
 
-	J9Class **nextSlot();
+	J9Class *nextSlot();
 
 };
 

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -2549,14 +2549,11 @@ MM_CopyForwardScheme::scanClassObjectSlots(MM_EnvironmentVLHGC *env, MM_Allocati
 			 */
 			if (J9_ARE_ANY_BITS_SET(J9CLASS_EXTENDED_FLAGS(classPtr), J9ClassIsAnonymous)) {
 				GC_ClassIteratorClassSlots classSlotIterator(_javaVM, classPtr);
-				J9Class **classSlotPtr;
-				while (success && (NULL != (classSlotPtr = classSlotIterator.nextSlot()))) {
-					/* GC_ClassIteratorClassSlots can return NULL in *classSlotPtr so it should to be filtered out */
-					if (NULL != *classSlotPtr) {
-						slotPtr = &((*classSlotPtr)->classObject);
-						/* Copy/Forward the slot reference and perform any inter-region remember work that is required */
-						success = copyAndForward(env, reservingContext, classObject, slotPtr);
-					}
+				J9Class *classPtr;
+				while (success && (NULL != (classPtr = classSlotIterator.nextSlot()))) {
+					slotPtr = &(classPtr->classObject);
+					/* Copy/Forward the slot reference and perform any inter-region remember work that is required */
+					success = copyAndForward(env, reservingContext, classObject, slotPtr);
 				}
 			}
 

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -775,14 +775,11 @@ MM_GlobalMarkingScheme::scanClassObject(MM_EnvironmentVLHGC *env, J9Object *clas
 			 */
 			if (J9_ARE_ANY_BITS_SET(J9CLASS_EXTENDED_FLAGS(classPtr), J9ClassIsAnonymous)) {
 				GC_ClassIteratorClassSlots classSlotIterator(_javaVM, classPtr);
-				J9Class **classSlotPtr;
-				while(NULL != (classSlotPtr = classSlotIterator.nextSlot())) {
-					/* GC_ClassIteratorClassSlots can return NULL in *classSlotPtr so it should to be filtered out */
-					if (NULL != *classSlotPtr) {
-						J9Object *value = (*classSlotPtr)->classObject;
-						markObject(env, value);
-						rememberReferenceIfRequired(env, classObject, value);
-					}
+				J9Class *classPtr;
+				while (NULL != (classPtr = classSlotIterator.nextSlot())) {
+					J9Object *value = classPtr->classObject;
+					markObject(env, value);
+					rememberReferenceIfRequired(env, classObject, value);
 				}
 			}
 			classPtr = classPtr->replacedClass;


### PR DESCRIPTION
- Refactor both iterators' nextSlot() method to return class
address (J9Class *) instead of class slot address (J9Class **).
- Changed all uses of the iterators to fit the new changes.
- Disabled CheckError in CheckEngine as it is only place in code
that requires classSlots, but would not work with new signature of
the iterators

Signed-off-by: Oussama Saoudi <oussama.saoudi@ibm.com>