### PR TITLE
Changes in inlined test for checkcast/instanceof in AOT code

### DIFF
--- a/runtime/compiler/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/codegen/J9TreeEvaluator.cpp
@@ -595,7 +595,15 @@ uint32_t getInstanceOfOrCheckCastTopProfiledClass(TR::CodeGenerator *cg, TR::Nod
    TR_ByteCodeInfo bcInfo = node->getByteCodeInfo();
    TR_ValueProfileInfoManager *valueProfileInfo = TR_ValueProfileInfoManager::get(comp);
 
-   if (!valueProfileInfo)
+   // We do not have validation record to verify that relocated profiled class
+   // in the load run is instanceof castclass or not. So without that
+   // verification, we could end up generating code where we have a defined
+   // relationship between profiled class and cast class which could not be
+   // true in load run and we could end up with incorrect execution in the
+   // application. 
+   // TODO: Once we have validation record for instanceOfOrCheckCastNoCacheUpdate
+   // enable profiled class test in AOT when SVM is enabled.
+   if (!valueProfileInfo || comp->compileRelocatableCode())
       {
       return 0;
       }
@@ -844,7 +852,9 @@ uint32_t J9::TreeEvaluator::calculateInstanceOfOrCheckCastSequences(TR::Node *in
 
          // If the caller doesn't provide the output param don't bother with guessing.
          //
-         if (compileTimeGuessClass && !TR::Compiler->cls.isConcreteClass(cg->comp(), castClass))
+         if ((!cg->comp()->compileRelocatableCode() || cg->comp()->getOption(TR_UseSymbolValidationManager)) 
+               && compileTimeGuessClass
+               && !TR::Compiler->cls.isConcreteClass(cg->comp(), castClass))
             {
             // Figuring out that an interface/abstract class has a single concrete implementation is not as useful for instanceof as it is for checkcast.
             // For checkcast we expect the cast to succeed and the single concrete implementation is the logical class to do a quick up front test against.


### PR DESCRIPTION
This commit contains following changes.
1. For relocatable code, we currently do not have validation record to
   verify the profiled class is instanceof the cast class in the load
   run or not. This could lead relocated code that is functionally
   incorrect. Disabling the inlined profiled class test for AOT Code.
2. On x86, use of profiled classes for inlined instanceof/checkcast test
   is diffrent where we populate the dataslot in the snippet with top
   profiled class if we found one from profiled data that is instance of
   cast class else it is initialized with NULL and will be populated at
   runtime when we find one. Similar to 1 above, this will suffer fromt
   the same symptom where we do not have validation record to verify
   assumption. Disabling use of profiled class under AOT.
3. At compile time we add test in inlined sequence of checkcast code
   in case we found single concrete subclass for interface/abstract
   class. API findSingleConcreteSubClass is validated under SVM only so
   under AOT, we should only be generating that test when SVM is
   enabled.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>