### PR TITLE
JDK17 adopts RI java.lang.String - rename String.hashCode to hash

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -246,7 +246,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 	private final byte[] value;
 	private final byte coder;
-	private int hashCode;
+	private int hash;
 
 	static {
 		stringArray = new String[stringArraySize];
@@ -824,7 +824,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 				value = compressedAsciiTable[theChar];
 				coder = LATIN1;
-				hashCode = theChar;
+				hash = theChar;
 			} else {
 				char theChar = helpers.getCharFromArrayByIndex(data, start);
 
@@ -837,7 +837,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				}
 
 				coder = UTF16;
-				hashCode = theChar;
+				hash = theChar;
 
 				if (enableCompression) {
 					initCompressionFlag();
@@ -887,7 +887,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 				value = compressedAsciiTable[theChar];
 				coder = LATIN1;
-				hashCode = theChar;
+				hash = theChar;
 			} else {
 				char theChar = helpers.getCharFromArrayByIndex(data, start);
 
@@ -900,7 +900,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				}
 
 				coder = UTF16;
-				hashCode = theChar;
+				hash = theChar;
 
 				if (enableCompression) {
 					initCompressionFlag();
@@ -944,7 +944,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public String(String string) {
 		value = string.value;
 		coder = string.coder;
-		hashCode = string.hashCode;
+		hash = string.hash;
 	}
 
 	/**
@@ -1706,10 +1706,10 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				if (s1Value == s2Value) {
 					return true;
 				} else {
-					// There was a time hole between first read of s.hashCode and second read if another thread does hashcode
+					// There was a time hole between first read of s.hash and second read if another thread does hashcode
 					// computing for incoming string object
-					int s1hash = s1.hashCode;
-					int s2hash = s2.hashCode;
+					int s1hash = s1.hash;
+					int s2hash = s2.hash;
 
 					if (s1hash != 0 && s2hash != 0 && s1hash != s2hash) {
 						return false;
@@ -2001,16 +2001,16 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 * @see #equals
 	 */
 	public int hashCode() {
-		if (hashCode == 0 && value.length > 0) {
+		if (hash == 0 && value.length > 0) {
 			// Check if the String is compressed
 			if (enableCompression && (compressionFlag == null || coder == LATIN1)) {
-				hashCode = hashCodeImplCompressed(value, 0, lengthInternal());
+				hash = hashCodeImplCompressed(value, 0, lengthInternal());
 			} else {
-				hashCode = hashCodeImplDecompressed(value, 0, lengthInternal());
+				hash = hashCodeImplDecompressed(value, 0, lengthInternal());
 			}
 		}
 
-		return hashCode;
+		return hash;
 	}
 
 	private static int hashCodeImplCompressed(byte[] value, int offset, int count) {
@@ -4184,7 +4184,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 	private final char[] value;
 	private final int count;
-	private int hashCode;
+	private int hash;
 
 	static {
 		stringArray = new String[stringArraySize];
@@ -4744,7 +4744,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 					value = compressedAsciiTable[theChar];
 					count = 1;
 
-					hashCode = theChar;
+					hash = theChar;
 				} else {
 
 					char theChar = data[start];
@@ -4757,7 +4757,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 					count = 1 | uncompressedBit;
 
-					hashCode = theChar;
+					hash = theChar;
 
 					initCompressionFlag();
 				}
@@ -4796,7 +4796,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				value = decompressedAsciiTable[theChar];
 				count = 1;
 
-				hashCode = theChar;
+				hash = theChar;
 			} else {
 				if (start == 0) {
 					value = data;
@@ -4823,7 +4823,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 					value = compressedAsciiTable[theChar];
 					count = 1;
 
-					hashCode = theChar;
+					hash = theChar;
 				} else {
 					char theChar = data[start];
 
@@ -4835,7 +4835,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 					count = 1 | uncompressedBit;
 
-					hashCode = theChar;
+					hash = theChar;
 
 					initCompressionFlag();
 				}
@@ -4874,7 +4874,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				value = decompressedAsciiTable[theChar];
 				count = 1;
 
-				hashCode = theChar;
+				hash = theChar;
 			} else {
 				if (start == 0 && sharingIsAllowed) {
 					value = data;
@@ -4898,7 +4898,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public String(String string) {
 		value = string.value;
 		count = string.count;
-		hashCode = string.hashCode;
+		hash = string.hash;
 	}
 
 	/**
@@ -5740,10 +5740,10 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				return true;
 			}
 
-			// There was a time hole between first read of s.hashCode and second read if another thread does hashcode
+			// There was a time hole between first read of s.hash and second read if another thread does hashcode
 			// computing for incoming string object
-			int s1hash = s1.hashCode;
-			int s2hash = s2.hashCode;
+			int s1hash = s1.hash;
+			int s2hash = s2.hash;
 
 			if (s1hash != 0 && s2hash != 0 && s1hash != s2hash) {
 				return false;
@@ -6057,18 +6057,18 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 * @see #equals
 	 */
 	public int hashCode() {
-		if (hashCode == 0) {
+		if (hash == 0) {
 			int length = lengthInternal();
 			if (length > 0) {
 				// Check if the String is compressed
 				if (enableCompression && (compressionFlag == null || count >= 0)) {
-					hashCode = hashCodeImplCompressed(value, 0, length);
+					hash = hashCodeImplCompressed(value, 0, length);
 				} else {
-					hashCode = hashCodeImplDecompressed(value, 0, length);
+					hash = hashCodeImplDecompressed(value, 0, length);
 				}
 			}
 		}
-		return hashCode;
+		return hash;
 	}
 
 	private static int hashCodeImplCompressed(char[] value, int offset, int count) {

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5023,7 +5023,7 @@ TR_J9VMBase::getStringFieldByName(TR::Compilation * comp, TR::SymbolReference * 
       pResult = (U_8*)string + J9VMJAVALANGSTRING_COUNT_OFFSET(vmThread());
    else if (field == TR::Symbol::Java_lang_String_hashCode)
       {
-      if (J9VMJAVALANGSTRING_HASHCODE(vmThread(), string) == 0)
+      if (J9VMJAVALANGSTRING_HASH(vmThread(), string) == 0)
          {
          // If not already computed, compute and clobber
          //
@@ -5036,9 +5036,9 @@ TR_J9VMBase::getStringFieldByName(TR::Compilation * comp, TR::SymbolReference * 
             sum += thisChar * scale;
             }
 
-         J9VMJAVALANGSTRING_SET_HASHCODE(vmThread(), string, sum);
+         J9VMJAVALANGSTRING_SET_HASH(vmThread(), string, sum);
          }
-      pResult = (U_8*)string + J9VMJAVALANGSTRING_HASHCODE_OFFSET(vmThread());
+      pResult = (U_8*)string + J9VMJAVALANGSTRING_HASH_OFFSET(vmThread());
       }
    else if (field == TR::Symbol::Java_lang_String_value)
       pResult = (U_8*)string + J9VMJAVALANGSTRING_VALUE_OFFSET(vmThread());

--- a/runtime/compiler/il/J9Symbol.cpp
+++ b/runtime/compiler/il/J9Symbol.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -126,7 +126,7 @@
        {r(TR::Symbol::Java_lang_J9VMInternals_jitHelpers,             "java/lang/J9VMInternals", "jitHelpers", "Lcom/ibm/jit/JITHelpers;")},
        {r(TR::Symbol::Java_lang_String_count,                         "java/lang/String", "count", "I")},
        {r(TR::Symbol::Java_lang_String_enableCompression,             "java/lang/String", "enableCompression", "Z") },
-       {r(TR::Symbol::Java_lang_String_hashCode,                      "java/lang/String", "hashCode", "I")},
+       {r(TR::Symbol::Java_lang_String_hashCode,                      "java/lang/String", "hash", "I")},
        {r(TR::Symbol::Java_lang_String_value,                         "java/lang/String", "value", "[B")},
        {r(TR::Symbol::Java_lang_String_value,                         "java/lang/String", "value", "[C")},
        {r(TR::Symbol::Java_lang_StringBuffer_count,                   "java/lang/StringBuffer", "count", "I")},

--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -422,7 +422,7 @@ stringHashEqualFn(void *leftKey, void *rightKey, void *userData)
 		bool rightCompressed = IS_STRING_COMPRESSED_VM(javaVM, right_s);
 
 		/* Lengths have different significance for String and UTF8 */
-		if ((J9VMJAVALANGSTRING_HASHCODE_VM(javaVM, left_s) != J9VMJAVALANGSTRING_HASHCODE_VM(javaVM, right_s))
+		if ((J9VMJAVALANGSTRING_HASH_VM(javaVM, left_s) != J9VMJAVALANGSTRING_HASH_VM(javaVM, right_s))
 			|| (leftLength != rightLength))	{
 			return FALSE;
 		}
@@ -508,10 +508,10 @@ stringHashFn(void *key, void *userData)
 		hashCode = u8Ptr->hash;
 	} else {
 		j9object_t s = *(j9object_t*)key;
-		hashCode = J9VMJAVALANGSTRING_HASHCODE_VM(javaVM, s);
+		hashCode = J9VMJAVALANGSTRING_HASH_VM(javaVM, s);
 		if (hashCode == 0) {
 			hashCode = computeJavaHashForExpandedString(javaVM, s);
-			J9VMJAVALANGSTRING_SET_HASHCODE_VM(javaVM, s, hashCode);
+			J9VMJAVALANGSTRING_SET_HASH_VM(javaVM, s, hashCode);
 		}
 	}
 

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -175,7 +175,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<fieldalias name="value" signature="[C" versions="8"/>
 	</fieldref>
 	<fieldref class="java/lang/String" name="count" signature="I" versions="8"/>
-	<fieldref class="java/lang/String" name="hashCode" signature="I"/>
+	<fieldref class="java/lang/String" name="hash" signature="I"/>
 	<fieldref class="java/lang/String" name="coder" signature="B" versions="9-"/>
 	<fieldref class="java/lang/StackTraceElement" name="moduleName" signature="Ljava/lang/String;" flags="opt_module" versions="9-"/>
 	<fieldref class="java/lang/StackTraceElement" name="moduleVersion" signature="Ljava/lang/String;" flags="opt_module" versions="9-"/>

--- a/runtime/vm/KeyHashTable.c
+++ b/runtime/vm/KeyHashTable.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -218,7 +218,7 @@ classHashFn(void *key, void *userData)
 	if (type == TYPE_UNICODE) {
 		j9object_t stringObject = (j9object_t)name;
 
-		hash = J9VMJAVALANGSTRING_HASHCODE_VM(javaVM, stringObject);
+		hash = J9VMJAVALANGSTRING_HASH_VM(javaVM, stringObject);
 		if (0 == hash) {
 			j9object_t charArray = J9VMJAVALANGSTRING_VALUE_VM(javaVM, stringObject);
 			U_32 i = 0;
@@ -236,7 +236,7 @@ classHashFn(void *key, void *userData)
 				}
 			}
 
-			J9VMJAVALANGSTRING_SET_HASHCODE_VM(javaVM, stringObject, hash);
+			J9VMJAVALANGSTRING_SET_HASH_VM(javaVM, stringObject, hash);
 		}
 		type = TYPE_CLASS;
 	} else {


### PR DESCRIPTION
Match RI `java.lang.String` `private int hash` field across Java levels to avoid different names decorated via "#if JAVA_SPEC_VERSION" particularly in JIT code space.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>