### PR TITLE
Implement RAII for JITServer persistent allocation

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8862,15 +8862,6 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
          that->_methodBeingCompiled->_compErrCode = compilationFailure;
          }
 
-#if defined(J9VM_OPT_JITSERVER)
-      if (compiler && compiler->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
-         {
-         compiler->getOptions()->closeLogFileForClientOptions();
-         if (!that->getPerClientPersistentMemory()) // threw while outside of per-client region, re-enter it here
-            that->enterPerClientAllocationRegion();
-         }
-#endif /* defined(J9VM_OPT_JITSERVER) */
-
       if (compiler)
          {
          // The KOT needs to survive at least until we're done committing virtual guards and we must not be holding the

--- a/runtime/compiler/env/JITServerAllocationRegion.hpp
+++ b/runtime/compiler/env/JITServerAllocationRegion.hpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef JITSERVER_ALLOCATION_REGION_HPP
+#define JITSERVER_ALLOCATION_REGION_HPP
+#include "control/CompilationThread.hpp"
+namespace JITServer
+{
+   /**
+    * @brief The JITServer::PerClientAllocationRegion class wraps enter/exitPerClientAllocationRegion
+    * with RAII functionality to help automate the lifetime of a per-client allocation region.
+    */
+   class PerClientAllocationRegion
+      {
+      public:
+      /**
+       * @brief Declare the beginning of a per-client allocation region.
+       * If already inside a per-client allocation region or per-client allocator
+       * cannot be used, will do nothing.
+       */
+      PerClientAllocationRegion(TR::CompilationInfoPerThreadBase *compInfoPT)
+         : _compInfoPT(compInfoPT)
+         {
+         _compInfoPT->enterPerClientAllocationRegion();
+         }
+
+      /**
+       * @brief Automatically notify the end of a per-client allocation region
+       * and switch back to the global allocator.
+       */
+      ~PerClientAllocationRegion()
+         {
+         _compInfoPT->exitPerClientAllocationRegion();
+         }
+
+      private:
+      TR::CompilationInfoPerThreadBase *_compInfoPT;
+      };
+
+
+   /**
+    * @brief The JITServer::GlobalAllocationRegion class wraps exit/enterPerClientAllocationRegion
+    * with RAII functionality to help automate the lifetime of a global allocation region.
+    */
+   class GlobalAllocationRegion
+      {
+      public:
+      /**
+       * @brief Declare the beginning of a global allocation region.
+       * If already inside a global allocation region, this will do nothing.
+       */
+      GlobalAllocationRegion(TR::CompilationInfoPerThreadBase *compInfoPT)
+         : _compInfoPT(compInfoPT)
+         {
+         _compInfoPT->exitPerClientAllocationRegion();
+         }
+
+      /**
+       * @brief Automatically notify the end of a global allocation region
+       * and switch back to the per-client allocator.
+       */
+      ~GlobalAllocationRegion()
+         {
+         _compInfoPT->enterPerClientAllocationRegion();
+         }
+
+      private:
+      TR::CompilationInfoPerThreadBase *_compInfoPT;
+      };
+} // namespace JITServer
+#endif // JITSERVER_ALLOCATION_REGION_HPP

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -70,6 +70,9 @@
 #include "optimizer/UseDefInfo.hpp"
 #include "ras/Debug.hpp"
 #include "omrformatconsts.h"
+#if defined(J9VM_OPT_JITSERVER)
+#include "env/JITServerAllocationRegion.hpp"
+#endif
 
 #define OPT_DETAILS "O^O NEWLOOPREDUCER: "
 #define VERBOSE 0
@@ -1037,186 +1040,184 @@ TR_CISCGraph::makePreparedCISCGraphs(TR::Compilation *c)
    // Prepared CISC graphs are static, i.e. initialized only once.
    // Need to use the global allocator here.
    if (c->isOutOfProcessCompilation())
-      c->fej9()->_compInfoPT->exitPerClientAllocationRegion();
-#endif
-   int32_t num = 0;
-   bool genTRxx = c->cg()->getSupportsArrayTranslateTRxx();
-   bool genSIMD = c->cg()->getSupportsVectorRegisters() && !c->getOption(TR_DisableSIMDArrayTranslate);
-   bool genTRTO255 = c->cg()->getSupportsArrayTranslateTRTO255();
-   bool genTRTO = c->cg()->getSupportsArrayTranslateTRTO();
-   bool genTROTNoBreak = c->cg()->getSupportsArrayTranslateTROTNoBreak();
-   bool genTROT = c->cg()->getSupportsArrayTranslateTROT();
-   bool genTRT =  c->cg()->getSupportsArrayTranslateAndTest();
-   bool genMemcpy = c->cg()->getSupportsReferenceArrayCopy() || c->cg()->getSupportsPrimitiveArrayCopy();
-   bool genMemset = c->cg()->getSupportsArraySet();
-   bool genMemcmp = c->cg()->getSupportsArrayCmp();
-   bool genIDiv2Mul = c->cg()->getSupportsLoweringConstIDiv();
-   bool genLDiv2Mul = c->cg()->getSupportsLoweringConstLDiv();
-   // FIXME: We need getSupportsCountDecimalDigit() like interface
-   // this idiom is only enabled on 390 for the moment
-
-#if defined(J9VM_OPT_JITSERVER)
-   // Enabling genDecimal generates the TROT instruction on Z which is currently not
-   // relocatable for remote compiles. Thus we disable this option for remote compiles for now.
-   bool genDecimal = c->target().cpu.isZ() && !c->isOutOfProcessCompilation();
+      {
+      JITServer::GlobalAllocationRegion globalAllocationRegion(c->fej9()->_compInfoPT);
 #else
-   bool genDecimal = c->target().cpu.isZ();
-#endif /* defined(J9VM_OPT_JITSERVER) */
-   bool genBitOpMem = c->target().cpu.isZ();
-   bool is64Bit = c->target().is64Bit();
-   bool isBig = c->target().cpu.isBigEndian();
-   int32_t ctrl = (is64Bit ? CISCUtilCtl_64Bit : 0) | (isBig ? CISCUtilCtl_BigEndian : 0);
-
-   // THESE ARE NOT GUARANTEED OR TESTED TO WORK ON WCODE.
-   // Problems encountered include ahSize=0 on WCode leading to hash collision when adding node for make*CISCGraphs.
-   if (genMemcmp)
       {
-      preparedCISCGraphs[num] =  makeMemCmpGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeMemCmpIndexOfGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeMemCmpSpecialGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      }
-   if (genTRT)
-      {
-      preparedCISCGraphs[num] =  makeTRTGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeTRTGraph2(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeTRT4NestedArrayGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      //preparedCISCGraphs[num] =  makeTRT4NestedArrayIfGraph(c, ctrl); setEssentialNodes(preparedCISCGraphs[num]); num++;
-      }
-   if (genMemset)
-      {
-      preparedCISCGraphs[num] =  makeMemSetGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-#if STRESS_TEST
-      preparedCISCGraphs[num] =  makeMixedMemSetGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
 #endif
-      preparedCISCGraphs[num] = makePtrArraySetGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      // Causes perf degradations on Xalan strlen16 opportunities. SRSTU is only better on long strings.
-      //preparedCISCGraphs[num] = makeStrlen16Graph(c, ctrl);
-      //setEssentialNodes(preparedCISCGraphs[num++]);
-      }
-   if (genMemcpy)
-      {
-      preparedCISCGraphs[num] =  makeMemCpyGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeMemCpyDecGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeMemCpySpecialGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeMemCpyByteToCharGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeMemCpyByteToCharBndchkGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeMemCpyCharToByteGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeMEMCPYChar2ByteGraph2(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeMEMCPYChar2ByteMixedGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      // disabled for now
-#if STRESS_TEST
-      preparedCISCGraphs[num] =  makeMEMCPYByte2IntGraph(c, ctrl); setEssentialNodes(preparedCISCGraphs[num]); num++;
-      preparedCISCGraphs[num] =  makeMEMCPYInt2ByteGraph(c, ctrl); setEssentialNodes(preparedCISCGraphs[num]); num++;
-#endif
-      }
-
-   if (genTRTO255 || genTRTO || genSIMD || genTRxx)
-      {
-      preparedCISCGraphs[num] =  makeCopyingTRTxGraph(c, ctrl, 0);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeCopyingTRTxGraph(c, ctrl, 1);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeCopyingTRTxGraph(c, ctrl, 2);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeCopyingTRTxThreeIfsGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeCopyingTRTOInduction1Graph(c, ctrl, 0);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeCopyingTRTOInduction1Graph(c, ctrl, 1);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeCopyingTRTOInduction1Graph(c, ctrl, 2);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-
-      }
-
-   if (genTROTNoBreak || genTROT || genSIMD || genTRxx)
-      {
-      preparedCISCGraphs[num] =  makeCopyingTROxGraph(c, ctrl, 0);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeCopyingTROxGraph(c, ctrl, 1);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      }
-
-   if (genTRxx)
-      {
-      if (c->getOption(TR_EnableCopyingTROTInduction1Idioms))
-         {
-         preparedCISCGraphs[num] =  makeCopyingTROTInduction1Graph(c, ctrl, 0);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         preparedCISCGraphs[num] =  makeCopyingTROTInduction1Graph(c, ctrl, 1);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         }
-      preparedCISCGraphs[num] =  makeCopyingTROOSpecialGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-#if STRESS_TEST
-      preparedCISCGraphs[num] =  makeCopyingTRTTSpecialGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-#endif
-      if (is64Bit)
-         {
-         preparedCISCGraphs[num] =  makeCopyingTRTOGraphSpecial(c, ctrl);
-         setEssentialNodes(preparedCISCGraphs[num++]);
-         }
-      preparedCISCGraphs[num] =  makeTROTArrayGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeTRTOArrayGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeTRTOArrayGraphSpecial(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      }
-   if (genDecimal)
-      {
-      // Needs to be modified
-      preparedCISCGraphs[num] =  makeCountDecimalDigitIntGraph(c, ctrl, genIDiv2Mul);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeIntToStringGraph(c, ctrl, genIDiv2Mul);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      preparedCISCGraphs[num] =  makeCountDecimalDigitLongGraph(c, ctrl, genLDiv2Mul);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-#if STRESS_TEST
-      preparedCISCGraphs[num] =  makeLongToStringGraph(c, ctrl); setEssentialNodes(preparedCISCGraphs[num]); num++;
-#endif
-      }
-   if (genBitOpMem)
-      {
-      preparedCISCGraphs[num] =  makeBitOpMemGraph(c, ctrl);
-      setEssentialNodes(preparedCISCGraphs[num++]);
-      }
-
-   TR_ASSERT(num <= MAX_PREPARED_GRAPH, "incorrect number of graphs!");
-   numPreparedCISCGraphs = num;
-
-   // set minimumHotnessPrepared;
-   minimumHotnessPrepared = scorching;
-   for (;--num >= 0;)
-      {
-      TR_Hotness hotness = preparedCISCGraphs[num]->getHotness();
-      if (minimumHotnessPrepared > hotness)
-         minimumHotnessPrepared = hotness;
-      }
+      int32_t num = 0;
+      bool genTRxx = c->cg()->getSupportsArrayTranslateTRxx();
+      bool genSIMD = c->cg()->getSupportsVectorRegisters() && !c->getOption(TR_DisableSIMDArrayTranslate);
+      bool genTRTO255 = c->cg()->getSupportsArrayTranslateTRTO255();
+      bool genTRTO = c->cg()->getSupportsArrayTranslateTRTO();
+      bool genTROTNoBreak = c->cg()->getSupportsArrayTranslateTROTNoBreak();
+      bool genTROT = c->cg()->getSupportsArrayTranslateTROT();
+      bool genTRT =  c->cg()->getSupportsArrayTranslateAndTest();
+      bool genMemcpy = c->cg()->getSupportsReferenceArrayCopy() || c->cg()->getSupportsPrimitiveArrayCopy();
+      bool genMemset = c->cg()->getSupportsArraySet();
+      bool genMemcmp = c->cg()->getSupportsArrayCmp();
+      bool genIDiv2Mul = c->cg()->getSupportsLoweringConstIDiv();
+      bool genLDiv2Mul = c->cg()->getSupportsLoweringConstLDiv();
+      // FIXME: We need getSupportsCountDecimalDigit() like interface
+      // this idiom is only enabled on 390 for the moment
 
 #if defined(J9VM_OPT_JITSERVER)
-   // Return to per-client allocation
-   if (c->isOutOfProcessCompilation())
-      c->fej9()->_compInfoPT->enterPerClientAllocationRegion();
+      // Enabling genDecimal generates the TROT instruction on Z which is currently not
+      // relocatable for remote compiles. Thus we disable this option for remote compiles for now.
+      bool genDecimal = c->target().cpu.isZ() && !c->isOutOfProcessCompilation();
+#else
+      bool genDecimal = c->target().cpu.isZ();
+#endif /* defined(J9VM_OPT_JITSERVER) */
+      bool genBitOpMem = c->target().cpu.isZ();
+      bool is64Bit = c->target().is64Bit();
+      bool isBig = c->target().cpu.isBigEndian();
+      int32_t ctrl = (is64Bit ? CISCUtilCtl_64Bit : 0) | (isBig ? CISCUtilCtl_BigEndian : 0);
+
+      // THESE ARE NOT GUARANTEED OR TESTED TO WORK ON WCODE.
+      // Problems encountered include ahSize=0 on WCode leading to hash collision when adding node for make*CISCGraphs.
+      if (genMemcmp)
+         {
+         preparedCISCGraphs[num] =  makeMemCmpGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeMemCmpIndexOfGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeMemCmpSpecialGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         }
+      if (genTRT)
+         {
+         preparedCISCGraphs[num] =  makeTRTGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeTRTGraph2(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeTRT4NestedArrayGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         //preparedCISCGraphs[num] =  makeTRT4NestedArrayIfGraph(c, ctrl); setEssentialNodes(preparedCISCGraphs[num]); num++;
+         }
+      if (genMemset)
+         {
+         preparedCISCGraphs[num] =  makeMemSetGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+#if STRESS_TEST
+         preparedCISCGraphs[num] =  makeMixedMemSetGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
 #endif
+         preparedCISCGraphs[num] = makePtrArraySetGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         // Causes perf degradations on Xalan strlen16 opportunities. SRSTU is only better on long strings.
+         //preparedCISCGraphs[num] = makeStrlen16Graph(c, ctrl);
+         //setEssentialNodes(preparedCISCGraphs[num++]);
+         }
+      if (genMemcpy)
+         {
+         preparedCISCGraphs[num] =  makeMemCpyGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeMemCpyDecGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeMemCpySpecialGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeMemCpyByteToCharGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeMemCpyByteToCharBndchkGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeMemCpyCharToByteGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeMEMCPYChar2ByteGraph2(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeMEMCPYChar2ByteMixedGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         // disabled for now
+#if STRESS_TEST
+         preparedCISCGraphs[num] =  makeMEMCPYByte2IntGraph(c, ctrl); setEssentialNodes(preparedCISCGraphs[num]); num++;
+         preparedCISCGraphs[num] =  makeMEMCPYInt2ByteGraph(c, ctrl); setEssentialNodes(preparedCISCGraphs[num]); num++;
+#endif
+         }
+
+      if (genTRTO255 || genTRTO || genSIMD || genTRxx)
+         {
+         preparedCISCGraphs[num] =  makeCopyingTRTxGraph(c, ctrl, 0);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeCopyingTRTxGraph(c, ctrl, 1);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeCopyingTRTxGraph(c, ctrl, 2);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeCopyingTRTxThreeIfsGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeCopyingTRTOInduction1Graph(c, ctrl, 0);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeCopyingTRTOInduction1Graph(c, ctrl, 1);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeCopyingTRTOInduction1Graph(c, ctrl, 2);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+
+         }
+
+      if (genTROTNoBreak || genTROT || genSIMD || genTRxx)
+         {
+         preparedCISCGraphs[num] =  makeCopyingTROxGraph(c, ctrl, 0);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeCopyingTROxGraph(c, ctrl, 1);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         }
+
+      if (genTRxx)
+         {
+         if (c->getOption(TR_EnableCopyingTROTInduction1Idioms))
+            {
+            preparedCISCGraphs[num] =  makeCopyingTROTInduction1Graph(c, ctrl, 0);
+            setEssentialNodes(preparedCISCGraphs[num++]);
+            preparedCISCGraphs[num] =  makeCopyingTROTInduction1Graph(c, ctrl, 1);
+            setEssentialNodes(preparedCISCGraphs[num++]);
+            }
+         preparedCISCGraphs[num] =  makeCopyingTROOSpecialGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+#if STRESS_TEST
+         preparedCISCGraphs[num] =  makeCopyingTRTTSpecialGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+#endif
+         if (is64Bit)
+            {
+            preparedCISCGraphs[num] =  makeCopyingTRTOGraphSpecial(c, ctrl);
+            setEssentialNodes(preparedCISCGraphs[num++]);
+            }
+         preparedCISCGraphs[num] =  makeTROTArrayGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeTRTOArrayGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeTRTOArrayGraphSpecial(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         }
+      if (genDecimal)
+         {
+         // Needs to be modified
+         preparedCISCGraphs[num] =  makeCountDecimalDigitIntGraph(c, ctrl, genIDiv2Mul);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeIntToStringGraph(c, ctrl, genIDiv2Mul);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         preparedCISCGraphs[num] =  makeCountDecimalDigitLongGraph(c, ctrl, genLDiv2Mul);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+#if STRESS_TEST
+         preparedCISCGraphs[num] =  makeLongToStringGraph(c, ctrl); setEssentialNodes(preparedCISCGraphs[num]); num++;
+#endif
+         }
+      if (genBitOpMem)
+         {
+         preparedCISCGraphs[num] =  makeBitOpMemGraph(c, ctrl);
+         setEssentialNodes(preparedCISCGraphs[num++]);
+         }
+
+      TR_ASSERT(num <= MAX_PREPARED_GRAPH, "incorrect number of graphs!");
+      numPreparedCISCGraphs = num;
+
+      // set minimumHotnessPrepared;
+      minimumHotnessPrepared = scorching;
+      for (;--num >= 0;)
+         {
+         TR_Hotness hotness = preparedCISCGraphs[num]->getHotness();
+         if (minimumHotnessPrepared > hotness)
+            minimumHotnessPrepared = hotness;
+         }
+      }
    }
 
 void


### PR DESCRIPTION
This commit adds two classes:
- `JITServer::PerClientAllocationRegion`
- `JITServer::GlobalAllocationRegion`
They implement a RAII mechanism for per-client/global allocation regions
which enables creation of critical section-like regions for
memory allocation.

Closes: #12032 