### PR TITLE
Simplify build instructions for Windows

### DIFF
--- a/doc/build-instructions/Build_Instructions_V11.md
+++ b/doc/build-instructions/Build_Instructions_V11.md
@@ -102,7 +102,7 @@ apt-get update \
 ```
 
 2. The previous step installed g++-7 and gcc-7 packages, which might be different
-than the default version installed on your system. Export variables to set the 
+than the default version installed on your system. Export variables to set the
 version used in the build.
 ```
 export CC=gcc-7 CXX=g++-7
@@ -158,8 +158,8 @@ bash configure --with-boot-jdk=/usr/lib/jvm/adoptojdk-java-11
 Mixed references is the default to build when no options are specified. _Note that `--with-cmake=no` cannot be used to build mixed references._ `configure` options include:
 - `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
 - `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks 
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice 
+- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
+- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`
@@ -293,8 +293,8 @@ where `<cups_include_path>` is the absolute path to CUPS. For example, `/opt/fre
 Mixed references is the default to build when no options are specified. _Note that `--with-cmake=no` cannot be used to build mixed references._ `configure` options include:
 - `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
 - `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks 
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice 
+- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
+- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`
@@ -370,16 +370,10 @@ You must install a number of software dependencies to create a suitable build en
 - [Microsoft Visual Studio 2017]( https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=15), which is the default compiler level used by OpenJDK11; or [Microsoft Visual Studio 2013]( https://go.microsoft.com/fwlink/?LinkId=532495), which is chosen to compile if VS2017 isn't installed.
 - [Freemarker V2.3.8](https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download) - only when building with `--with-cmake=no`
 - [LLVM/Clang](http://releases.llvm.org/7.0.0/LLVM-7.0.0-win64.exe)
-- [NASM Assembler v2.13.03 or newer](https://www.nasm.us/pub/nasm/releasebuilds/?C=M;O=D)
 
 Add the binary path of Clang to the `PATH` environment variable to override the older version of clang integrated in Cygwin. e.g.
 ```
 export PATH="/cygdrive/c/Program Files/LLVM/bin:$PATH" (in Cygwin)
-```
-
-Add the path to `nasm.exe` to the `PATH` environment variable to override the older version of NASM installed in Cygwin. e.g.
-```
-export PATH="/cygdrive/c/Program Files/NASM:$PATH" (in Cygwin)
 ```
 
 Update your `LIB` and `INCLUDE` environment variables to provide a path to the Windows debugging tools with the following commands:
@@ -464,8 +458,8 @@ Note: there is no need to specify --with-toolchain-version for 2017 as it will b
 Mixed references is the default to build when no options are specified. _Note that `--with-cmake=no` cannot be used to build mixed references._ `configure` options include:
 - `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
 - `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks 
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice 
+- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
+- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl=path_to_library`, where `path_to_library` specifies the path to the prebuilt OpenSSL library that you obtained in **2. Get the source**. If you want to include the OpenSSL cryptographic library in the OpenJDK binary, you must also include `--enable-openssl-bundling`.
@@ -602,8 +596,8 @@ bash configure --with-boot-jdk=<path_to_boot_JDK11>
 Mixed references is the default to build when no options are specified. _Note that `--with-cmake=no` cannot be used to build mixed references._ `configure` options include:
 - `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
 - `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks 
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice 
+- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
+- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl=path_to_library`, where `path_to_library` specifies the path to the prebuilt OpenSSL library that you obtained in **2. Get the source**. If you want to include the OpenSSL cryptographic library in the OpenJDK binary, you must also include `--enable-openssl-bundling`.
@@ -746,8 +740,8 @@ bash configure --openjdk-target=${OPENJ9_CC_PREFIX} \
 Mixed references is the default to build when no options are specified. _Note that `--with-cmake=no` cannot be used to build mixed references._ `configure` options include:
 - `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
 - `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks 
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice 
+- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
+- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that uses OpenSSL, you must specify `--with-openssl={system|path_to_library}`
@@ -939,7 +933,7 @@ Login: `root`
 Password: `riscv`
 
 The following screen messages show up after logging in the system with the root account
-e.g. 
+e.g.
 ```
 Welcome to the Fedora/RISC-V stage4 disk image
 https://fedoraproject.org/wiki/Architectures/RISC-V
@@ -986,7 +980,7 @@ Login: `root`
 Password: `riscv`
 
 The following screen messages show up after logging in the system with the root account
