### PR TITLE
JITServer support for transforming OpenJDK MethodHandles

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1071,6 +1071,29 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, arrayElementKnotIndex, knot->getPointerLocation(arrayElementKnotIndex));
          }
          break;
+      case MessageType::VM_isLambdaFormGeneratedMethod:
+         {
+         auto recv = client->getRecvData<TR_OpaqueMethodBlock *>();
+         client->write(response, fe->isLambdaFormGeneratedMethod(std::get<0>(recv)));
+         }
+         break;
+      case MessageType::VM_vTableOrITableIndexFromMemberName:
+         {
+         auto recv = client->getRecvData<TR::KnownObjectTable::Index>();
+         client->write(response, fe->vTableOrITableIndexFromMemberName(comp, std::get<0>(recv)));
+         }
+         break;
+      case MessageType::VM_getMemberNameFieldKnotIndexFromMethodHandleKnotIndex:
+         {
+         auto recv = client->getRecvData<TR::KnownObjectTable::Index, std::string>();
+         auto &memberNameStr = std::get<1>(recv);
+         TR::KnownObjectTable::Index fieldKnotIndex = 
+            fe->getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(
+               comp, std::get<0>(recv),
+               &memberNameStr[0]);
+         client->write(response, fieldKnotIndex, knot->getPointerLocation(fieldKnotIndex));
+         }
+         break;
 #endif // J9VM_OPT_OPENJDK_METHODHANDLE
       case MessageType::mirrorResolvedJ9Method:
          {

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4915,7 +4915,7 @@ TR_J9VMBase::vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownO
       return vTableOrITableIndexFromMemberName(object);
       }
    return -1;
-    }
+   }
 
 TR::KnownObjectTable::Index
 TR_J9VMBase::getKnotIndexOfInvokeCacheArrayAppendixElement(TR::Compilation *comp, uintptr_t *invokeCacheArray)
@@ -4995,6 +4995,16 @@ TR_J9VMBase::getSignatureForLinkToStaticForInvokeDynamic(TR::Compilation* comp, 
    return linkToStaticSignature;
    }
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
+
+TR::KnownObjectTable::Index
+TR_J9VMBase::getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, char *fieldName)
+   {
+   TR::VMAccessCriticalSection dereferenceKnownObjectField(this);
+   TR::KnownObjectTable *knot = comp->getKnownObjectTable();
+   uintptr_t mhObject = knot->getPointer(mhIndex);
+   uintptr_t mnObject = getReferenceField(mhObject, fieldName, "Ljava/lang/invoke/MemberName;");
+   return knot->getOrCreateIndex(mnObject);
+   }
 
 /**
  * \brief

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -805,25 +805,25 @@ public:
     *    Return MemberName.vmindex, a J9JNIMethodID pointer containing vtable/itable offset for the MemberName method
     *    Caller must acquire VM access
     */
-   J9JNIMethodID* jniMethodIdFromMemberName(uintptr_t memberName);
+   virtual J9JNIMethodID* jniMethodIdFromMemberName(uintptr_t memberName);
    /*
     * \brief
     *    Return MemberName.vmindex, a J9JNIMethodID pointer containing vtable/itable offset for the MemberName method
     *    VM access is not required
     */
-   J9JNIMethodID* jniMethodIdFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
+   virtual J9JNIMethodID* jniMethodIdFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
    /*
     * \brief
     *    Return vtable or itable index of a method represented by MemberName
     *    Caller must acquire VM access
     */
-   int32_t vTableOrITableIndexFromMemberName(uintptr_t memberName);
+   virtual int32_t vTableOrITableIndexFromMemberName(uintptr_t memberName);
    /*
     * \brief
     *    Return vtable or itable index of a method represented by MemberName
     *    VM access is not required
     */
