### PR TITLE
JDK17 adopts RI java.lang.String

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*******************************************************************************
  * Copyright (c) 2007, 2021 IBM Corp. and others
  *
@@ -366,10 +366,18 @@ final class Access implements JavaLangAccess {
 
 /*[IF JAVA_SPEC_VERSION >= 10]*/
 	public String newStringUTF8NoRepl(byte[] bytes, int offset, int length) {
+		/*[IF JAVA_SPEC_VERSION < 17]*/
 		return StringCoding.newStringUTF8NoRepl(bytes, offset, length);
+		/*[ELSE] JAVA_SPEC_VERSION < 17 */
+		return String.newStringUTF8NoRepl(bytes, offset, length);
+		/*[ENDIF] JAVA_SPEC_VERSION < 17 */
 	}
 	public byte[] getBytesUTF8NoRepl(String str) {
+		/*[IF JAVA_SPEC_VERSION < 17]*/
 		return StringCoding.getBytesUTF8NoRepl(str);
+		/*[ELSE] JAVA_SPEC_VERSION < 17 */
+		return String.getBytesUTF8NoRepl(str);
+		/*[ENDIF] JAVA_SPEC_VERSION < 17 */
 	}
 /*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 
@@ -378,10 +386,18 @@ final class Access implements JavaLangAccess {
 		Thread.blockedOn(interruptible);
 	}
 	public byte[] getBytesNoRepl(String str, Charset charset) throws CharacterCodingException {
+		/*[IF JAVA_SPEC_VERSION < 17]*/
 		return StringCoding.getBytesNoRepl(str, charset);
+		/*[ELSE] JAVA_SPEC_VERSION < 17 */
+		return String.getBytesNoRepl(str, charset);
+		/*[ENDIF] JAVA_SPEC_VERSION < 17 */
 	}
 	public String newStringNoRepl(byte[] bytes, Charset charset) throws CharacterCodingException {
+		/*[IF JAVA_SPEC_VERSION < 17]*/
 		return StringCoding.newStringNoRepl(bytes, charset);
+		/*[ELSE] JAVA_SPEC_VERSION < 17 */
+		return String.newStringNoRepl(bytes, charset);
+		/*[ENDIF] JAVA_SPEC_VERSION < 17 */
 	}
 /*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION < 17]*/
 /*******************************************************************************
  * Copyright (c) 1998, 2021 IBM Corp. and others
  *

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -287,6 +287,7 @@ public final class System {
 			unsafe.putObject(unsafe.staticFieldBase(f2), unsafe.staticFieldOffset(f2), com.ibm.jit.JITHelpers.getHelpers());
 		} catch (NoSuchFieldException e) { }
 
+		/*[IF JAVA_SPEC_VERSION < 17]*/
 		/**
 		 * When the System Property == true, then disable sharing (i.e. arraycopy the underlying value array) in
 		 * String.substring(int) and String.substring(int, int) methods whenever offset is zero. Otherwise, enable
@@ -300,11 +301,12 @@ public final class System {
 		/*[PR JAZZ 58297] - continue with the rules defined by JAZZ 57070 - Build a Java 8 J9 JCL using the SIDECAR18 preprocessor configuration */
 		// Check the default encoding
 		/*[Bug 102075] J2SE Setting -Dfile.encoding=junk fails to run*/
-		/*[IF Sidecar19-SE]*/
+		/*[IF JAVA_SPEC_VERSION >= 11]*/
 		StringCoding.encode(String.LATIN1, new byte[1]);
 		/*[ELSE]*/
 		StringCoding.encode(new char[1], 0, 1);
-		/*[ENDIF]*/
+		/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
+		/*[ENDIF] JAVA_SPEC_VERSION < 17 */
 
 		/*[IF Sidecar18-SE-OpenJ9]*/
 		Properties props = internalGetProperties();

--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -52,6 +52,7 @@
    java_lang_Character_isAlphabetic,
    java_lang_Character_isUpperCase,
    java_lang_Character_isLowerCase,
+   java_lang_Character_toLowerCase,
    java_lang_Class_newInstance,
    java_lang_Class_newInstanceImpl,
    java_lang_Class_newInstancePrototype,
@@ -202,11 +203,24 @@
    java_lang_String_getChars_charArray,
    java_lang_String_getChars_byteArray,
 
+   java_lang_String_checkIndex,
+   java_lang_String_coder,
+   java_lang_String_decodeUTF8_UTF16,
+   java_lang_String_isLatin1,
+   java_lang_String_startsWith,
+
    java_lang_StringLatin1_indexOf,
 
