### PR TITLE
(0.25.0) Added missing volatile keywords to J9Profiler

### DIFF
--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -246,7 +246,7 @@ class TR_PersistentProfileInfo
    int32_t _maxCount;
 
    // Manage several uses of this info
-   intptr_t _refCount;
+   volatile intptr_t _refCount;
 
    // Flag to determine whether the information is being actively updated
    bool _active;
@@ -1033,15 +1033,15 @@ class TR_JProfilerThread
    size_t getProfileInfoFootprint() { return _footprint * sizeof(TR_PersistentProfileInfo); }
 
    protected:
-   TR_PersistentProfileInfo *deleteProfileInfo(TR_PersistentProfileInfo **prevNext, TR_PersistentProfileInfo *info);
+   TR_PersistentProfileInfo *deleteProfileInfo(TR_PersistentProfileInfo * volatile *prevNext, TR_PersistentProfileInfo *info);
 
-   TR_PersistentProfileInfo *_listHead;
-   uintptr_t                 _footprint;
-   TR::Monitor              *_jProfilerMonitor;
-   j9thread_t                _jProfilerOSThread;
-   J9VMThread               *_jProfilerThread;
-   volatile State            _state;
-   static const uint32_t     _waitMillis = 500;
+   TR_PersistentProfileInfo * volatile  _listHead;
+   volatile uintptr_t                   _footprint;
+   TR::Monitor                         *_jProfilerMonitor;
+   j9thread_t                           _jProfilerOSThread;
+   J9VMThread                          *_jProfilerThread;
+   volatile State                       _state;
+   static const uint32_t                _waitMillis = 500;
    };
 
 #endif


### PR DESCRIPTION
This is a copy of: https://github.com/eclipse/openj9/pull/11845

Added volatile keyword to member variables in TR_PersistentProfileInfo and
TR_JProfilerThread that can be accessed by multiple threads.

Adjusted usage of these variable to ensure the volatile quality is preserved
through casting.

Also changed some C style casts to reinterpret_cast to be more specific.

Issue: #11526
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>