### PR TITLE
Add JITServer support for new invokedynamic and invokehandle

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -556,22 +556,6 @@ J9::SymbolReferenceTable::findOrCreateMethodTypeTableEntrySymbol(TR::ResolvedMet
    return symRef;
    }
 
-#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
-TR::SymbolReference *
-J9::SymbolReferenceTable::refineInvokeCacheElementSymRefWithKnownObjectIndex(TR::SymbolReference * originalSymRef, uintptr_t arrayElementRef)
-   {
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
-   TR_ASSERT(fej9->haveAccess(), "Require VM access to be acquired by caller");
-   TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
-   if (!knot) return originalSymRef;
-   TR::KnownObjectTable::Index arrayElementKnotIndex = TR::KnownObjectTable::UNKNOWN;
-   arrayElementKnotIndex = knot->getOrCreateIndex(arrayElementRef);
-   TR::SymbolReference *newRef = findOrCreateSymRefWithKnownObject(originalSymRef, arrayElementKnotIndex);
-   return newRef;
-   }
-
-#endif
-
 TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateVarHandleMethodTypeTableEntrySymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex)
    {

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -108,14 +108,6 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    TR::SymbolReference * findOrCreateHandleMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, bool * unresolvedInCP = 0);
    TR::SymbolReference * findOrCreateHandleMethodSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, char *signature);
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
-   /**
-    * \brief
-    *    Refines invokeCache element symRef with known object index for invokehandle and invokedynamic bytecode
-    *
-    * \param originalSymRef the original symref to refine
-    * \param arrayElementRef the array element ref
-    * \return TR::SymbolReference* the refined symRef
-    */
    TR::SymbolReference * refineInvokeCacheElementSymRefWithKnownObjectIndex(TR::SymbolReference * originalSymRef, uintptr_t arrayElementRef);
 
 #endif

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -777,27 +777,52 @@ public:
     *    Return MemberName.vmtarget, a J9method pointer for method represented by `memberName`
     *    Caller must acquire VM access
     */
-   TR_OpaqueMethodBlock* targetMethodFromMemberName(uintptr_t memberName);
+   virtual TR_OpaqueMethodBlock* targetMethodFromMemberName(uintptr_t memberName);
    /*
     * \brief
     *    Return MemberName.vmtarget, a J9method pointer for method represented by `memberName`
     *    VM access is not required
     */
-   TR_OpaqueMethodBlock* targetMethodFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
+   virtual TR_OpaqueMethodBlock* targetMethodFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
    /*
     * \brief
     *    Return MethodHandle.form.vmentry.vmtarget, J9method for the underlying java method
     *    The J9Method is the target to be invoked intrinsically by MethodHandle.invokeBasic
     *    Caller must acquire VM access
     */
-   TR_OpaqueMethodBlock* targetMethodFromMethodHandle(uintptr_t methodHandle);
+   virtual TR_OpaqueMethodBlock* targetMethodFromMethodHandle(uintptr_t methodHandle);
    /*
     * \brief
     *    Return MethodHandle.form.vmentry.vmtarget, J9method for the underlying java method
     *    The J9Method is the target to be invoked intrinsically by MethodHandle.invokeBasic
     *    VM access is not required
     */
