### PR TITLE
Fix Windows compile error for OJDK MH build

### DIFF
--- a/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
+++ b/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
@@ -314,7 +314,7 @@ getSignatureFromMethodType(J9VMThread *currentThread, j9object_t typeObject, UDA
 
 	/* Copy class signatures to descriptor string */
 	for (U_32 i = 0; i < numArgs; i++) {
-		U_32 len = strlen(signatures[i]);
+		UDATA len = strlen(signatures[i]);
 		strncpy(cursor, signatures[i], len);
 		cursor += len;
 	}

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -362,25 +362,10 @@ omr_add_exports(jclse
 	Java_java_lang_Thread_stopImpl
 	Java_java_lang_Thread_suspendImpl
 	Java_java_lang_Thread_yield
-	Java_java_lang_invoke_InterfaceHandle_registerNatives
 	Java_java_lang_invoke_MethodHandleResolver_getCPClassNameAt
 	Java_java_lang_invoke_MethodHandleResolver_getCPMethodHandleAt
 	Java_java_lang_invoke_MethodHandleResolver_getCPMethodTypeAt
 	Java_java_lang_invoke_MethodHandleResolver_getCPTypeAt
-	Java_java_lang_invoke_MethodHandle_invoke
-	Java_java_lang_invoke_MethodHandle_invokeExact
-	Java_java_lang_invoke_MethodHandle_requestCustomThunkFromJit
-	Java_java_lang_invoke_MethodHandle_vmRefFieldOffset
-	Java_java_lang_invoke_MethodType_makeTenured
-	Java_java_lang_invoke_MutableCallSite_freeGlobalRef
-	Java_java_lang_invoke_MutableCallSite_registerNatives
-	Java_java_lang_invoke_PrimitiveHandle_lookupField
-	Java_java_lang_invoke_PrimitiveHandle_lookupMethod
-	Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromConstructor
-	Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromField
-	Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromMethod
-	Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromSpecialHandle
-	Java_java_lang_invoke_ThunkTuple_registerNatives
 	Java_java_lang_ref_Finalizer_runAllFinalizersImpl
 	Java_java_lang_ref_Finalizer_runFinalizationImpl
 	Java_java_lang_ref_Reference_reprocess
@@ -450,6 +435,26 @@ omr_add_exports(jclse
 	Java_sun_reflect_ConstantPool_getStringAt0
 	Java_sun_reflect_ConstantPool_getUTF8At0
 )
+
+if(J9VM_OPT_METHOD_HANDLE)
+	omr_add_exports(jclse
+		Java_java_lang_invoke_InterfaceHandle_registerNatives
+		Java_java_lang_invoke_MethodHandle_invoke
+		Java_java_lang_invoke_MethodHandle_invokeExact
+		Java_java_lang_invoke_MethodHandle_requestCustomThunkFromJit
+		Java_java_lang_invoke_MethodHandle_vmRefFieldOffset
+		Java_java_lang_invoke_MethodType_makeTenured
+		Java_java_lang_invoke_MutableCallSite_freeGlobalRef
+		Java_java_lang_invoke_MutableCallSite_registerNatives
+		Java_java_lang_invoke_PrimitiveHandle_lookupField
+		Java_java_lang_invoke_PrimitiveHandle_lookupMethod
+		Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromConstructor
+		Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromField
+		Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromMethod
+		Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromSpecialHandle
+		Java_java_lang_invoke_ThunkTuple_registerNatives
+	)
+endif()
 
 if(J9VM_OPT_SIDECAR)
 	omr_add_exports(jclse
@@ -527,6 +532,9 @@ if(NOT JAVA_SPEC_VERSION LESS 9)
 			Java_java_lang_invoke_FieldVarHandle_lookupField
 			Java_java_lang_invoke_FieldVarHandle_unreflectField
 		)
+		if(J9VM_OPT_PANAMA)
+			omr_add_exports(jclse Java_java_lang_invoke_MethodHandles_findNativeAddress)
+		endif()
 	endif()
 
 	omr_add_exports(jclse
@@ -569,9 +577,6 @@ if(NOT JAVA_SPEC_VERSION LESS 9)
 		Java_jdk_internal_reflect_ConstantPool_getNameAndTypeRefInfoAt0
 		Java_jdk_internal_reflect_ConstantPool_getTagAt0
 	)
-	if(J9VM_OPT_PANAMA)
-		omr_add_exports(jclse Java_java_lang_invoke_MethodHandles_findNativeAddress)
-	endif()
 endif()
 
 # java 11+
@@ -588,8 +593,12 @@ if(NOT JAVA_SPEC_VERSION LESS 15)
 	omr_add_exports(jclse
 		Java_java_lang_Class_isHiddenImpl
 		Java_java_lang_ClassLoader_defineClassImpl1
-		Java_java_lang_invoke_MethodHandleNatives_checkClassBytes
 	)
+	if(J9VM_OPT_METHOD_HANDLE)
+		omr_add_exports(jclse
+			Java_java_lang_invoke_MethodHandleNatives_checkClassBytes
+		)
+	endif()
 endif()
 
 # java 16+

--- a/runtime/jcl/module.xml
+++ b/runtime/jcl/module.xml
@@ -23,6 +23,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 <module xmlns:xi="http://www.w3.org/2001/XInclude">
 
 	<xi:include href="uma/java_lang_invoke_MethodHandleNatives_exports.xml"></xi:include>
+	<xi:include href="uma/java_dyn_methodhandle_exports.xml"></xi:include>
 	<xi:include href="uma/sun_misc_Unsafe_exports.xml"></xi:include>
 	<xi:include href="uma/unsafemem_inl_exports.xml"></xi:include>
 	<xi:include href="uma/se6_vm-side_natives_exports.xml"></xi:include>
@@ -45,6 +46,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	</xi:include>
 
 	<xi:include href="uma/java_lang_invoke_MethodHandleNatives_objects.xml"></xi:include>
+	<xi:include href="uma/java_dyn_methodhandle_objects.xml"></xi:include>
 	<xi:include href="uma/sun_misc_Unsafe_objects.xml"></xi:include>
 	<xi:include href="uma/se6_vm-side_natives_objects.xml"></xi:include>
 	<xi:include href="uma/se6_vm-side_lifecycle_objects.xml"></xi:include>
@@ -84,6 +86,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group name="se6_vm-side_natives"/>
 			<group name="java_lang_invoke_MethodHandleNatives">
 				<include-if condition="spec.flags.opt_openjdkMethodhandle"/>
+			</group>
+			<group name="java_dyn_methodhandle">
+				<include-if condition="spec.flags.opt_methodHandle"/>
 			</group>
 			<group name="jithelpers"/>
 			<group name="sun_misc_Unsafe"/>
@@ -150,6 +155,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group name="se6_vm-side_natives"/>
 			<group name="java_lang_invoke_MethodHandleNatives">
 				<include-if condition="spec.flags.opt_openjdkMethodhandle"/>
+			</group>
+			<group name="java_dyn_methodhandle">
+				<include-if condition="spec.flags.opt_methodHandle"/>
 			</group>
 			<group name="jithelpers"/>
 			<group name="sun_misc_Unsafe"/>

--- a/runtime/jcl/uma/java_dyn_methodhandle_exports.xml
+++ b/runtime/jcl/uma/java_dyn_methodhandle_exports.xml
@@ -1,0 +1,38 @@
+<!-- 
+	Copyright (c) 2021, 2021 IBM Corp. and others
+	
+	This program and the accompanying materials are made available under
+	the terms of the Eclipse Public License 2.0 which accompanies this
+	distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+	or the Apache License, Version 2.0 which accompanies this distribution and
+	is available at https://www.apache.org/licenses/LICENSE-2.0.
+	
+	This Source Code may also be made available under the following
+	Secondary Licenses when the conditions for such availability set
+	forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+	General Public License, version 2 with the GNU Classpath
+	Exception [1] and GNU General Public License, version 2 with the
+	OpenJDK Assembly Exception [2].
+	
+	[1] https://www.gnu.org/software/classpath/license.html
+	[2] http://openjdk.java.net/legal/assembly-exception.html
+
+	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<exports group="java_dyn_methodhandle">
+	<export name="Java_java_lang_invoke_InterfaceHandle_registerNatives" />
+	<export name="Java_java_lang_invoke_MethodHandle_invoke" />
+	<export name="Java_java_lang_invoke_MethodHandle_invokeExact" />
+	<export name="Java_java_lang_invoke_MethodHandle_requestCustomThunkFromJit" />
+	<export name="Java_java_lang_invoke_MethodHandle_vmRefFieldOffset" />
+	<export name="Java_java_lang_invoke_MethodType_makeTenured" />
+	<export name="Java_java_lang_invoke_MutableCallSite_freeGlobalRef" />
+	<export name="Java_java_lang_invoke_MutableCallSite_registerNatives" />
+	<export name="Java_java_lang_invoke_PrimitiveHandle_lookupField" />
+	<export name="Java_java_lang_invoke_PrimitiveHandle_lookupMethod" />
+	<export name="Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromConstructor" />
+	<export name="Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromField" />
+	<export name="Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromMethod" />
+	<export name="Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromSpecialHandle" />
+	<export name="Java_java_lang_invoke_ThunkTuple_registerNatives" />
+</exports>

--- a/runtime/jcl/uma/java_dyn_methodhandle_objects.xml
+++ b/runtime/jcl/uma/java_dyn_methodhandle_objects.xml
@@ -1,28 +1,25 @@
 <!-- 
-	Copyright (c) 2007, 2021 IBM Corp. and others
-	
+	Copyright (c) 2021, 2021 IBM Corp. and others
 	This program and the accompanying materials are made available under
 	the terms of the Eclipse Public License 2.0 which accompanies this
 	distribution and is available at https://www.eclipse.org/legal/epl-2.0/
 	or the Apache License, Version 2.0 which accompanies this distribution and
 	is available at https://www.apache.org/licenses/LICENSE-2.0.
-	
 	This Source Code may also be made available under the following
 	Secondary Licenses when the conditions for such availability set
 	forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
 	General Public License, version 2 with the GNU Classpath
 	Exception [1] and GNU General Public License, version 2 with the
 	OpenJDK Assembly Exception [2].
-	
 	[1] https://www.gnu.org/software/classpath/license.html
 	[2] http://openjdk.java.net/legal/assembly-exception.html
-
 	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-<objects group="se7">
-	<object name="java_lang_Access" />
-	<object name="java_lang_Class" />
-	<object name="sun_misc_Perf" />
-	<object name="sun_reflect_ConstantPool" />
-	<object name="extendedosmbean" />
+<objects group="java_dyn_methodhandle">
+	<object name="java_dyn_methodhandle" >
+		<include-if condition="spec.flags.opt_methodHandle" />
+	</object>
+	<object name="java_dyn_methodtype" >
+		<include-if condition="spec.flags.opt_methodHandle" />
+	</object>
 </objects>

--- a/runtime/jcl/uma/se15_exports.xml
+++ b/runtime/jcl/uma/se15_exports.xml
@@ -1,5 +1,5 @@
 <!-- 
-Copyright (c) 2020, 2020 IBM Corp. and others
+Copyright (c) 2020, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,5 +23,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<export name="Java_java_lang_Class_permittedSubclassesImpl"/>
 	<export name="Java_java_lang_Class_isHiddenImpl"/>
 	<export name="Java_java_lang_ClassLoader_defineClassImpl1"/>
-	<export name="Java_java_lang_invoke_MethodHandleNatives_checkClassBytes"/>
+	<export name="Java_java_lang_invoke_MethodHandleNatives_checkClassBytes">
+		<include-if condition="spec.flags.opt_methodHandle" />
+	</export>
 </exports>

--- a/runtime/jcl/uma/se7_exports.xml
+++ b/runtime/jcl/uma/se7_exports.xml
@@ -1,5 +1,5 @@
 <!-- 
-	Copyright (c) 2007, 2020 IBM Corp. and others
+	Copyright (c) 2007, 2021 IBM Corp. and others
 	
 	This program and the accompanying materials are made available under
 	the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,24 +44,10 @@
 	<export name="Java_sun_reflect_ConstantPool_getDoubleAt0" />
 	<export name="Java_sun_reflect_ConstantPool_getStringAt0" />
 	<export name="Java_sun_reflect_ConstantPool_getUTF8At0" />
-	<export name="Java_java_lang_invoke_PrimitiveHandle_lookupMethod" />
-	<export name="Java_java_lang_invoke_MethodHandle_requestCustomThunkFromJit" />
-	<export name="Java_java_lang_invoke_PrimitiveHandle_lookupField" />
-	<export name="Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromField" />
-	<export name="Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromMethod" />
-	<export name="Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromConstructor" />
-	<export name="Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromSpecialHandle" />
-	<export name="Java_java_lang_invoke_MethodHandle_vmRefFieldOffset" />
-	<export name="Java_java_lang_invoke_MethodHandle_invoke" />
-	<export name="Java_java_lang_invoke_MethodHandle_invokeExact" />
 	<export name="Java_java_lang_invoke_MethodHandleResolver_getCPTypeAt" />
 	<export name="Java_java_lang_invoke_MethodHandleResolver_getCPMethodTypeAt" />
 	<export name="Java_java_lang_invoke_MethodHandleResolver_getCPMethodHandleAt" />
 	<export name="Java_java_lang_invoke_MethodHandleResolver_getCPClassNameAt" />
-	<export name="Java_java_lang_invoke_ThunkTuple_registerNatives" />
-	<export name="Java_java_lang_invoke_InterfaceHandle_registerNatives" />
-	<export name="Java_java_lang_invoke_MethodType_makeTenured" />
-	<export name="Java_java_lang_invoke_MutableCallSite_freeGlobalRef" />
 	<export name="Java_com_ibm_oti_shared_SharedAbstractHelper_getIsVerboseImpl" />
 	<export name="Java_com_ibm_oti_shared_SharedClassAbstractHelper_initializeShareableClassloaderImpl" />
 	<export name="Java_com_ibm_oti_shared_SharedClassStatistics_freeSpaceBytesImpl" />
@@ -76,7 +62,6 @@
 	<export name="Java_com_ibm_oti_shared_SharedClassURLHelperImpl_storeSharedClassImpl3" />
 	<export name="Java_com_ibm_oti_shared_SharedDataHelperImpl_findSharedDataImpl" />
 	<export name="Java_com_ibm_oti_shared_SharedDataHelperImpl_storeSharedDataImpl" />
-	<export name="Java_java_lang_invoke_MutableCallSite_registerNatives" />
 	<export name="Java_com_ibm_lang_management_internal_ExtendedOperatingSystemMXBeanImpl_getTotalProcessorUsageImpl" />
 	<export name="Java_com_ibm_lang_management_internal_ExtendedOperatingSystemMXBeanImpl_getProcessorUsageImpl" />
 	<export name="Java_com_ibm_lang_management_internal_ExtendedOperatingSystemMXBeanImpl_getMemoryUsageImpl" />

--- a/runtime/jcl/uma/se9_exports.xml
+++ b/runtime/jcl/uma/se9_exports.xml
@@ -1,5 +1,5 @@
 <!-- 
-	Copyright (c) 2016, 2020 IBM Corp. and others
+	Copyright (c) 2016, 2021 IBM Corp. and others
 	
 	This program and the accompanying materials are made available under
 	the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,6 +65,6 @@
 	<export name="Java_java_lang_StackWalker_walkWrapperImpl" />
 	<export name="Java_java_lang_StackWalker_getImpl" />
 	<export name="Java_java_lang_invoke_MethodHandles_findNativeAddress">
-		<include-if condition="spec.flags.opt_panama" />
+		<include-if condition="spec.flags.opt_panama and spec.flags.opt_methodHandle" />
 	</export>
 </exports>

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -919,36 +919,38 @@ jlong JNICALL Java_sun_misc_Perf_highResFrequency(JNIEnv *env, jobject perf);
 void JNICALL Java_jdk_internal_perf_Perf_registerNatives(JNIEnv *env, jclass clazz);
 
 /* java_dyn_methodhandle.c */
-jclass JNICALL Java_java_lang_invoke_PrimitiveHandle_lookupMethod(JNIEnv *env, jobject handle, jclass lookupClass, jstring name, jstring signature, jbyte kind, jclass specialCaller);
-void JNICALL Java_java_lang_invoke_MethodHandle_requestCustomThunkFromJit(JNIEnv* env, jobject handle, jobject thunk);
-jclass JNICALL Java_java_lang_invoke_PrimitiveHandle_lookupField(JNIEnv *env, jobject handle, jclass lookupClass, jstring name, jstring signature, jboolean isStatic, jclass accessClass);
+#if defined(J9VM_OPT_METHOD_HANDLE)
+void		JNICALL Java_java_lang_invoke_InterfaceHandle_registerNatives(JNIEnv *env, jclass nativeClass);
+jobject		JNICALL Java_java_lang_invoke_MethodHandle_invoke(JNIEnv *env, jclass ignored, jobject handle, jobject args);
+jobject		JNICALL Java_java_lang_invoke_MethodHandle_invokeExact(JNIEnv *env, jclass ignored, jobject handle, jobject args);
+void		JNICALL Java_java_lang_invoke_MethodHandle_requestCustomThunkFromJit(JNIEnv* env, jobject handle, jobject thunk);
+jint		JNICALL Java_java_lang_invoke_MethodHandle_vmRefFieldOffset(JNIEnv *env, jclass clazz, jclass ignored);
+void		JNICALL Java_java_lang_invoke_MutableCallSite_freeGlobalRef(JNIEnv *env, jclass mutableCallSite, jlong bypassOffset);
+void		JNICALL Java_java_lang_invoke_MutableCallSite_registerNatives(JNIEnv *env, jclass nativeClass);
+jclass		JNICALL Java_java_lang_invoke_PrimitiveHandle_lookupField(JNIEnv *env, jobject handle, jclass lookupClass, jstring name, jstring signature, jboolean isStatic, jclass accessClass);
+jclass		JNICALL Java_java_lang_invoke_PrimitiveHandle_lookupMethod(JNIEnv *env, jobject handle, jclass lookupClass, jstring name, jstring signature, jbyte kind, jclass specialCaller);
+jboolean	JNICALL Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromConstructor(JNIEnv *env, jclass clazz, jobject handle, jobject ctor);
+jboolean	JNICALL Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromField(JNIEnv *env, jclass clazz, jobject handle, jobject reflectField);
+jboolean	JNICALL Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromMethod(JNIEnv *env, jclass clazz, jobject handle, jclass declaringClass, jobject method, jbyte kind, jclass specialToken);
+jboolean	JNICALL Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromSpecialHandle(JNIEnv *env, jclass clazz, jobject handle, jobject specialHandle);
+void		JNICALL Java_java_lang_invoke_ThunkTuple_registerNatives(JNIEnv *env, jclass nativeClass);
+
 UDATA lookupField(JNIEnv *env, jboolean isStatic, J9Class *j9LookupClass, jstring name, J9UTF8 *sigUTF, J9Class **definingClass, UDATA *romField, jclass accessClass);
-jboolean JNICALL Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromField(JNIEnv *env, jclass clazz, jobject handle, jobject reflectField);
-jboolean JNICALL Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromMethod(JNIEnv *env, jclass clazz, jobject handle, jclass declaringClass, jobject method, jbyte kind, jclass specialToken);
-jboolean JNICALL Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromConstructor(JNIEnv *env, jclass clazz, jobject handle, jobject ctor);
-jlong JNICALL Java_java_lang_invoke_MethodHandle_findVMDispatchTarget(JNIEnv *env, jclass clazz, jint kind);
-jboolean JNICALL Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromSpecialHandle(JNIEnv *env, jclass clazz, jobject handle, jobject specialHandle);
-jint JNICALL Java_java_lang_invoke_MethodHandle_vmRefFieldOffset(JNIEnv *env, jclass clazz, jclass ignored);
-jint JNICALL Java_java_lang_invoke_MethodHandle_addressSize(JNIEnv *env, jclass clazz);
-jobject JNICALL Java_java_lang_invoke_MethodHandle_invokeExact(JNIEnv *env, jclass ignored, jobject handle, jobject args);
-jobject JNICALL Java_java_lang_invoke_MethodHandle_invokeGeneric(JNIEnv *env, jclass ignored, jobject handle, jobject args);
-jobject JNICALL Java_java_lang_invoke_MethodHandle_invoke(JNIEnv *env, jclass ignored, jobject handle, jobject args);
-void JNICALL Java_java_lang_invoke_ThunkTuple_registerNatives(JNIEnv *env, jclass nativeClass);
-void JNICALL Java_java_lang_invoke_InterfaceHandle_registerNatives(JNIEnv *env, jclass nativeClass);
-jlong JNICALL Java_java_lang_invoke_MethodHandle_vtableOffset(JNIEnv *env, jclass ignored);
-void JNICALL Java_java_lang_invoke_MutableCallSite_freeGlobalRef(JNIEnv *env, jclass mutableCallSite, jlong bypassOffset);
 void setClassLoadingConstraintLinkageError(J9VMThread *vmThread, J9Class *methodOrFieldClass, J9UTF8 *signatureUTF8);
 #ifdef J9VM_OPT_PANAMA
 extern J9_CFUNC jlong JNICALL
 Java_java_lang_invoke_MethodHandles_findNativeAddress(JNIEnv *env, jclass jlClass, jstring methodName);
 #endif
-
-/* java_dyn_methodtype.c */
-jobject JNICALL Java_java_lang_invoke_MethodType_makeTenured(JNIEnv *env, jclass clazz, jobject receiverObject);
 #if JAVA_SPEC_VERSION >= 15
 extern J9_CFUNC void JNICALL
 Java_java_lang_invoke_MethodHandleNatives_checkClassBytes(JNIEnv *env, jclass jlClass, jbyteArray classRep);
 #endif /* JAVA_SPEC_VERSION >= 15 */
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
+
+/* java_dyn_methodtype.c */
+#if defined(J9VM_OPT_METHOD_HANDLE)
+jobject JNICALL Java_java_lang_invoke_MethodType_makeTenured(JNIEnv *env, jclass clazz, jobject receiverObject);
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 
 /* java_lang_invoke_MethodHandleNatives.cpp */
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)


### PR DESCRIPTION
Fixes the compile warning (conversion from size_t to U_32) on Windows

Refactor build files for java_dyn_methodhandle/methodtype
- New uma export/object for java_dyn_methodhandle/methodtype
- clean unimplemented headers in j9protos.h:
        Java_java_lang_invoke_MethodHandle_addressSize
        Java_java_lang_invoke_MethodHandle_invokeGeneric
        Java_java_lang_invoke_MethodHandle_findVMDispatchTarget
        Java_java_lang_invoke_MethodHandle_vtableOffset
- add missing header to j9protos.h:
        Java_java_lang_invoke_MutableCallSite_registerNatives
- ifdef all java_dyn_methodhandle/methodtype API under opt_methodHandle
- same changes done for CMake build files

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>