### PR TITLE
Extend class loader table to support JITServer AOT cache

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -2176,7 +2176,7 @@ static void jitHookClassLoaderUnload(J9HookInterface * * hookInterface, UDATA ev
    if (compInfo->getPersistentInfo()->isRuntimeInstrumentationEnabled())
       compInfo->getHWProfiler()->invalidateProfilingBuffers();
 
-   compInfo->getPersistentInfo()->getPersistentClassLoaderTable()->removeClassLoader(classLoader);
+   compInfo->getPersistentInfo()->getPersistentClassLoaderTable()->removeClassLoader(vmThread, classLoader);
    }
 
 #endif /* defined (J9VM_GC_DYNAMIC_CLASS_UNLOADING)*/
@@ -3581,7 +3581,7 @@ void jitHookClassLoadHelper(J9VMThread *vmThread,
       TR::Options::_numberOfUserClassesLoaded ++;
       }
 
-   compInfo->getPersistentInfo()->getPersistentClassLoaderTable()->associateClassLoaderWithClass(classLoader, clazz);
+   compInfo->getPersistentInfo()->getPersistentClassLoaderTable()->associateClassLoaderWithClass(vmThread, classLoader, clazz);
 
    // Update the count for the newInstance
    //

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2015,8 +2015,8 @@ J9::Options::fePreProcess(void * base)
          const char *xxUseJITServerOption = "-XX:+UseJITServer";
          const char *xxDisableUseJITServerOption = "-XX:-UseJITServer";
 
-         int32_t xxUseJITServerArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxUseJITServerOption, 0);
-         int32_t xxDisableUseJITServerArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxDisableUseJITServerOption, 0);
+         int32_t xxUseJITServerArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxUseJITServerOption, 0);
+         int32_t xxDisableUseJITServerArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableUseJITServerOption, 0);
 
          // Check if option is at all specified
          if (xxUseJITServerArgIndex > xxDisableUseJITServerArgIndex)
@@ -2027,8 +2027,8 @@ J9::Options::fePreProcess(void * base)
             const char *xxJITServerTechPreviewMessageOption = "-XX:+JITServerTechPreviewMessage";
             const char *xxDisableJITServerTechPreviewMessageOption = "-XX:-JITServerTechPreviewMessage";
 
-            int32_t xxJITServerTechPreviewMessageArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerTechPreviewMessageOption, 0);
-            int32_t xxDisableJITServerTechPreviewMessageArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxDisableJITServerTechPreviewMessageOption, 0);
+            int32_t xxJITServerTechPreviewMessageArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxJITServerTechPreviewMessageOption, 0);
+            int32_t xxDisableJITServerTechPreviewMessageArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableJITServerTechPreviewMessageOption, 0);
 
             if (xxJITServerTechPreviewMessageArgIndex >= xxDisableJITServerTechPreviewMessageArgIndex)
                {

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1098,12 +1098,16 @@ static void JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compI
    const char *xxJITServerSSLKeyOption = "-XX:JITServerSSLKey=";
    const char *xxJITServerSSLCertOption = "-XX:JITServerSSLCert=";
    const char *xxJITServerSSLRootCertsOption = "-XX:JITServerSSLRootCerts=";
+   const char *xxJITServerUseAOTCacheOption = "-XX:+JITServerUseAOTCache";
+   const char *xxDisableJITServerUseAOTCacheOption = "-XX:-JITServerUseAOTCache";
 
    int32_t xxJITServerPortArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerPortOption, 0);
    int32_t xxJITServerTimeoutArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerTimeoutOption, 0);
    int32_t xxJITServerSSLKeyArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerSSLKeyOption, 0);
    int32_t xxJITServerSSLCertArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerSSLCertOption, 0);
    int32_t xxJITServerSSLRootCertsArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxJITServerSSLRootCertsOption, 0);
+   int32_t xxJITServerUseAOTCacheArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxJITServerUseAOTCacheOption, 0);
+   int32_t xxDisableJITServerUseAOTCacheArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisableJITServerUseAOTCacheOption, 0);
 
    if (xxJITServerPortArgIndex >= 0)
       {
@@ -1146,6 +1150,9 @@ static void JITServerParseCommonOptions(J9JavaVM *vm, TR::CompilationInfo *compI
       if (!cert.empty())
          compInfo->setJITServerSslRootCerts(cert);
       }
+
+   if (xxJITServerUseAOTCacheArgIndex > xxDisableJITServerUseAOTCacheArgIndex)
+      compInfo->getPersistentInfo()->setJITServerUseAOTCache(true);
    }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 

--- a/runtime/compiler/env/ClassLoaderTable.hpp
+++ b/runtime/compiler/env/ClassLoaderTable.hpp
@@ -38,10 +38,10 @@ public:
    TR_PERSISTENT_ALLOC(TR_Memory::PersistentCHTable)
    TR_PersistentClassLoaderTable(TR_PersistentMemory *persistentMemory);
 
-   void associateClassLoaderWithClass(void *loader, TR_OpaqueClassBlock *clazz);
+   void associateClassLoaderWithClass(J9VMThread *vmThread, void *loader, TR_OpaqueClassBlock *clazz);
    void *lookupClassChainAssociatedWithClassLoader(void *loader) const;
    void *lookupClassLoaderAssociatedWithClassChain(void *chain) const;
