### PR TITLE
Move JITServer client options to compilation thread object

### DIFF
--- a/runtime/compiler/control/MethodToBeCompiled.cpp
+++ b/runtime/compiler/control/MethodToBeCompiled.cpp
@@ -87,8 +87,6 @@ void TR_MethodToBeCompiled::initialize(TR::IlGeneratorMethodDetails & details, v
 #if defined(J9VM_OPT_JITSERVER)
    _remoteCompReq = false;
    _stream = NULL;
-   _clientOptions = NULL;
-   _clientOptionsSize = 0;
    _origOptLevel = unknownHotness;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
@@ -100,9 +98,6 @@ void TR_MethodToBeCompiled::initialize(TR::IlGeneratorMethodDetails & details, v
 void
 TR_MethodToBeCompiled::shutdown()
    {
-#if defined(J9VM_OPT_JITSERVER)
-   freeJITServerAllocations();
-#endif /* defined(J9VM_OPT_JITSERVER) */
    TR::MonitorTable *table = TR::MonitorTable::get();
    if (!table) return;
    table->removeAndDestroy(_monitor);
@@ -150,15 +145,5 @@ uint64_t
 TR_MethodToBeCompiled::getClientUID() const
    {
    return _stream->getClientId();
-   }
-
-void
-TR_MethodToBeCompiled::freeJITServerAllocations()
-   {
-   if (_clientOptions)
-      {
-      TR::Compiler->persistentMemory()->freePersistentMemory((void *)_clientOptions);
-      _clientOptions = NULL;
-      }
    }
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/control/MethodToBeCompiled.hpp
+++ b/runtime/compiler/control/MethodToBeCompiled.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,7 +73,6 @@ struct TR_MethodToBeCompiled
    void unsetRemoteCompReq() { _remoteCompReq = false; }
    bool isOutOfProcessCompReq() const { return _stream != NULL; } // at the server
    uint64_t getClientUID() const;
-   void freeJITServerAllocations(); // Clean up client options which were allocated using persistent allocator
    bool hasChangedToLocalSyncComp() const { return (_origOptLevel != unknownHotness); }
 #else
    bool isRemoteCompReq() const { return false; } // at the client
@@ -136,8 +135,6 @@ struct TR_MethodToBeCompiled
 #if defined(J9VM_OPT_JITSERVER)
    bool                   _remoteCompReq; // Comp request should be sent remotely to JITServer
    JITServer::ServerStream  *_stream; // A non-NULL field denotes an out-of-process compilation request
-   char                  *_clientOptions;
-   size_t                 _clientOptionsSize;
    TR_Hotness             _origOptLevel; //  Cache original optLevel when transforming a remote sync compilation to a local cheap one
 #endif /* defined(J9VM_OPT_JITSERVER) */
    }; // TR_MethodToBeCompiled


### PR DESCRIPTION
Client options were previously stored in `MethodToBeCompiled`
entries. This commit moves them to `TR::CompilationInfoPerThreadRemote`
object. This removes the need to deallocate JITServer memory when
recycling a compilation entry. It makes implementing changes to
memory allocation, such as #11686 easier.