### PR TITLE
Deprecate ObjectModel preMove/postMove over new API

### DIFF
--- a/runtime/gc_vlhgc/WriteOnceCompactor.cpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.cpp
@@ -1171,8 +1171,7 @@ MMINLINE void
 MM_WriteOnceCompactor::preObjectMove(MM_EnvironmentVLHGC* env, J9Object *objectPtr, UDATA *objectSizeAfterMove)
 {
 	*objectSizeAfterMove = _extensions->objectModel.getConsumedSizeInBytesWithHeaderForMove(objectPtr);
-	_extensions->objectModel.preMove(env->getOmrVMThread(), objectPtr); // To be deprecated
-	//env->preObjectMoveForCompact(objectPtr); // Will substitute line above
+	env->preObjectMoveForCompact(objectPtr);
 }
 
 MMINLINE void
@@ -1182,19 +1181,8 @@ MM_WriteOnceCompactor::postObjectMove(MM_EnvironmentVLHGC* env, J9Object *newLoc
 	if (_extensions->objectModel.isRemembered(newLocation)) {
 		_extensions->objectModel.clearRemembered(newLocation);
 	}
-	if (_extensions->objectModel.isIndexable(newLocation)) {
-		_extensions->indexableObjectModel.fixupInternalLeafPointersAfterCopy((J9IndexableObject*) newLocation, (J9IndexableObject*) objectPtr);
 
-		/* Updates internal data address of indexable objects. Every indexable object have a void *dataAddr
-		 * that always points to the array data. It will always point to the address right after the header,
-		 * in case of contiguous data it will point to the data itself, and in case of discontiguous
-		 * arraylet it will point to the first arrayiod. dataAddr is only updated if dataAddr points to data
-		 * within heap. */
-		_extensions->indexableObjectModel.fixupDataAddr(newLocation);
-	}
-
-	_extensions->objectModel.postMove(env->getOmrVMThread(), newLocation); // To be deprecated along with lines above
-	//env->postObjectMoveForCompact(newLocation, objectPtr); // Will substitute lines above
+	env->postObjectMoveForCompact(newLocation, objectPtr);
 }
 
 void


### PR DESCRIPTION
Update WriteOnceCompactor to use new pre/postObjectMoveForCompact
This is phase 3 of required changes highlighted in https://github.com/eclipse/openj9/pull/11890#discussion_r575252566

Also remove calculateObjectDetailsForCopy from ObjectModel since it's not needed anymore (they're both in ObjectModelBase)

Depends on: https://github.com/eclipse/omr/pull/5843

Signed-off-by: Igor Braga <higorb1@gmail.com>