-   int32_t vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
+   virtual int32_t vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex);
    /*
     * \brief
     *    Create and return a resolved method from member name index of an invoke cache array.
@@ -888,6 +888,16 @@ public:
 #endif
 
    // JSR292 }}}
+
+   /**
+    * \brief
+    *   Return a Known Object Table index of a java/lang/invoke/MemberName field
+    *
+    * \param comp the compilation object
+    * \param mhIndex known object index of the java/lang/invoke/MemberName object
+    * \param fieldName the name of the field for which we return the known object index
+    */
+   virtual TR::KnownObjectTable::Index getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, char *fieldName);
 
    virtual uintptr_t getFieldOffset( TR::Compilation * comp, TR::SymbolReference* classRef, TR::SymbolReference* fieldRef);
    /*

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -221,7 +221,13 @@ public:
    virtual TR_ResolvedMethod *targetMethodFromInvokeCacheArrayMemberNameObj(TR::Compilation *comp, TR_ResolvedMethod *owningMethod, uintptr_t *invokeCacheArray) override;
    virtual TR::KnownObjectTable::Index getKnotIndexOfInvokeCacheArrayAppendixElement(TR::Compilation *comp, uintptr_t *invokeCacheArray) override;
    virtual TR::SymbolReference* refineInvokeCacheElementSymRefWithKnownObjectIndex(TR::Compilation *comp, TR::SymbolReference *originalSymRef, uintptr_t *invokeCacheArray) override;
+
+   virtual J9JNIMethodID* jniMethodIdFromMemberName(uintptr_t memberName) override;
+   virtual J9JNIMethodID* jniMethodIdFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex) override;
+   virtual int32_t vTableOrITableIndexFromMemberName(uintptr_t memberName) override;
+   virtual int32_t vTableOrITableIndexFromMemberName(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex) override;
 #endif
+   virtual TR::KnownObjectTable::Index getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, char *fieldName) override;
 
 private:
    bool instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* castClass, bool cacheUpdate);

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1645,6 +1645,7 @@ TR_ResolvedJ9JITServerMethod::packMethodInfo(TR_ResolvedJ9JITServerMethodInfo &m
    methodInfoStruct.virtualMethodIsOverridden = resolvedMethod->virtualMethodIsOverridden();
    methodInfoStruct.addressContainingIsOverriddenBit = resolvedMethod->addressContainingIsOverriddenBit();
    methodInfoStruct.classLoader = resolvedMethod->getClassLoader();
+   methodInfoStruct.isLambdaFormGeneratedMethod = static_cast<TR_J9VMBase *>(fe)->isLambdaFormGeneratedMethod(resolvedMethod);
 
    TR_PersistentJittedBodyInfo *bodyInfo = NULL;
    // Method may not have been compiled
@@ -1700,6 +1701,7 @@ TR_ResolvedJ9JITServerMethod::unpackMethodInfo(TR_OpaqueMethodBlock * aMethod, T
    _virtualMethodIsOverridden = methodInfoStruct.virtualMethodIsOverridden;
    _addressContainingIsOverriddenBit = methodInfoStruct.addressContainingIsOverriddenBit;
    _classLoader = methodInfoStruct.classLoader;
+   _isLambdaFormGeneratedMethod = methodInfoStruct.isLambdaFormGeneratedMethod;
 
    auto &bodyInfoStr = std::get<1>(methodInfo);
    auto &methodInfoStr = std::get<2>(methodInfo);

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -51,6 +51,7 @@ TR_ResolvedJ9JITServerMethodInfoStruct
    bool virtualMethodIsOverridden;
    void *addressContainingIsOverriddenBit;
    J9ClassLoader *classLoader;
+   bool isLambdaFormGeneratedMethod;
    };
 
 
@@ -228,6 +229,7 @@ public:
    void cacheResolvedMethodsCallees(int32_t ttlForUnresolved = 2);
    void cacheFields();
    int32_t collectImplementorsCapped(TR_OpaqueClassBlock *topClass, int32_t maxCount, int32_t cpIndexOrOffset, TR_YesNoMaybe useGetResolvedInterfaceMethod, TR_ResolvedMethod **implArray);
+   bool isLambdaFormGeneratedMethod() { return _isLambdaFormGeneratedMethod; }
    static void packMethodInfo(TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_ResolvedJ9Method *resolvedMethod, TR_FrontEnd *fe);
 
 protected:
@@ -255,6 +257,7 @@ private:
    TR_PersistentJittedBodyInfo *_bodyInfo; // cached info coming from the client; uses heap memory
                                            // If method is not yet compiled this is null
    TR_IPMethodHashTableEntry *_iProfilerMethodEntry;
+   bool _isLambdaFormGeneratedMethod;
 
    char* getROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
    virtual char * fieldOrStaticName(I_32 cpIndex, int32_t & len, TR_Memory * trMemory, TR_AllocationKind kind = heapAlloc) override;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -102,7 +102,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 23;
+   static const uint16_t MINOR_NUMBER = 24;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -187,6 +187,9 @@ enum MessageType : uint16_t
    VM_getKnotIndexOfInvokeCacheArrayAppendixElement,
    VM_targetMethodFromInvokeCacheArrayMemberNameObj,
    VM_refineInvokeCacheElementSymRefWithKnownObjectIndex,
+   VM_isLambdaFormGeneratedMethod,
+   VM_vTableOrITableIndexFromMemberName,
+   VM_getMemberNameFieldKnotIndexFromMethodHandleKnotIndex,
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled,
@@ -429,6 +432,9 @@ static const char *messageNames[] =
    "VM_getKnotIndexOfInvokeCacheArrayAppendixElement",
    "VM_targetMethodFromInvokeCacheArrayMemberNameObj",
    "VM_refineInvokeCacheElementSymRefWithKnownObjectIndex",
+   "VM_isLambdaFormGeneratedMethod",
+   "VM_vTableOrITableIndexFromMemberName",
+   "VM_getMemberNameFieldKnotIndexFromMethodHandleKnotIndex",
    "CompInfo_isCompiled",
    "CompInfo_getPCIfCompiled",
    "CompInfo_getInvocationCount",

--- a/runtime/compiler/optimizer/MethodHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/MethodHandleTransformer.cpp
@@ -24,7 +24,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "codegen/CodeGenerator.hpp"
-#include "env/VMAccessCriticalSection.hpp"
 #include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/ResolvedMethod.hpp"
@@ -357,10 +356,7 @@ TR_MethodHandleTransformer::getObjectInfoOfNode(TR::Node* node)
            auto mhIndex = getObjectInfoOfNode(node->getFirstArgument());
            if (knot && isKnownObject(mhIndex) && !knot->isNull(mhIndex))
               {
-              TR::VMAccessCriticalSection dereferenceKnownObjectField(comp()->fej9());
-              uintptr_t mhObject = knot->getPointer(mhIndex);
-              uintptr_t mnObject = comp()->fej9()->getReferenceField(mhObject, "member", "Ljava/lang/invoke/MemberName;");
-              auto mnIndex = knot->getOrCreateIndex(mnObject);
+              auto mnIndex = comp()->fej9()->getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(comp(), mhIndex, "member");
               if (trace())
                  traceMsg(comp(), "Get DirectMethodHandle.member known object %d\n", mnIndex);
               return mnIndex;
@@ -371,10 +367,7 @@ TR_MethodHandleTransformer::getObjectInfoOfNode(TR::Node* node)
            auto mhIndex = getObjectInfoOfNode(node->getFirstArgument());
            if (knot && isKnownObject(mhIndex) && !knot->isNull(mhIndex))
               {
-              TR::VMAccessCriticalSection dereferenceKnownObjectField(comp()->fej9());
-              uintptr_t mhObject = knot->getPointer(mhIndex);
-              uintptr_t mnObject = comp()->fej9()->getReferenceField(mhObject, "initMethod", "Ljava/lang/invoke/MemberName;");
-              auto mnIndex = knot->getOrCreateIndex(mnObject);
+              auto mnIndex = comp()->fej9()->getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(comp(), mhIndex, "initMethod");
               if (trace())
                  traceMsg(comp(), "Get DirectMethodHandle.initMethod known object %d\n", mnIndex);
               return mnIndex;

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -269,6 +269,7 @@ class ClientSessionData
       bool _isMethodTracingEnabled;
       TR_OpaqueClassBlock * _owningClass;
       bool _isCompiledWhenProfiling; // To record if the method is compiled when doing Profiling
+      bool _isLambdaFormGeneratedMethod;
       }; // struct J9MethodInfo
 
    /**


### PR DESCRIPTION
This commit implements JITServer support for #11634.

- Override new front-end queries for JITServer
- Add a new front-end query
`getMemberNameFieldKnotIndexFromMethodHandleKnotIndex`
to encapsulate a sequence of operations requiring VM access and
override this query for JITServer.