### PR TITLE
[v0.25.0] Reinforce the check on the sealed classes in JEP397

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2020 IBM Corp. and others
+# Copyright (c) 2000, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2009,4 +2009,22 @@ J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_BASED.sample_input_2=Foo
 J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_BASED.explanation=The class has specified the bytecode monitorenter or monitorexit operation which cannot be performed on a value-based class but the object on stack is an instance of value-based class.
 J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_BASED.system_action=The JVM will throw an VirtualMachineError.
 J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_BASED.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+# Message to use when class/interface is not in the same module as its sealed super class/interface
+# argument 1 is the class name
+J9NLS_VM_CLASS_LOADING_ERROR_SEALED_SUPER_IN_DIFFERENT_MODULE=The class/interface %2$.*1$s is not in the same module as its sealed super class/interface.
+# START NON-TRANSLATABLE
+J9NLS_VM_CLASS_LOADING_ERROR_SEALED_SUPER_IN_DIFFERENT_MODULE.explanation=The specified class must be in the same module as its sealed super class/interface.
+J9NLS_VM_CLASS_LOADING_ERROR_SEALED_SUPER_IN_DIFFERENT_MODULE.system_action=The JVM will throw an IncompatibleClassChangeError.
+J9NLS_VM_CLASS_LOADING_ERROR_SEALED_SUPER_IN_DIFFERENT_MODULE.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+# Message to use when non-public class/interface is not in the same package as its sealed super class/interface
+# argument 1 is the class name
+J9NLS_VM_CLASS_LOADING_ERROR_SEALED_SUPER_IN_DIFFERENT_PACKAGE=The non-public class/interface %2$.*1$s is not in the same package as its sealed super class/interface.
+# START NON-TRANSLATABLE
+J9NLS_VM_CLASS_LOADING_ERROR_SEALED_SUPER_IN_DIFFERENT_PACKAGE.explanation=The specified non-public class must be in the same package as its sealed super class/interface.
+J9NLS_VM_CLASS_LOADING_ERROR_SEALED_SUPER_IN_DIFFERENT_PACKAGE.system_action=The JVM will throw an IncompatibleClassChangeError.
+J9NLS_VM_CLASS_LOADING_ERROR_SEALED_SUPER_IN_DIFFERENT_PACKAGE.user_response=Contact the provider of the classfile for a corrected version.
 # END NON-TRANSLATABLE

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -874,3 +874,6 @@ TraceExit=Trc_VM_resolveInvokeDynamic_Exit Overhead=1 Level=3 Template="resolveI
 TraceEntry=Trc_VM_sendResolveOpenJDKInvokeHandle_Entry Overhead=1 Level=2 Template="sendResolveOpenJDKInvokeHandle"
 TraceExit=Trc_VM_sendResolveOpenJDKInvokeHandle_Exit Overhead=1 Level=2 Template="sendResolveOpenJDKInvokeHandle"
 TraceEntry=Trc_VM_romClassLoadFromCookie_Entry2 Overhead=1 Level=3 Template="romClassLoadFromCookie vmStruct=%p clsNamePtr=%p clsName=%.*s romClassBytes=%p romClassLength=%d"
+
+TraceException=Trc_VM_CreateRAMClassFromROMClass_sealedSuperFromDifferentModule Overhead=1 Level=1 Template="The sealed super class/interface (RAM class=%p) is not in the same module as %.*s"
+TraceException=Trc_VM_CreateRAMClassFromROMClass_sealedSuperFromDifferentPackage Overhead=1 Level=1 Template="The sealed super class/interface (RAM class=%p) is not in the same package as %.*s (non-public)"

--- a/test/functional/Java16andUp/build.xml
+++ b/test/functional/Java16andUp/build.xml
@@ -35,12 +35,45 @@
 	<!--Properties for this particular build-->
 	<property name="src" location="./src"/>
 	<property name="build" location="./bin"/>
+	<property name="module_src_root" location="./modules"/>
+	<property name="module_bin_root" location="./module_bin"/>
+	<property name="dest_module_bin" location="${DEST}/module_bin"/>
 	<property name="LIB" value="asm,testng,jcommander"/>
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
 
 	<target name="init">
 		<mkdir dir="${DEST}" />
 		<mkdir dir="${build}"/>
