### PR TITLE
Correctly destroy monitors at JITServer

### DIFF
--- a/runtime/compiler/env/JITServerPersistentCHTable.cpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.cpp
@@ -49,7 +49,7 @@ JITServerPersistentCHTable::~JITServerPersistentCHTable()
       _trPersistentMemory->freePersistentMemory(classInfo);
       }
    _classMap.clear();
-   _chTableMonitor->destroy();
+   TR::Monitor::destroy(_chTableMonitor);
    }
 
 bool

--- a/runtime/compiler/infra/J9Monitor.cpp
+++ b/runtime/compiler/infra/J9Monitor.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,7 +42,7 @@ J9::Monitor::create(char *name)
 void
 J9::Monitor::destroy(TR::Monitor *monitor)
    {
-   // The monitor will be destroyed when the monitor table is destroyed
+   TR::MonitorTable::get()->removeAndDestroy(monitor);
    }
 
 bool
@@ -73,7 +73,7 @@ void
 J9::Monitor::destroy()
    {
    j9thread_monitor_destroy(_monitor);
-   }  //FIXME: remove from the table as well
+   }
 
 void
 J9::Monitor::wait()

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -86,23 +86,23 @@ ClientSessionData::~ClientSessionData()
    // This is because in some places from where the session is destroyed,
    // per-client allocation region cannot be entered.
    clearCaches();
-   _romMapMonitor->destroy();
-   _classMapMonitor->destroy();
-   _classChainDataMapMonitor->destroy();
-   _sequencingMonitor->destroy();
-   _constantPoolMapMonitor->destroy();
-   _staticMapMonitor->destroy();
+   TR::Monitor::destroy(_romMapMonitor);
+   TR::Monitor::destroy(_classMapMonitor);
+   TR::Monitor::destroy(_classChainDataMapMonitor);
+   TR::Monitor::destroy(_sequencingMonitor);
+   TR::Monitor::destroy(_constantPoolMapMonitor);
+   TR::Monitor::destroy(_staticMapMonitor);
    if (_vmInfo)
       {
       destroyJ9SharedClassCacheDescriptorList();
       _persistentMemory->freePersistentMemory(_vmInfo);
       }
-   _thunkSetMonitor->destroy();
+   TR::Monitor::destroy(_thunkSetMonitor);
 
    omrthread_rwmutex_destroy(_classUnloadRWMutex);
    _classUnloadRWMutex = NULL;
 
-   _wellKnownClassesMonitor->destroy();
+   TR::Monitor::destroy(_wellKnownClassesMonitor);
    }
 
 void

--- a/runtime/compiler/runtime/JITServerSharedROMClassCache.cpp
+++ b/runtime/compiler/runtime/JITServerSharedROMClassCache.cpp
@@ -115,7 +115,7 @@ JITServerSharedROMClassCache::~JITServerSharedROMClassCache()
       shutdown(false);
 
    for (size_t i = 0; i < _numPartitions; ++i)
-      _monitors[i]->destroy();
+      TR::Monitor::destroy(_monitors[i]);
 
    TR::Compiler->persistentGlobalAllocator().deallocate(_partitions);
    TR::Compiler->persistentGlobalAllocator().deallocate(_monitors);

--- a/runtime/compiler/runtime/JITServerStatisticsThread.cpp
+++ b/runtime/compiler/runtime/JITServerStatisticsThread.cpp
@@ -200,7 +200,7 @@ JITServerStatisticsThread::stopStatisticsThread(J9JITConfig * jitConfig)
       getStatisticsThreadMonitor()->exit();
 
       //Monitor is no longer needed
-      getStatisticsThreadMonitor()->destroy();
+      TR::Monitor::destroy(_statisticsThreadMonitor);
       _statisticsThreadMonitor = NULL;
       }
    }


### PR DESCRIPTION
JITServer creates and destroys monitors dynamically, for instance the ones used to synchronize access to various data stored in the client session. There are two issues with the way it currently handles destroying these monitors:

- Most of the code uses the wrong API. Monitors created with `TR::Monitor::create()` are supposed to be destroyed with the static method `TR::Monitor::destroy(TR::Monitor *monitor)`, not with the instance method `TR::Monitor::destroy()`. The instance method is supposed to be used for monitors initialized with `TR::Monitor::init()` in cases where the storage of the monitor object is managed by the caller (and it's not added to the monitor table).

- `TR::Monitor::destroy(TR::Monitor *monitor)` is implemented as a no-op. This doesn't make much of a difference for local JIT since the monitors are normally effectively static. However, on the JITServer this results in memory leaks when client sessions are destroyed.

This PR addresses both of these issues.