### PR TITLE
Adaptive GC Threading Options

### DIFF
--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -930,7 +930,41 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			}
 			extensions->aliasInhibitingThresholdPercentage = ((double)percentage) / 100.0;
 
-			continue ;
+			continue;
+		}
+
+		if (try_scan(&scan_start, "adaptiveThreadingSensitivityFactor=")) {
+			UDATA sensitivityFactor = 0;
+			if (!scan_udata_helper(vm, &scan_start, &sensitivityFactor, "adaptiveThreadingSensitivityFactor=")) {
+				returnValue = JNI_EINVAL;
+				break;
+			}
+			extensions->adaptiveThreadingSensitivityFactor = ((float)sensitivityFactor) / 10.0f;
+
+			continue;
+		}
+
+		if (try_scan(&scan_start, "adaptiveThreadingWeightActiveThreads=")) {
+			UDATA adaptiveThreadingWeightActiveThreads = 0;
+			if (!scan_udata_helper(vm, &scan_start, &adaptiveThreadingWeightActiveThreads, "adaptiveThreadingWeightActiveThreads=")) {
+				returnValue = JNI_EINVAL;
+				break;
+			}
+
+			extensions->adaptiveThreadingWeightActiveThreads = ((float)adaptiveThreadingWeightActiveThreads) / 100.0f;
+
+			continue;
+		}
+
+		if (try_scan(&scan_start, "adaptiveThreadBooster=")) {
+			UDATA adaptiveThreadBooster = 0;
+			if (!scan_udata_helper(vm, &scan_start, &adaptiveThreadBooster, "adaptiveThreadBooster=")) {
+				returnValue = JNI_EINVAL;
+				break;
+			}
+			extensions->adaptiveThreadBooster = ((float)adaptiveThreadBooster) / 100.0f;
+
+			continue;
 		}
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)

--- a/runtime/gc_modron_startup/mmparseXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXgc.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -535,6 +535,7 @@ enum INIT_STAGE {
 #define MAPOPT_XXPARALLELCMSTHREADS_EQUALS "-XX:ParallelCMSThreads="
 #define MAPOPT_XXCONCGCTHREADS_EQUALS "-XX:ConcGCThreads="
 #define MAPOPT_XXPARALLELGCTHREADS_EQUALS "-XX:ParallelGCThreads="
+#define MAPOPT_XXPARALLELGCMAXTHREADS_EQUALS "-XX:ParallelGCMaxThreads="
 
 #define VMOPT_XXACTIVEPROCESSORCOUNT_EQUALS "-XX:ActiveProcessorCount="
 
@@ -550,6 +551,7 @@ enum INIT_STAGE {
 #define VMOPT_XXIDLETUNINGIGNOREUNRECOGNIZEDOPTIONSENABLE "-XX:+IdleTuningIgnoreUnrecognizedOptions"
 #define VMOPT_XCONCURRENTBACKGROUND "-Xconcurrentbackground"
 #define VMOPT_XGCTHREADS "-Xgcthreads"
+#define VMOPT_XGCMAXTHREADS "-Xgcmaxthreads"
 
 #define VMOPT_XXSHOW_EXTENDED_NPE_MESSAGE "-XX:+ShowCodeDetailsInExceptionMessages"
 #define VMOPT_XXNOSHOW_EXTENDED_NPE_MESSAGE "-XX:-ShowCodeDetailsInExceptionMessages"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -4459,6 +4459,11 @@ registerVMCmdLineMappings(J9JavaVM* vm)
 		return RC_FAILED;
 	}
 
+	/* Map -XX:ParallelMaxGCThreads=N  to -XgcmaxthreadsN */
+	if (registerCmdLineMapping(vm, MAPOPT_XXPARALLELGCMAXTHREADS_EQUALS, VMOPT_XGCMAXTHREADS, EXACT_MAP_WITH_OPTIONS) == RC_FAILED) {
+		return RC_FAILED;
+	}
+
 	return 0;
 }
 #endif /* J9VM_OPT_SIDECAR */


### PR DESCRIPTION
See related OMR changes https://github.com/eclipse/omr/pull/5830

**Introducing the following options to toggle and tune Adaptive Threading:**

**XX:**
- `-XX:[+-]AdaptiveGCThreading` to enable/disable the GC adaptive threading optimization.
- `-XX:ParallelGCMaxThreads=` Mapped to `Xgcmaxthreads` (see below)

**Xgc:**
- `-Xgcmaxthreads` The max number of threads available to Adaptive Threading (Similar to Xgcthreads, except it doesn't set forced thread count flag )



**XXgc**
- `-XXgc:adaptiveThreadingWeightActiveThreads=` Weight given to current active threads when averaging projected threads with current active threads.
- `-XXgc:adaptiveThreadBooster=` Used to boost calculated thread count, gives opportunity for low thread count to grow.
- `-XXgc:adaptiveThreadingSensitivityFactor= ` Used by Adaptive Model to determine sensitivity/tolerance to stalling, higher number translates to less stall being tolerated.

Depends: https://github.com/eclipse/omr/pull/5830

Signed-off-by: Salman Rana <salman.rana@ibm.com>