### PR TITLE
AArch64: Support Internal Pointer

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2630,11 +2630,6 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
       }
 
 #if defined(TR_HOST_ARM64)
-   // Internal Pointers support is not available in AArch64 yet.
-   // OpenJ9 issue #6367 tracks the work to enable.
-   //
-   self()->setOption(TR_DisableInternalPointers);
-
    // ArraySet support is not available in AArch64 yet.
    // OpenJ9 issue #6443 tracks the work to enable.
    //


### PR DESCRIPTION
Add logic to initialize internal pointer and pinning array slots in the method prologue.
Remove code that sets `TR_DisableInternalPointers` option for aarch64.

Depends on: 
- https://github.com/eclipse/omr/pull/5849
- https://github.com/eclipse/omr/pull/5857

Closes: #6367

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>