### PR TITLE
memset controlFileStatus to 0 on Windows to avoid garbage values

### DIFF
--- a/runtime/port/win32/j9shmem.c
+++ b/runtime/port/win32/j9shmem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -86,6 +86,10 @@ j9shmem_open(struct J9PortLibrary *portLibrary, const char* cacheDirName, uintpt
 	/* clear portable error number */
 	omrerror_set_last_error(0, 0);
 
+	if (NULL != controlFileStatus) {
+		memset(controlFileStatus, 0, sizeof(J9ControlFileStatus));
+	}
+	
 	if (NULL == cacheDirName) {
 		Trc_PRT_shmem_j9shmem_open_ExitNullCacheDirName();
 		return J9PORT_ERROR_SHMEM_OPFAILED;

--- a/runtime/port/win32/j9shsem_deprecated.c
+++ b/runtime/port/win32/j9shsem_deprecated.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,6 +74,10 @@ j9shsem_deprecated_open (struct J9PortLibrary *portLibrary, const char* cacheDir
 
 	/* clear portable error number */
 	omrerror_set_last_error(0, 0);
+	
+	if (NULL != controlFileStatus) {
+		memset(controlFileStatus, 0, sizeof(J9ControlFileStatus));
+	}
 
 	if (cacheDirName == NULL) {
 		Trc_PRT_shsem_j9shsem_deprecated_open_ExitNullCacheDirName();


### PR DESCRIPTION
The same as Unix implementation, in j9shmem_open() and
j9shsem_deprecated_open() controlFileStatus should be memset to 0 on
Windows.

Closes #11908 
Closes #11843

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>