### PR TITLE
Deprecate PrefetchInsertion optimization

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2020 IBM Corp. and others
+# Copyright (c) 2000, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -218,7 +218,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/optimizer/OSRDefAnalysis.cpp \
     omr/compiler/optimizer/PartialRedundancy.cpp \
     omr/compiler/optimizer/PreExistence.cpp \
-    omr/compiler/optimizer/PrefetchInsertion.cpp \
     omr/compiler/optimizer/Reachability.cpp \
     omr/compiler/optimizer/ReachingDefinitions.cpp \
     omr/compiler/optimizer/RedundantAsyncCheckRemoval.cpp \

--- a/runtime/compiler/optimizer/J9Optimizer.cpp
+++ b/runtime/compiler/optimizer/J9Optimizer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -203,7 +203,6 @@ static const OptimizationStrategy fsdStrategyOptsForMethodsWithoutSlotSharing[] 
    { OMR::localDeadStoreElimination,   OMR::IfEnabled }, //remove the astore if no literal pool is required
    { OMR::localCSE,                    OMR::IfEnabled },  //common up lit pool refs in the same block
    { OMR::deadTreesElimination,        OMR::IfEnabled }, // cleanup at the end
-   { OMR::prefetchInsertionGroup,      OMR::IfLoops   }, // created IL should not be moved
    { OMR::treeSimplification,          OMR::IfEnabledMarkLastRun       }, // Simplify non-normalized address computations introduced by prefetch insertion
    { OMR::trivialDeadTreeRemoval,      OMR::IfEnabled }, // final cleanup before opcode expansion
    { OMR::globalDeadStoreElimination,            },
@@ -358,7 +357,6 @@ static const OptimizationStrategy warmStrategyOpts[] =
    { OMR::localCSE,                                  OMR::IfEnabled  },  //common up lit pool refs in the same block
    { OMR::deadTreesElimination,                      OMR::IfEnabled                  }, // cleanup at the end
    { OMR::signExtendLoadsGroup,                      OMR::IfEnabled                  }, // last opt before GRA
-   { OMR::prefetchInsertionGroup,                    OMR::IfLoops                    }, // created IL should not be moved
    { OMR::treeSimplification,                        OMR::IfEnabledMarkLastRun       }, // Simplify non-normalized address computations introduced by prefetch insertion
    { OMR::trivialDeadTreeRemoval,                    OMR::IfEnabled                  }, // final cleanup before opcode expansion
    { OMR::globalDeadStoreElimination,                OMR::IfVoluntaryOSR            },
@@ -436,7 +434,6 @@ const OptimizationStrategy hotStrategyOpts[] =
    { OMR::loopAliasRefinerGroup,                 OMR::IfLoops     },
    { OMR::recompilationModifier,                 OMR::IfEnabledAndNotProfiling },
    { OMR::sequentialStoreSimplificationGroup,                             }, // reduce sequential stores into an arrayset
-   { OMR::prefetchInsertionGroup,                OMR::IfLoops                  }, // created IL should not be moved
    { OMR::partialRedundancyEliminationGroup                               },
    { OMR::globalDeadStoreElimination,            OMR::IfLoopsAndNotProfiling   },
    { OMR::inductionVariableAnalysis,             OMR::IfLoopsAndNotProfiling   },
@@ -522,7 +519,6 @@ const OptimizationStrategy scorchingStrategyOpts[] =
    { OMR::recompilationModifier,                 OMR::IfEnabled   },
 
    { OMR::sequentialStoreSimplificationGroup                 }, // reduce sequential stores into an arrayset
-   { OMR::prefetchInsertionGroup,                OMR::IfLoops     }, // created IL should not be moved
    { OMR::partialRedundancyEliminationGroup                  },
    { OMR::globalDeadStoreElimination,            OMR::IfLoops     },
    { OMR::inductionVariableAnalysis,             OMR::IfLoops     },
@@ -620,7 +616,6 @@ static const OptimizationStrategy AOTStrategyOpts[] =
    { OMR::globalDeadStoreElimination,            OMR::IfMoreThanOneBlock}, // global dead store removal
    { OMR::deadTreesElimination                             }, // cleanup after dead store removal
    { OMR::compactNullChecks                                }, // cleanup at the end
-   { OMR::prefetchInsertionGroup,                OMR::IfLoops   }, // created IL should not be moved
    { OMR::finalGlobalGroup                                 }, // done just before codegen
    { OMR::regDepCopyRemoval                                },
    { OMR::endOpts                                          }


### PR DESCRIPTION
The optimization has O(n^2) complexity and is currently disabled for
forward array traversals, and recently we've had to disable it under
all array traversals for concurrent scavenge. As read barriers become
more prominent, the introduction of the dataAddr pointer in the header
will force us to further limit this optimization.

This optimization was originally introduced in 2010 for z196
z/Architecture processor to accelerate SPEC workloads. It showed
minimal improvement (1.5%) according to historical data dug up prior to
open sourcing the project. The hardware is hardly used today since it
is so old. In recent iterations of the hardware, software prefetching
has been discouraged due to advancements in hardware prefetching.
Similar observations were seen when we removed prefetching from our
zero memory routines.

Moreover, the phantom words past the end of the GC heap were removed
several years ago, forcing us to disable this optimization for forward
array traversals. As mentioned previously we have been encountering
bugs in this optimization recently due to changes in the JVM and the
fact that this optimization introduces loads on the heap which
previously did not exist.

In the PR we detail performance numbers for several workloads where
we believed this optimization may have provided a benefit. Across all
platforms measured we no longer see a benefit (and sometimes a
degradation) from running this optimization. Here we deprecate the
optimization as we still have access to the original source code in
the history if we ever need to resurrect this effort.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>