### PR TITLE
Fix error introduced by #12148

### DIFF
--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -358,8 +358,8 @@ tryAgain:
 					ramClassRefWrapper->modifiers = -1;
 				}
 			}
-			goto done;
 		}
+		goto done;
 	}
 
 	/* Perform a package access check from the current class to the resolved class.


### PR DESCRIPTION
NULL class allowed to percolate to access checks causes a crash.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>