### PR TITLE
Fix tracing for 9416

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1737,7 +1737,7 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
    void *classChain = NULL;
 
    // all kinds of validations may need to rely on the entire class chain, so make sure we can build one first
-   classChain = fej9->sharedCache()->rememberClass(definingClass);
+   classChain = fej9->sharedCache()->rememberClass(true, comp, definingClass);
    if (!classChain)
       {
       ADD_TRACING_BUFFER_MESSAGE(comp, "relo::storeValRecordIfNec, classChain NULL, %p, %p, %d, %p\n", definingClass, constantPool, cpIndex, ramMethod);


### PR DESCRIPTION
When the tracing to debug #9416 was first added, a minor change was
missed that would allow the tracing of rememberClass. This commit fixes
it so that the tracing is enabled.

Signed-off-by: Irwin D'Souza <dsouzai.gh@gmail.com>