### PR TITLE
Exclude jdk8 special.system for Mac and Windows

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -555,6 +555,8 @@ x86-64_windows:
   build_env:
     vars: 'PATH+TOOLS=/cygdrive/c/openjdk/LLVM64/bin:/cygdrive/c/openjdk/nasm-2.13.03'
   excluded_tests:
+    8:
+      - special.system
     11:
       - special.system
 #========================================#
@@ -644,6 +646,8 @@ x86-64_mac:
   build_env:
     vars: 'OPENJ9_JAVA_OPTIONS=-Xdump:system+java:events=systhrow,filter=java/lang/ClassCastException,request=exclusive+prepwalk+preempt'
   excluded_tests:
+    8:
+      - special.system
     11:
       - special.system
 #========================================#


### PR DESCRIPTION
This is configuration for the nightly builds. With mixed builds taking
more time to run other test suites, the available machine capacity can't
handle running special.system as well.

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>