-   TR_OpaqueMethodBlock* targetMethodFromMethodHandle(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
+   virtual TR_OpaqueMethodBlock* targetMethodFromMethodHandle(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
+
+   /*
+    * \brief
+    *    Create and return a resolved method from member name index of an invoke cache array.
+    *    Encapsulates code that requires VM access to make JITServer support easier.
+    */
+   virtual TR_ResolvedMethod* targetMethodFromInvokeCacheArrayMemberNameObj(TR::Compilation *comp, TR_ResolvedMethod *owningMethod, uintptr_t *invokeCacheArray);
+
+   /*
+    * \brief
+    *    Return a Known Object Table index of an invoke cache array appendix element.
+    *    Encapsulates code that requires VM access to make JITServer support easier.
+    */
+   virtual TR::KnownObjectTable::Index getKnotIndexOfInvokeCacheArrayAppendixElement(TR::Compilation *comp, uintptr_t *invokeCacheArray);
+
+   /**
+    * \brief
+    *    Refines invokeCache element symRef with known object index for invokehandle and invokedynamic bytecode
+    *
+    * \param comp the compilation object
+    * \param originalSymRef the original symref to refine
+    * \param invokeCacheArray the array containing the element we use to get known object index
+    * \return TR::SymbolReference* the refined symRef
+    */
+   virtual TR::SymbolReference* refineInvokeCacheElementSymRefWithKnownObjectIndex(TR::Compilation *comp, TR::SymbolReference *originalSymRef, uintptr_t *invokeCacheArray);
 
    /*
     * \brief

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -123,6 +123,13 @@ TR_J9ServerVM::createResolvedMethod(TR_Memory * trMemory, TR_OpaqueMethodBlock *
    }
 
 TR_ResolvedMethod *
+TR_J9ServerVM::createResolvedMethod(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod,
+                                    TR_ResolvedMethod * owningMethod, const TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_OpaqueClassBlock *classForNewInstance)
+   {
+   return createResolvedMethodWithSignature(trMemory, aMethod, classForNewInstance, NULL, -1, owningMethod, methodInfo);
+   }
+
+TR_ResolvedMethod *
 TR_J9ServerVM::createResolvedMethodWithSignature(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_OpaqueClassBlock *classForNewInstance,
                                                  char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod)
    {
@@ -143,6 +150,38 @@ TR_J9ServerVM::createResolvedMethodWithSignature(TR_Memory * trMemory, TR_Opaque
    else
       {
       result = new (trMemory->trHeapMemory()) TR_ResolvedJ9JITServerMethod(aMethod, this, trMemory, owningMethod);
+      if (classForNewInstance)
+         {
+         result->setClassForNewInstance((J9Class*)classForNewInstance);
+         TR_ASSERT(result->isNewInstanceImplThunk(), "createResolvedMethodWithSignature: if classForNewInstance is given this must be a thunk");
+         }
+      }
+   if (signature)
+      result->setSignature(signature, signatureLength, trMemory);
+   return result;
+   }
+
+TR_ResolvedMethod *
+TR_J9ServerVM::createResolvedMethodWithSignature(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_OpaqueClassBlock *classForNewInstance,
+                                                 char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod, const TR_ResolvedJ9JITServerMethodInfo &methodInfo)
+   {
+   TR_ResolvedJ9Method *result = NULL;
+   if (_compInfoPT->getCompilation()->compileRelocatableCode())
+      {
+#if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT)
+      result = new (trMemory->trHeapMemory()) TR_ResolvedRelocatableJ9JITServerMethod(aMethod, this, trMemory, methodInfo, owningMethod);
+      TR::Compilation *comp = _compInfoPT->getCompilation();
+      if (comp && comp->getOption(TR_UseSymbolValidationManager))
+         {
+         TR::SymbolValidationManager *svm = comp->getSymbolValidationManager();
+         if (!svm->isAlreadyValidated(result->containingClass()))
+            return NULL;
+         }
+#endif
+      }
+   else
+      {
+      result = new (trMemory->trHeapMemory()) TR_ResolvedJ9JITServerMethod(aMethod, this, trMemory, methodInfo, owningMethod);
       if (classForNewInstance)
          {
          result->setClassForNewInstance((J9Class*)classForNewInstance);
@@ -2002,6 +2041,102 @@ TR_J9ServerVM::getHighTenureAddress()
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    return _compInfoPT->getClientData()->getOrCacheVMInfo(stream)->_highTenureAddress;
    }
+
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+TR_OpaqueMethodBlock*
+TR_J9ServerVM::targetMethodFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex)
+   {
+   auto knot = comp->getKnownObjectTable();
+   if (objIndex != TR::KnownObjectTable::UNKNOWN &&
+       knot &&
+       !knot->isNull(objIndex))
+      {
+      JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+      stream->write(JITServer::MessageType::VM_targetMethodFromMemberName, objIndex);
+      return std::get<0>(stream->read<TR_OpaqueMethodBlock *>());
+      }
+   return NULL;
+   }
+
+TR_OpaqueMethodBlock*
+TR_J9ServerVM::targetMethodFromMemberName(uintptr_t memberName)
+   {
+   TR_ASSERT_FATAL(false, "targetMethodFromMemberName must not be called on JITServer");
+   return NULL;
+   }
+
+TR_OpaqueMethodBlock*
+TR_J9ServerVM::targetMethodFromMethodHandle(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex)
+   {
+   auto knot = comp->getKnownObjectTable();
+   if (objIndex != TR::KnownObjectTable::UNKNOWN &&
+       knot &&
+       !knot->isNull(objIndex))
+      {
+      JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+      stream->write(JITServer::MessageType::VM_targetMethodFromMethodHandle, objIndex);
+      return std::get<0>(stream->read<TR_OpaqueMethodBlock *>());
+      }
+   return NULL;
+   }
+
+TR_OpaqueMethodBlock*
+TR_J9ServerVM::targetMethodFromMethodHandle(uintptr_t methodHandle)
+   {
+   TR_ASSERT_FATAL(false, "targetMethodFromMethodHandle must not be called on JITServer");
+   return NULL;
+   }
+
+TR::KnownObjectTable::Index
+TR_J9ServerVM::getKnotIndexOfInvokeCacheArrayAppendixElement(TR::Compilation *comp, uintptr_t *invokeCacheArray)
+   {
+   TR::KnownObjectTable *knot = comp->getOrCreateKnownObjectTable();
+   if (!knot) return TR::KnownObjectTable::UNKNOWN;
+
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(
+      JITServer::MessageType::VM_getKnotIndexOfInvokeCacheArrayAppendixElement,
+      invokeCacheArray
+      );
+   auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t *>();
+   TR::KnownObjectTable::Index idx = std::get<0>(recv);
+   knot->updateKnownObjectTableAtServer(idx, std::get<1>(recv));
+   return idx;
+   }
+
+TR_ResolvedMethod *
+TR_J9ServerVM::targetMethodFromInvokeCacheArrayMemberNameObj(TR::Compilation *comp, TR_ResolvedMethod *owningMethod, uintptr_t *invokeCacheArray)
+   {
+   TR_OpaqueMethodBlock *targetMethodObj = 0;
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(
+      JITServer::MessageType::VM_targetMethodFromInvokeCacheArrayMemberNameObj,
+      static_cast<TR_ResolvedJ9JITServerMethod *>(owningMethod)->getRemoteMirror(),
+      invokeCacheArray
+      );
+   auto recv = stream->read<TR_OpaqueMethodBlock*, TR_ResolvedJ9JITServerMethodInfo>();
+   targetMethodObj = std::get<0>(recv);
+   auto &methodInfo = std::get<1>(recv);
+   return createResolvedMethod(comp->trMemory(), targetMethodObj, owningMethod, methodInfo);
+   }
+
+TR::SymbolReference*
+TR_J9ServerVM::refineInvokeCacheElementSymRefWithKnownObjectIndex(TR::Compilation *comp, TR::SymbolReference *originalSymRef, uintptr_t *invokeCacheArray)
+   {
+   TR::KnownObjectTable *knot = comp->getOrCreateKnownObjectTable();
+   if (!knot) return originalSymRef;
+
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(
+      JITServer::MessageType::VM_refineInvokeCacheElementSymRefWithKnownObjectIndex,
+      invokeCacheArray
+      );
+   auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t *>();
+   TR::KnownObjectTable::Index idx = std::get<0>(recv);
+   knot->updateKnownObjectTableAtServer(idx, std::get<1>(recv));
+   return comp->getSymRefTab()->findOrCreateSymRefWithKnownObject(originalSymRef, idx);
+   }
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 bool
 TR_J9SharedCacheServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT)

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -24,6 +24,7 @@
 #define VMJ9SERVER_H
 
 #include "env/VMJ9.h"
+#include "env/j9methodServer.hpp"
 
 /**
  * @class TR_J9ServerVM
@@ -61,8 +62,9 @@ public:
    virtual bool isSameOrSuperClass(J9Class *superClass, J9Class *subClass) override;
    virtual TR::Method * createMethod(TR_Memory *, TR_OpaqueClassBlock *, int32_t) override;
    virtual TR_ResolvedMethod * createResolvedMethod(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_ResolvedMethod * owningMethod, TR_OpaqueClassBlock *classForNewInstance) override;
-   virtual TR_ResolvedMethod * createResolvedMethodWithSignature(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_OpaqueClassBlock *classForNewInstance,
-                                                                 char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod) override;
+   TR_ResolvedMethod * createResolvedMethod(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_ResolvedMethod * owningMethod, const TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_OpaqueClassBlock *classForNewInstance = NULL);
+   virtual TR_ResolvedMethod * createResolvedMethodWithSignature(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_OpaqueClassBlock *classForNewInstance, char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod) override;
+   TR_ResolvedMethod * createResolvedMethodWithSignature(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_OpaqueClassBlock *classForNewInstance, char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod, const TR_ResolvedJ9JITServerMethodInfo &methodInfo);
    virtual TR_YesNoMaybe isInstanceOf(TR_OpaqueClassBlock * a, TR_OpaqueClassBlock *b, bool objectTypeIsFixed, bool castTypeIsFixed = true, bool optimizeForAOT = false) override;
    virtual TR_OpaqueClassBlock * getSystemClassFromClassName(const char * name, int32_t length, bool isVettedForAOT = false) override;
    virtual TR_OpaqueClassBlock * getByteArrayClass() override;
@@ -203,6 +205,17 @@ public:
    virtual bool getNurserySpaceBounds(uintptr_t *base, uintptr_t *top) override;
    virtual UDATA getLowTenureAddress() override;
    virtual UDATA getHighTenureAddress() override;
+
+   // Openjdk implementation
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+   virtual TR_OpaqueMethodBlock* targetMethodFromMemberName(uintptr_t memberName) override;
+   virtual TR_OpaqueMethodBlock* targetMethodFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex) override;
+   virtual TR_OpaqueMethodBlock* targetMethodFromMethodHandle(uintptr_t methodHandle) override;
+   virtual TR_OpaqueMethodBlock* targetMethodFromMethodHandle(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex) override;
+   virtual TR_ResolvedMethod *targetMethodFromInvokeCacheArrayMemberNameObj(TR::Compilation *comp, TR_ResolvedMethod *owningMethod, uintptr_t *invokeCacheArray) override;
+   virtual TR::KnownObjectTable::Index getKnotIndexOfInvokeCacheArrayAppendixElement(TR::Compilation *comp, uintptr_t *invokeCacheArray) override;
+   virtual TR::SymbolReference* refineInvokeCacheElementSymRefWithKnownObjectIndex(TR::Compilation *comp, TR::SymbolReference *originalSymRef, uintptr_t *invokeCacheArray) override;
+#endif
 
 private:
    bool instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* castClass, bool cacheUpdate);

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3463,12 +3463,12 @@ TR_J9ByteCodeIlGenerator::loadInvokeCacheArrayElements(TR::SymbolReference *tabl
       // the object reference of the appendix object from the invokeCacheArray entry
       TR_ResolvedJ9Method* owningMethod = static_cast<TR_ResolvedJ9Method *>(_methodSymbol->getResolvedMethod());
       TR::Node * appendixNode = _stack->top();
-      TR::SymbolReference * appendixSymRef = NULL;
-         {
-         TR::VMAccessCriticalSection vmAccess(fej9());
-         uintptr_t arrayElementRef = (uintptr_t) fej9()->getReferenceElement(*invokeCacheArray, JSR292_invokeCacheArrayAppendixIndex); // this will not work in AOT and JITServer
-         appendixSymRef = symRefTab()->refineInvokeCacheElementSymRefWithKnownObjectIndex(appendixNode->getSymbolReference(), arrayElementRef);
-         }
+      TR::SymbolReference * appendixSymRef = 
+         fej9()->refineInvokeCacheElementSymRefWithKnownObjectIndex(
+                  comp(),
+                  appendixNode->getSymbolReference(),
+                  invokeCacheArray
+                  );
       appendixNode->setSymbolReference(appendixSymRef);
       }
    }

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -102,7 +102,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 22;
+   static const uint16_t MINOR_NUMBER = 23;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -182,6 +182,11 @@ enum MessageType : uint16_t
    VM_stackWalkerMaySkipFramesSVM,
    VM_getFields,
    VM_increaseOSRGlobalBufferSize,
+   VM_targetMethodFromMemberName,
+   VM_targetMethodFromMethodHandle,
+   VM_getKnotIndexOfInvokeCacheArrayAppendixElement,
+   VM_targetMethodFromInvokeCacheArrayMemberNameObj,
+   VM_refineInvokeCacheElementSymRefWithKnownObjectIndex,
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled,
@@ -419,6 +424,11 @@ static const char *messageNames[] =
    "VM_stackWalkerMaySkipFramesSVM",
    "VM_getFields",
    "VM_increaseOSRGlobalBufferSize",
+   "VM_targetMethodFromMemberName",
+   "VM_targetMethodFromMethodHandle",
+   "VM_getKnotIndexOfInvokeCacheArrayAppendixElement",
+   "VM_targetMethodFromInvokeCacheArrayMemberNameObj",
+   "VM_refineInvokeCacheElementSymRefWithKnownObjectIndex",
    "CompInfo_isCompiled",
    "CompInfo_getPCIfCompiled",
    "CompInfo_getInvocationCount",


### PR DESCRIPTION
This enables JITServer support for #10607.
Parts of the new Method Handle code require holding
VM access in the JIT, so to make it work on JITServer,
all such code has been wrapped in front-end calls.
When executed on the server, these front-end queries will
send a message to the client, which will do the required
work while holding VM access and send the result to the server.

This commit also refactors
`TR_ResolvedJ9JITServerMethod::getResolvedHandle(Dynamic)Method` to
make it compatible with the new method handle implementation
and adds a server-side version of `createResolvedMethod(WithSignature)`
that takes `TR_ResolvedJ9JITServerMethodInfo` as parameter, allowing
to create a resolved method without a remote call if we already
prefetched the method info.