### PR TITLE
Try to ensure the same options are used for jitdump compilations

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8214,29 +8214,6 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                options->setOption(TR_UseSymbolValidationManager, false);
                }
 
-            // Set JitDump specific options
-            if (details.isJitDumpMethod() && options->getDebug())
-               {
-               options->setOption(TR_TraceAll);
-               options->setOption(TR_EnableParanoidOptCheck);
-
-               // Trace crashing optimization or the codegen depending on where we crashed
-               UDATA vmState = that->_compInfo.getVMStateOfCrashedThread();
-               if ((vmState & J9VMSTATE_JIT_CODEGEN) == J9VMSTATE_JIT_CODEGEN)
-                  {
-                  options->setOption(TR_TraceCG);
-                  options->setOption(TR_TraceRA);
-                  }
-               else if ((vmState & J9VMSTATE_JIT_OPTIMIZER) == J9VMSTATE_JIT_OPTIMIZER)
-                  {
-                  OMR::Optimizations opt = static_cast<OMR::Optimizations>((vmState & 0xFF00) >> 8);
-                  if (0 < opt && opt < OMR::numOpts)
-                     {
-                     options->enableTracing(opt);
-                     }
-                  }
-               }
-
             // Adjust Options for AOT compilation
             if (vm->isAOT_DEPRECATED_DO_NOT_USE())
                {
@@ -8611,6 +8588,66 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
 
             TR_ASSERT(TR::comp() == NULL, "there seems to be a current TLS TR::Compilation object %p for this thread. At this point there should be no current TR::Compilation object", TR::comp());
 
+            }
+
+         // Finally, set JitDump specific options as the last step of options adjustments
+         if (details.isJitDumpMethod() && options->getDebug())
+            {
+            auto jitDumpDetails = static_cast<J9::JitDumpMethodDetails&>(details);
+            if (jitDumpDetails.getOptionsFromOriginalCompile() != NULL)
+               {
+               // We have the original `TR::Options` from the crashed compilation. The above logic which adjusts
+               // various options is timing sensitive, and can be dependent on the VM state (startup vs not), which
+               // can drastically change how the compilation looks (ex. is NextGenHCR enabled, is SVM to be used).
+               //
+               // Ideally we would just copy construct the current options from the original crashed compile, however
+               // this is currently not possible. Although a copy constructor exists, it is not a good idea to use it
+               // here due to a number of problems:
+               //
+               // 1. The non-copy constructor takes care of initializing tracing, among other things, which may have
+               //    not been active on the original compilation. There is currently no easy way for us to reinitialize
+               //    such logic.
+               //
+               // 2. Options can be set at any point during the compilation, and decisions to set options can be based
+               //    off of whether other options are set or not. This is very problematic. For example during the
+               //    original compilation we may have set option A at some point X during the compilation thus changing
+               //    the value of that option from that point onward. This means that if we were to copy construct the
+               //    set of options from the original compile right here for the JitDump compilation then option A
+               //    would yield a different value from the start of the compilation until point X.
+               //
+               // This should eventually be improved if the options framework is ever simplified to contain only option
+               // values, not things like optimization plans, start PCs, compile thread IDs, etc.
+               //
+               // Because of this limitation we do our best to only copy options which are known to be timing sensitive
+               // and that could change between the JitDump compilation and the original compilation. This is not a
+               // silver bullet, and should be updated as we encounter more sources of non-determinism for JitDump
+               // recompilation.
+
+               TR::Options* optionsFromOriginalCompile = jitDumpDetails.getOptionsFromOriginalCompile();
+
+               options->setOption(TR_UseSymbolValidationManager, optionsFromOriginalCompile->getOption(TR_UseSymbolValidationManager));
+               options->setOption(TR_DisableGuardedCountingRecompilations, optionsFromOriginalCompile->getOption(TR_DisableGuardedCountingRecompilations));
+               options->setOption(TR_DisableNextGenHCR, optionsFromOriginalCompile->getOption(TR_DisableNextGenHCR));
+               }
+
+            options->setOption(TR_TraceAll);
+            options->setOption(TR_EnableParanoidOptCheck);
+
+            // Trace crashing optimization or the codegen depending on where we crashed
+            UDATA vmState = that->_compInfo.getVMStateOfCrashedThread();
+            if ((vmState & J9VMSTATE_JIT_CODEGEN) == J9VMSTATE_JIT_CODEGEN)
+               {
+               options->setOption(TR_TraceCG);
+               options->setOption(TR_TraceRA);
+               }
+            else if ((vmState & J9VMSTATE_JIT_OPTIMIZER) == J9VMSTATE_JIT_OPTIMIZER)
+               {
+               OMR::Optimizations opt = static_cast<OMR::Optimizations>((vmState & 0xFF00) >> 8);
+               if (0 < opt && opt < OMR::numOpts)
+                  {
+                  options->enableTracing(opt);
+                  }
+               }
             }
 
          // In JITServer, we would like to use JITClient's processor info for the compilation

