### PR TITLE
Revert "Skip self-storing stores"

### DIFF
--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -7564,13 +7564,6 @@ TR_J9ByteCodeIlGenerator::storeAuto(TR::DataType type, int32_t slot, bool isAdju
       }
 
    symRef = symRefTab()->findOrCreateAutoSymbol(_methodSymbol, slot, type, true, false, true, isAdjunct);
-
-   // Self-storing, skip the store
-   if (storeValue->getOpCode().isLoadDirect() && storeValue->getOpCode().hasSymbolReference() && storeValue->getSymbolReference() == symRef)
-      {
-      return;
-      }
-
    if (storeValue->isDualHigh() || storeValue->isSelectHigh() || isAdjunct)
       symRef->setIsDual();
 


### PR DESCRIPTION
This reverts commit 6cb4bad2932f14cf4d628288e7921a673c4b05cd.

We can simply skip a store from a local to the same local because the
local's value might have changed between the load and the store.

Closes: #12191 

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>