### PR TITLE
Allow AOT Warm compilations during startup under FSD

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8195,17 +8195,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
             bool aotCompilationReUpgradedToWarm = false;
-
-            // When FSD is enabled, involuntary OSR is also enabled. This means that the code
-            // size increases because of all of the catch block + code blocks, and the data
-            // size increases because of the additional information required in the the
-            // J9JITExceptionTable. This means that for applications that do not use a very
-            // large SCC, the number of methods that can now be put into the SCC reduces.
-            // In this scenario, startup is dominated by the number of AOT loads can that be
-            // performed rather than code quality. Therefore, disabling AOT Warm during startup
-            // disables inlining, thus dramatically reducing the code & data size.
-            if (that->_methodBeingCompiled->_useAotCompilation
-                && !TR::Options::getCmdLineOptions()->getOption(TR_FullSpeedDebug))
+            if (that->_methodBeingCompiled->_useAotCompilation)
                {
                // In some circumstances AOT compilations are performed at warm
                if ((TR::Options::getCmdLineOptions()->getAggressivityLevel() == TR::Options::AGGRESSIVE_AOT ||


### PR DESCRIPTION
The initial change to enable AOT compilations under FSD did not allow
AOT warm compilations during startup as this improved startup. However,
this was only necessary if the SCC used is small; when using a bigger
SCC, the regression disappears and in fact, startup can even be
improved.

The reason why a larger SCC helps is because under FSD, the AOT bodies
are much bigger because of all the OSR code blocks. As a result, the SCC
could not hold as many AOT warm bodies as it can without FSD.

Signed-off-by: Irwin D'Souza <dsouzai.gh@gmail.com>