### PR TITLE
Fix missing update of the set of classes cached at JITServer

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1091,6 +1091,10 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
       case MessageType::ResolvedMethod_getRemoteROMClassAndMethods:
          {
          J9Class *clazz = std::get<0>(client->getRecvData<J9Class *>());
+            {
+            OMR::CriticalSection romClassCache(compInfo->getclassesCachedAtServerMonitor());
+            compInfo->getclassesCachedAtServer().insert(clazz);
+            }
          client->write(response, JITServerHelpers::packRemoteROMClassInfo(clazz, fe->vmThread(), trMemory, true));
          }
          break;

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -3075,26 +3075,22 @@ remoteCompile(
       }
 
    if (compiler->getOption(TR_UseSymbolValidationManager))
-       {
-       // We do not want client to validate anything during compilation, because
-       // validations are done on the server. Creating heuristic region makes SVM assume that everything is valdiated.
-       compiler->enterHeuristicRegion();
-       }
+      {
+      // We do not want client to validate anything during compilation, because
+      // validations are done on the server. Creating heuristic region makes SVM assume that everything is valdiated.
+      compiler->enterHeuristicRegion();
+      }
 
    if (compiler->isOptServer())
       compiler->setOption(TR_Server);
 
-      // Check the _classesCachedAtServer set to determine whether JITServer is likely to have this class already cached.
-      // If so, do not send the ROMClass content to save network traffic.
-      bool serializeClass = false;
+   // Check the _classesCachedAtServer set to determine whether JITServer is likely to have this class already cached.
+   // If so, do not send the ROMClass content to save network traffic.
+   bool serializeClass = false;
       {
       OMR::CriticalSection romClassCache(compInfo->getclassesCachedAtServerMonitor());
-      if (compInfo->getclassesCachedAtServer().find(clazz) == compInfo->getclassesCachedAtServer().end())
-         {
-         // clazz not found. Send the romClass to JITServer.
-         compInfo->getclassesCachedAtServer().insert(clazz);
-         serializeClass = true;
-         }
+      // Send the romClass to JITServer if clazz was not already in the set
+      serializeClass = compInfo->getclassesCachedAtServer().insert(clazz).second;
       }
 
    auto classInfoTuple = JITServerHelpers::packRemoteROMClassInfo(clazz, compiler->fej9vm()->vmThread(), compiler->trMemory(), serializeClass);


### PR DESCRIPTION
When handling the `ResolvedMethod_getRemoteROMClassAndMethods` message at the JIT client, the class being sent to the server should be added to set of classes cached at the server, in order to avoid sending its ROMClass again if the client requests a compilation of a method of this class in the future.

This PR also makes adding to the set of cached classes before sending the compilation request more efficient by avoiding a double hash lookup.