### PR TITLE
(0.25.0) Decompress String before invoking decompressedArrayCopy

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -718,7 +718,12 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			value = StringUTF16.newBytesFor(concatlen);
 			coder = UTF16;
 
-			decompressedArrayCopy(s.value, 0, value, 0, slen);
+			// Check if the String is compressed
+			if (enableCompression && s.coder == LATIN1) {
+				decompress(s.value, 0, value, 0, slen);
+			} else {
+				decompressedArrayCopy(s.value, 0, value, 0, slen);
+			}		
 
 			helpers.putCharInArrayByIndex(value, slen, c);
 
@@ -4621,8 +4626,12 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				value = new char[concatlen];
 				count = (concatlen) | uncompressedBit;
 
-				System.arraycopy(s.value, 0, value, 0, slen);
-
+				// Check if the String is compressed
+				if (enableCompression && s.count >= 0) {
+					decompress(s.value, 0, value, 0, slen);
+				} else {
+					decompressedArrayCopy(s.value, 0, value, 0, slen);
+				}
 				value[slen] = c;
 
 				initCompressionFlag();

--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -48,6 +48,7 @@
 		<testCaseName>stringConcatOptTest</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
+			<variation>-XX:+CompactStrings</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xjit:count=1,disableAsyncCompilation,verbose,vlog=$(Q)$(REPORTDIR)$(D)jitv.log$(Q) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \

--- a/test/functional/JIT_Test/src/jit/test/stringconcat/StringConcatTest.java
+++ b/test/functional/JIT_Test/src/jit/test/stringconcat/StringConcatTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -80,7 +80,17 @@ public class StringConcatTest {
 	private String buildNullStr_Middle(){
 		return Integer.toString(-5) + " is bigger than " + Integer.toString(1) + null + " to a less than sane person";
 	}
-		
+
+	private String concatChar(String s, char c) {
+		return new StringBuilder().append(s).append(c).toString();
+	}
+
+	@Test(invocationCount=2)
+	public void testStringPeepholeInitStringCharReduction() {
+		String str = concatChar("abcd", '\u205e');
+		AssertJUnit.assertEquals("abcd\u205e", str);
+	}
+
 	public void testNullStr_End(){
 		String str = buildNullStr_End();
 		str = buildNullStr_End();


### PR DESCRIPTION
In the private String(String,Char) constructor, it is possible
that to end up in the else block where the String is
compressed, but the char > 255. In such a case, the String needs
to be decompressed correctly before being copied over. This
commit ensures that is done correctly now. A test is also added
to catch this corner case now.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>