### PR TITLE
Refactor and document the JitDump process

### DIFF
--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -429,15 +429,6 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
    // get crashed thread's own compinfo
    TR::CompilationInfoPerThread *threadCompInfo = compInfo->getCompInfoForThread(crashedThread);
 
-   // Crashes on the diagnostic thread should not be processed
-   if (threadCompInfo && threadCompInfo->isDiagnosticThread())
-      {
-      jitDumpFailedBecause(crashedThread, "detected recursive crash");
-      trfprintf(logFile, "Detected recursive crash. No log created.\n");
-      trfclose(logFile);
-      return OMR_ERROR_NONE;
-      }
-
    // get the method currently being compiled
    TR_MethodToBeCompiled *currentMethodBeingCompiled = 0;
    if (threadCompInfo)

--- a/runtime/nls/dump/j9dmp.nls
+++ b/runtime/nls/dump/j9dmp.nls
@@ -570,16 +570,6 @@ J9NLS_DMP_OCCURRED_THREAD_NAME_ID.link=
 
 # END NON-TRANSLATABLE
 
-J9NLS_DMP_JIT_METHODS_ON_STACK=JIT dump found %1$d JIT methods on the stack
-# START NON-TRANSLATABLE
-J9NLS_DMP_JIT_METHODS_ON_STACK.explanation=The dump is reporting how many JIT methods were found on the stack after it was walked.
-J9NLS_DMP_JIT_METHODS_ON_STACK.system_action=The JVM continues.
-J9NLS_DMP_JIT_METHODS_ON_STACK.user_response=Diagnostic information, provide this information to your service representative.
-J9NLS_DMP_JIT_METHODS_ON_STACK.sample_input_1=7
-J9NLS_DMP_JIT_METHODS_ON_STACK.link=
-
-# END NON-TRANSLATABLE
-
 J9NLS_DMP_JIT_RECURSIVE_CRASH=JIT dump recursive crash occurred on diagnostic thread
 # START NON-TRANSLATABLE
 J9NLS_DMP_JIT_RECURSIVE_CRASH.explanation=The dump is reporting a reproduction of the original unhandled exception, with tracing.

--- a/runtime/nls/dump/j9dmp.nls
+++ b/runtime/nls/dump/j9dmp.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2019 IBM Corp. and others
+# Copyright (c) 2000, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/dump/j9dmp.nls
+++ b/runtime/nls/dump/j9dmp.nls
@@ -530,3 +530,82 @@ J9NLS_DMP_EXIT_SHUTDOWN_UNKNOWN.system_action=The JVM exits.
 J9NLS_DMP_EXIT_SHUTDOWN_UNKNOWN.user_response=This exit was requested by the user.
 J9NLS_DMP_EXIT_SHUTDOWN_UNKNOWN.link=
 # END NON-TRANSLATABLE
