### PR TITLE
Do not protect the last metadata page if the cache is locked

### DIFF
--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -1628,15 +1628,7 @@ SH_CacheMap::runEntryPointChecks(J9VMThread* currentThread, void* address, const
 		}
 
 		if (true == hasMutex) {
-			if (!_ccHead->isLocked()) {
-				_ccHead->protectPartiallyFilledPages(currentThread);
-			} else {
-				/* Do not protect last partially filled metadata page when cache is locked.
-				 * During lock state, whole of metadata in the cache is unprotected.
-				 * As such, protecting only the last partially filled page is not of much use.
-				 */
-				_ccHead->protectPartiallyFilledPages(currentThread, true, false, true);
-			}
+			_ccHead->protectPartiallyFilledPages(currentThread);
 			if (doExitMutex) {
 				_ccHead->exitWriteMutex(currentThread, "runEntryPointChecks");
 			}

--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -5809,6 +5809,11 @@ SH_CompositeCacheImpl::protectPartiallyFilledPages(J9VMThread *currentThread,  b
 		 */
 		BlockPtr segmentPtrPage = (BlockPtr)ROUND_DOWN_TO(_osPageSize, (UDATA)SEGUPDATEPTR(_theca));
 		BlockPtr updatePtrPage = (BlockPtr)ROUND_DOWN_TO(_osPageSize, (UDATA)UPDATEPTR(_theca));
+		
+		/* Do not protect last partially filled metadata page when cache is locked.
+		 * During lock state, whole of metadata in the cache is unprotected.
+		 */
+		protectMetadataPage = protectMetadataPage && !isLocked();
 
 		if ((segmentPtrPage != updatePtrPage) || (protectSegmentPage == protectMetadataPage)) {
 			if (protectSegmentPage) {


### PR DESCRIPTION
protectPartiallyFilledPages() should not memory protect the partially
filled metadata page if the cache is locked. It could result in
segmentation fault later if the update is on the that page.

Fixes #11988

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>