+   java_lang_StringUTF16_charAt,
+   java_lang_StringUTF16_checkIndex,
+   java_lang_StringUTF16_compareCodePointCI,
+   java_lang_StringUTF16_compareToCIImpl,
+   java_lang_StringUTF16_compareValues,
    java_lang_StringUTF16_getChar,
    java_lang_StringUTF16_indexOf,
+   java_lang_StringUTF16_length,
    java_lang_StringUTF16_newBytesFor,
+   java_lang_StringUTF16_putChar,
    java_lang_StringUTF16_toBytes,
 
    java_lang_StringBuffer_append,

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -416,6 +416,7 @@ J9::Compilation::isConverterMethod(TR::RecognizedMethod rm)
       {
       case TR::sun_nio_cs_ISO_8859_1_Encoder_encodeISOArray:
       case TR::java_lang_StringCoding_implEncodeISOArray:
+      case TR::java_lang_String_decodeUTF8_UTF16:
       case TR::sun_nio_cs_ISO_8859_1_Decoder_decodeISO8859_1:
       case TR::sun_nio_cs_US_ASCII_Encoder_encodeASCII:
       case TR::sun_nio_cs_US_ASCII_Decoder_decodeASCII:

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3175,6 +3175,11 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_String_split_str_int,       "split",               "(Ljava/lang/String;I)[Ljava/lang/String;")},
       {x(TR::java_lang_String_getChars_charArray,  "getChars",            "(II[CI)V")},
       {x(TR::java_lang_String_getChars_byteArray,  "getChars",            "(II[BI)V")},
+      {x(TR::java_lang_String_checkIndex,          "checkIndex",          "(II)V")},
+      {x(TR::java_lang_String_coder,               "coder",               "()B")},
+      {x(TR::java_lang_String_decodeUTF8_UTF16,    "decodeUTF8_UTF16",    "([BII[BIZ)I")},
+      {x(TR::java_lang_String_isLatin1,            "isLatin1",            "()Z")},
+      {x(TR::java_lang_String_startsWith,          "startsWith",          "(Ljava/lang/String;I)Z")},
       {  TR::unknownMethod}
       };
 
@@ -3195,7 +3200,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_StringCoding_implEncodeISOArray, "implEncodeISOArray", "([BI[BII)I")},
       {x(TR::java_lang_StringCoding_encode8859_1,       "encode8859_1",       "(B[B)[B")},
       {x(TR::java_lang_StringCoding_encodeASCII,        "encodeASCII",        "(B[B)[B")},
-      {x(TR::java_lang_StringCoding_encodeUTF8,         "encodeUTF8",         "(B[B)[B")},
+      {x(TR::java_lang_StringCoding_encodeUTF8,         "encodeUTF8",         "(B[BZ)[B")},
       {  TR::unknownMethod}
       };
 
@@ -3560,10 +3565,17 @@ void TR_ResolvedJ9Method::construct()
 
    static X StringUTF16Methods[] =
       {
-      { x(TR::java_lang_StringUTF16_getChar,                                  "getChar",        "([BI)C")},
-      { x(TR::java_lang_StringUTF16_indexOf,                                  "indexOf",        "([BI[BII)I")},
-      { x(TR::java_lang_StringUTF16_newBytesFor,                              "newBytesFor",    "(I)[B")},
-      { x(TR::java_lang_StringUTF16_toBytes,                                  "toBytes",        "([CII)[B")},
+      { x(TR::java_lang_StringUTF16_charAt,                                   "charAt",             "([BI)C")},
+      { x(TR::java_lang_StringUTF16_checkIndex,                               "checkIndex",         "(I[B)V")},
+      { x(TR::java_lang_StringUTF16_compareCodePointCI,                       "compareCodePointCI", "(II)I")},
+      { x(TR::java_lang_StringUTF16_compareToCIImpl,                          "compareToCIImpl",    "([BII[BII)I")},
+      { x(TR::java_lang_StringUTF16_compareValues,                            "compareValues",      "([B[BII)I")},
+      { x(TR::java_lang_StringUTF16_getChar,                                  "getChar",            "([BI)C")},
+      { x(TR::java_lang_StringUTF16_indexOf,                                  "indexOf",            "([BI[BII)I")},
+      { x(TR::java_lang_StringUTF16_length,                                   "length",             "([B)I")},
+      { x(TR::java_lang_StringUTF16_newBytesFor,                              "newBytesFor",        "(I)[B")},
+      { x(TR::java_lang_StringUTF16_putChar,                                  "putChar",            "([BII)V")},
+      { x(TR::java_lang_StringUTF16_toBytes,                                  "toBytes",            "([CII)[B")},
       { TR::unknownMethod }
       };
 
