### PR TITLE
Make diagnostic thread compilations uninterruptible

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -4310,7 +4310,7 @@ TR::CompilationInfoPerThread::processEntry(TR_MethodToBeCompiled &entry, J9::J9S
 
    // We have acquired VM access above and will be releasing it below. It is possible however that during the
    // compilation process in the above `compile(...)` call we have released VM access and have subsequently
-   // crashed or asserted. In such a scenarion the JitDump process will have started and queued the method
+   // crashed or asserted. In such a scenario the JitDump process will have started and queued the method
    // for recompilation with a custom signal handler to catch the crash/assertion and return. The JitDump
    // compilation will have hopefully crashed/asserted in the same place as the original compilation, and
    // thus we will not be holding VM access at that point. This means we will return from the above call to
@@ -7969,6 +7969,8 @@ TR::CompilationInfoPerThreadBase::compile(J9VMThread * vmThread,
          uintptr_t protectedResult = 0;
          if (entry->getMethodDetails().isJitDumpMethod())
             {
+            TR::CompilationInfoPerThreadBase::UninterruptibleOperation jitDumpRecompilation(*this);
+
             protectedResult = j9sig_protect(wrappedCompile, static_cast<void*>(&compParam),
                                                 jitDumpSignalHandler, 
                                                 vmThread, flags, &result);

--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -533,7 +533,7 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
                         // We are a compilation thread
 
                         // See comment below for the same call on why this is needed
-                        TR::CompilationInfoPerThreadBase::UninterruptibleOperation generateJitDumpForCrashedThread(*threadCompInfo);
+                        TR::CompilationInfoPerThreadBase::UninterruptibleOperation jitDumpForCrashedCompilationThread(*threadCompInfo);
 
                         // See comment below for the same call on why this is needed
                         TR::VMAccessCriticalSection requestSynchronousCompilation(TR_J9VMBase::get(jitConfig, crashedThread));
@@ -680,7 +680,7 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
          // classes may cause compilations to be interrupted. Because the crashed thread is not a diagnostic thread,
          // the call to print the crashed thread IL may get interrupted and the jitdump will be incomplete. We prevent
          // this from occuring by disallowing interruptions until we are done generating the jitdump.
-         TR::CompilationInfoPerThreadBase::UninterruptibleOperation generateJitDumpForCrashedThread(*threadCompInfo);
+         TR::CompilationInfoPerThreadBase::UninterruptibleOperation jitDumpForCrashedCompilationThread(*threadCompInfo);
 
          // if the compilation is in progress, dump interesting things from it and then recompile
          if (comp)


### PR DESCRIPTION
It is possible that due to an external effect, for example running
out of JIT code cache, GC wanting to unload classes, etc. the
diagnostic thread compilation may be interrupted. We want to ensure
this does not happen by making compilations on the diagnostic thread
uninterruptible so that we can always generate a JitDump.

Closes: #11860

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>