### PR TITLE
Enable TR_DebugInliner in JitDump for crashed in inliner

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8676,6 +8676,18 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                   {
                   options->enableTracing(opt);
                   }
+
+               // Enable additional tracing which are not part of standard optimizer tracing infrastructure
+               switch (opt)
+                  {
+                  case OMR::Optimizations::inlining:
+                  case OMR::Optimizations::targetedInlining:
+                  case OMR::Optimizations::trivialInlining:
+                     {
+                     options->setOption(TR_DebugInliner);
+                     break;
+                     }
+                  }
                }
             }
 


### PR DESCRIPTION
Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>