### PR TITLE
Clean up tree lowering for ArrayStoreCHK

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3078,6 +3078,23 @@ static TR::ILOpCodes udataCmpEqOpCode(TR::Compilation * comp)
       }
    }
 
+TR::Node *
+TR_J9VMBase::testAreSomeClassFlagsSet(TR::Node *j9ClassRefNode, uint32_t flagsToTest)
+   {
+   TR::SymbolReference *classFlagsSymRef = TR::comp()->getSymRefTab()->findOrCreateClassFlagsSymbolRef();
+
+   TR::Node *loadClassFlags = TR::Node::createWithSymRef(TR::iloadi, 1, 1, j9ClassRefNode, classFlagsSymRef);
+   TR::Node *isValueTypeNode = TR::Node::create(TR::iand, 2, loadClassFlags, TR::Node::iconst(j9ClassRefNode, flagsToTest));
+
+   return isValueTypeNode;
+   }
+
+TR::Node *
+TR_J9VMBase::testIsClassValueType(TR::Node *j9ClassRefNode)
+   {
+   return testAreSomeClassFlagsSet(j9ClassRefNode, J9ClassIsValueType);
+   }
+
 TR::TreeTop *
 TR_J9VMBase::lowerAsyncCheck(TR::Compilation * comp, TR::Node * root, TR::TreeTop * treeTop)
    {

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1000,6 +1000,25 @@ public:
 
    TR::Node * initializeLocalObjectFlags(TR::Compilation *, TR::Node * allocationNode, TR_OpaqueClassBlock * ramClass);
 
+   /**
+    * \brief Load class flags field of the specified class and test whether any of the
+    *        specified flags is set.
+    * \param j9ClassRefNode A node representing a reference to a \ref J9Class
+    * \param flagsToTest    The class field flags that are to be checked
+    * \return \ref TR::Node that evaluates to a non-zero integer if any of the specified
+    *         flags is set; or evaluates to zero, otherwise.
+    */
+   TR::Node * testAreSomeClassFlagsSet(TR::Node *j9ClassRefNode, uint32_t flagsToTest);
+
+   /**
+    * \brief Load class flags field of the specified class and test whether the value type
+    *        field is set.
+    * \param j9ClassRefNode A node representing a reference to a \ref J9Class
+    * \return \ref TR::Node that evaluates to a non-zero integer if the class is a value type,
+    *         or zero if the class is an identity type
+    */
+   TR::Node * testIsClassValueType(TR::Node *j9ClassRefNode);
+
    virtual J9JITConfig *getJ9JITConfig() { return _jitConfig; }
 
    virtual int32_t getCompThreadIDForVMThread(void *vmThread);


### PR DESCRIPTION
This pull request addresses comments on `TreeLowering::lowerArrayStoreCHK` that arose in the review of pull request #11968.  In particular:

- Corrected `lowerArrayStoreCHK` comments to indicate that only `awrtbari` is expected to be a child of an `ArrayStoreCHK`, and added a fatal assertion to confirm that.
- Moved generation of IL that examines the flags field of a class into `TR_J9VMBase` to isolate optimizer from detailed knowledge of J9.
- Removed a redundant call to `copyByteCodeInfo`.