### PR TITLE
(0.25.0) Change TR_ASSERT_FATAL into failCompilation call

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -866,29 +866,11 @@ J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * ow
       containingClass =
          owningMethod->definingClassFromCPFieldRef(comp(), cpIndex, isStatic, &fromResolvedJ9Method);
 
-      if (comp()->compileRelocatableCode())
-         {
-         TR_ASSERT_FATAL(
-            containingClass != NULL,
-            "failed to get defining class of field ref cpIndex=%d in owning method J9Method=%p\n"
-            "\tTR_ResolvedJ9Method::definingClassFromCPFieldRef=%p, TR_ResolvedRelocatableJ9Method::definingClassFromCPFieldRef=%p\n"
-            "\tfromResolvedJ9Method=%p\n"
-            "\tTR_UseSymbolValidationManager=%d",
-            cpIndex,
-            owningMethod->getNonPersistentIdentifier(),
-            owningMethod->TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp(), owningMethod->cp(), cpIndex, isStatic),
-            static_cast<TR_ResolvedRelocatableJ9Method *>(owningMethod)->definingClassFromCPFieldRef(comp(), cpIndex, isStatic),
-            fromResolvedJ9Method,
-            comp()->getOption(TR_UseSymbolValidationManager));
-         }
-      else
-         {
-         TR_ASSERT_FATAL(
-            containingClass != NULL,
-            "failed to get defining class of field ref cpIndex=%d in owning method J9Method=%p",
+      if (containingClass == NULL)
+         comp()->failCompilation<TR::CompilationException>(
+            "failed to get defining class of resolved field ref cpIndex=%d in owning method J9Method=%p",
             cpIndex,
             owningMethod->getNonPersistentIdentifier());
-         }
 
       ResolvedFieldShadowKey key(containingClass, offset, type);
       TR::SymbolReference *symRef =


### PR DESCRIPTION
`findOrCreateShadowSymbol()` tries to reuse symrefs produced by
`findOrFabricateShadowSymbol()` when the shadow corresponds to the same
field. Detecting that the fields are in fact the same requires checking
that the defining class is the same. Normally, the expectation is that
if a cp field ref is resolved, then the cp ref pointing to the defining
class must also be resolved. However, in #9416, it appears as though
this may not always be the case, which triggers an assert. As a
temporary work around, the assert is changed to an abort compilation to
avoid taking the JVM. Because the assert is useful for detecting such
cases, this patch is only submitted for the release branch so that
further investigation can continue on the main development branch.

The mainline code uses a different assert when compiling relocatable
code to add extra debug information to the assert message in those
cases. Since this commit effectively hides any occurrences of the issue
reported in #9416, I don't believe there is any value in keeping the
extra debug information. So, I've simplified the two asserts back into a
single check that throws an exception of failure.

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>