### PR TITLE
Change IdentityInterface to match Reference Implementation

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/IdentityObject.java
+++ b/jcl/src/java.base/share/classes/java/lang/IdentityObject.java
@@ -22,6 +22,6 @@ package java.lang;
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-public interface IdentityInterface {
+public interface IdentityObject {
 
 }

--- a/runtime/oti/cfr.h
+++ b/runtime/oti/cfr.h
@@ -948,7 +948,7 @@ typedef struct J9CfrClassFile {
 #define CFR_FOUND_CHARS_IN_EXTENDED_MUE_FORM 0x1
 #define CFR_FOUND_SEPARATOR_IN_MUE_FORM 0x2
 
-#define IDENTITY_OBJECT_NAME "java/lang/IdentityInterface"
+#define IDENTITY_OBJECT_NAME "java/lang/IdentityObject"
 
 #ifdef __cplusplus
 }

--- a/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_Class.java
@@ -446,7 +446,7 @@ public void test_getMethods_subtest6() throws Exception {
 	ClzImpl clzImpl = new ClzImpl();
 	for (Method method : clzImpl.getClass().getMethods()) {
 		for (Class<?> anInterface : method.getDeclaringClass().getInterfaces()) {
-			if (!anInterface.getName().equals("java.lang.IdentityInterface")) {
+			if (anInterface.getName().equals("org.openj9.test.java.lang.Test_Class$InterFaceLayerOne")) {
 				Method intfMethod = anInterface.getMethod(method.getName(), method.getParameterTypes());
 				Assert.assertEquals(intfMethod.toString(), "public abstract org.openj9.test.java.lang.Test_Class$ClzParent org.openj9.test.java.lang.Test_Class$InterfaceLayerThreeB.getType()");	
 			}

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -3035,12 +3035,12 @@ public class ValueTypeTests {
 	static public void testIdentityObjectOnValueType() throws Throwable {
 		String fields[] = {"longField:J"};
 		Class valueClass = ValueTypeGenerator.generateValueClass("testIdentityObjectOnValueType", fields);
-		assertFalse(Arrays.asList(valueClass.getInterfaces()).contains(IdentityInterface.class));
+		assertFalse(Arrays.asList(valueClass.getInterfaces()).contains(IdentityObject.class));
 	}
 
 	@Test(priority = 1)
 	static public void testIdentityObjectOnAbstract() throws Throwable {
-		assertFalse(Arrays.asList(AbstractClass.class.getInterfaces()).contains(IdentityInterface.class));
+		assertFalse(Arrays.asList(AbstractClass.class.getInterfaces()).contains(IdentityObject.class));
 	}
 	private static abstract class AbstractClass {
 		private int x;
@@ -3055,14 +3055,14 @@ public class ValueTypeTests {
 
 	@Test(priority = 1)
 	static public void testIdentityObjectOnJLObject() throws Throwable {
-		assertFalse(Arrays.asList(Object.class.getInterfaces()).contains(IdentityInterface.class));
+		assertFalse(Arrays.asList(Object.class.getInterfaces()).contains(IdentityObject.class));
 	}
 
 	@Test(priority = 1)
 	static public void testIdentityObjectOnRef() throws Throwable {
 		String fields[] = {"longField:J"};
 		Class refClass = ValueTypeGenerator.generateRefClass("testIdentityObjectOnRef", fields);
-		assertTrue(Arrays.asList(refClass.getInterfaces()).contains(IdentityInterface.class));
+		assertTrue(Arrays.asList(refClass.getInterfaces()).contains(IdentityObject.class));
 	}
 
 	static MethodHandle generateGetter(Class<?> clazz, String fieldName, Class<?> fieldType) {


### PR DESCRIPTION
Change the IdentityInterface interface to be called
IdentityObject instead. This is done to be compatible with
the openjdk reference implementation.

Resolves: https://github.com/eclipse/openj9/issues/12181

Signed-off-by: Oussama Saoudi <oussama.saoudi@ibm.com>