### PR TITLE
Add support for jitdump agent sub-options

### DIFF
--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1133,6 +1133,53 @@ extern J9_CFUNC struct J9Method* jitResolveStaticMethodRef(J9VMThread *vmStruct,
 extern J9_CFUNC struct J9Method* jitResolveSpecialMethodRef(J9VMThread *vmStruct, J9ConstantPool *constantPool, UDATA cpOrSplitIndex, UDATA resolveFlags);
 extern J9_CFUNC struct J9Class * jitGetDeclaringClassOfROMField(J9VMThread *vmStruct, J9Class *clazz, J9ROMFieldShape *romField);
 
+typedef struct J9MethodFromSignatureWalkState {
+	const char *className;
+	U_32 classNameLength;
+	struct J9JNINameAndSignature nameAndSig;
+	struct J9VMThread *vmThread;
+	struct J9ClassLoaderWalkState classLoaderWalkState;
+} J9MethodFromSignatureWalkState;
+
+/**
+ * Cleans up the iterator after matching all methods found.
+ *
+ * @param state The inlialized iterator state
+ */
+extern J9_CFUNC void
+allMethodsFromSignatureEndDo(J9MethodFromSignatureWalkState *state);
+
+/**
+ * Advances the iterator looking for the next method matching the exact signature provided during initialization.
+ *
+ * @param state The inlialized iterator state
+ *
+ * @return      J9Method matching the exact signature provided during initialization of the iterator in the class loader
+ *              if it exists; NULL if no such method is found.
+ */
+extern J9_CFUNC struct J9Method *
+allMethodsFromSignatureNextDo(J9MethodFromSignatureWalkState *state);
+
+/**
+ * Initializes the iterator state and returns the first method matching the supplied exact (no wildcards allowed)
+ * signature from any class loader.
+ *
+ * @param state            The iterator state which will be initialized.
+ * @param vm               The VM instance to look for methods in.
+ * @param flags            The flags forwarded to class loader iterator functions
+ * @param className        The class name including the package.
+ * @param classNameLength  The length (in number of bytes) of the class name
+ * @param methodName       The method name
+ * @param methodNameLength The length (in number of bytes) of the method name
+ * @param methodSig        The method signature
+ * @param methodSigLength  The length (in number of bytes) of the method signature
+ *
+ * @return                 J9Method matching the exact signature provided in the first class loader it is found; NULL if
+ *                         no such method is found.
+ */
+extern J9_CFUNC struct J9Method *
+allMethodsFromSignatureStartDo(J9MethodFromSignatureWalkState *state, J9JavaVM* vm, UDATA flags, const char *className, U_32 classNameLength, const char *methodName, U_32 methodNameLength, const char *methodSig, U_32 methodSigLength);
+
 #endif /* J9VM_INTERP_NATIVE_SUPPORT*/
 #endif /* _J9VMJITNATIVECOMPILESUPPORT_ */
 

--- a/runtime/oti/jitprotos.h
+++ b/runtime/oti/jitprotos.h
@@ -88,6 +88,18 @@ extern J9_CFUNC J9JITHashTable *avl_jit_artifact_insert_existing_table (J9AVLTre
 extern J9_CFUNC J9AVLTree * jit_allocate_artifacts (J9PortLibrary * portLibrary);
 
 extern J9_CFUNC UDATA  jitWalkStackFrames (J9StackWalkState *walkState);
+
+/**
+ * Attempts to search for JIT method metadata given a program counter (PC).
+ *
+ * @param vmThread The thread which is attempting this search.
+ * @param jitPC    The program counter (PC) to search for.
+ *
+ * @return         The metadata corresponding to the method which was JIT compiled at the specified PC if such a method
+ *                 exists; NULL if no such method can be found.
+ * 
+ * @note           If jitPC is NULL this function will return NULL.
+ */
 extern J9_CFUNC J9JITExceptionTable * jitGetExceptionTableFromPC (J9VMThread * vmThread, UDATA jitPC);
 extern J9_CFUNC UDATA  jitGetOwnedObjectMonitors(J9StackWalkState *state);
 #if (defined(J9VM_INTERP_STACKWALK_TRACING)) /* priv. proto (autogen) */


### PR DESCRIPTION
Sometimes, no matter how hard we try to heuristically determine what
tracing or options to enable for jitdump compiles, it may not be enough
diagnostics to determine the root cause of the problem. Manual
intervention is required in such cases. Currently this involves setting
-Xjit: options to add additional tracing and hoping to reproduce the
problem.

The current approach has several limitations:

- Tracing a method unconditionally (before a problem ever happens) can
make the problem completely stop happening due to the non-deterministic
nature of the JIT compiler

- Tracing with -Xjit: will always generate a trace file, even when no
problem happens

- Tracing with -Xjit: requires specifying the exact method to trace, or
a class of methods which can be problematic if the error at hand happens
in a variety of different methods, or even generated methods with unique
names

To overcome this limitation we can use the `opts=` sub-option of the
-Xdump command [1] which allows the user to specify any sub-options to
a particular command. We parse this command during the jitdump process
and we interpret it as a user specified method which we will trigger a
JitDump recompilation.

The user can specify a full method signature, for example:

```
-Xdump:jit:
    events=throw,
    filter=*NullPointerException#java/util/Calendar.setTime,
    range=1..1,
    opts=java/lang/String.indexOf(II)I
```

In the above example we tell the dump agent to trigger a JitDump when a
`NullPointerException` is thrown in the `java/util/Calendar.setTime`
method, and when that happens we want to recompile the method specified
in the `opts=` option, i.e. `java/lang/String.indexOf(II)I`.

The purpose of this sub-option is to debug non-deterministic style
problems described previously. Using this JitDump sub-option avoids the
non-determinism introduced by attempting to trace methods during their
first compilation.

[1] https://www.eclipse.org/openj9/docs/xdump/#optsltoptionsgt

Closes: #9479

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>