### PR TITLE
Fix compilation failure for non valhalla test builds

### DIFF
--- a/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_Class.java
@@ -446,7 +446,7 @@ public void test_getMethods_subtest6() throws Exception {
 	ClzImpl clzImpl = new ClzImpl();
 	for (Method method : clzImpl.getClass().getMethods()) {
 		for (Class<?> anInterface : method.getDeclaringClass().getInterfaces()) {
-			if (IdentityInterface.class != anInterface) {
+			if (!anInterface.getName().equals("java.lang.IdentityInterface")) {
 				Method intfMethod = anInterface.getMethod(method.getName(), method.getParameterTypes());
 				Assert.assertEquals(intfMethod.toString(), "public abstract org.openj9.test.java.lang.Test_Class$ClzParent org.openj9.test.java.lang.Test_Class$InterfaceLayerThreeB.getType()");	
 			}


### PR DESCRIPTION
Perform a fix to no longer reference the IdentityInterface class
directly when skipping a case in a test due to injection. Instead,
the interface name is compared to IdentityInterface to determine
whether to skip.

This arises because the IdentityInterface is
compiled only in Valhalla Builds

Fixes https://github.com/eclipse/openj9/issues/12027