### PR TITLE
set controlFileStatus to 0 at the beginning of shmem and shsem APIs

### DIFF
--- a/runtime/port/sysvipc/j9shmem.c
+++ b/runtime/port/sysvipc/j9shmem.c
@@ -327,6 +327,10 @@ j9shmem_open (J9PortLibrary *portLibrary, const char* cacheDirName, uintptr_t gr
 	Trc_PRT_shmem_j9shmem_open_Entry(rootname, size, perm);
 
 	clearPortableError(portLibrary);
+	
+	if (NULL != controlFileStatus) {
+		memset(controlFileStatus, 0, sizeof(J9ControlFileStatus));
+	}
 
 	if (cacheDirName == NULL) {
 		Trc_PRT_shmem_j9shmem_open_ExitNullCacheDirName();
@@ -358,10 +362,6 @@ j9shmem_open (J9PortLibrary *portLibrary, const char* cacheDirName, uintptr_t gr
 		tmphandle->currentStorageProtectKey = getStorageKey();
 	}	
 #endif
-	
-	if (NULL != controlFileStatus) {
-		memset(controlFileStatus, 0, sizeof(J9ControlFileStatus));
-	}
 
 	for (retryIfReadOnlyCount = 10; retryIfReadOnlyCount > 0; retryIfReadOnlyCount -= 1) {
 		/*Open control file with write lock*/

--- a/runtime/port/sysvipc/j9shsem_deprecated.c
+++ b/runtime/port/sysvipc/j9shsem_deprecated.c
@@ -236,6 +236,10 @@ j9shsem_deprecated_open (struct J9PortLibrary *portLibrary, const char* cacheDir
 	Trc_PRT_shsem_j9shsem_open_Entry(semname, setSize, permission);
 
 	clearPortableError(portLibrary);
+	
+	if (NULL != controlFileStatus) {
+		memset(controlFileStatus, 0, sizeof(J9ControlFileStatus));
+	}
 
 	if (cacheDirName == NULL) {
 		Trc_PRT_shsem_j9shsem_deprecated_open_ExitNullCacheDirName();
@@ -254,10 +258,6 @@ j9shsem_deprecated_open (struct J9PortLibrary *portLibrary, const char* cacheDir
 		return J9PORT_ERROR_SHSEM_OPFAILED;
 	}
 	tmphandle->baseFile = (char *) (((char *) tmphandle) + handleStructLength);
-
-	if (NULL != controlFileStatus) {
-		memset(controlFileStatus, 0, sizeof(J9ControlFileStatus));
-	}
 
 	for (retryIfReadOnlyCount = 10; retryIfReadOnlyCount > 0; retryIfReadOnlyCount -= 1) {
 		/*Open control file with write lock*/


### PR DESCRIPTION
Move the code to memset controlFileStatus to the beginning of
j9shmem_open() and j9shsem_deprecated_open() to avoid garbage values on
Unix implementation.

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>