+	</target>
+	
+	<property name="MODULE_NAME_ROOT" value="org.openj9test.modularity" />
+	<property name="MODULE_PATH_ROOT" value="org/openj9/test/modularity"/>
+	
+	<target name="compile_modules" depends="init" description="Create the base modules for the sealed classes">
+		<mkdir dir="${module_bin_root}" />
+		<copy file="${LIB_DIR}/testng.jar" todir="${module_bin_root}" />
+		<copy file="${LIB_DIR}/jcommander.jar" todir="${module_bin_root}" />
+		<copy file="${LIB_DIR}/asm.jar" todir="${module_bin_root}" />
+		<for list="moduleX,moduleY" param="mod">
+			<sequential>
+				<var name="module_src_dir" value="${module_src_root}/${MODULE_NAME_ROOT}.@{mod}" />
+				<var name="module_bin_dir" value="${module_bin_root}/${MODULE_NAME_ROOT}.@{mod}" />
+				<mkdir dir="${module_bin_dir}" />
+				<var name="modpath" value="--module-path ${module_bin_root} -d ${module_bin_dir}" />
+				<javac srcdir="${module_src_dir}" destdir="${module_bin_dir}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${module_src_dir}" />
+					<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
+					<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
+					<compilerarg line="${modpath}" />
+					<classpath>
+						<pathelement location="${LIB_DIR}/testng.jar"/>
+						<pathelement location="${LIB_DIR}/jcommander.jar"/>
+						<pathelement location="${LIB_DIR}/asm.jar" />
+						<pathelement location="${build}" />
+					</classpath>
+				</javac>
+			</sequential>
+		</for>
 	</target>
 
 	<target name="compile" depends="init,getDependentLibs" description="Using java ${JDK_VERSION} to compile the source" >
@@ -53,6 +86,7 @@
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}"/>
+			<exclude name="**/modules/**" />
 			<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
 			<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
 			<classpath>
@@ -64,10 +98,16 @@
 		</javac>
 	</target>
 
-	<target name="dist" depends="compile,dist_functional" description="generate the distribution" >
+	<target name="dist" depends="compile,dist_functional,compile_modules" description="generate the distribution" >
+		<echo>copy ${module_bin_root} to ${dest_module_bin}</echo>
+		<mkdir dir="${dest_module_bin}"/>
+		<copy todir="${dest_module_bin}">
+			<fileset dir="${module_bin_root}"/>
+		</copy>
 		<mkdir dir="${DEST}"/>
 		<jar jarfile="${DEST}/GeneralTest.jar" filesonly="true">
 			<fileset dir="${build}"/>
+			<fileset dir="${dest_module_bin}"/>
 			<fileset dir="${src}/../" includes="*.properties,*.xml"/>
 		</jar>
 		<copy todir="${DEST}">

--- a/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/module-info.java
+++ b/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/module-info.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+module org.openj9test.modularity.moduleX {
+	exports org.openj9.test.modularity.pkgA;
+	exports org.openj9.test.modularity.pkgD;
+	requires testng;
+	requires org.objectweb.asm;
+}

--- a/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/org/openj9/test/modularity/pkgA/SuperClassSealed.java
+++ b/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/org/openj9/test/modularity/pkgA/SuperClassSealed.java
@@ -1,0 +1,32 @@
+package org.openj9.test.modularity.pkgA;
+
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import org.openj9.test.modularity.pkgD.SubClassPermitted1;
+
+public sealed class SuperClassSealed permits TestSubclass1,SubClassPermitted1 {
+}
+
+/* Only used for the placeholder in the PermittedSubclasses attribute of the sealed superclass */
+non-sealed class TestSubclass1 extends SuperClassSealed {
+}

--- a/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/org/openj9/test/modularity/pkgA/SuperInterfaceSealed.java
+++ b/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/org/openj9/test/modularity/pkgA/SuperInterfaceSealed.java
@@ -1,0 +1,32 @@
+package org.openj9.test.modularity.pkgA;
+
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import org.openj9.test.modularity.pkgD.SubClassPermitted2;
+
+public sealed interface SuperInterfaceSealed permits TestSubclass2, SubClassPermitted2 {
+}
+
+/* Only used for the placeholder in the PermittedSubclasses attribute of the sealed superinterface */
+non-sealed class TestSubclass2 implements SuperInterfaceSealed {
+}

--- a/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/org/openj9/test/modularity/pkgD/SubClassPermitted1.java
+++ b/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/org/openj9/test/modularity/pkgD/SubClassPermitted1.java
@@ -1,0 +1,28 @@
+package org.openj9.test.modularity.pkgD;
+
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import org.openj9.test.modularity.pkgA.SuperClassSealed;
+
+public non-sealed class SubClassPermitted1 extends SuperClassSealed {
+}