@@ -3637,6 +3649,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_Character_isLowerCase,         "isLowerCase",          "(I)Z")},
       {x(TR::java_lang_Character_isWhitespace,        "isWhitespace",         "(I)Z")},
       {x(TR::java_lang_Character_isAlphabetic,        "isAlphabetic",         "(I)Z")},
+      {x(TR::java_lang_Character_toLowerCase,         "toLowerCase",          "(I)I")},
       {  TR::unknownMethod}
       };
 

--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -177,10 +177,16 @@ static TR::RecognizedMethod canSkipNullChecks[] =
    TR::java_lang_String_equalsIgnoreCase,
    TR::java_lang_String_indexOf_fast,
    TR::java_lang_String_isCompressed,
+   TR::java_lang_String_coder,
+   TR::java_lang_String_isLatin1,
+   TR::java_lang_String_startsWith,
    TR::java_lang_StringBuffer_capacityInternal,
    TR::java_lang_StringBuffer_lengthInternalUnsynchronized,
    TR::java_lang_StringBuilder_capacityInternal,
    TR::java_lang_StringBuilder_lengthInternal,
+   TR::java_lang_StringUTF16_charAt,
+   TR::java_lang_StringUTF16_checkIndex,
+   TR::java_lang_StringUTF16_length,
    TR::java_util_Hashtable_clone,
    TR::java_util_Hashtable_contains,
    TR::java_util_HashtableHashEnumerator_hasMoreElements,
@@ -234,6 +240,7 @@ static TR::RecognizedMethod canSkipBoundChecks[] =
    //TR::java_util_ArrayList_remove,
    //TR::java_util_ArrayList_ensureCapacity,
    //TR::java_util_ArrayList_get,
+   TR::java_lang_Character_toLowerCase,
    TR::java_lang_invoke_FilterArgumentsHandle_invokeExact,
    TR::java_lang_invoke_CollectHandle_invokeExact,
    TR::java_lang_String_trim,
@@ -260,6 +267,12 @@ static TR::RecognizedMethod canSkipBoundChecks[] =
    TR::java_lang_String_hashCodeImplDecompressed,
    TR::java_lang_String_unsafeCharAt,
    TR::java_lang_String_split_str_int,
+   TR::java_lang_String_startsWith,
+   TR::java_lang_StringUTF16_charAt,
+   TR::java_lang_StringUTF16_checkIndex,
+   TR::java_lang_StringUTF16_compareCodePointCI,
+   TR::java_lang_StringUTF16_compareToCIImpl,
+   TR::java_lang_StringUTF16_compareValues,
    TR::java_util_Hashtable_get,
    TR::java_util_Hashtable_put,
    TR::java_util_Hashtable_clone,
@@ -455,6 +468,7 @@ static TR::RecognizedMethod canSkipChecksOnArrayCopies[] =
    // NOTE!! add methods whose checks can be skipped by sov library to the beginning of the list (see stopMethod below)
    //TR::java_util_ArrayList_ensureCapacity,
    //TR::java_util_ArrayList_remove,   /* ArrayList is NOT synchronized and therefore it's unsafe to remove checks! */
+   TR::java_lang_Character_toLowerCase,
    TR::java_lang_String_concat,
    TR::java_lang_String_replace,
    TR::java_lang_String_toLowerCase,
