### PR TITLE
Update MethodHandleResolver.sendResolveMethodHandle

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleResolver.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleResolver.java
@@ -393,21 +393,24 @@ final class MethodHandleResolver {
 			String name,
 			String typeDescriptor,
 			ClassLoader loader) throws Throwable {
-		MethodType type = null;
 /*[IF OPENJDK_METHODHANDLES]*/
+		Object type = null;
+		MethodType mt = null;
 		switch (cpRefKind) {
 		case 1: /* getField */
 		case 2: /* getStatic */
 		case 3: /* putField */
 		case 4: /* putStatic */
-			type = MethodTypeHelper.vmResolveFromMethodDescriptorString("(" + typeDescriptor + ")V", loader, null);
+			mt = MethodTypeHelper.vmResolveFromMethodDescriptorString("(" + typeDescriptor + ")V", loader, null);
+			type = mt.parameterType(0);
 			break;
 		case 5: /* invokeVirtual */
 		case 6: /* invokeStatic */
 		case 7: /* invokeSpecial */
 		case 8: /* newInvokeSpecial */
 		case 9: /* invokeInterface */
-			type = MethodTypeHelper.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
+			mt = MethodTypeHelper.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
+			type = mt;
 			break;
 		default:
 			/*[MSG "K0686", "Unknown reference kind: '{0}'"]*/
@@ -415,10 +418,11 @@ final class MethodHandleResolver {
 		}
 
 		final MethodHandles.Lookup lookup = new MethodHandles.Lookup(currentClass);
-		inaccessibleTypeCheck(lookup, type);
+		inaccessibleTypeCheck(lookup, mt);
 		
 		return MethodHandleNatives.linkMethodHandleConstant(currentClass, cpRefKind, referenceClazz, name, type);
 /*[ELSE] OPENJDK_METHODHANDLES*/
+		MethodType type = null;
 		try {
 			MethodHandles.Lookup lookup = new MethodHandles.Lookup(currentClass, false);
 			MethodHandle result = null;


### PR DESCRIPTION
For field types, `MethodHandleNatives.linkMethodHandleConstant` expects
`type` to be the first parameter of the `MethodType`, which is an instance
of `Class`. Otherwise, it throws an `IllegalArgumentException`.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>