--- a/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/org/openj9/test/modularity/pkgD/SubClassPermitted2.java
+++ b/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/org/openj9/test/modularity/pkgD/SubClassPermitted2.java
@@ -1,0 +1,29 @@
+package org.openj9.test.modularity.pkgD;
+
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import org.openj9.test.modularity.pkgA.SuperInterfaceSealed;
+import org.openj9.test.modularity.pkgD.SuperClassInSamePkg;
+
+public non-sealed class SubClassPermitted2 extends SuperClassInSamePkg implements SuperInterfaceSealed {
+}

--- a/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/org/openj9/test/modularity/pkgD/SuperClassInSamePkg.java
+++ b/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/org/openj9/test/modularity/pkgD/SuperClassInSamePkg.java
@@ -1,0 +1,25 @@
+package org.openj9.test.modularity.pkgD;
+
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+public class SuperClassInSamePkg {}

--- a/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/org/openj9/test/modularity/pkgD/Test_SubClass.java
+++ b/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleX/org/openj9/test/modularity/pkgD/Test_SubClass.java
@@ -1,0 +1,75 @@
+package org.openj9.test.modularity.pkgD;
+
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+import org.objectweb.asm.*;
+import static org.objectweb.asm.Opcodes.V_PREVIEW;
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+import static org.objectweb.asm.Opcodes.V16;
+
+/**
+ * Test cases for JEP 397: Sealed Classes (Second Preview)
+ * 
+ * Verify whether it works good when the subclass is in a different package
+ * from the sealed super class/interface within the same named module.
+ */
+@Test(groups = { "level.sanity" })
+public class Test_SubClass {
+	static String subClassName = "org.openj9.test.modularity.pkgD.SubClassPermitted1";
+	
+	/* sealed classes are still a preview feature as of jdk 16, and OpenJ9 requires that
+	 * major version match the latest supported version when --enable-preview flag is active
+	 */
+	private static int latestPreviewVersion;
+	static {
+		String runtimeVersion = System.getProperty("java.version");
+		int versionNum = Integer.parseInt(runtimeVersion.substring(0, 2));
+		switch (versionNum) {
+			case 16:
+				latestPreviewVersion = V16;
+				break;
+			case 17:
+				latestPreviewVersion = 61; // does ASM support jdk17 yet?
+				break;
+			default:
+				latestPreviewVersion = V16; // next release
+		}
+	}
+	
+	@Test
+	public void test_subClassInTheDifferentPackageFromSealedSuperClass() throws ClassNotFoundException {
+		String subClassName = "org.openj9.test.modularity.pkgD.SubClassPermitted1";
+		ClassLoader classloader = Test_SubClass.class.getClassLoader();
+		Class<?> subClass = classloader.loadClass(subClassName);
+	}
+	
+	@Test
+	public void test_subClassInTheDifferentPackageFromSealedSuperInterface() throws ClassNotFoundException {
+		String subClassName = "org.openj9.test.modularity.pkgD.SubClassPermitted2";
+		ClassLoader classloader = Test_SubClass.class.getClassLoader();
+		Class<?> subClass = classloader.loadClass(subClassName);
+	}
+}

--- a/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleY/module-info.java
+++ b/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleY/module-info.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+module org.openj9test.modularity.moduleY {
+	exports org.openj9.test.modularity.pkgB;
+	requires org.openj9test.modularity.moduleX;
+	requires testng;
+	requires org.objectweb.asm;
+}

--- a/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleY/org/openj9/test/modularity/pkgB/SuperClassFromPkgB.java
+++ b/test/functional/Java16andUp/modules/org.openj9test.modularity.moduleY/org/openj9/test/modularity/pkgB/SuperClassFromPkgB.java
@@ -1,0 +1,25 @@
+package org.openj9.test.modularity.pkgB;
+
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+public class SuperClassFromPkgB {}

--- a/test/functional/Java16andUp/playlist.xml
+++ b/test/functional/Java16andUp/playlist.xml
@@ -43,4 +43,87 @@
 			<subset>16+</subset>
 		</subsets>
 	</test>
