### PR TITLE
Refactor TR_InlinedCallSite and TR_AOTMethodInfo usage

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -99,9 +99,7 @@ J9::AheadOfTimeCompile::findCorrectInlinedSiteIndex(void *constantPool, uintptr_
       }
    else
       {
-      TR_InlinedCallSite &inlinedCallSite = comp->getInlinedCallSite(inlinedSiteIndex);
-      TR_AOTMethodInfo *callSiteMethodInfo = (TR_AOTMethodInfo *)inlinedCallSite._methodInfo;
-      constantPoolForSiteIndex = (uintptr_t)callSiteMethodInfo->resolvedMethod->constantPool();
+      constantPoolForSiteIndex = (uintptr_t)comp->getInlinedResolvedMethod(inlinedSiteIndex)->constantPool();
       }
 
    bool matchFound = false;
@@ -124,10 +122,7 @@ J9::AheadOfTimeCompile::findCorrectInlinedSiteIndex(void *constantPool, uintptr_
          // Look for the first call site whose inlined method's constant pool matches ours and return that site index as the correct one.
          for (uintptr_t i = 0; i < comp->getNumInlinedCallSites(); i++)
             {
-            TR_InlinedCallSite &inlinedCallSite = comp->getInlinedCallSite(i);
-            TR_AOTMethodInfo *callSiteMethodInfo = (TR_AOTMethodInfo *)inlinedCallSite._methodInfo;
-
-            if ((uintptr_t)constantPool == (uintptr_t)callSiteMethodInfo->resolvedMethod->constantPool())
+            if ((uintptr_t)constantPool == (uintptr_t)comp->getInlinedResolvedMethod(i)->constantPool())
                {
                matchFound = true;
                inlinedSiteIndex = i;
@@ -408,9 +403,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
              kind == TR_InlinedAbstractMethodWithNopGuard ||
              kind == TR_InlinedAbstractMethod)
             {
-            TR_InlinedCallSite *inlinedCallSite = &comp->getInlinedCallSite(inlinedSiteIndex);
-            TR_AOTMethodInfo *aotMethodInfo = (TR_AOTMethodInfo *)inlinedCallSite->_methodInfo;
-            resolvedMethod = aotMethodInfo->resolvedMethod;
+            resolvedMethod = comp->getInlinedResolvedMethod(inlinedSiteIndex);
             }
          else
             {
@@ -499,8 +492,7 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR_ResolvedMethod *owningMethod = callSymRef->getOwningMethod(comp);
 
-         TR_InlinedCallSite & ics = comp->getInlinedCallSite(inlinedSiteIndex);
-         TR_ResolvedMethod *inlinedMethod = ((TR_AOTMethodInfo *)ics._methodInfo)->resolvedMethod;
+         TR_ResolvedMethod *inlinedMethod = comp->getInlinedResolvedMethod(inlinedSiteIndex);
          TR_OpaqueClassBlock *inlinedCodeClass = reinterpret_cast<TR_OpaqueClassBlock *>(inlinedMethod->classOfMethod());
 
          J9ROMClass *romClass = reinterpret_cast<J9ROMClass *>(fej9->getPersistentClassPointerFromClassPointer(inlinedCodeClass));
@@ -2164,8 +2156,7 @@ void J9::AheadOfTimeCompile::interceptAOTRelocation(TR::ExternalRelocation *relo
          }
 
       uintptr_t inlinedSiteIndex = static_cast<uintptr_t>(aconstNode->getInlinedSiteIndex());
-      TR_InlinedCallSite & ics = TR::comp()->getInlinedCallSite(inlinedSiteIndex);
-      TR_ResolvedMethod *inlinedMethod = ((TR_AOTMethodInfo *)ics._methodInfo)->resolvedMethod;
+      TR_ResolvedMethod *inlinedMethod = TR::comp()->getInlinedResolvedMethod(inlinedSiteIndex);
       TR_OpaqueMethodBlock *inlinedJ9Method = inlinedMethod->getPersistentIdentifier();
 
       /* If the j9method from the aconst node is the same as the j9method at

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2773,8 +2773,7 @@ static void addInliningTableRelocations(TR::CodeGenerator *cg, uint32_t inlinedC
             }
          else
             {
-            TR_InlinedCallSite &callSite = cg->comp()->getInlinedCallSite(counter);
-            TR_AOTMethodInfo *methodInfo = reinterpret_cast<TR_AOTMethodInfo *>(callSite._methodInfo);
+            TR_AOTMethodInfo *methodInfo = cg->comp()->getInlinedAOTMethodInfo(counter);
 
             addInlinedSiteRelocation(cg, methodInfo->reloKind, NULL, counter, methodInfo->callSymRef, methodInfo->receiver, NULL);
             }

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1207,8 +1207,7 @@ J9::Compilation::getReloTypeForMethodToBeInlined(TR_VirtualGuardSelection *guard
          TR_OpaqueMethodBlock *caller;
          if (site)
             {
-            TR_AOTMethodInfo *aotMethodInfo = (TR_AOTMethodInfo *)site->_methodInfo;
-            caller = aotMethodInfo->resolvedMethod->getNonPersistentIdentifier();
+            caller = site->_methodInfo;
             }
          else
             {

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -7416,14 +7416,7 @@ TR_J9VM::inlineNativeCall(TR::Compilation * comp, TR::TreeTop * callNodeTreeTop,
                if (callerIndex != -1)
                   {
                   callerMethod = (J9Method *) comp->getInlinedCallSite(callerIndex)._methodInfo;
-                  if (isAOT_DEPRECATED_DO_NOT_USE())
-                     {
-                     callerClass = (J9Class*) ((TR_AOTMethodInfo *)callerMethod)->resolvedMethod->containingClass();
-                     }
-                  else
-                     {
-                     callerClass = (J9Class*) getClassOfMethod((TR_OpaqueMethodBlock*) callerMethod);
-                     }
+                  callerClass = (J9Class*) comp->getInlinedResolvedMethod(callerIndex)->containingClass();
                   }
                else
                   {
@@ -8958,7 +8951,7 @@ TR_J9SharedCacheVM::isReferenceArray(TR_OpaqueClassBlock *classPointer)
 TR_OpaqueMethodBlock *
 TR_J9SharedCacheVM::getInlinedCallSiteMethod(TR_InlinedCallSite *ics)
    {
-   return (TR_OpaqueMethodBlock *)((TR_AOTMethodInfo *)(ics->_vmMethodInfo))->resolvedMethod->getPersistentIdentifier();
+   return ics->_methodInfo;
    }
 
 // Answer the following conservatively until we know how to do better

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2650,7 +2650,7 @@ TR_J9SharedCacheServerVM::isReferenceArray(TR_OpaqueClassBlock *classPointer)
 TR_OpaqueMethodBlock *
 TR_J9SharedCacheServerVM::getInlinedCallSiteMethod(TR_InlinedCallSite *ics)
    {
-   return (TR_OpaqueMethodBlock *)((TR_AOTMethodInfo *)(ics->_vmMethodInfo))->resolvedMethod->getPersistentIdentifier();
+   return ics->_methodInfo;
    }
 
 uintptr_t

--- a/runtime/compiler/ras/DebugExt.cpp
+++ b/runtime/compiler/ras/DebugExt.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1624,7 +1624,7 @@ TR_DebugExt::printInlinedCallSites(TR::FILE *pOutFile, TR::ResolvedMethodSymbol 
    for (int32_t i = 0; i < localInlinedCallSites.size(); ++i)
          {
          TR_InlinedCallSite & ics = localInlinedCallSites.element(i).site();
-         TR_OpaqueMethodBlock *mb = _isAOT ? (TR_OpaqueMethodBlock*) ((TR_AOTMethodInfo *)ics._methodInfo)->resolvedMethod->getNonPersistentIdentifier() : ics._vmMethodInfo;
+         TR_OpaqueMethodBlock *mb = ics._methodInfo;
 
          trfprintf(pOutFile, "    %4d       %4d       %5d       %s !trprint j9method %p\n", i, ics._byteCodeInfo.getCallerIndex(),
                        ics._byteCodeInfo.getByteCodeIndex(), getMethodName(mb), mb);

--- a/runtime/compiler/runtime/HWProfiler.cpp
+++ b/runtime/compiler/runtime/HWProfiler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -700,21 +700,10 @@ TR_OpaqueMethodBlock *
 TR_HWProfiler::getMethodFromBCInfo(TR_ByteCodeInfo &bcInfo, TR::Compilation *comp)
    {
    TR_OpaqueMethodBlock *method = NULL;
-
-   if (comp->fej9()->isAOT_DEPRECATED_DO_NOT_USE())
-      {
-      if (bcInfo.getCallerIndex() >= 0)
-         method = (TR_OpaqueMethodBlock *)(((TR_AOTMethodInfo *)comp->getInlinedCallSite(bcInfo.getCallerIndex())._vmMethodInfo)->resolvedMethod->getNonPersistentIdentifier());
-      else
-         method = (TR_OpaqueMethodBlock *)(comp->getCurrentMethod()->getNonPersistentIdentifier());
-      }
+   if (bcInfo.getCallerIndex() >= 0)
+      method = comp->getInlinedCallSite(bcInfo.getCallerIndex())._methodInfo;
    else
-      {
-      if (bcInfo.getCallerIndex() >= 0)
-         method = (TR_OpaqueMethodBlock *)(comp->getInlinedCallSite(bcInfo.getCallerIndex())._vmMethodInfo);
-      else
-         method = (TR_OpaqueMethodBlock *)(comp->getCurrentMethod()->getPersistentIdentifier());
-      }
+      method = comp->getCurrentMethod()->getPersistentIdentifier();
 
    return method;
    }

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1683,21 +1683,10 @@ static TR_OpaqueMethodBlock *
 getMethodFromBCInfo(TR_ByteCodeInfo &bcInfo, TR::Compilation *comp)
    {
    TR_OpaqueMethodBlock *method = NULL;
-
-   if (comp->fej9()->isAOT_DEPRECATED_DO_NOT_USE())
-      {
-      if (bcInfo.getCallerIndex() >= 0)
-         method = (TR_OpaqueMethodBlock *)(((TR_AOTMethodInfo *)comp->getInlinedCallSite(bcInfo.getCallerIndex())._vmMethodInfo)->resolvedMethod->getNonPersistentIdentifier());
-      else
-         method = (TR_OpaqueMethodBlock *)(comp->getCurrentMethod()->getNonPersistentIdentifier());
-      }
+   if (bcInfo.getCallerIndex() >= 0)
+      method = comp->getInlinedCallSite(bcInfo.getCallerIndex())._methodInfo;
    else
-      {
-      if (bcInfo.getCallerIndex() >= 0)
-         method = (TR_OpaqueMethodBlock *)(comp->getInlinedCallSite(bcInfo.getCallerIndex())._vmMethodInfo);
-      else
-         method = (TR_OpaqueMethodBlock *)(comp->getCurrentMethod()->getPersistentIdentifier());
-      }
+      method = comp->getCurrentMethod()->getPersistentIdentifier();
 
    return method;
    }

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -2520,11 +2520,7 @@ TR_CallSiteInfo::hasSamePartialBytecodeInfo(
       if (callSiteInfo1._byteCodeInfo.getByteCodeIndex() != callSiteInfo2._byteCodeInfo.getByteCodeIndex())
          break;
       TR_OpaqueMethodBlock *method1 = callSiteInfo1._methodInfo;
-      if (comp->fej9()->isAOT_DEPRECATED_DO_NOT_USE())
-         method1 = ((TR_AOTMethodInfo *)method1)->resolvedMethod->getPersistentIdentifier();
       TR_OpaqueMethodBlock *method2 = callSiteInfo2._methodInfo;
-      if (comp->fej9()->isAOT_DEPRECATED_DO_NOT_USE())
-         method2 = ((TR_AOTMethodInfo *)method2)->resolvedMethod->getPersistentIdentifier();
       if (method1 != method2)
          break;
       callSite1 = callSiteInfo1._byteCodeInfo.getCallerIndex();


### PR DESCRIPTION
This commit depends on eclipse/omr#5850.
It adapts changes to `TR_InlinedCallSite` and `TR_AOTMethodInfo`
for OpenJ9, which enables us to always use `TR_InlinedCallSite::_method`
to get a pointer to the inlined method block instead of going through
the AOT method info. This commit also simplifies code that retrieved
resolved method from callsites, replacing code that uses
`TR_AOTMethodInfo`
with an existing method `OMR::Comilation::getInlinedResolvedMethod`.