-e.g. 
+e.g.
 ```
 Welcome to the Fedora/RISC-V disk image
 https://fedoraproject.org/wiki/Architectures/RISC-V
@@ -1017,7 +1011,7 @@ SMP Mon Jan 6 17:31:22 UTC 2020 riscv64 riscv64 riscv64 GNU/Linux
 
 :bulb:
 Given that the root account is rejected in login remotely via SSH, you need
-to create a user account on `Fedora_Developer_Rawhide` to establish another 
+to create a user account on `Fedora_Developer_Rawhide` to establish another
 session to communicate with the target system as follows:
 
 Create a user account on `Fedora_Developer_Rawhide`:
@@ -1219,7 +1213,7 @@ Run the following configure command to set up the cross-compilation environment 
 export RISCV64=<path_to_gnu_cross_toolchain>  #e.g. /opt/riscv_toolchain_linux
 export PATH="$RISCV64/bin:$PATH"
 
-bash configure --disable-warnings-as-errors \ 
+bash configure --disable-warnings-as-errors \
                --disable-ddr \
                --with-boot-jdk=<path_to_build_JDK_for_cross_compilation> \   #the `build-JDK` created at step 5
                --with-build-jdk=<path_to_build_JDK_for_cross_compilation> \  #the `build-JDK` created at step 5
@@ -1233,7 +1227,7 @@ For installed cross-toolchain package, run the following configure command to se
 ```
 export RISCV_TOOLCHAIN_TYPE=install  #specify the install type to use the installed cross-toolchain for the cross-compilation
 
-bash configure --disable-warnings-as-errors \ 
+bash configure --disable-warnings-as-errors \
                --disable-ddr \
                --with-boot-jdk=<path_to_build_JDK_for_cross_compilation> \   #the `build-JDK` created at step 5
                --with-build-jdk=<path_to_build_JDK_for_cross_compilation> \  #the `build-JDK` created at step 5
@@ -1255,8 +1249,8 @@ You can check the version of OpenSSL on your target system as follows:
 e.g.
 ```
 <your_fedora_mount_directory>/usr/bin# file openssl
-openssl: ELF 64-bit LSB executable, UCB RISC-V, version 1 (SYSV), 
-dynamically linked, interpreter /lib/ld-linux-riscv64-lp64d.so.1, 
+openssl: ELF 64-bit LSB executable, UCB RISC-V, version 1 (SYSV),
+dynamically linked, interpreter /lib/ld-linux-riscv64-lp64d.so.1,
 for GNU/Linux 4.15.0, BuildID[sha1]=715cfde5a3bdc6ff31b6cc2e449f06df1b3c465a, not stripped
 ```
 

--- a/doc/build-instructions/Build_Instructions_V16.md
+++ b/doc/build-instructions/Build_Instructions_V16.md
@@ -149,8 +149,8 @@ bash configure --with-boot-jdk=/usr/lib/jvm/adoptojdk-java-15
 Mixed references is the default to build when no options are specified. _Note that `--with-cmake=no` cannot be used to build mixed references._ `configure` options include:
 - `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
 - `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks 
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice 
+- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
+- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`
@@ -286,8 +286,8 @@ where `<cups_include_path>` is the absolute path to CUPS. For example, `/opt/fre
 Mixed references is the default to build when no options are specified. _Note that `--with-cmake=no` cannot be used to build mixed references._ `configure` options include:
 - `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
 - `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks 
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice 
+- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
+- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`
@@ -363,16 +363,10 @@ You must install a number of software dependencies to create a suitable build en
 - [Microsoft Visual Studio 2019](https://aka.ms/vs/16/release/vs_community.exe), which is the default compiler level used by OpenJDK16.
 - [Freemarker V2.3.8](https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download) - only when building with `--with-cmake=no`
 - [LLVM/Clang](http://releases.llvm.org/7.0.0/LLVM-7.0.0-win64.exe)
-- [NASM Assembler v2.13.03 or newer](https://www.nasm.us/pub/nasm/releasebuilds/?C=M;O=D)
 
 Add the binary path of Clang to the `PATH` environment variable to override the older version of clang integrated in Cygwin. e.g.
 ```
 export PATH="/cygdrive/c/Program Files/LLVM/bin:$PATH" (in Cygwin)
-```
-
-Add the path to `nasm.exe` to the `PATH` environment variable to override the older version of NASM installed in Cygwin. e.g.
-```
-export PATH="/cygdrive/c/Program Files/NASM:$PATH" (in Cygwin)
 ```
 
 Update your `LIB` and `INCLUDE` environment variables to provide a path to the Windows debugging tools with the following commands:
@@ -451,8 +445,8 @@ Note: If you have multiple versions of Visual Studio installed, you can enforce 
 Mixed references is the default to build when no options are specified. _Note that `--with-cmake=no` cannot be used to build mixed references._ `configure` options include:
 - `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
 - `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks 
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice 
+- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
+- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl=path_to_library`, where `path_to_library` specifies the path to the prebuilt OpenSSL library that you obtained in **2. Get the source**. If you want to include the OpenSSL cryptographic library in the OpenJDK binary, you must also include `--enable-openssl-bundling`.
@@ -589,8 +583,8 @@ bash configure --with-boot-jdk=<path_to_boot_JDK15>
 Mixed references is the default to build when no options are specified. _Note that `--with-cmake=no` cannot be used to build mixed references._ `configure` options include:
 - `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
 - `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks 
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice 
+- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
+- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl=path_to_library`, where `path_to_library` specifies the path to the prebuilt OpenSSL library that you obtained in **2. Get the source**. If you want to include the OpenSSL cryptographic library in the OpenJDK binary, you must also include `--enable-openssl-bundling`.
@@ -732,8 +726,8 @@ bash configure --openjdk-target=${OPENJ9_CC_PREFIX} \
 Mixed references is the default to build when no options are specified. _Note that `--with-cmake=no` cannot be used to build mixed references._ `configure` options include:
 - `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
 - `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks 
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice 
+- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
+- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that uses OpenSSL, you must specify `--with-openssl={system|path_to_library}`

--- a/doc/build-instructions/Build_Instructions_V8.md
+++ b/doc/build-instructions/Build_Instructions_V8.md
@@ -103,7 +103,7 @@ apt-get update \
 ```
 
 2. The previous step installed g++-7 and gcc-7 packages, which might be different