-   void removeClassLoader(void *loader);
+   void removeClassLoader(J9VMThread *vmThread, void *loader);
 
    void setSharedCache(TR_SharedCache *sharedCache) { _sharedCache = sharedCache; }
 

--- a/runtime/compiler/env/ClassLoaderTable.hpp
+++ b/runtime/compiler/env/ClassLoaderTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,53 +23,38 @@
 #ifndef CLASSLOADERTABLE_INCL
 #define CLASSLOADERTABLE_INCL
 
-#include "compile/Compilation.hpp"
 #include "env/SharedCache.hpp"
-#include "infra/Link.hpp"
-#include "infra/List.hpp"
-#include "infra/Array.hpp"
-#include "runtime/RuntimeAssumptions.hpp"
+#include "env/TRMemory.hpp"
 
-class TR_Debug;
-class TR_DebugExt;
 
-#define   CLASSLOADERTABLE_SIZE   2053
+#define CLASSLOADERTABLE_SIZE 2053
 
 struct TR_ClassLoaderInfo;
 
 class TR_PersistentClassLoaderTable
    {
-   public:
+public:
 
-   TR_ALLOC(TR_Memory::PersistentCHTable)
-   TR_PersistentClassLoaderTable(TR_PersistentMemory *);
+   TR_PERSISTENT_ALLOC(TR_Memory::PersistentCHTable)
+   TR_PersistentClassLoaderTable(TR_PersistentMemory *persistentMemory);
 
-   void associateClassLoaderWithClass(void *classLoaderPointer, TR_OpaqueClassBlock *clazz);
-   void *lookupClassLoaderAssociatedWithClassChain(void *classChainPointer);
-   void *lookupClassChainAssociatedWithClassLoader(void *classLoaderPointer);
-   void removeClassLoader(void *classLoaderPointer);
+   void associateClassLoaderWithClass(void *loader, TR_OpaqueClassBlock *clazz);
+   void *lookupClassChainAssociatedWithClassLoader(void *loader) const;
+   void *lookupClassLoaderAssociatedWithClassChain(void *chain) const;
+   void removeClassLoader(void *loader);
 
    void setSharedCache(TR_SharedCache *sharedCache) { _sharedCache = sharedCache; }
 
-   private:
+private:
 
    friend class TR_Debug;
    friend class TR_DebugExt;
 
-   TR_PersistentMemory *trPersistentMemory() { return _trPersistentMemory; }
-
-
-   int32_t hashLoader(void *classLoaderPointer);
-   int32_t hashClassChain(void *classChain);
-
-   TR_ClassLoaderInfo * _loaderTable[CLASSLOADERTABLE_SIZE];
-   TR_ClassLoaderInfo * _classChainTable[CLASSLOADERTABLE_SIZE];
-   TR_PersistentMemory *_trPersistentMemory;
-
-   TR_SharedCache *sharedCache() { return _sharedCache; }
+   TR_PersistentMemory *const _persistentMemory;
    TR_SharedCache *_sharedCache;
 
-   static int32_t _numClassLoaders;
+   TR_ClassLoaderInfo *_loaderTable[CLASSLOADERTABLE_SIZE];
+   TR_ClassLoaderInfo *_chainTable[CLASSLOADERTABLE_SIZE];
    };
 
 #endif

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -158,6 +158,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _JITServerPort(38400),
          _socketTimeoutMs(2000),
          _clientUID(0),
+         _JITServerUseAOTCache(false),
 #endif /* defined(J9VM_OPT_JITSERVER) */
       OMR::PersistentInfoConnector(pm)
       {}
@@ -331,6 +332,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    void setJITServerPort(uint32_t port) { _JITServerPort = port; }
    uint64_t getClientUID() const { return _clientUID; }
    void setClientUID(uint64_t val) { _clientUID = val; }
+   bool getJITServerUseAOTCache() const { return _JITServerUseAOTCache; }
+   void setJITServerUseAOTCache(bool use) { _JITServerUseAOTCache = use; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    private:
@@ -420,6 +423,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    uint32_t    _JITServerPort;
    uint32_t    _socketTimeoutMs; // timeout for communication sockets used in out-of-process JIT compilation
    uint64_t    _clientUID;
+   bool        _JITServerUseAOTCache;
 #endif /* defined(J9VM_OPT_JITSERVER) */
    };
 


### PR DESCRIPTION
This PR makes the following changes:

- A third index is added to the class loader table - name of the first class loaded by the given class loader. This mapping will be used to find the right class loader to lookup classes in when deserializing cached AOT methods received from the JITServer. The mapping between class loaders and the name of the first loaded class is maintained only if the JVM uses the JITServer and the new runtime option `-XX:+JITServerUseAOTCache` is specified (it's disabled by default).

- The multi-index map is now more space-efficient: the same entry struct is linked into multiple lists (one for each hash table). Removing an entry when a class loader is unloaded is now O(1) as it doesn't scan the whole class chain hash table. The implementation is refactored to avoid duplicating the code for manipulating the hash tables.

- Added comments describing how the access to the class loader table is synchronized, and runtime assertions to check the necessary assumptions. Fixed a missing memory barrier.

Issue: #12153