### PR TITLE
AArch64: Enable Idle GC Tuning

### DIFF
--- a/runtime/cmake/caches/linux_aarch64.cmake
+++ b/runtime/cmake/caches/linux_aarch64.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020, 2020 IBM Corp. and others
+# Copyright (c) 2020, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,6 +31,7 @@ set(J9VM_JIT_NEW_DUAL_HELPERS OFF CACHE BOOL "")
 set(J9VM_OPT_ZERO ON CACHE BOOL "")
 
 set(OMR_GC_CONCURRENT_SCAVENGER ON CACHE BOOL "")
+set(OMR_GC_IDLE_HEAP_MANAGER ON CACHE BOOL "")
 
 include("${CMAKE_CURRENT_LIST_DIR}/linux.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/common.cmake")

--- a/runtime/gc_glue_java/configure_includes/configure_linux_aarch64.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_aarch64.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019, 2020 IBM Corp. and others
+# Copyright (c) 2019, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,6 +35,7 @@ CONFIGURE_ARGS += \
 	--enable-OMR_ENV_DATA64 \
 	--enable-OMR_ENV_LITTLE_ENDIAN \
 	--enable-OMR_GC_CONCURRENT_SCAVENGER \
+	--enable-OMR_GC_IDLE_HEAP_MANAGER \
 	--enable-OMR_GC_TLH_PREFETCH_FTA \
 	--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2227,7 +2227,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 			 */
 			if (J9_ARE_ANY_BITS_SET(vm->vmRuntimeStateListener.idleTuningFlags, J9_IDLE_TUNING_GC_ON_IDLE | J9_IDLE_TUNING_COMPACT_ON_IDLE)) {
 				BOOLEAN idleGCTuningSupported = FALSE;
-#if (defined(LINUX) && (defined(J9HAMMER) || defined(J9X86) || defined(S39064) || defined(PPC64) || defined(RISCV64))) || defined(J9ZOS39064)
+#if (defined(LINUX) && (defined(J9HAMMER) || defined(J9X86) || defined(S39064) || defined(PPC64) || defined(J9AARCH64) || defined(RISCV64))) || defined(J9ZOS39064)
 				/* & only for gencon GC policy */
 				if (J9_GC_POLICY_GENCON == ((OMR_VM *)vm->omrVM)->gcPolicy) {
 					idleGCTuningSupported = TRUE;


### PR DESCRIPTION
This commit enables idle GC Tuning for AArch64.

Closes: #12143

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>