@@ -513,6 +527,7 @@ J9::MethodSymbol::safeToSkipChecksOnArrayCopies()
 //
 static TR::RecognizedMethod canSkipZeroInitializationOnNewarrays[] =
    {
+   TR::java_lang_Character_toLowerCase,
    TR::java_lang_String_init,
    TR::java_lang_String_init_int_int_char_boolean,
    TR::java_lang_String_concat,

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -368,6 +368,9 @@ TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::No
       case TR::java_lang_String_charAt:
       case TR::java_lang_String_charAtInternal_I:
       case TR::java_lang_String_charAtInternal_IB:
+      case TR::java_lang_String_checkIndex:
+      case TR::java_lang_String_coder:
+      case TR::java_lang_String_isLatin1:
       case TR::java_lang_String_length:
       case TR::java_lang_String_lengthInternal:
       case TR::java_lang_String_isCompressed:
@@ -375,6 +378,9 @@ TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::No
       case TR::java_lang_StringBuffer_lengthInternalUnsynchronized:
       case TR::java_lang_StringBuilder_capacityInternal:
       case TR::java_lang_StringBuilder_lengthInternal:
+      case TR::java_lang_StringUTF16_charAt:
+      case TR::java_lang_StringUTF16_checkIndex:
+      case TR::java_lang_StringUTF16_length:
       case TR::java_lang_StringUTF16_newBytesFor:
       case TR::java_util_HashMap_get:
       case TR::java_util_HashMap_getNode:
@@ -2442,6 +2448,7 @@ TR_J9InlinerPolicy::skipHCRGuardForCallee(TR_ResolvedMethod *callee)
       case TR::java_lang_String_charAtInternal_IB:
       case TR::java_lang_String_lengthInternal:
       case TR::java_lang_String_isCompressed:
+      case TR::java_lang_StringUTF16_length:
       case TR::java_lang_StringBuffer_capacityInternal:
       case TR::java_lang_StringBuffer_lengthInternalUnsynchronized:
       case TR::java_lang_StringBuilder_capacityInternal:
@@ -4932,6 +4939,7 @@ TR_InlinerFailureReason
       case TR::com_ibm_jit_JITHelpers_getJ9ClassFromObject64:
       case TR::com_ibm_jit_JITHelpers_getClassInitializeStatus:
       case TR::java_lang_StringUTF16_getChar:
+      case TR::java_lang_StringUTF16_putChar:
       case TR::java_lang_StringUTF16_toBytes:
       case TR::java_lang_invoke_MethodHandle_asType:
             return DontInline_Callee;

--- a/runtime/compiler/optimizer/UnsafeFastPath.cpp
+++ b/runtime/compiler/optimizer/UnsafeFastPath.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -311,6 +311,7 @@ static bool needUnsignedConversion(TR::RecognizedMethod methodToReduce)
       case TR::com_ibm_jit_JITHelpers_getCharFromArrayByIndex:
       case TR::com_ibm_jit_JITHelpers_getCharFromArrayVolatile:
       case TR::java_lang_StringUTF16_getChar:
+      case TR::java_lang_StringUTF16_putChar:
          return true;
       }
 
@@ -531,6 +532,7 @@ int32_t TR_UnsafeFastPath::perform()
             case TR::com_ibm_jit_JITHelpers_putObjectInArrayVolatile:
             case TR::com_ibm_jit_JITHelpers_putObjectInArray:
             case TR::java_lang_StringUTF16_getChar:
+            case TR::java_lang_StringUTF16_putChar:
                isArrayOperation = true;
                break;
             default:

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1016,6 +1016,37 @@ done:
 	}
 
 	/**
+	 * Check if the UTF8 byte stream contains only ISO-8859-1/Latin-1 characters.
+	 *
+	 * @param data[in] the UTF8 byte stream
+	 * @param length[in] the length of incoming UTF8 byte stream
+	 *
+	 * @returns true if data only contains Latin-1 characters, false if otherwise
+	 */
+	static VMINLINE bool
+	isLatin1String(const U_8 *data, UDATA length)
+	{
+		bool isLatin1 = true;
+		while (0 != length) {
+			U_16 unicode = 0;
+			UDATA consumed = decodeUTF8CharN(data, &unicode, length);
+			if (consumed > 0) {
+				if (unicode > 0xFF) {
+					isLatin1 = false;
+					break;
+				}
+				data += consumed;
+				length -= consumed;
+			} else {
+				/* invalid UTF data */
+				isLatin1 = false;
+				break;
+			}
+		}
+		return isLatin1;
+	}
+
+	/**
 	 * Decode a single unicode character from a valid UTF8 byte stream.
 	 *
 	 * @param input[in] the UTF8 data


### PR DESCRIPTION
Not include OpenJ9 `java.lang.String` for `JDK17`;
Update `JDK17` `StringCoding` references which have been moved into `String`;
Support `ISO-8859-1`/`Latin-1` characters between `0x80` and `0xFF` in String compression mode which is required by RI `String`.

~depends https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/295~ - **merged**
unlock https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/296 https://github.com/eclipse/openj9/pull/12547

fixes https://github.com/eclipse/openj9/issues/12398

Signed-off-by: Jason Feng <fengj@ca.ibm.com>