+
+J9NLS_DMP_JIT_ORDINARY_METHOD=JIT dump method being compiled is an ordinary method
+# START NON-TRANSLATABLE
+J9NLS_DMP_JIT_ORDINARY_METHOD.explanation=The dump has reported that the method the unhandled exception occurred in is an ordinary method.
+J9NLS_DMP_JIT_ORDINARY_METHOD.system_action=The JVM continues.
+J9NLS_DMP_JIT_ORDINARY_METHOD.user_response=Diagnostic information, provide this information to your service representative.
+J9NLS_DMP_JIT_ORDINARY_METHOD.link=
+
+# END NON-TRANSLATABLE
+
+J9NLS_DMP_JIT_NOTIFIED_WAITING_THREADS=JIT dump notified all waiting threads of the current method the be compiled
+# START NON-TRANSLATABLE
+J9NLS_DMP_JIT_NOTIFIED_WAITING_THREADS.explanation=The compilation threads waiting on the method to be compiled monitor will be notified.
+J9NLS_DMP_JIT_NOTIFIED_WAITING_THREADS.system_action=The JVM continues.
+J9NLS_DMP_JIT_NOTIFIED_WAITING_THREADS.user_response=Diagnostic information, provide this information to your service representative.
+J9NLS_DMP_JIT_NOTIFIED_WAITING_THREADS.link=
+
+# END NON-TRANSLATABLE
+
+J9NLS_DMP_JIT_OPTIMIZATION_PLAN=JIT dump could not allocate a new optimization plan
+# START NON-TRANSLATABLE
+J9NLS_DMP_JIT_OPTIMIZATION_PLAN.explanation=The dump could not allocate a new optimization plan for recompilation.
+J9NLS_DMP_JIT_OPTIMIZATION_PLAN.system_action=The JVM will not recompile the current method and will continue.
+J9NLS_DMP_JIT_OPTIMIZATION_PLAN.user_response=Diagnostic information, provide this information to your service representative.
+J9NLS_DMP_JIT_OPTIMIZATION_PLAN.link=
+
+# END NON-TRANSLATABLE
+
+J9NLS_DMP_OCCURRED_THREAD_NAME_ID=%1$s dump occurred in '%2$s' thread 0x%3$p
+# START NON-TRANSLATABLE
+J9NLS_DMP_OCCURRED_THREAD_NAME_ID.explanation=The dump is reporting which thread caused the unhandled exception.
+J9NLS_DMP_OCCURRED_THREAD_NAME_ID.system_action=The JVM continues.
+J9NLS_DMP_OCCURRED_THREAD_NAME_ID.user_response=Diagnostic information, provide this information to your service representative.
+J9NLS_DMP_OCCURRED_THREAD_NAME_ID.sample_input_1=JIT
+J9NLS_DMP_OCCURRED_THREAD_NAME_ID.sample_input_2=main
+J9NLS_DMP_OCCURRED_THREAD_NAME_ID.sample_input_3=1280FF00
+J9NLS_DMP_OCCURRED_THREAD_NAME_ID.link=
+
+# END NON-TRANSLATABLE
+
+J9NLS_DMP_JIT_METHODS_ON_STACK=JIT dump found %1$d JIT methods on the stack
+# START NON-TRANSLATABLE
+J9NLS_DMP_JIT_METHODS_ON_STACK.explanation=The dump is reporting how many JIT methods were found on the stack after it was walked.
+J9NLS_DMP_JIT_METHODS_ON_STACK.system_action=The JVM continues.
+J9NLS_DMP_JIT_METHODS_ON_STACK.user_response=Diagnostic information, provide this information to your service representative.
+J9NLS_DMP_JIT_METHODS_ON_STACK.sample_input_1=7
+J9NLS_DMP_JIT_METHODS_ON_STACK.link=
+
+# END NON-TRANSLATABLE
+
+J9NLS_DMP_JIT_RECURSIVE_CRASH=JIT dump recursive crash occurred on diagnostic thread
+# START NON-TRANSLATABLE
+J9NLS_DMP_JIT_RECURSIVE_CRASH.explanation=The dump is reporting a reproduction of the original unhandled exception, with tracing.
+J9NLS_DMP_JIT_RECURSIVE_CRASH.system_action=The JVM continues.
+J9NLS_DMP_JIT_RECURSIVE_CRASH.user_response=Diagnostic information, provide this information to your service representative.
+J9NLS_DMP_JIT_RECURSIVE_CRASH.link=
+
+# END NON-TRANSLATABLE
+
+J9NLS_DMP_JIT_RECOMPILING_METHOD=JIT dump is recompiling %.*s.%.*s%.*s
+# START NON-TRANSLATABLE
+J9NLS_DMP_JIT_RECOMPILING_METHOD.explanation=The dump is recompiling the specified method signature.
+J9NLS_DMP_JIT_RECOMPILING_METHOD.system_action=The JVM continues.
+J9NLS_DMP_JIT_RECOMPILING_METHOD.user_response=Diagnostic information, provide this information to your service representative.
+J9NLS_DMP_JIT_RECOMPILING_METHOD.sample_input_1=java/lang/String
+J9NLS_DMP_JIT_RECOMPILING_METHOD.sample_input_2=equals
+J9NLS_DMP_JIT_RECOMPILING_METHOD.sample_input_3=(Ljava/lang/Object;)Z
+J9NLS_DMP_JIT_RECOMPILING_METHOD.link=
+
+# END NON-TRANSLATABLE
+
+J9NLS_DMP_JIT_TRACE_IL_CRASHED_THREAD=JIT dump is tracing the IL of the method on the crashed compilation thread
+# START NON-TRANSLATABLE
+J9NLS_DMP_JIT_TRACE_IL_CRASHED_THREAD.explanation=The dump is tracing the IL of the crashed thread in its current state before recompiling the method for tracing.
+J9NLS_DMP_JIT_TRACE_IL_CRASHED_THREAD.system_action=The JVM continues.
+J9NLS_DMP_JIT_TRACE_IL_CRASHED_THREAD.user_response=Diagnostic information, provide this information to your service representative.
+J9NLS_DMP_JIT_TRACE_IL_CRASHED_THREAD.link=
+
+# END NON-TRANSLATABLE


