### PR TITLE
JDK17 adopts RI String - replace enableCompression with COMPACT_STRINGS

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/AlgorithmVersion.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/AlgorithmVersion.java
@@ -72,6 +72,8 @@ public final class AlgorithmVersion {
 
 	public static final String MIXED_REFERENCE_MODE = "MIXED_REFERENCE_MODE";
 
+	public static final String JAVA_LANG_STRING_VERSION = "ALG_VM_JAVA_LANG_STRING_VERSION";
+
 	// Fields
 	private static AlgorithmVersion DEFAULT_VERSION;
 	private static int vmMajorVersion;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ObjectHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ObjectHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -193,7 +193,13 @@ public class J9ObjectHelper
 		} else {
 			stringLength = getIntField(objPointer, getFieldOffset(objPointer, "count", "I"));
 
-			boolean enableCompression = getBooleanField(objPointer, getFieldOffset(objPointer, "enableCompression", "Z"));
+			String enableCompressionFieldName;
+			if (AlgorithmVersion.getVersionOf(AlgorithmVersion.JAVA_LANG_STRING_VERSION).getAlgorithmVersion() >= 1) {
+				enableCompressionFieldName = "COMPACT_STRINGS";
+			} else {
+				enableCompressionFieldName = "enableCompression";
+			}
+			boolean enableCompression = getBooleanField(objPointer, getFieldOffset(objPointer, enableCompressionFieldName, "Z"));
 
 			if (enableCompression) {
 				if (stringLength >= 0) {

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -95,18 +95,14 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	/**
 	 * Determines whether String compression is enabled.
 	 */
-	static final boolean enableCompression = com.ibm.oti.vm.VM.J9_STRING_COMPRESSION_ENABLED;
+	static final boolean COMPACT_STRINGS = com.ibm.oti.vm.VM.J9_STRING_COMPRESSION_ENABLED;
 
 	static final byte LATIN1 = 0;
 	static final byte UTF16 = 1;
-	static final boolean COMPACT_STRINGS;
-	static {
-		COMPACT_STRINGS = enableCompression;
-	}
 
 	// returns UTF16 when COMPACT_STRINGS is false
 	byte coder() {
-		if (enableCompression) {
+		if (COMPACT_STRINGS) {
 			return coder;
 		} else {
 			return UTF16;
@@ -126,7 +122,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 */
 	void getBytes(byte[] bytes, int srcIndex, int destIndex, byte coder, int length) {
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || this.coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || this.coder == LATIN1)) {
 			if (String.LATIN1 == coder) {
 				compressedArrayCopy(value, srcIndex, bytes, destIndex, length);
 			} else {
@@ -144,7 +140,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		int currentLength = lengthInternal();
 
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || this.coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || this.coder == LATIN1)) {
 			if (String.LATIN1 == coder) {
 				compressedArrayCopy(value, 0, bytes, offset, currentLength);
 			} else {
@@ -419,7 +415,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 	boolean isCompressed() {
 		// Check if the String is compressed
-		if (enableCompression) {
+		if (COMPACT_STRINGS) {
 			if (null == compressionFlag) {
 				return true;
 			} else {
@@ -431,7 +427,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	}
 
 	String(byte[] byteArray, byte coder) {
-		if (enableCompression) {
+		if (COMPACT_STRINGS) {
 			if (String.LATIN1 == coder) {
 				value = byteArray;
 			} else {
@@ -463,7 +459,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public String() {
 		value = emptyValue;
 
-		if (enableCompression) {
+		if (COMPACT_STRINGS) {
 			coder = LATIN1;
 		} else {
 			coder = UTF16;
@@ -555,7 +551,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			value = scResult.value;
 			coder = scResult.coder;
 
-			if (enableCompression && scResult.coder == UTF16) {
+			if (COMPACT_STRINGS && scResult.coder == UTF16) {
 				initCompressionFlag();
 			}
 		} else {
@@ -587,7 +583,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		data.getClass(); // Implicit null check
 
 		if (start >= 0 && 0 <= length && length <= data.length - start) {
-			if (enableCompression && high == 0) {
+			if (COMPACT_STRINGS && high == 0) {
 				value = new byte[length];
 				coder = LATIN1;
 
@@ -602,7 +598,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 					helpers.putCharInArrayByIndex(value, i, (char) (high + (data[start++] & 0xff)));
 				}
 
-				if (enableCompression) {
+				if (COMPACT_STRINGS) {
 					initCompressionFlag();
 				}
 			}
@@ -654,7 +650,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			value = scResult.value;
 			coder = scResult.coder;
 
-			if (enableCompression && scResult.coder == UTF16) {
+			if (COMPACT_STRINGS && scResult.coder == UTF16) {
 				initCompressionFlag();
 			}
 		} else {
@@ -707,7 +703,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || s.coder == LATIN1) && c <= 255) {
+		if (COMPACT_STRINGS && (null == compressionFlag || s.coder == LATIN1) && c <= 255) {
 			value = new byte[concatlen];
 			coder = LATIN1;
 
@@ -719,7 +715,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			coder = UTF16;
 
 			// Check if the String is compressed
-			if (enableCompression && s.coder == LATIN1) {
+			if (COMPACT_STRINGS && s.coder == LATIN1) {
 				decompress(s.value, 0, value, 0, slen);
 			} else {
 				decompressedArrayCopy(s.value, 0, value, 0, slen);
@@ -727,7 +723,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			helpers.putCharInArrayByIndex(value, slen, c);
 
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				initCompressionFlag();
 			}
 		}
@@ -754,7 +750,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 *          a non-null array of characters
 	 */
 	String(char[] data, boolean ignore) {
-		if (enableCompression && canEncodeAsLatin1(data, 0, data.length)) {
+		if (COMPACT_STRINGS && canEncodeAsLatin1(data, 0, data.length)) {
 			value = new byte[data.length];
 			coder = LATIN1;
 
@@ -765,7 +761,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			decompressedArrayCopy(data, 0, value, 0, data.length);
 
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				initCompressionFlag();
 			}
 		}
@@ -789,7 +785,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 */
 	public String(char[] data, int start, int length) {
 		if (start >= 0 && 0 <= length && length <= data.length - start) {
-			if (enableCompression && canEncodeAsLatin1(data, start, length)) {
+			if (COMPACT_STRINGS && canEncodeAsLatin1(data, start, length)) {
 				value = new byte[length];
 				coder = LATIN1;
 
@@ -800,7 +796,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 				decompressedArrayCopy(data, start, value, 0, length);
 
-				if (enableCompression) {
+				if (COMPACT_STRINGS) {
 					initCompressionFlag();
 				}
 			}
@@ -813,13 +809,13 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		if (length == 0) {
 			value = emptyValue;
 
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				coder = LATIN1;
 			} else {
 				coder = UTF16;
 			}
 		} else if (length == 1) {
-			if (enableCompression && compressed) {
+			if (COMPACT_STRINGS && compressed) {
 				char theChar = helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(data, start));
 
 				value = compressedAsciiTable[theChar];
@@ -839,12 +835,12 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				coder = UTF16;
 				hash = theChar;
 
-				if (enableCompression) {
+				if (COMPACT_STRINGS) {
 					initCompressionFlag();
 				}
 			}
 		} else {
-			if (enableCompression && compressed) {
+			if (COMPACT_STRINGS && compressed) {
 				if (start == 0 && data.length == length) {
 					value = data;
 				} else {
@@ -865,7 +861,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 				coder = UTF16;
 
-				if (enableCompression) {
+				if (COMPACT_STRINGS) {
 					initCompressionFlag();
 				}
 			}
@@ -876,13 +872,13 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		if (length == 0) {
 			value = emptyValue;
 
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				coder = LATIN1;
 			} else {
 				coder = UTF16;
 			}
 		} else if (length == 1) {
-			if (enableCompression && compressed) {
+			if (COMPACT_STRINGS && compressed) {
 				char theChar = helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(data, start));
 
 				value = compressedAsciiTable[theChar];
@@ -902,12 +898,12 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				coder = UTF16;
 				hash = theChar;
 
-				if (enableCompression) {
+				if (COMPACT_STRINGS) {
 					initCompressionFlag();
 				}
 			}
 		} else {
-			if (enableCompression && compressed) {
+			if (COMPACT_STRINGS && compressed) {
 				if (sharingIsAllowed && start == 0 && data.length == length) {
 					value = data;
 				} else {
@@ -928,7 +924,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 				coder = UTF16;
 
-				if (enableCompression) {
+				if (COMPACT_STRINGS) {
 					initCompressionFlag();
 				}
 			}
@@ -978,7 +974,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 		}
 
-		if (enableCompression && (null == compressionFlag || (s1.coder | s2.coder) == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || (s1.coder | s2.coder) == LATIN1)) {
 			value = new byte[concatlen];
 			coder = LATIN1;
 
@@ -989,20 +985,20 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			coder = UTF16;
 
 			// Check if the String is compressed
-			if (enableCompression && s1.coder == LATIN1) {
+			if (COMPACT_STRINGS && s1.coder == LATIN1) {
 				decompress(s1.value, 0, value, 0, s1len);
 			} else {
 				decompressedArrayCopy(s1.value, 0, value, 0, s1len);
 			}
 
 			// Check if the String is compressed
-			if (enableCompression && s2.coder == LATIN1) {
+			if (COMPACT_STRINGS && s2.coder == LATIN1) {
 				decompress(s2.value, 0, value, s1len, s2len);
 			} else {
 				decompressedArrayCopy(s2.value, 0, value, s1len, s2len);
 			}
 
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				initCompressionFlag();
 			}
 		}
@@ -1035,7 +1031,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 		int concatlen = (int) totalLen;
 
-		if (enableCompression && (null == compressionFlag || (s1.coder | s2.coder | s3.coder) == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || (s1.coder | s2.coder | s3.coder) == LATIN1)) {
 			value = new byte[concatlen];
 			coder = LATIN1;
 
@@ -1047,27 +1043,27 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			coder = UTF16;
 
 			// Check if the String is compressed
-			if (enableCompression && s1.coder == LATIN1) {
+			if (COMPACT_STRINGS && s1.coder == LATIN1) {
 				decompress(s1.value, 0, value, 0, s1len);
 			} else {
 				decompressedArrayCopy(s1.value, 0, value, 0, s1len);
 			}
 
 			// Check if the String is compressed
-			if (enableCompression && s2.coder == LATIN1) {
+			if (COMPACT_STRINGS && s2.coder == LATIN1) {
 				decompress(s2.value, 0, value, s1len, s2len);
 			} else {
 				decompressedArrayCopy(s2.value, 0, value, s1len, s2len);
 			}
 
 			// Check if the String is compressed
-			if (enableCompression && s3.coder == LATIN1) {
+			if (COMPACT_STRINGS && s3.coder == LATIN1) {
 				decompress(s3.value, 0, value, s1len + s2len, s3len);
 			} else {
 				decompressedArrayCopy(s3.value, 0, value, (s1len + s2len), s3len);
 			}
 
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				initCompressionFlag();
 			}
 		}
@@ -1104,7 +1100,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 		}
 
-		if (enableCompression && (null == compressionFlag || s1.coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || s1.coder == LATIN1)) {
 			value = new byte[len];
 			coder = LATIN1;
 
@@ -1151,7 +1147,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			// Copy in s1 contents
 			decompressedArrayCopy(s1.value, 0, value, 0, s1len);
 
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				initCompressionFlag();
 			}
 		}
@@ -1213,7 +1209,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 		int len = (int) totalLen;
 
-		if (enableCompression && (null == compressionFlag || (s1.coder | s2.coder | s3.coder) == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || (s1.coder | s2.coder | s3.coder) == LATIN1)) {
 			value = new byte[len];
 			coder = LATIN1;
 
@@ -1274,7 +1270,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			start = start - s3len;
 
 			// Check if the String is compressed
-			if (enableCompression && s3.coder == LATIN1) {
+			if (COMPACT_STRINGS && s3.coder == LATIN1) {
 				decompress(s3.value, 0, value, start, s3len);
 			} else {
 				decompressedArrayCopy(s3.value, 0, value, start, s3len);
@@ -1284,7 +1280,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			start = start - s2len;
 
 			// Check if the String is compressed
-			if (enableCompression && s2.coder == LATIN1) {
+			if (COMPACT_STRINGS && s2.coder == LATIN1) {
 				decompress(s2.value, 0, value, start, s2len);
 			} else {
 				decompressedArrayCopy(s2.value, 0, value, start, s2len);
@@ -1311,7 +1307,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			start = index2 + 1 - s1len;
 
 			// Check if the String is compressed
-			if (enableCompression && s1.coder == LATIN1) {
+			if (COMPACT_STRINGS && s1.coder == LATIN1) {
 				decompress(s1.value, 0, value, start, s1len);
 			} else {
 				decompressedArrayCopy(s1.value, 0, value, start, s1len);
@@ -1334,7 +1330,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				helpers.putCharInArrayByIndex(value, index1--, (char) '-');
 			}
 
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				initCompressionFlag();
 			}
 		}
@@ -1368,7 +1364,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public char charAt(int index) {
 		if (0 <= index && index < lengthInternal()) {
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 				return helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, index));
 			} else {
 				return helpers.getCharFromArrayByIndex(value, index);
@@ -1381,7 +1377,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	// Internal version of charAt used for extracting a char from a String in compression related code.
 	char charAtInternal(int index) {
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 			return helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, index));
 		} else {
 			return helpers.getCharFromArrayByIndex(value, index);
@@ -1396,7 +1392,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	// is being used.
 	char charAtInternal(int index, byte[] value) {
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 			return helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, index));
 		} else {
 			return helpers.getCharFromArrayByIndex(value, index);
@@ -1434,7 +1430,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		byte[] s1Value = s1.value;
 		byte[] s2Value = s2.value;
 
-		if (enableCompression && (null == compressionFlag || (s1.coder | s2.coder) == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || (s1.coder | s2.coder) == LATIN1)) {
 			while (o1 < end) {
 				int result =
 					helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(s1Value, o1++)) -
@@ -1521,7 +1517,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		byte[] s1Value = s1.value;
 		byte[] s2Value = s2.value;
 
-		if (enableCompression && (null == compressionFlag || (s1.coder | s2.coder) == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || (s1.coder | s2.coder) == LATIN1)) {
 			while (o1 < end) {
 				byte byteAtO1 = helpers.getByteFromArrayByIndex(s1Value, o1++);
 				byte byteAtO2 = helpers.getByteFromArrayByIndex(s2Value, o2++);
@@ -1597,7 +1593,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 		}
 
-		if (enableCompression && ((null == compressionFlag) || ((s1.coder | s2.coder) == LATIN1))) {
+		if (COMPACT_STRINGS && ((null == compressionFlag) || ((s1.coder | s2.coder) == LATIN1))) {
 			byte[] buffer = new byte[concatlen];
 
 			compressedArrayCopy(s1.value, 0, buffer, 0, s1len);
@@ -1608,14 +1604,14 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			byte[] buffer = StringUTF16.newBytesFor(concatlen);
 
 			// Check if the String is compressed
-			if (enableCompression && s1.coder == LATIN1) {
+			if (COMPACT_STRINGS && s1.coder == LATIN1) {
 				decompress(s1.value, 0, buffer, 0, s1len);
 			} else {
 				decompressedArrayCopy(s1.value, 0, buffer, 0, s1len);
 			}
 
 			// Check if the String is compressed
-			if (enableCompression && s2.coder == LATIN1) {
+			if (COMPACT_STRINGS && s2.coder == LATIN1) {
 				decompress(s2.value, 0, buffer, s1len, s2len);
 			} else {
 				decompressedArrayCopy(s2.value, 0, buffer, s1len, s2len);
@@ -1809,7 +1805,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		byte[] s1Value = s1.value;
 		byte[] s2Value = s2.value;
 
-		if (enableCompression && (null == compressionFlag || (s1.coder | s2.coder) == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || (s1.coder | s2.coder) == LATIN1)) {
 			// Compare the last chars.
 			// In order to tell 2 chars are different:
 			// Under string compression, the compressible char set obeys 1-1 mapping for upper/lower case,
@@ -1918,7 +1914,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public void getBytes(int start, int end, byte[] data, int index) {
 		if (0 <= start && start <= end && end <= lengthInternal() && 0 <= index && ((end - start) <= (data.length - index))) {
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 				compressedArrayCopy(value, start, data, index, end - start);
 			} else {
 				compress(value, start, data, index, end - start);
@@ -1975,7 +1971,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	// Caller of this method must validate bound safety for String indexing and array copying.
 	void getCharsNoBoundChecks(int start, int end, char[] data, int index) {
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 			decompress(value, start, data, index, end - start);
 		} else {
 			decompressedArrayCopy(value, start, data, index, end - start);
@@ -1986,7 +1982,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	// Caller of this method must validate bound safety for String indexing and array copying.
 	void getCharsNoBoundChecks(int start, int end, byte[] data, int index) {
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 			decompress(value, start, data, index, end - start);
 		} else {
 			decompressedArrayCopy(value, start, data, index, end - start);
@@ -2003,7 +1999,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public int hashCode() {
 		if (hash == 0 && value.length > 0) {
 			// Check if the String is compressed
-			if (enableCompression && (compressionFlag == null || coder == LATIN1)) {
+			if (COMPACT_STRINGS && (compressionFlag == null || coder == LATIN1)) {
 				hash = hashCodeImplCompressed(value, 0, lengthInternal());
 			} else {
 				hash = hashCodeImplDecompressed(value, 0, lengthInternal());
@@ -2077,7 +2073,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				byte[] array = value;
 
 				// Check if the String is compressed
-				if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+				if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 					if (c <= 255) {
 						return helpers.intrinsicIndexOfLatin1(array, (byte)c, start, len);
 					}
@@ -2236,7 +2232,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				byte[] array = value;
 
 				// Check if the String is compressed
-				if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+				if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 					if (c <= 255) {
 						byte b = (byte) c;
 
@@ -2364,7 +2360,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 * @return the number of characters in this String
 	 */
 	int lengthInternal() {
-		if (enableCompression) {
+		if (COMPACT_STRINGS) {
 			return value.length >> coder;
 		} else {
 			return value.length >> 1;
@@ -2416,7 +2412,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		// Index of the last char to compare
 		int end = length - 1;
 
-		if (enableCompression && ((compressionFlag == null) || ((s1.coder | s2.coder) == LATIN1))) {
+		if (COMPACT_STRINGS && ((compressionFlag == null) || ((s1.coder | s2.coder) == LATIN1))) {
 			if (helpers.getByteFromArrayByIndex(s1Value, s1Start + end) != helpers.getByteFromArrayByIndex(s2Value, s2Start + end)) {
 				return false;
 			} else {
@@ -2493,7 +2489,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		byte[] s1Value = s1.value;
 		byte[] s2Value = s2.value;
 
-		if (enableCompression && (null == compressionFlag || (s1.coder | s2.coder) == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || (s1.coder | s2.coder) == LATIN1)) {
 			while (o1 < end) {
 				byte byteAtO1 = helpers.getByteFromArrayByIndex(s1Value, o1++);
 				byte byteAtO2 = helpers.getByteFromArrayByIndex(s2Value, o2++);
@@ -2551,7 +2547,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		int len = lengthInternal();
 
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 			if (newChar <= 255) {
 				byte[] buffer = new byte[len];
 
@@ -2634,7 +2630,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public String strip() {
 		String result;
 
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 			result = StringLatin1.strip(value);
 		} else {
 			result = StringUTF16.strip(value);
@@ -2654,7 +2650,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public String stripLeading() {
 		String result;
 
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 			result = StringLatin1.stripLeading(value);
 		} else {
 			result = StringUTF16.stripLeading(value);
@@ -2674,7 +2670,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public String stripTrailing() {
 		String result;
 
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 			result = StringLatin1.stripTrailing(value);
 		} else {
 			result = StringUTF16.stripTrailing(value);
@@ -2694,7 +2690,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public boolean isBlank() {
 		int index;
 
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 			index = StringLatin1.indexOfNonWhitespace(value);
 		} else {
 			index = StringUTF16.indexOfNonWhitespace(value);
@@ -2714,7 +2710,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 * @since 11
 	 */
 	public Stream<String> lines() {
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 			return StringLatin1.lines(value);
 		} else {
 			return StringUTF16.lines(value);
@@ -2743,7 +2739,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			boolean isCompressed = false;
 
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 				isCompressed = true;
 			}
 
@@ -2775,7 +2771,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		if (0 <= start && start <= end && end <= len) {
 			boolean isCompressed = false;
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 				isCompressed = true;
 			}
 
@@ -2796,7 +2792,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		char[] buffer = new char[len];
 
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 			decompress(value, 0, buffer, 0, len);
 		} else {
 			decompressedArrayCopy(value, 0, buffer, 0, len);
@@ -2859,7 +2855,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				&& (language == "en") //$NON-NLS-1$
 				&& (sLength <= (Integer.MAX_VALUE / 2));
 
-		if (enableCompression && ((null == compressionFlag) || (coder == LATIN1))) {
+		if (COMPACT_STRINGS && ((null == compressionFlag) || (coder == LATIN1))) {
 			if (useIntrinsic) {
 				byte[] output = new byte[sLength << coder];
 
@@ -2918,7 +2914,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				&& (language == "en") //$NON-NLS-1$
 				&& (sLength <= (Integer.MAX_VALUE / 2));
 
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 			if (useIntrinsic) {
 				byte[] output = new byte[sLength << coder];
 
@@ -2950,7 +2946,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		int end = last;
 
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 			while ((start <= end) && (helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, start)) <= ' ')) {
 				start++;
 			}
@@ -3028,7 +3024,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		String string;
 
 		if (value <= 255) {
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				string = new String(compressedAsciiTable[value], 0, 1, true);
 			} else {
 				string = new String(decompressedAsciiTable[value], 0, 1, false);
@@ -3198,7 +3194,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			int substituteLength = substitute.lengthInternal();
 			int length = lengthInternal();
 			if (substituteLength < 2) {
-				if (enableCompression && isCompressed() && (substituteLength == 0 || substitute.isCompressed())) {
+				if (COMPACT_STRINGS && isCompressed() && (substituteLength == 0 || substitute.isCompressed())) {
 					byte[] newChars = new byte[length];
 					byte toReplace = helpers.getByteFromArrayByIndex(regex.value, 0);
 					byte replacement = (byte)-1;  // assign dummy value that will never be used
@@ -3216,7 +3212,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 						}
 					}
 					return new String(newChars, 0, newCharIndex, true);
-				} else if (!enableCompression || !isCompressed()) {
+				} else if (!COMPACT_STRINGS || !isCompressed()) {
 					byte[] newChars = StringUTF16.newBytesFor(length);
 					char toReplace = regex.charAtInternal(0);
 					char replacement = (char)-1; // assign dummy value that will never be used
@@ -3339,7 +3335,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			byte[] chars = this.value;
 
-			final boolean compressed = enableCompression && (null == compressionFlag || coder == LATIN1);
+			final boolean compressed = COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1);
 
 			int start = 0, current = 0, end = lengthInternal();
 			if (regex.lengthInternal() == 1 || singleEscapeLiteral) {
@@ -3437,7 +3433,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 */
 	public String(int[] data, int start, int length) {
 		if (start >= 0 && 0 <= length && length <= data.length - start) {
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				byte[] bytes = StringLatin1.toBytes(data, start, length);
 
 				if (bytes != null) {
@@ -3488,7 +3484,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 		if (index >= 0 && index < len) {
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 				return helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, index));
 			} else {
 				char high = charAtInternal(index);
@@ -3522,7 +3518,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 		if (index > 0 && index <= len) {
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 				return helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, index - 1));
 			} else {
 				char low = charAtInternal(index - 1);
@@ -3558,7 +3554,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 		if (start >= 0 && start <= end && end <= len) {
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 				return end - start;
 			} else {
 				int count = 0;
@@ -3596,7 +3592,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 		if (start >= 0 && start <= len) {
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 				int index = start + codePointCount;
 
 				if (index > len) {
@@ -3907,7 +3903,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			value = scResult.value;
 			coder = scResult.coder;
 
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				initCompressionFlag();
 			}
 		} else {
@@ -3985,7 +3981,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public IntStream chars() {
 		Spliterator.OfInt spliterator;
 
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 			spliterator = new StringLatin1.CharsSpliterator(value, Spliterator.IMMUTABLE);
 		} else {
 			spliterator = new StringUTF16.CharsSpliterator(value, Spliterator.IMMUTABLE);
@@ -3998,7 +3994,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public IntStream codePoints() {
 		Spliterator.OfInt spliterator;
 
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 			spliterator = new StringLatin1.CharsSpliterator(value, Spliterator.IMMUTABLE);
 		} else {
 			spliterator = new StringUTF16.CodePointsSpliterator(value, Spliterator.IMMUTABLE);
@@ -4032,7 +4028,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			/*[MSG "K0800", "Invalid Unicode code point - {0}"]*/
 			throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K0800", Integer.toString(codePoint)));   //$NON-NLS-1$
 		} else if (codePoint <= 255) {
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				string = new String(compressedAsciiTable[codePoint], LATIN1);
 			} else {
 				string = new String(decompressedAsciiTable[codePoint], UTF16);
@@ -4077,7 +4073,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 		int repeatlen = length * count;
 
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || coder == LATIN1)) {
 			byte[] buffer = new byte[repeatlen];
 
 			for (int i = 0; i < count; i++) {
@@ -4105,7 +4101,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	/**
 	 * Determines whether String compression is enabled.
 	 */
-	static final boolean enableCompression = com.ibm.oti.vm.VM.J9_STRING_COMPRESSION_ENABLED;
+	static final boolean COMPACT_STRINGS = com.ibm.oti.vm.VM.J9_STRING_COMPRESSION_ENABLED;
 
 	/**
 	 * CaseInsensitiveComparator compares Strings ignoring the case of the characters.
@@ -4333,7 +4329,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 	boolean isCompressed() {
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || count >= 0)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 			return true;
 		} else {
 			return false;
@@ -4428,7 +4424,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		if (start >= 0 && 0 <= length && length <= data.length - start) {
 			char[] buffer = StringCoding.decode(data, start, length);
 
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				if (canEncodeAsLatin1(buffer, 0, buffer.length)) {
 					value = new char[(buffer.length + 1) >>> 1];
 					count = buffer.length;
@@ -4473,7 +4469,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		data.getClass(); // Implicit null check
 
 		if (start >= 0 && 0 <= length && length <= data.length - start) {
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				if (high == 0) {
 					value = new char[(length + 1) >>> 1];
 					count = length;
@@ -4548,7 +4544,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		if (start >= 0 && 0 <= length && length <= data.length - start) {
 			char[] buffer = StringCoding.decode(encoding, data, start, length);
 
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				if (canEncodeAsLatin1(buffer, 0, buffer.length)) {
 					value = new char[(buffer.length + 1) >>> 1];
 					count = buffer.length;
@@ -4613,7 +4609,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 		}
 
-		if (enableCompression) {
+		if (COMPACT_STRINGS) {
 			// Check if the String is compressed
 			if ((null == compressionFlag || s.count >= 0) && c <= 255) {
 				value = new char[(concatlen + 1) >>> 1];
@@ -4627,7 +4623,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				count = (concatlen) | uncompressedBit;
 
 				// Check if the String is compressed
-				if (enableCompression && s.count >= 0) {
+				if (COMPACT_STRINGS && s.count >= 0) {
 					decompress(s.value, 0, value, 0, slen);
 				} else {
 					decompressedArrayCopy(s.value, 0, value, 0, slen);
@@ -4667,7 +4663,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 *          a non-null array of characters
 	 */
 	String(char[] data, boolean ignore) {
-		if (enableCompression) {
+		if (COMPACT_STRINGS) {
 			if (canEncodeAsLatin1(data, 0, data.length)) {
 				value = new char[(data.length + 1) >>> 1];
 				count = data.length;
@@ -4707,7 +4703,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 */
 	public String(char[] data, int start, int length) {
 		if (start >= 0 && 0 <= length && length <= data.length - start) {
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				if (canEncodeAsLatin1(data, start, length)) {
 					value = new char[(length + 1) >>> 1];
 					count = length;
@@ -4733,7 +4729,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	}
 
 	String(char[] data, int start, int length, boolean compressed) {
-		if (enableCompression) {
+		if (COMPACT_STRINGS) {
 			if (length == 0) {
 				value = emptyValue;
 				count = 0;
@@ -4812,7 +4808,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	}
 
 	String(char[] data, int start, int length, boolean compressed, boolean sharingIsAllowed) {
-		if (enableCompression) {
+		if (COMPACT_STRINGS) {
 			if (length == 0) {
 				value = emptyValue;
 				count = 0;
@@ -4911,7 +4907,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		synchronized (buffer) {
 			char[] chars = buffer.shareValue();
 
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				if (buffer.isCompressed()) {
 					value = chars;
 					count = buffer.length();
@@ -4949,7 +4945,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 		}
 
-		if (enableCompression) {
+		if (COMPACT_STRINGS) {
 			if (null == compressionFlag || (s1.count | s2.count) >= 0) {
 				value = new char[(concatlen + 1) >>> 1];
 				count = concatlen;
@@ -5012,7 +5008,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 		int concatlen = (int) totalLen;
 
-		if (enableCompression) {
+		if (COMPACT_STRINGS) {
 			if (null == compressionFlag || (s1.count | s2.count | s3.count) >= 0) {
 				value = new char[(concatlen + 1) >>> 1];
 				count = concatlen;
@@ -5088,7 +5084,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 		}
 
-		if (enableCompression) {
+		if (COMPACT_STRINGS) {
 			// Check if the String is compressed
 			if (null == compressionFlag || s1.count >= 0) {
 				value = new char[(len + 1) >>> 1];
@@ -5222,7 +5218,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 		int len = (int) totalLen;
 
-		if (enableCompression) {
+		if (COMPACT_STRINGS) {
 			if (null == compressionFlag || (s1.count | s2.count | s3.count) >= 0) {
 				value = new char[(len + 1) >>> 1];
 				count = len;
@@ -5429,7 +5425,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public char charAt(int index) {
 		if (0 <= index && index < lengthInternal()) {
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || count >= 0)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 				return helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, index));
 			}
 
@@ -5442,7 +5438,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	// Internal version of charAt used for extracting a char from a String in compression related code.
 	char charAtInternal(int index) {
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || count >= 0)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 			return helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, index));
 		}
 
@@ -5457,7 +5453,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	// is being used.
 	char charAtInternal(int index, char[] value) {
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || count >= 0)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 			return helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, index));
 		}
 
@@ -5497,7 +5493,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		char[] s1Value = s1.value;
 		char[] s2Value = s2.value;
 
-		if (enableCompression && (null == compressionFlag || (s1.count | s2.count) >= 0)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || (s1.count | s2.count) >= 0)) {
 			while (o1 < end) {
 				if ((result =
 						helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(s1Value, o1++)) -
@@ -5572,7 +5568,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		char[] s1Value = s1.value;
 		char[] s2Value = s2.value;
 
-		if (enableCompression && ((null == compressionFlag) || ((s1.count | s2.count) >= 0))) {
+		if (COMPACT_STRINGS && ((null == compressionFlag) || ((s1.count | s2.count) >= 0))) {
 			while (o1 < end) {
 				byte byteAtO1;
 				byte byteAtO2;
@@ -5630,7 +5626,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 		}
 
-		if (enableCompression && ((null == compressionFlag) || ((s1.count | s2.count) >= 0))) {
+		if (COMPACT_STRINGS && ((null == compressionFlag) || ((s1.count | s2.count) >= 0))) {
 			char[] buffer = new char[(concatlen + 1) >>> 1];
 
 			compressedArrayCopy(s1.value, 0, buffer, 0, s1len);
@@ -5641,14 +5637,14 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			char[] buffer = new char[concatlen];
 
 			// Check if the String is compressed
-			if (enableCompression && s1.count >= 0) {
+			if (COMPACT_STRINGS && s1.count >= 0) {
 				decompress(s1.value, 0, buffer, 0, s1len);
 			} else {
 				System.arraycopy(s1.value, 0, buffer, 0, s1len);
 			}
 
 			// Check if the String is compressed
-			if (enableCompression && s2.count >= 0) {
+			if (COMPACT_STRINGS && s2.count >= 0) {
 				decompress(s2.value, 0, buffer, s1len, s2len);
 			} else {
 				System.arraycopy(s2.value, 0, buffer, s1len, s2len);
@@ -5789,12 +5785,12 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		 * deduplicate because doing so would require updating both value and
 		 * count, and other threads could see an inconsistent state.
 		 *
-		 * If (!enableCompression), then both strings are always uncompressed.
-		 * If OTOH (enableCompression) but (null == compressionFlag), then both
+		 * If (!COMPACT_STRINGS), then both strings are always uncompressed.
+		 * If OTOH (COMPACT_STRINGS) but (null == compressionFlag), then both
 		 * strings must be compressed. So it's only necessary to check the
-		 * compression bits when (enableCompression && null != compressionFlag).
+		 * compression bits when (COMPACT_STRINGS && null != compressionFlag).
 		 */
-		if (!enableCompression || null == compressionFlag || (s1.count ^ s2.count) >= 0) {
+		if (!COMPACT_STRINGS || null == compressionFlag || (s1.count ^ s2.count) >= 0) {
 			long valueFieldOffset = UnsafeHelpers.valueFieldOffset;
 
 			if (com.ibm.oti.vm.VM.J9_JIT_STRING_DEDUP_POLICY == com.ibm.oti.vm.VM.J9_JIT_STRING_DEDUP_POLICY_FAVOUR_LOWER) {
@@ -5853,7 +5849,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		char[] s1Value = s1.value;
 		char[] s2Value = s2.value;
 
-		if (enableCompression && (null == compressionFlag || (s1.count | s2.count) >= 0)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || (s1.count | s2.count) >= 0)) {
 			// Compare the last chars.
 			// In order to tell 2 chars are different:
 			// Under string compression, the compressible char set obeys 1-1 mapping for upper/lower case,
@@ -5920,7 +5916,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		char[] buffer;
 
 		// Check if the String is compressed
-		if (enableCompression && count >= 0) {
+		if (COMPACT_STRINGS && count >= 0) {
 			buffer = new char[currentLength];
 			decompress(value, 0, buffer, 0, currentLength);
 		} else {
@@ -5953,7 +5949,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public void getBytes(int start, int end, byte[] data, int index) {
 		if (0 <= start && start <= end && end <= lengthInternal() && 0 <= index && ((end - start) <= (data.length - index))) {
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || count >= 0)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 				compressedArrayCopy(value, start, data, index, end - start);
 			} else {
 				compress(value, start, data, index, end - start);
@@ -5966,7 +5962,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	void getBytes(int start, int end, char[] data, int index) {
 		if (0 <= start && start <= end && end <= lengthInternal()) {
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || count >= 0)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 				compressedArrayCopy(value, start, data, index, end - start);
 			} else {
 				compress(value, start, data, index, end - start);
@@ -5999,7 +5995,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		char[] buffer;
 
 		// Check if the String is compressed
-		if (enableCompression && count >= 0) {
+		if (COMPACT_STRINGS && count >= 0) {
 			buffer = new char[currentLength];
 			decompress(value, 0, buffer, 0, currentLength);
 		} else {
@@ -6028,7 +6024,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 */
 	public void getChars(int start, int end, char[] data, int index) {
 		if (0 <= start && start <= end && end <= lengthInternal() && 0 <= index && ((end - start) <= (data.length - index))) {
-			if (enableCompression && (null == compressionFlag || count >= 0)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 				decompress(value, start, data, index, end - start);
 			} else {
 				System.arraycopy(value, start, data, index, end - start);
@@ -6042,7 +6038,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	// Caller of this method must validate bound safety for String indexing and array copying.
 	void getCharsNoBoundChecks(int start, int end, char[] data, int index) {
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || count >= 0)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 			decompress(value, start, data, index, end - start);
 		} else {
 			decompressedArrayCopy(value, start, data, index, end - start);
@@ -6061,7 +6057,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			int length = lengthInternal();
 			if (length > 0) {
 				// Check if the String is compressed
-				if (enableCompression && (compressionFlag == null || count >= 0)) {
+				if (COMPACT_STRINGS && (compressionFlag == null || count >= 0)) {
 					hash = hashCodeImplCompressed(value, 0, length);
 				} else {
 					hash = hashCodeImplDecompressed(value, 0, length);
@@ -6135,7 +6131,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				char[] array = value;
 
 				// Check if the String is compressed
-				if (enableCompression && (null == compressionFlag || count >= 0)) {
+				if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 					if (c <= 255) {
 						return helpers.intrinsicIndexOfLatin1(array, (byte)c, start, len);
 					}
@@ -6221,7 +6217,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			char[] s1Value = s1.value;
 			char[] s2Value = s2.value;
 
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				if (null == compressionFlag || (s1.count | s2.count) >= 0) {
 					// Both s1 and s2 are compressed.
 					return helpers.intrinsicIndexOfStringLatin1(s1Value, s1len, s2Value, s2len, start);
@@ -6314,7 +6310,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				char[] array = value;
 
 				// Check if the String is compressed
-				if (enableCompression && (null == compressionFlag || count >= 0)) {
+				if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 					if (c <= 255) {
 						byte b = (byte) c;
 
@@ -6404,7 +6400,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				char[] s1Value = s1.value;
 				char[] s2Value = s2.value;
 
-				if (enableCompression && (null == compressionFlag || (s1.count | s2.count) >= 0)) {
+				if (COMPACT_STRINGS && (null == compressionFlag || (s1.count | s2.count) >= 0)) {
 					char firstChar = helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(s2Value, 0));
 
 					while (true) {
@@ -6474,7 +6470,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 * @return the number of characters in this String
 	 */
 	int lengthInternal() {
-		if (enableCompression) {
+		if (COMPACT_STRINGS) {
 			// Check if the String is compressed
 			if (compressionFlag == null || count >= 0) {
 				return count;
@@ -6531,7 +6527,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		// Index of the last char to compare
 		int end = length - 1;
 
-		if (enableCompression && ((compressionFlag == null) || ((s1.count | s2.count) >= 0))) {
+		if (COMPACT_STRINGS && ((compressionFlag == null) || ((s1.count | s2.count) >= 0))) {
 			if (helpers.getByteFromArrayByIndex(s1Value, s1Start + end) != helpers.getByteFromArrayByIndex(s2Value, s2Start + end)) {
 				return false;
 			} else {
@@ -6608,7 +6604,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		char[] s1Value = s1.value;
 		char[] s2Value = s2.value;
 
-		if (enableCompression && (null == compressionFlag || (s1.count | s2.count) >= 0)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || (s1.count | s2.count) >= 0)) {
 			while (o1 < end) {
 				byte byteAtO1 = helpers.getByteFromArrayByIndex(s1Value, o1++);
 				byte byteAtO2 = helpers.getByteFromArrayByIndex(s2Value, o2++);
@@ -6654,7 +6650,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		int len = lengthInternal();
 
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || count >= 0)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 			if (newChar <= 255) {
 				char[] buffer = new char[(len + 1) >>> 1];
 
@@ -6744,7 +6740,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 		if (0 <= start && start <= len) {
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || count >= 0)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 				return new String(value, start, len - start, true, enableSharingInSubstringWhenOffsetIsZero);
 			} else {
 				return new String(value, start, len - start, false, enableSharingInSubstringWhenOffsetIsZero);
@@ -6775,7 +6771,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 		if (0 <= start && start <= end && end <= len) {
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || count >= 0)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 				return new String(value, start, end - start, true, enableSharingInSubstringWhenOffsetIsZero);
 			} else {
 				return new String(value, start, end - start, false, enableSharingInSubstringWhenOffsetIsZero);
@@ -6796,7 +6792,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		char[] buffer = new char[len];
 
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || count >= 0)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 			decompress(value, 0, buffer, 0, len);
 		} else {
 			System.arraycopy(value, 0, buffer, 0, len);
@@ -6921,7 +6917,7 @@ written authorization of the copyright holder.
 		}
 
 		if (helpers.supportsIntrinsicCaseConversion() && (language == "en")) { //$NON-NLS-1$
-			if (enableCompression && ((null == compressionFlag) || (count >= 0))) {
+			if (COMPACT_STRINGS && ((null == compressionFlag) || (count >= 0))) {
 				char[] output = new char[(sLength + 1) >>> 1];
 				if (helpers.toLowerIntrinsicLatin1(value, output, sLength)) {
 					return new String(output, 0, sLength, true);
@@ -6969,7 +6965,7 @@ written authorization of the copyright holder.
 					builder = new StringBuilder(len);
 
 					// Check if the String is compressed
-					if (enableCompression && (null == compressionFlag || count >= 0)) {
+					if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 						builder.append(value, 0, i, true);
 					} else {
 						builder.append(value, 0, i, false);
@@ -7253,7 +7249,7 @@ written authorization of the copyright holder.
 		}
 
 		if (helpers.supportsIntrinsicCaseConversion() && (language == "en")) { //$NON-NLS-1$
-			if (enableCompression && ((null == compressionFlag) || (count >= 0))) {
+			if (COMPACT_STRINGS && ((null == compressionFlag) || (count >= 0))) {
 				char[] output = new char[(sLength + 1) >>> 1];
 				if (helpers.toUpperIntrinsicLatin1(value, output, sLength)) {
 					return new String(output, 0, sLength, true);
@@ -7305,7 +7301,7 @@ written authorization of the copyright holder.
 						builder = new StringBuilder(len);
 
 						// Check if the String is compressed
-						if (enableCompression && (null == compressionFlag || count >= 0)) {
+						if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 							builder.append(value, 0, i, true);
 						} else {
 							builder.append(value, 0, i, false);
@@ -7362,7 +7358,7 @@ written authorization of the copyright holder.
 		int end = last;
 
 		// Check if the String is compressed
-		if (enableCompression && (null == compressionFlag || count >= 0)) {
+		if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 			while ((start <= end) && (helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, start)) <= ' ')) {
 				start++;
 			}
@@ -7440,7 +7436,7 @@ written authorization of the copyright holder.
 		String string;
 
 		if (value <= 255) {
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				string = new String(compressedAsciiTable[value], 0, 1, true);
 			} else {
 				string = new String(decompressedAsciiTable[value], 0, 1, false);
@@ -7540,7 +7536,7 @@ written authorization of the copyright holder.
 				return false;
 			}
 
-			if (enableCompression && buffer.isCompressed()) {
+			if (COMPACT_STRINGS && buffer.isCompressed()) {
 				return regionMatches(0, new String(buffer.getValue(), 0, size, true), 0, size);
 			} else {
 				return regionMatches(0, new String(buffer.getValue(), 0, size, false), 0, size);
@@ -7589,7 +7585,7 @@ written authorization of the copyright holder.
 			int substituteLength = substitute.lengthInternal();
 			int length = lengthInternal();
 			if (substituteLength < 2) {
-				if (enableCompression && isCompressed() && (substituteLength == 0 || substitute.isCompressed())) {
+				if (COMPACT_STRINGS && isCompressed() && (substituteLength == 0 || substitute.isCompressed())) {
 					char[] newChars = new char[(length + 1) >>> 1];
 					byte toReplace = helpers.getByteFromArrayByIndex(regex.value, 0);
 					byte replacement = (byte)-1;  // assign dummy value that will never be used
@@ -7607,7 +7603,7 @@ written authorization of the copyright holder.
 						}
 					}
 					return new String(newChars, 0, newCharIndex, true);
-				} else if (!enableCompression || !isCompressed()) {
+				} else if (!COMPACT_STRINGS || !isCompressed()) {
 					char[] newChars = new char[length];
 					char toReplace = regex.charAtInternal(0);
 					char replacement = (char)-1; // assign dummy value that will never be used
@@ -7730,7 +7726,7 @@ written authorization of the copyright holder.
 
 			char[] chars = this.value;
 
-			final boolean compressed = enableCompression && (null == compressionFlag || count >= 0);
+			final boolean compressed = COMPACT_STRINGS && (null == compressionFlag || count >= 0);
 
 			int start = 0, current = 0, end = lengthInternal();
 			if (regex.lengthInternal() == 1 || singleEscapeLiteral) {
@@ -7831,7 +7827,7 @@ written authorization of the copyright holder.
 			int size = 0;
 
 			// Optimistically assume we can compress data[]
-			boolean canEncodeAsLatin1 = enableCompression;
+			boolean canEncodeAsLatin1 = COMPACT_STRINGS;
 
 			for (int i = start; i < start + length; ++i) {
 				int codePoint = data[i];
@@ -7884,7 +7880,7 @@ written authorization of the copyright holder.
 			} else {
 				value = new char[size];
 
-				if (enableCompression) {
+				if (COMPACT_STRINGS) {
 					count = size | uncompressedBit;
 
 					initCompressionFlag();
@@ -7921,7 +7917,7 @@ written authorization of the copyright holder.
 	public String(StringBuilder builder) {
 		char[] chars = builder.shareValue();
 
-		if (enableCompression) {
+		if (COMPACT_STRINGS) {
 			if (builder.isCompressed()) {
 				value = chars;
 				count = builder.lengthInternal();
@@ -7951,7 +7947,7 @@ written authorization of the copyright holder.
 
 		if (index >= 0 && index < len) {
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || count >= 0)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 				return helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, index));
 			} else {
 				char high = charAtInternal(index);
@@ -7985,7 +7981,7 @@ written authorization of the copyright holder.
 
 		if (index > 0 && index <= len) {
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || count >= 0)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 				return helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, index - 1));
 			} else {
 				char low = charAtInternal(index - 1);
@@ -8021,7 +8017,7 @@ written authorization of the copyright holder.
 
 		if (start >= 0 && start <= end && end <= len) {
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || count >= 0)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 				return end - start;
 			} else {
 				int count = 0;
@@ -8059,7 +8055,7 @@ written authorization of the copyright holder.
 
 		if (start >= 0 && start <= len) {
 			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || count >= 0)) {
+			if (COMPACT_STRINGS && (null == compressionFlag || count >= 0)) {
 				int index = start + codePointCount;
 
 				if (index > len) {
@@ -8367,7 +8363,7 @@ written authorization of the copyright holder.
 		if (start >= 0 && 0 <= length && length <= data.length - start) {
 			char[] chars = StringCoding.decode(charset, data, start, length);
 
-			if (enableCompression) {
+			if (COMPACT_STRINGS) {
 				if (canEncodeAsLatin1(chars, 0, chars.length)) {
 					value = new char[(chars.length + 1) >>> 1];
 					count = chars.length;
@@ -8403,7 +8399,7 @@ written authorization of the copyright holder.
 		char[] buffer;
 
 		// Check if the String is compressed
-		if (enableCompression && count >= 0) {
+		if (COMPACT_STRINGS && count >= 0) {
 			buffer = new char[currentLength];
 			decompress(value, 0, buffer, 0, currentLength);
 		} else {

--- a/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar16 & !Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -124,7 +124,7 @@ public StringBuffer(int capacity) {
 	}
 	int arraySize = capacity;
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		arraySize = (capacity + 1) >>> 1;
 	}
 	value = new char[arraySize];
@@ -147,7 +147,7 @@ public StringBuffer (String string) {
 		newLength = stringLength;
 	}
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		if (string.isCompressed ()) {
 			value = new char[(newLength + 1) >>> 1];
 
@@ -196,7 +196,7 @@ public synchronized StringBuffer append (char[] chars) {
 		throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 	}
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		// Check if the StringBuffer is compressed
 		if (count >= 0 && String.canEncodeAsLatin1(chars, 0, chars.length)) {
 			if (newLength > currentCapacity) {
@@ -257,7 +257,7 @@ public synchronized StringBuffer append (char chars[], int start, int length) {
 			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 		}
 		
-		if (String.enableCompression) {
+		if (String.COMPACT_STRINGS) {
 			// Check if the StringBuffer is compressed
 			if (count >= 0 && String.canEncodeAsLatin1(chars, start, length)) {
 				if (newLength > currentCapacity) {
@@ -307,7 +307,7 @@ synchronized StringBuffer append (char[] chars, int start, int length, boolean c
 		throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 	}
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		// Check if the StringBuffer is compressed
 		if (count >= 0 && compressed) {
 			if (newLength > currentCapacity) {
@@ -370,7 +370,7 @@ public synchronized StringBuffer append(char ch) {
 		throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 	}
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		// Check if the StringBuffer is compressed
 		if (count >= 0 && ch <= 255) {
 			if (newLength > currentCapacity) {
@@ -438,7 +438,7 @@ public StringBuffer append (float value) {
  */
 public synchronized StringBuffer append(int value) {
 	if (value != Integer.MIN_VALUE) {
-		if (String.enableCompression && count >= 0) {
+		if (String.COMPACT_STRINGS && count >= 0) {
 			return append(Integer.toString(value));
 		} else {
 			int currentLength = lengthInternalUnsynchronized();
@@ -464,7 +464,7 @@ public synchronized StringBuffer append(int value) {
 
 			Integer.getChars(value, newLength, this.value);
 
-			if (String.enableCompression) {
+			if (String.COMPACT_STRINGS) {
 				count = newLength | uncompressedBit;
 			} else {
 				count = newLength;
@@ -487,7 +487,7 @@ public synchronized StringBuffer append(int value) {
  */
 public synchronized StringBuffer append(long value) {
 	if (value != Long.MIN_VALUE) {
-		if (String.enableCompression && count >= 0) {
+		if (String.COMPACT_STRINGS && count >= 0) {
 			return append(Long.toString(value));
 		} else {
 			int currentLength = lengthInternalUnsynchronized();
@@ -513,7 +513,7 @@ public synchronized StringBuffer append(long value) {
 
 			Long.getChars(value, newLength, this.value);
 
-			if (String.enableCompression) {
+			if (String.COMPACT_STRINGS) {
 				count = newLength | uncompressedBit;
 			} else {
 				count = newLength;
@@ -560,7 +560,7 @@ public synchronized StringBuffer append (String string) {
 		throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 	}
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		// Check if the StringBuffer is compressed
 		if (count >= 0 && string.isCompressed ()) {
 			if (newLength > currentCapacity) {
@@ -650,7 +650,7 @@ public synchronized char charAt(int index) {
 	
 	if (index >= 0 && index < currentLength) {
 		// Check if the StringBuffer is compressed
-		if (String.enableCompression && count >= 0) {
+		if (String.COMPACT_STRINGS && count >= 0) {
 			return helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, index));
 		} else {
 			return value[index];
@@ -686,7 +686,7 @@ public synchronized StringBuffer delete(int start, int end) {
 				if (capacity >= 0) {
 					if (numberOfTailChars > 0) {
 						// Check if the StringBuffer is compressed
-						if (String.enableCompression && count >= 0) {
+						if (String.COMPACT_STRINGS && count >= 0) {
 							String.compressedArrayCopy(value, end, value, start, numberOfTailChars);
 						} else {
 							String.decompressedArrayCopy(value, end, value, start, numberOfTailChars);
@@ -696,7 +696,7 @@ public synchronized StringBuffer delete(int start, int end) {
 					char[] newData = new char[value.length];
 					
 					// Check if the StringBuffer is compressed
-					if (String.enableCompression && count >= 0) {
+					if (String.COMPACT_STRINGS && count >= 0) {
 						if (start > 0) {
 							String.compressedArrayCopy(value, 0, newData, 0, start);
 						}
@@ -722,7 +722,7 @@ public synchronized StringBuffer delete(int start, int end) {
 				throw new StringIndexOutOfBoundsException();
 			}
 			
-			if (String.enableCompression) {
+			if (String.COMPACT_STRINGS) {
 				// Check if the StringBuffer is compressed
 				if (count >= 0) {
 					count = currentLength - (end - start);
@@ -793,7 +793,7 @@ private void ensureCapacityImpl(int min) {
 	int newLength = min > newCapacity ? min : newCapacity;
 	
 	// Check if the StringBuilder is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		char[] newData = new char[(newLength + 1) >>> 1];
 		
 		String.compressedArrayCopy(value, 0, newData, 0, currentLength);
@@ -831,7 +831,7 @@ public synchronized void getChars(int start, int end, char[] buffer, int index) 
 			// have implicitly checked these conditions
 			if (start >= 0 && start <= end && index >= 0 && end - start <= buffer.length - index) {
 				// Check if the StringBuffer is compressed
-				if (String.enableCompression && count >= 0) {
+				if (String.COMPACT_STRINGS && count >= 0) {
 					String.decompress(value, start, buffer, index, end - start);
 					
 					return;
@@ -866,7 +866,7 @@ public synchronized StringBuffer insert(int index, char[] chars) {
 	if (0 <= index && index <= currentLength) {
 		move(chars.length, index);
 		
-		if (String.enableCompression) {
+		if (String.COMPACT_STRINGS) {
 			// Check if the StringBuffer is compressed
 			if (count >= 0 && String.canEncodeAsLatin1(chars, 0, chars.length)) {
 				String.compress(chars, 0, value, index, chars.length);
@@ -920,7 +920,7 @@ public synchronized StringBuffer insert(int index, char[] chars, int start, int 
 		if (start >= 0 && 0 <= length && length <= chars.length - start) {
 			move(length, index);
 			
-			if (String.enableCompression) {
+			if (String.COMPACT_STRINGS) {
 				// Check if the StringBuffer is compressed
 				if (count >= 0 && String.canEncodeAsLatin1(chars, start, length)) {
 					String.compress(chars, start, value, index, length);
@@ -960,7 +960,7 @@ synchronized StringBuffer insert(int index, char[] chars, int start, int length,
 	
 	move(length, index);
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		// Check if the StringBuffer is compressed
 		if (count >= 0 && compressed) {
 			String.compressedArrayCopy(chars, start, value, index, length);
@@ -1004,7 +1004,7 @@ public synchronized StringBuffer insert(int index, char ch) {
 	if (0 <= index && index <= currentLength) {
 		move(1, index);
 		
-		if (String.enableCompression ) {
+		if (String.COMPACT_STRINGS ) {
 			// Check if the StringBuffer is compressed
 			if (count >= 0 && ch <= 255) {
 				helpers.putByteInArrayByIndex(value, index, (byte) ch);
@@ -1133,7 +1133,7 @@ public synchronized StringBuffer insert(int index, String string) {
 		
 		move(stringLength, index);
 		
-		if (String.enableCompression) {
+		if (String.COMPACT_STRINGS) {
 			// Check if the StringBuffer is compressed
 			if (count >= 0 && string.isCompressed()) {
 				string.getBytes(0, stringLength, value, index);
@@ -1198,7 +1198,7 @@ public synchronized int length() {
  * @return the number of characters in this StringBuffer
  */
 private int lengthInternalUnsynchronized() {
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		// Check if the StringBuffer is compressed
 		if (count >= 0) {
 			return count;
@@ -1215,7 +1215,7 @@ private void move(int size, int index) {
 	int currentCapacity = capacityInternal();
 	
 	// Check if the StringBuffer is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		int newLength;
 		
 		if (currentCapacity - currentLength >= size) {
@@ -1287,7 +1287,7 @@ private void move(int size, int index) {
 public synchronized StringBuffer replace(int start, int end, String string) {
 	int currentLength = lengthInternalUnsynchronized();
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		// Check if the StringBuffer is compressed
 		if (count >= 0 && string.isCompressed()) {
 			if (start >= 0) {
@@ -1451,7 +1451,7 @@ public synchronized StringBuffer reverse() {
 	}
 	
 	// Check if the StringBuffer is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		// Check if the StringBuffer is not shared
 		if (capacity >= 0) {
 			for (int i = 0, mid = currentLength / 2, j = currentLength - 1; i < mid; ++i, --j) {
@@ -1573,7 +1573,7 @@ public synchronized void setCharAt(int index, char ch) {
 	int currentLength = lengthInternalUnsynchronized();
 	
 	if (0 <= index && index < currentLength) {
-		if (String.enableCompression) {
+		if (String.COMPACT_STRINGS) {
 			// Check if the StringBuffer is compressed
 			if (count >= 0 && ch <= 255) {
 				if (capacity < 0) {
@@ -1628,7 +1628,7 @@ public synchronized void setLength(int length) {
 	int currentCapacity = capacityInternal();
 	
 	// Check if the StringBuffer is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		if (length > currentCapacity) {
 			ensureCapacityImpl(length);
 		} else if (length > currentLength) {
@@ -1676,7 +1676,7 @@ public synchronized void setLength(int length) {
 		}
 	}
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		// Check if the StringBuffer is compressed
 		if (count >= 0) {
 			count = length;
@@ -1702,7 +1702,7 @@ public synchronized String substring(int start) {
 	int currentLength = lengthInternalUnsynchronized();
 
 	// Check if the StringBuffer is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		if (0 <= start && start <= currentLength) {
 			return new String(value, start, currentLength - start, true, false);
 		}
@@ -1729,7 +1729,7 @@ public synchronized String substring(int start, int end) {
 	int currentLength = lengthInternalUnsynchronized();
 	
 	// Check if the StringBuffer is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		if (0 <= start && start <= end && end <= currentLength) {
 			return new String(value, start, end - start, true, false);
 		}
@@ -1765,7 +1765,7 @@ public synchronized String toString () {
 		int wasted = currentCapacity - currentLength;
 		if (wasted >= 768 || (wasted >= INITIAL_SIZE && wasted >= (currentCapacity >> 1))) {
 			// Check if the StringBuffer is compressed
-			if (String.enableCompression && count >= 0) {
+			if (String.COMPACT_STRINGS && count >= 0) {
 				return new String (value, 0, currentLength, true, false);
 			} else {
 				return new String (value, 0, currentLength, false, false);
@@ -1776,7 +1776,7 @@ public synchronized String toString () {
 		int roundedCount = (currentLength + 3) & ~3;
 		if (roundedCount < currentCapacity) {
 			// Check if the StringBuffer is compressed
-			if (String.enableCompression && count >= 0) {
+			if (String.COMPACT_STRINGS && count >= 0) {
 				return new String (value, 0, currentLength, true, false);
 			} else {
 				return new String (value, 0, currentLength, false, false);
@@ -1787,7 +1787,7 @@ public synchronized String toString () {
 	capacity = capacity | sharedBit;
 	
 	// Check if the StringBuffer is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		return new String (value, 0, currentLength, true);
 	} else {
 		return new String (value, 0, currentLength, false);
@@ -1802,7 +1802,7 @@ private synchronized void writeObject(ObjectOutputStream stream) throws IOExcept
 	pf.put("count", currentLength); //$NON-NLS-1$  
 
 	// Check if the StringBuffer is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		char[] newData = new char[currentLength];
 		
 		String.decompress(value, 0, newData, 0, currentLength);
@@ -1828,7 +1828,7 @@ private void readObject(ObjectInputStream stream) throws IOException, ClassNotFo
 		throw new InvalidObjectException(com.ibm.oti.util.Msg.getString("K0199")); //$NON-NLS-1$
 	} 
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		if (String.canEncodeAsLatin1(streamValue, 0, streamValue.length)) {
 			value = new char[(streamValue.length + 1) >>> 1];
 			
@@ -1873,7 +1873,7 @@ public synchronized StringBuffer append(StringBuffer buffer) {
 	} else {
 		synchronized (buffer) {
 			// Check if the StringBuffer is compressed
-			if (String.enableCompression && buffer.count >= 0) {
+			if (String.COMPACT_STRINGS && buffer.count >= 0) {
 				return append(buffer.value, 0, buffer.lengthInternalUnsynchronized(), true);
 			} else {
 				return append(buffer.value, 0, buffer.lengthInternalUnsynchronized(), false);
@@ -1947,7 +1947,7 @@ public synchronized int indexOf(String subString, int start) {
 		char firstChar = subString.charAtInternal(0);
 		
 		// Check if the StringBuffer is compressed
-		if (String.enableCompression && count >= 0) {
+		if (String.COMPACT_STRINGS && count >= 0) {
 			if (!subString.isCompressed()) {
 				return -1;
 			}
@@ -2064,7 +2064,7 @@ public synchronized int lastIndexOf(String subString, int start) {
 			char firstChar = subString.charAtInternal(0);
 			
 			// Check if the StringBuffer is compressed
-			if (String.enableCompression && count >= 0) {
+			if (String.COMPACT_STRINGS && count >= 0) {
 				if (!subString.isCompressed()) {
 					return -1;
 				}
@@ -2147,7 +2147,7 @@ char[] shareValue() {
 
 boolean isCompressed() {
 	// Check if the StringBuffer is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		return true;
 	} else {
 		return false;
@@ -2175,7 +2175,7 @@ public StringBuffer(CharSequence sequence) {
 		newLength = size;
 	}
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		value = new char[(newLength + 1) >>> 1];
 	} else {
 		value = new char[newLength];
@@ -2188,7 +2188,7 @@ public StringBuffer(CharSequence sequence) {
 	} else if (sequence instanceof StringBuffer) {		
 		append((StringBuffer)sequence);
 	} else {		
-		if (String.enableCompression) {
+		if (String.COMPACT_STRINGS) {
 			boolean isCompressed = true;
 			
 			for (int i = 0; i < size; ++i) {
@@ -2254,7 +2254,7 @@ public synchronized StringBuffer append(CharSequence sequence) {
 			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 		}
 		
-		if (String.enableCompression) {
+		if (String.COMPACT_STRINGS) {
 			boolean isCompressed = true;
 			
 			if (count >= 0) {
@@ -2335,7 +2335,7 @@ public synchronized StringBuffer append(CharSequence sequence, int start, int en
 				StringBuffer buffer = (StringBuffer) sequence;
 				
 				// Check if the StringBuffer is compressed
-				if (String.enableCompression && buffer.count >= 0) {
+				if (String.COMPACT_STRINGS && buffer.count >= 0) {
 					return append(buffer.value, start, end - start, true);
 				} else {
 					return append(buffer.value, start, end - start, false);
@@ -2345,7 +2345,7 @@ public synchronized StringBuffer append(CharSequence sequence, int start, int en
 			synchronized (sequence) {
 				StringBuilder builder = (StringBuilder) sequence;
 				
-				if (String.enableCompression && builder.isCompressed()) {
+				if (String.COMPACT_STRINGS && builder.isCompressed()) {
 					return append(builder.getValue(), start, end - start, true);
 				} else {
 					return append(builder.getValue(), start, end - start, false);
@@ -2361,7 +2361,7 @@ public synchronized StringBuffer append(CharSequence sequence, int start, int en
 				throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 			}
 			
-			if (String.enableCompression) {
+			if (String.COMPACT_STRINGS) {
 				boolean isCompressed = true;
 				
 				if (count >= 0) {
@@ -2445,7 +2445,7 @@ public synchronized StringBuffer insert(int index, CharSequence sequence) {
 				StringBuffer buffer = (StringBuffer) sequence;
 				
 				// Check if the StringBuffer is compressed
-				if (String.enableCompression && buffer.count >= 0) {
+				if (String.COMPACT_STRINGS && buffer.count >= 0) {
 					return insert(index, buffer.value, 0, buffer.lengthInternalUnsynchronized(), true);
 				} else {
 					return insert(index, buffer.value, 0, buffer.lengthInternalUnsynchronized(), false);
@@ -2455,7 +2455,7 @@ public synchronized StringBuffer insert(int index, CharSequence sequence) {
 			synchronized (sequence) {
 				StringBuilder builder = (StringBuilder) sequence;
 				
-				if (String.enableCompression && builder.isCompressed()) {
+				if (String.COMPACT_STRINGS && builder.isCompressed()) {
 					return insert(index, builder.getValue(), 0, builder.lengthInternal(), true);
 				} else {
 					return insert(index, builder.getValue(), 0, builder.lengthInternal(), false);
@@ -2469,7 +2469,7 @@ public synchronized StringBuffer insert(int index, CharSequence sequence) {
 				
 				int newLength = currentLength + sequneceLength;
 				
-				if (String.enableCompression) {
+				if (String.COMPACT_STRINGS) {
 					boolean isCompressed = true;
 					
 					for (int i = 0; i < sequneceLength; ++i) {
@@ -2547,7 +2547,7 @@ public synchronized StringBuffer insert(int index, CharSequence sequence, int st
 					StringBuffer buffer = (StringBuffer) sequence;
 					
 					// Check if the StringBuffer is compressed
-					if (String.enableCompression && buffer.count >= 0) {
+					if (String.COMPACT_STRINGS && buffer.count >= 0) {
 						return insert(index, buffer.value, start, end - start, true);
 					} else {
 						return insert(index, buffer.value, start, end - start, false);
@@ -2557,7 +2557,7 @@ public synchronized StringBuffer insert(int index, CharSequence sequence, int st
 				synchronized(sequence) {
 					StringBuilder builder = (StringBuilder) sequence;
 					
-					if (String.enableCompression && builder.isCompressed()) {
+					if (String.COMPACT_STRINGS && builder.isCompressed()) {
 						return insert(index, builder.getValue(), start, end - start, true);
 					} else {
 						return insert(index, builder.getValue(), start, end - start, false);
@@ -2571,7 +2571,7 @@ public synchronized StringBuffer insert(int index, CharSequence sequence, int st
 					
 					int newLength = currentLength + sequenceLength;
 					
-					if (String.enableCompression) {
+					if (String.COMPACT_STRINGS) {
 						boolean isCompressed = true;
 						
 						for (int i = 0; i < sequenceLength; ++i) {
@@ -2633,7 +2633,7 @@ public synchronized void trimToSize() {
 	int currentCapacity = capacityInternal();
 	
 	// Check if the StringBuffer is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		// Check if the StringBuffer is not shared
 		if (capacity >= 0 && currentCapacity != currentLength) {
 			char[] newData = new char[(currentLength + 1) / 2];
@@ -2670,7 +2670,7 @@ public synchronized int codePointAt(int index) {
 	
 	if (index >= 0 && index < currentLength) {
 		// Check if the StringBuffer is compressed
-		if (String.enableCompression && count >= 0) {
+		if (String.COMPACT_STRINGS && count >= 0) {
 			return helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, index));
 		} else {
 			int high = value[index];
@@ -2703,7 +2703,7 @@ public synchronized int codePointBefore(int index) {
 	
 	if (index > 0 && index <= currentLength) {
 		// Check if the StringBuffer is compressed
-		if (String.enableCompression && count >= 0) {
+		if (String.COMPACT_STRINGS && count >= 0) {
 			return helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, index - 1));
 		} else {
 			int low = value[index - 1];
@@ -2737,7 +2737,7 @@ public synchronized int codePointCount(int start, int end) {
 	
 	if (start >= 0 && start <= end && end <= currentLength) {
 		// Check if the StringBuffer is compressed
-		if (String.enableCompression && count >= 0) {
+		if (String.COMPACT_STRINGS && count >= 0) {
 			return end - start;
 		} else {
 			int count = 0;
@@ -2777,7 +2777,7 @@ public synchronized int offsetByCodePoints(int start, int codePointCount) {
 	
 	if (start >= 0 && start <= currentLength) {
 		// Check if the StringBuffer is compressed
-		if (String.enableCompression && count >= 0) {
+		if (String.COMPACT_STRINGS && count >= 0) {
 			int index = start + codePointCount;
 
 			if (index >= currentLength) {
@@ -2849,7 +2849,7 @@ public synchronized StringBuffer appendCodePoint(int codePoint) {
 			return append((char)codePoint);
 		} else if (codePoint < 0x110000) {
 			// Check if the StringBuffer is compressed
-			if (String.enableCompression && count >= 0) {
+			if (String.COMPACT_STRINGS && count >= 0) {
 				decompress(value.length);
 			}
 			
@@ -2871,7 +2871,7 @@ public synchronized StringBuffer appendCodePoint(int codePoint) {
 			value[currentLength] = (char) (Character.MIN_HIGH_SURROGATE + (codePoint >> 10));
 			value[currentLength + 1] = (char) (Character.MIN_LOW_SURROGATE + (codePoint & 0x3ff));
 
-			if (String.enableCompression) {
+			if (String.COMPACT_STRINGS) {
 				count = newLength | uncompressedBit;
 			} else {
 				count = newLength;

--- a/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar16 & !Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2020 IBM Corp. and others
+ * Copyright (c) 2005, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -124,7 +124,7 @@ public StringBuilder(int capacity) {
 	}
 	int arraySize = capacity;
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		arraySize = (capacity + 1) >>> 1;
 	}
 	value = new char[arraySize];
@@ -147,7 +147,7 @@ public StringBuilder (String string) {
 		newLength = stringLength;
 	}
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		if (string.isCompressed ()) {
 			value = new char[(newLength + 1) >>> 1];
 
@@ -196,7 +196,7 @@ public StringBuilder append (char[] chars) {
 		throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 	}
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		// Check if the StringBuilder is compressed
 		if (count >= 0 && String.canEncodeAsLatin1(chars, 0, chars.length)) {
 			if (newLength > currentCapacity) {
@@ -257,7 +257,7 @@ public StringBuilder append (char chars[], int start, int length) {
 			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 		}
 		
-		if (String.enableCompression) {
+		if (String.COMPACT_STRINGS) {
 			// Check if the StringBuilder is compressed
 			if (count >= 0 && String.canEncodeAsLatin1(chars, start, length)) {
 				if (newLength > currentCapacity) {
@@ -307,7 +307,7 @@ StringBuilder append (char[] chars, int start, int length, boolean compressed) {
 		throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 	}
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		// Check if the StringBuilder is compressed
 		if (count >= 0 && compressed) {
 			if (newLength > currentCapacity) {
@@ -370,7 +370,7 @@ public StringBuilder append(char ch) {
 		throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 	}
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		// Check if the StringBuilder is compressed
 		if (count >= 0 && ch <= 255) {
 			if (newLength > currentCapacity) {
@@ -438,7 +438,7 @@ public StringBuilder append (float value) {
  */
 public StringBuilder append(int value) {
 	if (value != Integer.MIN_VALUE) {
-		if (String.enableCompression && count >= 0) {
+		if (String.COMPACT_STRINGS && count >= 0) {
 			return append(Integer.toString(value));
 		} else {
 			int currentLength = lengthInternal();
@@ -464,7 +464,7 @@ public StringBuilder append(int value) {
 
 			Integer.getChars(value, newLength, this.value);
 
-			if (String.enableCompression) {
+			if (String.COMPACT_STRINGS) {
 				count = newLength | uncompressedBit;
 			} else {
 				count = newLength;
@@ -487,7 +487,7 @@ public StringBuilder append(int value) {
  */
 public StringBuilder append(long value) {
 	if (value != Long.MIN_VALUE) {
-		if (String.enableCompression && count >= 0) {
+		if (String.COMPACT_STRINGS && count >= 0) {
 			return append(Long.toString(value));
 		} else {
 			int currentLength = lengthInternal();
@@ -513,7 +513,7 @@ public StringBuilder append(long value) {
 
 			Long.getChars(value, newLength, this.value);
 
-			if (String.enableCompression) {
+			if (String.COMPACT_STRINGS) {
 				count = newLength | uncompressedBit;
 			} else {
 				count = newLength;
@@ -560,7 +560,7 @@ public StringBuilder append (String string) {
 		throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 	}
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		// Check if the StringBuilder is compressed
 		if (count >= 0 && string.isCompressed ()) {
 			if (newLength > currentCapacity) {
@@ -650,7 +650,7 @@ public char charAt(int index) {
 	
 	if (index >= 0 && index < currentLength) {
 		// Check if the StringBuilder is compressed
-		if (String.enableCompression && count >= 0) {
+		if (String.COMPACT_STRINGS && count >= 0) {
 			return helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, index));
 		} else {
 			return value[index];
@@ -686,7 +686,7 @@ public StringBuilder delete(int start, int end) {
 				if (capacity >= 0) {
 					if (numberOfTailChars > 0) {
 						// Check if the StringBuilder is compressed
-						if (String.enableCompression && count >= 0) {
+						if (String.COMPACT_STRINGS && count >= 0) {
 							String.compressedArrayCopy(value, end, value, start, numberOfTailChars);
 						} else {
 							String.decompressedArrayCopy(value, end, value, start, numberOfTailChars);
@@ -696,7 +696,7 @@ public StringBuilder delete(int start, int end) {
 					char[] newData = new char[value.length];
 					
 					// Check if the StringBuilder is compressed
-					if (String.enableCompression && count >= 0) {
+					if (String.COMPACT_STRINGS && count >= 0) {
 						if (start > 0) {
 							String.compressedArrayCopy(value, 0, newData, 0, start);
 						}
@@ -722,7 +722,7 @@ public StringBuilder delete(int start, int end) {
 				throw new StringIndexOutOfBoundsException();
 			}
 			
-			if (String.enableCompression) {
+			if (String.COMPACT_STRINGS) {
 				// Check if the StringBuilder is compressed
 				if (count >= 0) {
 					count = currentLength - (end - start);
@@ -793,7 +793,7 @@ private void ensureCapacityImpl(int min) {
 	int newLength = min > newCapacity ? min : newCapacity;
 	
 	// Check if the StringBuilder is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		char[] newData = new char[(newLength + 1) >>> 1];
 		
 		String.compressedArrayCopy(value, 0, newData, 0, currentLength);
@@ -831,7 +831,7 @@ public void getChars(int start, int end, char[] buffer, int index) {
 			// have implicitly checked these conditions
 			if (start >= 0 && start <= end && index >= 0 && end - start <= buffer.length - index) {
 				// Check if the StringBuilder is compressed
-				if (String.enableCompression && count >= 0) {
+				if (String.COMPACT_STRINGS && count >= 0) {
 					String.decompress(value, start, buffer, index, end - start);
 					
 					return;
@@ -866,7 +866,7 @@ public StringBuilder insert(int index, char[] chars) {
 	if (0 <= index && index <= currentLength) {
 		move(chars.length, index);
 		
-		if (String.enableCompression) {
+		if (String.COMPACT_STRINGS) {
 			// Check if the StringBuilder is compressed
 			if (count >= 0 && String.canEncodeAsLatin1(chars, 0, chars.length)) {
 				String.compress(chars, 0, value, index, chars.length);
@@ -920,7 +920,7 @@ public StringBuilder insert(int index, char[] chars, int start, int length) {
 		if (start >= 0 && 0 <= length && length <= chars.length - start) {
 			move(length, index);
 			
-			if (String.enableCompression) {
+			if (String.COMPACT_STRINGS) {
 				// Check if the StringBuilder is compressed
 				if (count >= 0 && String.canEncodeAsLatin1(chars, start, length)) {
 					String.compress(chars, start, value, index, length);
@@ -960,7 +960,7 @@ StringBuilder insert(int index, char[] chars, int start, int length, boolean com
 	
 	move(length, index);
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		// Check if the StringBuilder is compressed
 		if (count >= 0 && compressed) {
 			String.compressedArrayCopy(chars, start, value, index, length);
@@ -1004,7 +1004,7 @@ public StringBuilder insert(int index, char ch) {
 	if (0 <= index && index <= currentLength) {
 		move(1, index);
 		
-		if (String.enableCompression ) {
+		if (String.COMPACT_STRINGS ) {
 			// Check if the StringBuilder is compressed
 			if (count >= 0 && ch <= 255) {
 				helpers.putByteInArrayByIndex(value, index, (byte) ch);
@@ -1133,7 +1133,7 @@ public StringBuilder insert(int index, String string) {
 		
 		move(stringLength, index);
 		
-		if (String.enableCompression) {
+		if (String.COMPACT_STRINGS) {
 			// Check if the StringBuilder is compressed
 			if (count >= 0 && string.isCompressed()) {
 				string.getBytes(0, stringLength, value, index);
@@ -1198,7 +1198,7 @@ public int length() {
  * @return the number of characters in this StringBuilder
  */
 int lengthInternal() {
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		// Check if the StringBuilder is compressed
 		if (count >= 0) {
 			return count;
@@ -1215,7 +1215,7 @@ private void move(int size, int index) {
 	int currentCapacity = capacityInternal();
 	
 	// Check if the StringBuilder is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		int newLength;
 		
 		if (currentCapacity - currentLength >= size) {
@@ -1288,7 +1288,7 @@ private void move(int size, int index) {
 public StringBuilder replace(int start, int end, String string) {
 	int currentLength = lengthInternal();
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		// Check if the StringBuilder is compressed
 		if (count >= 0 && string.isCompressed()) {
 			if (start >= 0) {
@@ -1453,7 +1453,7 @@ public StringBuilder reverse() {
 	}
 	
 	// Check if the StringBuilder is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		// Check if the StringBuilder is not shared
 		if (capacity >= 0) {
 			for (int i = 0, mid = currentLength / 2, j = currentLength - 1; i < mid; ++i, --j) {
@@ -1575,7 +1575,7 @@ public void setCharAt(int index, char ch) {
 	int currentLength = lengthInternal();
 	
 	if (0 <= index && index < currentLength) {
-		if (String.enableCompression) {
+		if (String.COMPACT_STRINGS) {
 			// Check if the StringBuilder is compressed
 			if (count >= 0 && ch <= 255) {
 				if (capacity < 0) {
@@ -1630,7 +1630,7 @@ public void setLength(int length) {
 	int currentCapacity = capacityInternal();
 	
 	// Check if the StringBuilder is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		if (length > currentCapacity) {
 			ensureCapacityImpl(length);
 		} else if (length > currentLength) {
@@ -1678,7 +1678,7 @@ public void setLength(int length) {
 		}
 	}
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		// Check if the StringBuilder is compressed
 		if (count >= 0) {
 			count = length;
@@ -1704,7 +1704,7 @@ public String substring(int start) {
 	int currentLength = lengthInternal();
 	
 	// Check if the StringBuilder is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		if (0 <= start && start <= currentLength) {
 			return new String(value, start, currentLength - start, true, false);
 		}
@@ -1731,7 +1731,7 @@ public String substring(int start, int end) {
 	int currentLength = lengthInternal();
 	
 	// Check if the StringBuilder is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		if (0 <= start && start <= end && end <= currentLength) {
 			return new String(value, start, end - start, true, false);
 		}
@@ -1767,7 +1767,7 @@ public String toString () {
 		int wasted = currentCapacity - currentLength;
 		if (wasted >= 768 || (wasted >= INITIAL_SIZE && wasted >= (currentCapacity >> 1))) {
 			// Check if the StringBuffer is compressed
-			if (String.enableCompression && count >= 0) {
+			if (String.COMPACT_STRINGS && count >= 0) {
 				return new String (value, 0, currentLength, true, false);
 			} else {
 				return new String (value, 0, currentLength, false, false);
@@ -1778,7 +1778,7 @@ public String toString () {
 		int roundedCount = (currentLength + 3) & ~3;
 		if (roundedCount < currentCapacity) {
 			// Check if the StringBuffer is compressed
-			if (String.enableCompression && count >= 0) {
+			if (String.COMPACT_STRINGS && count >= 0) {
 				return new String (value, 0, currentLength, true, false);
 			} else {
 				return new String (value, 0, currentLength, false, false);
@@ -1789,7 +1789,7 @@ public String toString () {
 	capacity = capacity | sharedBit;
 	
 	// Check if the StringBuffer is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		return new String (value, 0, currentLength, true);
 	} else {
 		return new String (value, 0, currentLength, false);
@@ -1803,7 +1803,7 @@ private void writeObject(ObjectOutputStream stream) throws IOException {
 	stream.writeInt(currentLength);
 	
 	// Check if the StringBuilder is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		char[] newData = new char[currentLength];
 		
 		String.decompress(value, 0, newData, 0, currentLength);
@@ -1825,7 +1825,7 @@ private void readObject(ObjectInputStream stream) throws IOException, ClassNotFo
 		throw new InvalidObjectException(com.ibm.oti.util.Msg.getString("K0199")); //$NON-NLS-1$
 	} 
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		if (String.canEncodeAsLatin1(streamValue, 0, streamValue.length)) {
 			value = new char[(streamValue.length + 1) >>> 1];
 			
@@ -1868,7 +1868,7 @@ public StringBuilder append(StringBuffer buffer) {
 	}
 	
 	synchronized (buffer) {
-		if (String.enableCompression && buffer.isCompressed()) {
+		if (String.COMPACT_STRINGS && buffer.isCompressed()) {
 			return append(buffer.getValue(), 0, buffer.length(), true);
 		} else {
 			return append(buffer.getValue(), 0, buffer.length(), false);
@@ -1935,7 +1935,7 @@ public int indexOf(String subString, int start) {
 		char firstChar = subString.charAtInternal(0);
 		
 		// Check if the StringBuilder is compressed
-		if (String.enableCompression && count >= 0) {
+		if (String.COMPACT_STRINGS && count >= 0) {
 			if (!subString.isCompressed()) {
 				return -1;
 			}
@@ -2048,7 +2048,7 @@ public int lastIndexOf(String subString, int start) {
 			char firstChar = subString.charAtInternal(0);
 			
 			// Check if the StringBuilder is compressed
-			if (String.enableCompression && count >= 0) {
+			if (String.COMPACT_STRINGS && count >= 0) {
 				if (!subString.isCompressed()) {
 					return -1;
 				}
@@ -2131,7 +2131,7 @@ char[] shareValue() {
 
 boolean isCompressed() {
 	// Check if the StringBuilder is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		return true;
 	} else {
 		return false;
@@ -2157,7 +2157,7 @@ public StringBuilder(CharSequence sequence) {
 		newLength = size;
 	}
 	
-	if (String.enableCompression) {
+	if (String.COMPACT_STRINGS) {
 		value = new char[(newLength + 1) >>> 1];
 	} else {
 		value = new char[newLength];
@@ -2170,7 +2170,7 @@ public StringBuilder(CharSequence sequence) {
 	} else if (sequence instanceof StringBuffer) {		
 		append((StringBuffer)sequence);
 	} else {		
-		if (String.enableCompression) {
+		if (String.COMPACT_STRINGS) {
 			boolean isCompressed = true;
 			
 			for (int i = 0; i < size; ++i) {
@@ -2226,7 +2226,7 @@ public StringBuilder append(CharSequence sequence) {
 		StringBuilder builder = (StringBuilder) sequence;
 		
 		// Check if the StringBuilder is compressed
-		if (String.enableCompression && builder.count >= 0) {
+		if (String.COMPACT_STRINGS && builder.count >= 0) {
 			return append(builder.value, 0, builder.lengthInternal(), true);
 		} else {
 			return append(builder.value, 0, builder.lengthInternal(), false);
@@ -2243,7 +2243,7 @@ public StringBuilder append(CharSequence sequence) {
 			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 		}
 		
-		if (String.enableCompression) {
+		if (String.COMPACT_STRINGS) {
 			boolean isCompressed = true;
 			
 			if (count >= 0) {
@@ -2326,7 +2326,7 @@ public StringBuilder append(CharSequence sequence, int start, int end) {
 				throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 			}
 
-			if (String.enableCompression) {
+			if (String.COMPACT_STRINGS) {
 
 				// Check if the StringBuilder is compressed
 				if (count >= 0 && sequenceString.isCompressed()) {
@@ -2366,7 +2366,7 @@ public StringBuilder append(CharSequence sequence, int start, int end) {
 			synchronized (sequence) {
 				StringBuffer buffer = (StringBuffer) sequence;
 				
-				if (String.enableCompression && buffer.isCompressed()) {
+				if (String.COMPACT_STRINGS && buffer.isCompressed()) {
 					return append(buffer.getValue(), start, end - start, true);
 				} else {
 					return append(buffer.getValue(), start, end - start, false);
@@ -2377,7 +2377,7 @@ public StringBuilder append(CharSequence sequence, int start, int end) {
 				StringBuilder builder = (StringBuilder) sequence;
 				
 				// Check if the StringBuilder is compressed
-				if (String.enableCompression && builder.count >= 0) {
+				if (String.COMPACT_STRINGS && builder.count >= 0) {
 					return append(builder.value, start, end - start, true);
 				} else {
 					return append(builder.value, start, end - start, false);
@@ -2393,7 +2393,7 @@ public StringBuilder append(CharSequence sequence, int start, int end) {
 				throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 			}
 			
-			if (String.enableCompression) {
+			if (String.COMPACT_STRINGS) {
 				boolean isCompressed = true;
 				
 				if (count >= 0) {
@@ -2474,7 +2474,7 @@ public StringBuilder insert(int index, CharSequence sequence) {
 			synchronized(sequence) {
 				StringBuffer buffer = (StringBuffer) sequence;
 				
-				if (String.enableCompression && buffer.isCompressed()) {
+				if (String.COMPACT_STRINGS && buffer.isCompressed()) {
 					return insert(index, buffer.getValue(), 0, buffer.length(), true);
 				} else {
 					return insert(index, buffer.getValue(), 0, buffer.length(), false);
@@ -2485,7 +2485,7 @@ public StringBuilder insert(int index, CharSequence sequence) {
 				StringBuilder builder = (StringBuilder) sequence;
 				
 				// Check if the StringBuilder is compressed
-				if (String.enableCompression && builder.count >= 0) {
+				if (String.COMPACT_STRINGS && builder.count >= 0) {
 					return insert(index, builder.value, 0, builder.lengthInternal(), true);
 				} else {
 					return insert(index, builder.value, 0, builder.lengthInternal(), false);
@@ -2499,7 +2499,7 @@ public StringBuilder insert(int index, CharSequence sequence) {
 				
 				int newLength = currentLength + sequneceLength;
 				
-				if (String.enableCompression) {
+				if (String.COMPACT_STRINGS) {
 					boolean isCompressed = true;
 					
 					for (int i = 0; i < sequneceLength; ++i) {
@@ -2574,7 +2574,7 @@ public StringBuilder insert(int index, CharSequence sequence, int start, int end
 				synchronized(sequence) {
 					StringBuffer buffer = (StringBuffer) sequence;
 					
-					if (String.enableCompression && buffer.isCompressed()) {
+					if (String.COMPACT_STRINGS && buffer.isCompressed()) {
 						return insert(index, buffer.getValue(), start, end - start, true);
 					} else {
 						return insert(index, buffer.getValue(), start, end - start, false);
@@ -2585,7 +2585,7 @@ public StringBuilder insert(int index, CharSequence sequence, int start, int end
 					StringBuilder builder = (StringBuilder) sequence;
 					
 					// Check if the StringBuilder is compressed
-					if (String.enableCompression && builder.count >= 0) {
+					if (String.COMPACT_STRINGS && builder.count >= 0) {
 						return insert(index, builder.value, start, end - start, true);
 					} else {
 						return insert(index, builder.value, start, end - start, false);
@@ -2599,7 +2599,7 @@ public StringBuilder insert(int index, CharSequence sequence, int start, int end
 					
 					int newLength = currentLength + sequenceLength;
 					
-					if (String.enableCompression) {
+					if (String.COMPACT_STRINGS) {
 						boolean isCompressed = true;
 						
 						for (int i = 0; i < sequenceLength; ++i) {
@@ -2659,7 +2659,7 @@ public void trimToSize() {
 	int currentCapacity = capacityInternal();
 	
 	// Check if the StringBuilder is compressed
-	if (String.enableCompression && count >= 0) {
+	if (String.COMPACT_STRINGS && count >= 0) {
 		// Check if the StringBuilder is not shared
 		if (capacity >= 0 && currentCapacity != currentLength) {
 			char[] newData = new char[(currentLength + 1) / 2];
@@ -2695,7 +2695,7 @@ public int codePointAt(int index) {
 	
 	if (index >= 0 && index < currentLength) {
 		// Check if the StringBuilder is compressed
-		if (String.enableCompression && count >= 0) {
+		if (String.COMPACT_STRINGS && count >= 0) {
 			return helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, index));
 		} else {
 			int high = value[index];
@@ -2726,7 +2726,7 @@ public int codePointBefore(int index) {
 	
 	if (index > 0 && index <= currentLength) {
 		// Check if the StringBuilder is compressed
-		if (String.enableCompression && count >= 0) {
+		if (String.COMPACT_STRINGS && count >= 0) {
 			return helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, index - 1));
 		} else {
 			int low = value[index - 1];
@@ -2758,7 +2758,7 @@ public int codePointCount(int start, int end) {
 	
 	if (start >= 0 && start <= end && end <= currentLength) {
 		// Check if the StringBuilder is compressed
-		if (String.enableCompression && count >= 0) {
+		if (String.COMPACT_STRINGS && count >= 0) {
 			return end - start;
 		} else {
 			int count = 0;
@@ -2796,7 +2796,7 @@ public int offsetByCodePoints(int start, int codePointCount) {
 	
 	if (start >= 0 && start <= currentLength) {
 		// Check if the StringBuilder is compressed
-		if (String.enableCompression && count >= 0) {
+		if (String.COMPACT_STRINGS && count >= 0) {
 			int index = start + codePointCount;
 
 			if (index >= currentLength) {
@@ -2866,7 +2866,7 @@ public StringBuilder appendCodePoint(int codePoint) {
 			return append((char)codePoint);
 		} else if (codePoint < 0x110000) {
 			// Check if the StringBuilder is compressed
-			if (String.enableCompression && count >= 0) {
+			if (String.COMPACT_STRINGS && count >= 0) {
 				decompress(value.length);
 			}
 
@@ -2888,7 +2888,7 @@ public StringBuilder appendCodePoint(int codePoint) {
 			value[currentLength] = (char) (Character.MIN_HIGH_SURROGATE + (codePoint >> 10));
 			value[currentLength + 1] = (char) (Character.MIN_LOW_SURROGATE + (codePoint & 0x3ff));
 
-			if (String.enableCompression) {
+			if (String.COMPACT_STRINGS) {
 				count = newLength | uncompressedBit;
 			} else {
 				count = newLength;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5812,7 +5812,7 @@ TR_J9VMBase::getStringClassEnableCompressionFieldAddr(TR::Compilation *comp, boo
          if (classInfo && classInfo->isInitialized())
             {
             enableCompressionFieldAddr = (int32_t *)getStaticFieldAddress(stringClass,
-               (unsigned char *)"enableCompression", 17, (unsigned char *)"Z", 1);
+               (unsigned char *)"COMPACT_STRINGS", 15, (unsigned char *)"Z", 1);
             if (enableCompressionFieldAddr)
                {
                // Cache the address

--- a/runtime/compiler/il/J9Symbol.cpp
+++ b/runtime/compiler/il/J9Symbol.cpp
@@ -125,7 +125,7 @@
        {r(TR::Symbol::Java_io_ByteArrayOutputStream_count,            "java/io/ByteArrayOutputStream", "count", "I")},
        {r(TR::Symbol::Java_lang_J9VMInternals_jitHelpers,             "java/lang/J9VMInternals", "jitHelpers", "Lcom/ibm/jit/JITHelpers;")},
        {r(TR::Symbol::Java_lang_String_count,                         "java/lang/String", "count", "I")},
-       {r(TR::Symbol::Java_lang_String_enableCompression,             "java/lang/String", "enableCompression", "Z") },
+       {r(TR::Symbol::Java_lang_String_enableCompression,             "java/lang/String", "COMPACT_STRINGS", "Z") },
        {r(TR::Symbol::Java_lang_String_hashCode,                      "java/lang/String", "hash", "I")},
        {r(TR::Symbol::Java_lang_String_value,                         "java/lang/String", "value", "[B")},
        {r(TR::Symbol::Java_lang_String_value,                         "java/lang/String", "value", "[C")},

--- a/runtime/ddr/algorithm_versions.c
+++ b/runtime/ddr/algorithm_versions.c
@@ -47,6 +47,7 @@
 #if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
 #define MIXED_REFERENCE_MODE 1
 #endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#define ALG_VM_JAVA_LANG_STRING_VERSION 1
 
 /*
  * All constants in the table below must also be declared as macros above
@@ -75,6 +76,7 @@ J9DDRConstantTableBegin(DDRAlgorithmVersions)
 #if defined(MIXED_REFERENCE_MODE)
 	J9DDRConstantTableEntryWithValue("MIXED_REFERENCE_MODE", MIXED_REFERENCE_MODE)
 #endif /* defined(MIXED_REFERENCE_MODE) */
+	J9DDRConstantTableEntryWithValue("ALG_VM_JAVA_LANG_STRING_VERSION", ALG_VM_JAVA_LANG_STRING_VERSION)
 J9DDRConstantTableEnd
 
 J9DDRStructTableBegin(AlgorithmVersions)

--- a/test/functional/Java8andUp/src/org/openj9/test/com/ibm/jit/Test_JITHelpers.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/com/ibm/jit/Test_JITHelpers.java
@@ -1,7 +1,7 @@
 package org.openj9.test.com.ibm.jit;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -444,7 +444,7 @@ public class Test_JITHelpers {
 			// Latin1 tests are valid if and only if compact strings are enabled because of the way we extract the
 			// String.value field and pass it off to the intrinsicIndexOfLatin1 API. The only way to ensure
 			// the extracted array is in Latin1 format is to make sure compact strings are enabled.
-			Field enableCompressionField = String.class.getDeclaredField("enableCompression");
+			Field enableCompressionField = String.class.getDeclaredField("COMPACT_STRINGS");
 			enableCompressionField.setAccessible(true);
 
 			if ((boolean)enableCompressionField.get(null)) {
@@ -678,7 +678,7 @@ public class Test_JITHelpers {
 			// Latin1 tests are valid if and only if compact strings are enabled because of the way we extract the
 			// String.value field and pass it off to the intrinsicIndexOfStringLatin1 API. The only way to ensure
 			// the extracted array is in Latin1 format is to make sure compact strings are enabled.
-			Field enableCompressionField = String.class.getDeclaredField("enableCompression");
+			Field enableCompressionField = String.class.getDeclaredField("COMPACT_STRINGS");
 			enableCompressionField.setAccessible(true);
 
 			if ((boolean)enableCompressionField.get(null)) {


### PR DESCRIPTION
Match RI `java.lang.String` field `static final boolean COMPACT_STRINGS`, and remove `enableCompression`.

Note: OpenJ9 Java 9+ `COMPACT_STRINGS` field was a duplication of `enableCompression` to satisfy non-OpenJ9 JCL references to `String.COMPACT_STRINGS`.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>