-than the default version installed on your system. Export variables to set the 
+than the default version installed on your system. Export variables to set the
 version used in the build.
 ```
 export CC=gcc-7 CXX=g++-7
@@ -159,8 +159,8 @@ bash configure --with-boot-jdk=/usr/lib/jvm/adoptojdk-java-80
 Mixed references is the default to build when no options are specified. _Note that `--with-cmake=no` cannot be used to build mixed references._ `configure` options include:
 - `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
 - `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks 
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice 
+- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
+- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`
@@ -172,7 +172,7 @@ Mixed references is the default to build when no options are specified. _Note th
   - `path_to_library` uses a custom OpenSSL library that's already built.
 
   If you want to include the OpenSSL cryptographic library in the OpenJDK binary, you must include `--enable-openssl-bundling`.
-  
+
 :pencil: When building using `--with-cmake=no`, you must specify `freemarker.jar` with an absolute path, such as `--with-freemarker-jar=/root/freemarker.jar`.
 
 ### 4. Build
@@ -290,8 +290,8 @@ where `<cups_include_path>` is the absolute path to CUPS. For example, `/opt/fre
 Mixed references is the default to build when no options are specified. _Note that `--with-cmake=no` cannot be used to build mixed references._ `configure` options include:
 - `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
 - `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks 
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice 
+- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
+- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`
@@ -368,18 +368,12 @@ You must install a number of software dependencies to create a suitable build en
 - [Freemarker V2.3.8](https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download) - only when building with `--with-cmake=no`
 - [Freetype2 V2.5.3](https://www.freetype.org/)
 - [LLVM/Clang 64bit](http://releases.llvm.org/7.0.0/LLVM-7.0.0-win64.exe) or [LLVM/Clang 32bit](http://releases.llvm.org/7.0.0/LLVM-7.0.0-win32.exe)
-- [NASM Assembler v2.13.03 or newer](https://www.nasm.us/pub/nasm/releasebuilds/?C=M;O=D)
 
 Add the binary path of Clang to the `PATH` environment variable to override the older version of clang integrated in Cygwin. e.g.
 ```
 export PATH="/cygdrive/c/Program Files/LLVM/bin:$PATH" (in Cygwin for 64bit)
 or
 export PATH="/cygdrive/c/Program Files/LLVM_32/bin:$PATH" (in Cygwin for 32bit)
-```
-
-Add the path to `nasm.exe` to the `PATH` environment variable to override the older version of NASM installed in Cygwin. e.g.
-```
-export PATH="/cygdrive/c/Program Files/NASM:$PATH" (in Cygwin)
 ```
 
 Update your `LIB` and `INCLUDE` environment variables to provide a path to the Windows debugging tools with the following commands:
@@ -470,8 +464,8 @@ Note: If you have multiple versions of Visual Studio installed, you can enforce 
 Mixed references is the default to build when no options are specified. _Note that `--with-cmake=no` cannot be used to build mixed references._ `configure` options include:
 - `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
 - `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks 
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice 
+- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
+- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl=path_to_library`, where `path_to_library` specifies the path to the prebuilt OpenSSL library that you obtained in **2. Get the source**. If you want to include the OpenSSL cryptographic library in the OpenJDK binary, you must also include `--enable-openssl-bundling`.
@@ -632,8 +626,8 @@ bash configure \
 Mixed references is the default to build when no options are specified. _Note that `--with-cmake=no` cannot be used to build mixed references._ `configure` options include:
 - `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
 - `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks 
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice 
+- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
+- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl=path_to_library`, where `path_to_library` specifies the path to the prebuilt OpenSSL library that you obtained in **2. Get the source**. If you want to include the OpenSSL cryptographic library in the OpenJDK binary, you must also include `--enable-openssl-bundling`.
@@ -737,8 +731,8 @@ bash configure --with-boot-jdk=<path_to_boot_JDK>
 Mixed references is the default to build when no options are specified. _Note that `--with-cmake=no` cannot be used to build mixed references._ `configure` options include:
 - `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
 - `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks 
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice 
+- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
+- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that uses OpenSSL, you must specify `--with-openssl={system|path_to_library}`


### PR DESCRIPTION
The cygwin version of `nasm` is sufficient.