--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -286,6 +286,7 @@ static TR_CompilationErrorCode recompileMethodForLog(
    TR::CompilationInfo *compInfo,
    TR_Hotness          optimizationLevel,
    bool                profilingCompile,
+   TR::Options         *optionsFromOriginalCompile,
    bool                aotCompile,
    void               *oldStartPC,
    TR::FILE *logFile
@@ -326,7 +327,7 @@ static TR_CompilationErrorCode recompileMethodForLog(
    // TODO: this is indiscriminately compiling as J9::DumpMethodRequest, which is wrong;
    //       should be fixed by checking if the method is indeed DLT, and compiling DLT if so
       {
-      J9::JitDumpMethodDetails details(ramMethod, aotCompile);
+      J9::JitDumpMethodDetails details(ramMethod, optionsFromOriginalCompile, aotCompile);
       compInfo->compileMethod(vmThread, details, oldStartPC, TR_no, &compErrCode, &successfullyQueued, plan);
       }
 
@@ -607,6 +608,7 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
                   compInfo,
                   jittedMethodsOnStack[i]._optLevel,
                   false,
+                  NULL,
                   isAOTBody,
                   startPC,
                   logFile
@@ -687,6 +689,7 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
                         compInfo,
                         (TR_Hotness)comp->getOptLevel(),
                         comp->isProfilingCompilation(),
+                        comp->getOptions(),
                         comp->compileRelocatableCode(),
                         oldStartPC,
                         logFile

--- a/runtime/compiler/ilgen/IlGeneratorMethodDetails.hpp
+++ b/runtime/compiler/ilgen/IlGeneratorMethodDetails.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,16 +65,21 @@ class JitDumpMethodDetails : public TR::IlGeneratorMethodDetails
    // Objects cannot hold data of its own: must store in the _data union in TR::IlGeneratorMethodDetails
 
 public:
-   JitDumpMethodDetails(J9Method* method, bool aotCompile) : TR::IlGeneratorMethodDetails(method)
+   JitDumpMethodDetails(J9Method* method, TR::Options* optionsFromOriginalCompile, bool aotCompile)
+      : TR::IlGeneratorMethodDetails(method)
       {
+      _optionsFromOriginalCompile = optionsFromOriginalCompile;
       _data._aotCompile = aotCompile;
       }
-   JitDumpMethodDetails(const JitDumpMethodDetails& other) : TR::IlGeneratorMethodDetails(other.getMethod())
+      
+   JitDumpMethodDetails(const JitDumpMethodDetails& other)
+      : TR::IlGeneratorMethodDetails(other.getMethod())
       {
+      _optionsFromOriginalCompile = other._optionsFromOriginalCompile;
       _data._aotCompile = other._data._aotCompile;
       }
 
-   virtual const char * name()     const { return "DumpMethod"; }
+   virtual const char * name()     const { return "JitDumpMethod"; }
 
    virtual bool isOrdinaryMethod()   const { return false; }
    virtual bool isJitDumpMethod()    const { return true; }
@@ -87,6 +92,18 @@ public:
       }
 
    virtual bool supportsInvalidation() { return false; }
+
+   /**
+    * \brief
+    * Gets the options used in the original compilation which we are trying to reproduce.
+    * 
+    * \returns
+    * The options from the original compile if it exists; \c NULL otherwise.
+    */
+   TR::Options* getOptionsFromOriginalCompile() const
+      {
+      return _optionsFromOriginalCompile;
+      }
    };
 
 

--- a/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.hpp
+++ b/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,9 +35,10 @@ namespace J9 { typedef J9::IlGeneratorMethodDetails IlGeneratorMethodDetailsConn
 #include "ilgen/OMRIlGeneratorMethodDetails.hpp"
 
 #include <stdint.h>
-#include "infra/Annotations.hpp"
+#include "control/Options.hpp"
 #include "env/IO.hpp"
 #include "env/jittypes.h"
+#include "infra/Annotations.hpp"
 
 class J9Class;
 class J9Method;
@@ -156,6 +157,8 @@ protected:
       bool _aotCompile;
       } _data;
 
+   /// A cached options object from the original (crashed) compilation thread
+   TR::Options *_optionsFromOriginalCompile;
    };
 
 // Replay compilation support that must not be used by anyone else because it breaks encapsulation


### PR DESCRIPTION
We have the original `TR::Options` from the crashed compilation. The
above logic which adjusts various options is timing sensitive, and
can be dependent on the VM state (startup vs not), which can
drastically change how the compilation looks (ex. is NextGenHCR
enabled, is SVM to be used).

Ideally we would just copy construct the current options from the
original crashed compile, however this is currently not possible.
Although a copy constructor exists, it is not a good idea to use it
here due to a number of problems:

1. The non-copy constructor takes care of initializing tracing, among
   other things, which may have not been active on the original
   compilation. There is currently no easy way for us to reinitialize
   such logic.

2. Options can be set at any point during the compilation, and
   decisions to set options can be based off of whether other options
   are set or not. This is very problematic. For example during the
   original compilation we may have set option A at some point X
   during the compilation thus changing the value of that option from
   that point onward. This means that if we were to copy construct
   the set of options from the original compile right here for the
   JitDump compilation then option A would yield a different value
   from the start of the compilation until point X.

This should eventually be improved if the options framework is ever
simplified to contain only option values, not things like
optimization plans, start PCs, compile thread IDs, etc.

Because of this limitation we do our best to only copy options which
are known to be timing sensitive and that could change between the
JitDump compilation and the original compilation. This is not a
silver bullet, and should be updated as we encounter more sources of
non-determinism for JitDump recompilation.

Closes: #9137

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>