### PR TITLE
Store number of stack slots in vmThread.tempSlot for linkTo* calls

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6759,11 +6759,19 @@ TR_ResolvedJ9Method::shouldCompileTimeResolveMethod(I_32 cpIndex)
    if (classNameLength == strlen(JSR292_MethodHandle) &&
        !strncmp(className, JSR292_MethodHandle, classNameLength))
       {
-      // MethodHandle.invokeBasic has to be resolved to be recognized for special handling in tree
-      // lowering. Its resolution has no side effect and should always succeed.
+      // MethodHandle.invokeBasic and MethodHandle.linkTo* methods have to be
+      // resolved to be recognized for special handling in tree
+      // lowering. Their resolution has no side effect and should always succeed.
       //
-      if (methodNameLength == 11 &&
-          !strncmp(methodName, "invokeBasic", methodNameLength))
+      if ((methodNameLength == 11 &&
+            !strncmp(methodName, "invokeBasic", methodNameLength)) ||
+         (methodNameLength == 12 &&
+            !strncmp(methodName, "linkToStatic", methodNameLength)) ||
+         (methodNameLength == 13 &&
+            (!strncmp(methodName, "linkToSpecial", methodNameLength) ||
+             !strncmp(methodName, "linkToVirtual", methodNameLength))) ||
+         (methodNameLength == 15 &&
+            !strncmp(methodName, "linkToInterface", methodNameLength)))
          return true;
       }
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4753,6 +4753,23 @@ typedef struct J9VMThread {
 	void* heapBaseForBarrierRange0;
 	UDATA heapSizeForBarrierRange0;
 	UDATA* jniLocalReferences;
+	/**
+	 * tempSlot is an overloaded field used for multiple purposes.
+	 *
+	 * Note: Listed below is one such use, and the other uses of this field still need to be
+	 * documented.
+	 *
+	 * 1. OpenJDK MethodHandle implementation
+	 *		For signature-polymorphic INL calls from compiled code for the following methods:
+	 *		* java/lang/invoke/MethodHandle.invokeBasic
+	 *		* java/lang/invoke/MethodHandle.linkToStatic
+	 *		* java/lang/invoke/MethodHandle.linkToSpecial
+	 *		* java/lang/invoke/MethodHandle.linkToVirtual
+	 *		* java/lang/invoke/MethodHandle.linkToInterface
+	 *		the compiled code performs a store to this field right before the INL call. The
+	 *		stored value represents the number of stack slots occupied by the args, and the
+	 *		interpreter uses the value to locate the beginning of the arguments on the stack.
+	 */
 	UDATA tempSlot;
 	void* jitReturnAddress;
 	/* floatTemp1 must be 8-aligned */

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -8245,19 +8245,22 @@ done:
 	{
 		VM_BytecodeAction rc = GOTO_RUN_METHOD;
 		bool fromJIT = J9_ARE_ANY_BITS_SET(_currentThread->jitStackFrameFlags, J9_SSF_JIT_NATIVE_TRANSITION_FRAME);
-		UDATA methodArgCount = 0;
+		UDATA mhReceiverIndex = 0;
 
 		if (fromJIT) {
-			methodArgCount = _currentThread->tempSlot;
+			/* tempSlot contains the number of stack slots for the arguments, and the MH
+			 * receiver is the first argument.
+			 */
+			mhReceiverIndex = _currentThread->tempSlot - 1;
 		} else {
 			U_16 index = *(U_16 *)(_pc + 1);
 			J9ConstantPool *ramConstantPool = J9_CP_FROM_METHOD(_literals);
 			J9RAMMethodRef *ramMethodRef = ((J9RAMMethodRef *)ramConstantPool) + index;
 			UDATA volatile methodIndexAndArgCount = ramMethodRef->methodIndexAndArgCount;
-			methodArgCount = (methodIndexAndArgCount & 0xFF);
+			mhReceiverIndex = (methodIndexAndArgCount & 0xFF);
 		}
 
-		j9object_t mhReceiver = ((j9object_t *)_sp)[methodArgCount];
+		j9object_t mhReceiver = ((j9object_t *)_sp)[mhReceiverIndex];
 		if (J9_UNEXPECTED(NULL == mhReceiver)) {
 			return THROW_NPE;
 		}


### PR DESCRIPTION
linkTo* calls (linkToStatic, linkToSpecial, linkToVirtual and
linkToInterface) are also signature-polymorphic, requiring the JIT
to specify the number of stack slots used by the args
for the interpreter to locate the start of the args
on the stack. This is achieved by performing a store to
vmThread.tempSlot before the INL call, similar to how it was
done for invokeBasic. For invokeBasic, the value stored in
tempSlot is now the number of arg slots, and not the location of
the MH receiver object.

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>

Related: #11877 