+	
+	<test>
+		<testCaseName>Jep397Tests_testSubClassOfSealedSuperFromDifferentModule</testCaseName>
+		<variations>
+			<variation>--enable-preview</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+			-cp $(Q)$(TEST_RESROOT)$(D)module_bin$(D)org.openj9test.modularity.moduleX$(Q) \
+			-cp $(Q)$(TEST_RESROOT)$(D)module_bin$(D)org.openj9test.modularity.moduleY$(Q) \
+			--module-path $(Q)$(TEST_RESROOT)$(D)module_bin$(Q) \
+			--add-modules org.openj9test.modularity.moduleX,org.openj9test.modularity.moduleY \
+			--add-exports org.openj9test.modularity.moduleX/org.openj9.test.modularity.pkgA=ALL-UNNAMED \
+			--add-exports org.openj9test.modularity.moduleY/org.openj9.test.modularity.pkgB=ALL-UNNAMED \
+			--add-reads org.openj9test.modularity.moduleX=ALL-UNNAMED \
+			--add-reads org.openj9test.modularity.moduleY=ALL-UNNAMED \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testSubClassOfSealedSuperFromDifferentModule.xml$(Q) -testnames Jep397Tests_testSubClassOfSealedSuperFromDifferentModule \
+			-groups $(TEST_GROUP) \
+			-excludegroups $(DEFAULT_EXCLUDE); \
+			$(TEST_STATUS)
+		</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>16+</subset>
+		</subsets>
+	</test>
+	
+	<test>
+		<testCaseName>Jep397Tests_testSubClassOfSealedSuperFromDifferentPackageInSameUnamedModule</testCaseName>
+		<variations>
+			<variation>--enable-preview</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testSubClassOfSealedSuperFromDifferentPackageInSameUnamedModule.xml$(Q) -testnames Jep397Tests_testSubClassOfSealedSuperFromDifferentPackageInSameUnamedModule \
+			-groups $(TEST_GROUP) \
+			-excludegroups $(DEFAULT_EXCLUDE); \
+			$(TEST_STATUS)
+		</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>16+</subset>
+		</subsets>
+	</test>
+	
+	<test>
+		<testCaseName>Jep397Tests_testSubClassOfSealedSuperFromDifferentPackageInSameNamedModule</testCaseName>
+		<variations>
+			<variation>--enable-preview</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+			-cp $(Q)$(TEST_RESROOT)$(D)module_bin$(D)org.openj9test.modularity.moduleX$(Q) \
+			--module-path $(Q)$(TEST_RESROOT)$(D)module_bin$(Q) \
+			--add-modules org.openj9test.modularity.moduleX \
+			--add-exports org.openj9test.modularity.moduleX/org.openj9.test.modularity.pkgA=ALL-UNNAMED \
+			--add-exports org.openj9test.modularity.moduleX/org.openj9.test.modularity.pkgD=ALL-UNNAMED \
+			--add-reads org.openj9test.modularity.moduleX=ALL-UNNAMED \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testSubClassOfSealedSuperFromDifferentPackageInSameNamedModule.xml$(Q) -testnames Jep397Tests_testSubClassOfSealedSuperFromDifferentPackageInSameNamedModule \
+			-groups $(TEST_GROUP) \
+			-excludegroups $(DEFAULT_EXCLUDE); \
+			$(TEST_STATUS)
+		</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>16+</subset>
+		</subsets>
+	</test>
 </playlist>

--- a/test/functional/Java16andUp/src/org/openj9/test/java/lang/SuperClassInSamePkg.java
+++ b/test/functional/Java16andUp/src/org/openj9/test/java/lang/SuperClassInSamePkg.java
@@ -1,0 +1,25 @@
+package org.openj9.test.java.lang;
+
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+public class SuperClassInSamePkg {}

