### PR TITLE
Fix register usage in P awrtbari evaluator

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -1450,8 +1450,8 @@ TR::Register *J9::Power::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::Co
       TR::Register *destinationAddressRegister = cg->allocateRegister();
 
       TR::LoadStoreHandler::generateComputeAddressSequence(cg, destinationAddressRegister, node);
-      VMwrtbarEvaluator(node, storeRegister, destinationRegister, destinationAddressRegister, NULL, secondChild->isNonNull(), true, usingCompressedPointers, cg);
-      TR::LoadStoreHandler::generateStoreAddressSequence(cg, sourceRegister, node, destinationAddressRegister, storeOp, sizeofMR);
+      VMwrtbarEvaluator(node, sourceRegister, destinationRegister, destinationAddressRegister, NULL, secondChild->isNonNull(), true, usingCompressedPointers, cg);
+      TR::LoadStoreHandler::generateStoreAddressSequence(cg, storeRegister, node, destinationAddressRegister, storeOp, sizeofMR);
 
       cg->stopUsingRegister(destinationAddressRegister);
       }


### PR DESCRIPTION
The refactor of the POWER awrtbariEvaluator as a part of the POWER
LoadStore refactoring work (#11305) switched the usage of
sourceRegister and storeRegister which holds the full and compressed
refs respectively when using compressedRefs.

Original Code:
https://github.com/eclipse/openj9/blob/0283464fbbf67170558ac013378241f65a9afb8d/runtime/compiler/p/codegen/J9TreeEvaluator.cpp#L1523-L1552

`storeRegister` defined as:
https://github.com/eclipse/openj9/blob/e0a0f345a12aa81cf17372dc90717ca775dc5132/runtime/compiler/p/codegen/J9TreeEvaluator.cpp#L1445

Signed-off-by: Abdulrahman Alattas <rmnattas@gmail.com>