### PR TITLE
Update "!shrc stats" test to check for 4+ orphan classes

### DIFF
--- a/test/functional/cmdLineTests/shrcdbgddrext/shrcdbgextddrtests.xml
+++ b/test/functional/cmdLineTests/shrcdbgddrext/shrcdbgextddrtests.xml
@@ -139,7 +139,11 @@
                 <input>!shrc stats</input>
                 <input>quit</input>
         </command>
-  <output regex="no" type="success" >4 orphans</output>
+  <!-- 
+  Regex (>= 4) added for the success condition since there are additional
+  java/lang/invoke/BoundMethodHandle$Species orphan classes in OJDK MH builds.
+  -->
+  <output regex="yes" javaUtilPattern="yes" type="success" >([4-9]|[1-9][0-9]+) orphans</output>
   <output regex="no" type="failure">no shared cache</output>
   <output regex="no" type="failure">unable to read</output>
   <output regex="no" type="failure">could not read</output>


### PR DESCRIPTION
With OJDK MH, the number of orphan classes can vary between JDK
versions. Currently, the `!shrc stats` test checks that the number of
orphan classes are `4`. To accommodate OJDK MHs, the success condition for
the test has been updated to check for `>= 4` orphan classes.


Fixes: https://github.com/eclipse/openj9/issues/11940

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>