--- a/test/functional/Java16andUp/src/org/openj9/test/java/lang/Test_SubClass.java
+++ b/test/functional/Java16andUp/src/org/openj9/test/java/lang/Test_SubClass.java
@@ -1,0 +1,57 @@
+package org.openj9.test.java.lang;
+
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+import org.openj9.test.utilities.CustomClassLoader;
+import org.openj9.test.utilities.SealedClassGenerator;
+import org.openj9.test.java.pkgC.SuperClassSealed;
+import org.openj9.test.java.pkgC.SuperInterfaceSealed;
+import org.openj9.test.java.lang.SuperClassInSamePkg;
+/**
+ * Test cases for JEP 397: Sealed Classes (Second Preview)
+ * 
+ * Verify whether IncompatibleClassChangeError is thrown out when
+ * the specified non-public subclass is in a different package from
+ * the sealed super class/interface within the same unamed module.
+ */
+@Test(groups = { "level.sanity" })
+public class Test_SubClass {
+	@Test(expectedExceptions = java.lang.IncompatibleClassChangeError.class)
+	public void test_subClassInTheDifferentPackageFromSealedSuperClass() {
+		String subClassName = "TestSubclass";
+		CustomClassLoader classloader = new CustomClassLoader();
+		byte[] subClassNameBytes = SealedClassGenerator.generateSubclassInDifferentPackageFromSealedSuper(subClassName, SuperClassSealed.class, null);
+		Class<?> clazz = classloader.getClass(subClassName, subClassNameBytes);
+	}
+	
+	@Test(expectedExceptions = java.lang.IncompatibleClassChangeError.class)
+	public void test_subClassInTheDifferentPackageFromSealedSuperInterface() {
+		String subClassName = "TestSubclass";
+		CustomClassLoader classloader = new CustomClassLoader();
+		byte[] subClassNameBytes = SealedClassGenerator.generateSubclassInDifferentPackageFromSealedSuper(subClassName, SuperClassInSamePkg.class, SuperInterfaceSealed.class);
+		Class<?> clazz = classloader.getClass(subClassName, subClassNameBytes);
+	}
+}

--- a/test/functional/Java16andUp/src/org/openj9/test/java/pkgC/SuperClassSealed.java
+++ b/test/functional/Java16andUp/src/org/openj9/test/java/pkgC/SuperClassSealed.java
@@ -1,0 +1,30 @@
+package org.openj9.test.java.pkgC;
+
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+public sealed class SuperClassSealed permits TestSubclass1 {
+}
+
+/* Only used for the placeholder in the PermittedSubclasses attribute of the sealed superclass */
+non-sealed class TestSubclass1 extends SuperClassSealed {
+}

--- a/test/functional/Java16andUp/src/org/openj9/test/java/pkgC/SuperInterfaceSealed.java
+++ b/test/functional/Java16andUp/src/org/openj9/test/java/pkgC/SuperInterfaceSealed.java
@@ -1,0 +1,30 @@
+package org.openj9.test.java.pkgC;
+
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+public sealed interface SuperInterfaceSealed permits TestSubclass3 {
+}
+
+/* Only used for the placeholder in the PermittedSubclasses attribute of the sealed superinterface */
+non-sealed class TestSubclass3 implements SuperInterfaceSealed {
+}

--- a/test/functional/Java16andUp/testSubClassOfSealedSuperFromDifferentModule.xml
+++ b/test/functional/Java16andUp/testSubClassOfSealedSuperFromDifferentModule.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2021, 2021 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="Java16andUp suite" parallel="none" verbose="2">
+	<test name="Jep397Tests_testSubClassOfSealedSuperFromDifferentModule">
+		<classes>
+			<class name="org.openj9.test.modularity.pkgB.Test_SubClass"/>
+		</classes>
+	</test>
+</suite>

--- a/test/functional/Java16andUp/testSubClassOfSealedSuperFromDifferentPackageInSameNamedModule.xml
+++ b/test/functional/Java16andUp/testSubClassOfSealedSuperFromDifferentPackageInSameNamedModule.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2021, 2021 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="Java16andUp suite" parallel="none" verbose="2">
+	<test name="Jep397Tests_testSubClassOfSealedSuperFromDifferentPackageInSameNamedModule">
+		<classes>
+			<class name="org.openj9.test.modularity.pkgD.Test_SubClass"/>
+		</classes>
+	</test>
+</suite>

--- a/test/functional/Java16andUp/testSubClassOfSealedSuperFromDifferentPackageInSameUnamedModule.xml
+++ b/test/functional/Java16andUp/testSubClassOfSealedSuperFromDifferentPackageInSameUnamedModule.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2021, 2021 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="Java16andUp suite" parallel="none" verbose="2">
+	<test name="Jep397Tests_testSubClassOfSealedSuperFromDifferentPackageInSameUnamedModule">
+		<classes>
+			<class name="org.openj9.test.java.lang.Test_SubClass"/>
+		</classes>
+	</test>
+</suite>


### PR DESCRIPTION
The change is to add more check on the sealed classes
specified in JEP397: Sealed Classes (Second Preview)

Related: #11273

Port of https://github.com/eclipse/openj9/pull/12117 for the 0.25 release.