### PR TITLE
AArch64: Exclude cmdLineTester_jep178_staticLinking_SE80

### DIFF
--- a/test/functional/cmdLineTests/jep178staticLinkingTest/playlist.xml
+++ b/test/functional/cmdLineTests/jep178staticLinkingTest/playlist.xml
@@ -31,6 +31,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<comment>https://github.com/eclipse/openj9/issues/11854</comment>
 			<plat>ppc64le.*</plat>
 		</disabled>
+		<disabled>
+			<comment>https://github.com/eclipse/openj9/issues/12050</comment>
+			<plat>aarch64.*</plat>
+		</disabled>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DJAVATEST_ROOT=$(Q)$(JAVATEST_ROOT)$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) \


### PR DESCRIPTION
This commit excludes cmdLineTester_jep178_staticLinking_SE80 on AArch64.
Issue #12050.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>