### PR TITLE
Replace jdk15 with jdk16 in list of boot JDKs

### DIFF
--- a/buildenv/docker/mkdocker.sh
+++ b/buildenv/docker/mkdocker.sh
@@ -571,7 +571,7 @@ bootjdk_url() {
 }
 
 install_bootjdks() {
-  local versions="8 11 15"
+  local versions="8 11 16"
   echo ""
   echo "# Download and install boot JDKs from AdoptOpenJDK."
   echo "RUN cd /tmp \\"


### PR DESCRIPTION
Java 16 can be use to build jdk16 and will soon be required to build jdk17.