### PR DESCRIPTION
A series of commits (see description for explanations) which simplifies, documents where necessary, and refactors the code in JitDump.cpp. As a result of this final clean up PR, more tracing is provided to the user as the JitDump process progresses. Here are examples of how the JitDump looks now:

Application thread crashes:
```
JVMDUMP039I Processing dump event "gpf", detail "" at 2021/03/11 15:40:37 - please wait.
JVMDUMP032I JVM requested Java dump using '/Users/fjeremic/Projects/openj9-openjdk-jdk11/javacore.20210311.154037.69223.0001.txt' in response to an event
JVMDUMP010I Java dump written to /Users/fjeremic/Projects/openj9-openjdk-jdk11/javacore.20210311.154037.69223.0001.txt
JVMDUMP032I JVM requested JIT dump using '/Users/fjeremic/Projects/openj9-openjdk-jdk11/jitdump.20210311.154037.69223.0002.dmp' in response to an event
JVMDUMP051I JIT dump occurred in 'main' thread 0x00000000190F3F00
JVMDUMP053I JIT dump is recompiling java/lang/String.equals(Ljava/lang/Object;)Z
JVMDUMP053I JIT dump is recompiling java/lang/System.ensureProperties(Z)V
JVMDUMP053I JIT dump is recompiling java/lang/System.afterClinitInitialization()V
JVMDUMP053I JIT dump is recompiling java/lang/Thread.initialize(ZLjava/lang/ThreadGroup;Ljava/lang/Thread;Ljava/security/AccessControlContext;Z)V
JVMDUMP053I JIT dump is recompiling java/lang/Thread.<init>(Ljava/lang/String;Ljava/lang/Object;IZ)V
JVMDUMP010I JIT dump written to /Users/fjeremic/Projects/openj9-openjdk-jdk11/jitdump.20210311.154037.69223.0002.dmp
JVMDUMP013I Processed dump event "gpf", detail "".
```

Compilation thread crashes:
```
JVMDUMP039I Processing dump event "gpf", detail "" at 2021/03/11 15:40:59 - please wait.
JVMDUMP032I JVM requested Java dump using '/Users/fjeremic/Projects/openj9-openjdk-jdk11/javacore.20210311.154059.69227.0001.txt' in response to an event
JVMDUMP010I Java dump written to /Users/fjeremic/Projects/openj9-openjdk-jdk11/javacore.20210311.154059.69227.0001.txt
JVMDUMP032I JVM requested JIT dump using '/Users/fjeremic/Projects/openj9-openjdk-jdk11/jitdump.20210311.154059.69227.0002.dmp' in response to an event
JVMDUMP051I JIT dump occurred in 'JIT Compilation Thread-003' thread 0x0000000014813B00
JVMDUMP049I JIT dump notified all waiting threads of the current method the be compiled
JVMDUMP054I JIT dump is tracing the IL of the method on the crashed compilation thread
JVMDUMP048I JIT dump method being compiled is an ordinary method
JVMDUMP053I JIT dump is recompiling java/lang/String.equals(Ljava/lang/Object;)Z
JVMDUMP052I JIT dump recursive crash occurred on diagnostic thread
JVMDUMP010I JIT dump written to /Users/fjeremic/Projects/openj9-openjdk-jdk11/jitdump.20210311.154059.69227.0002.dmp
JVMDUMP013I Processed dump event "gpf", detail "".
```

Closes: #9120