### PR TITLE
JDK17 adds JavaLangAccess decodeASCII() & inflateBytesToChars()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2020 IBM Corp. and others
+ * Copyright (c) 2007, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -440,6 +440,27 @@ final class Access implements JavaLangAccess {
 		fromModule.implAddExports(pkg);
 	}
 /*[ENDIF] JAVA_SPEC_VERSION >= 16 */
+
+/*[IF JAVA_SPEC_VERSION >= 17]*/
+	// This implementation can be replaced with invoking of String.decodeASCII() after switching to RI String.
+	public int decodeASCII(byte[] srcBytes, int srcPos, char[] dstChars, int dstPos, int length) {
+		int numDecoded = 0;
+		while (numDecoded < length) {
+			byte srcByte = srcBytes[srcPos++];
+			if (srcByte >= 0) {
+				dstChars[dstPos++] = (char) srcByte;
+				numDecoded += 1;
+				continue;
+			}
+			break;
+		}
+		return numDecoded;
+	}
+
+	public void inflateBytesToChars(byte[] srcBytes, int srcOffset, char[] dstChars, int dstOffset, int length) {
+		StringLatin1.inflate(srcBytes, srcOffset, dstChars, dstOffset, length);
+	}
+/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 
 /*[ENDIF] Sidecar19-SE */
 }


### PR DESCRIPTION
This implementation can be replaced with invoking of `String.decodeASCII()` after switching to `RI` `String`.

With this PR, `JDK17` branch `openj9-staging` builds with `-version` output:
```
openjdk version "17-internal" 2021-09-14
OpenJDK Runtime Environment (build 17-internal+0-adhoc.fengjcaibmcom.jdk17-staging-0222)
Eclipse OpenJ9 VM (build jdk17access-520097e9f4, JRE 17 Mac OS X amd64-64-Bit Compressed References 20210222_000000 (JIT enabled, AOT enabled)
OpenJ9   - 520097e9f4
OMR      - e69c81f15
JCL      - f19e72246d4 based on jdk-17+10)
``` 

Related https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/290

Signed-off-by: Jason Feng <fengj@ca.ibm.com>