### PR TITLE
Preserve vector registers across helper calls on P

### DIFF
--- a/runtime/codert_vm/pnathelp.m4
+++ b/runtime/codert_vm/pnathelp.m4
@@ -20,7 +20,7 @@ dnl SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exc
 
 include(phelpers.m4)
 
-	.file "pnathelp.s"
+	START_FILE("pnathelp.s")
 
 define({CSECT_NAME},{pnathelp})
 
@@ -294,6 +294,31 @@ START_PROC($1)
 END_PROC($1)
 })
 
+dnl Helpers that are at a method invocation point.
+dnl
+dnl See definition of SAVE_C_VOLATILE_REGS in phelpers.m4
+dnl for details.
+
+undefine({MUST_PRESERVE_FPR})
+undefine({MUST_PRESERVE_VR})
+
+PICBUILDER_DUAL_MODE_HELPER(jitLookupInterfaceMethod,3)
+PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveInterfaceMethod,2)
+PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveSpecialMethod,3)
+PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveStaticMethod,3)
+PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveVirtualMethod,2)
+SLOW_PATH_ONLY_HELPER(jitInduceOSRAtCurrentPC,0)
+SLOW_PATH_ONLY_HELPER(jitInduceOSRAtCurrentPCAndRecompile,0)
+SLOW_PATH_ONLY_HELPER(jitRetranslateMethod,3)
+
+dnl Helpers that are not at a method invocation point.
+dnl
+dnl See definition of SAVE_C_VOLATILE_REGS in phelpers.m4
+dnl for details.
+
+define({MUST_PRESERVE_FPR})
+ifdef({ASM_J9VM_ENV_DATA64},{define({MUST_PRESERVE_VR})})
+
 dnl Runtime helpers
 
 DUAL_MODE_HELPER(jitNewValue,1)
@@ -356,7 +381,6 @@ dnl Only called from PicBuilder
 PICBUILDER_FAST_PATH_ONLY_HELPER(jitMethodIsNative,1)
 PICBUILDER_FAST_PATH_ONLY_HELPER(jitMethodIsSync,1)
 PICBUILDER_FAST_PATH_ONLY_HELPER(jitResolvedFieldIsVolatile,3)
-PICBUILDER_DUAL_MODE_HELPER(jitLookupInterfaceMethod,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveString,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveClass,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveClassFromStaticField,3)
@@ -364,10 +388,6 @@ PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveField,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveFieldSetter,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveStaticField,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveStaticFieldSetter,3)
-PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveInterfaceMethod,2)
-PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveSpecialMethod,3)
-PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveStaticMethod,3)
-PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveVirtualMethod,2)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveMethodType,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveMethodHandle,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveInvokeDynamic,3)
@@ -385,7 +405,6 @@ dnl Recompilation helpers
 
 SLOW_PATH_ONLY_HELPER(jitRetranslateCaller,2)
 SLOW_PATH_ONLY_HELPER(jitRetranslateCallerWithPreparation,3)
-SLOW_PATH_ONLY_HELPER(jitRetranslateMethod,3)
 
 dnl Exception throw helpers
 
@@ -419,8 +438,6 @@ FAST_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitWriteBarrierStoreMetronome,3)
 
 dnl Misc
 
-SLOW_PATH_ONLY_HELPER(jitInduceOSRAtCurrentPC,0)
-SLOW_PATH_ONLY_HELPER(jitInduceOSRAtCurrentPCAndRecompile,0)
 SLOW_PATH_ONLY_HELPER(jitNewInstanceImplAccessCheck,3)
 SLOW_PATH_ONLY_HELPER_NO_EXCEPTION_NO_RETURN_VALUE(jitCallCFunction,3)
 SLOW_PATH_ONLY_HELPER_NO_EXCEPTION_NO_RETURN_VALUE(jitCallJitAddPicToPatchOnClassUnload,2)

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -355,6 +355,10 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_preservedFPRs", offsetof(J9CInterpreterStackFrame, preservedFPRs)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_jitGPRs", offsetof(J9CInterpreterStackFrame, jitGPRs)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_jitFPRs", offsetof(J9CInterpreterStackFrame, jitFPRs)) |
+#if defined(J9VM_ENV_DATA64)
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_jitVRs", offsetof(J9CInterpreterStackFrame, jitVRs)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_preservedVRs", offsetof(J9CInterpreterStackFrame, preservedVRs)) |
+#endif /* J9VM_ENV_DATA64 */
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_jitCR", offsetof(J9CInterpreterStackFrame, jitCR)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_cframe_jitLR", offsetof(J9CInterpreterStackFrame, jitLR)) |
 #if !defined(LINUX) || defined(J9VM_ENV_DATA64)

--- a/runtime/oti/JITInterface.hpp
+++ b/runtime/oti/JITInterface.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -87,9 +87,9 @@ typedef struct {
 	union {
 		UDATA numbered[32];
 	} gpr;
-	U_64 fpr[32];
 	UDATA cr;
 	UDATA lr;
+	U_64 fpr[32];
 } J9JITRegisters;
 
 #elif defined(J9VM_ARCH_S390)

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5614,16 +5614,20 @@ typedef struct J9CInterpreterStackFrame {
 	UDATA currentTOC; /* callee saves incoming TOC in own frame */
 	UDATA outgoingArguments[J9_INLINE_JNI_MAX_ARG_COUNT];
 	UDATA jitGPRs[32]; /* r0-r31 */
-	U_8 jitFPRs[32 * 8]; /* fp0-fp31 */
 	UDATA jitCR;
 	UDATA jitLR;
+	U_8 jitFPRs[32 * 8]; /* fp0-fp31 */
 #if defined(J9VM_ENV_DATA64)
+	U_8 jitVRs[52 * 16]; /* vsr0-vsr51 */
 	UDATA align[3];
 #else /* J9VM_ENV_DATA64 */
 	UDATA align[1];
 #endif /* J9VM_ENV_DATA64 */
 	UDATA preservedGPRs[19]; /* r13-r31 */
 	U_8 preservedFPRs[18 * 8]; /* fp14-31 */
+#if defined(J9VM_ENV_DATA64)
+	U_8 preservedVRs[12 * 16]; /* vsr52-vsr63 */
+#endif /* J9VM_ENV_DATA64 */
 #elif defined(J9VM_ENV_DATA64) /* AIXPPC */
 #if defined(J9VM_ENV_LITTLE_ENDIAN)
 	/* Linux PPC 64 LE
@@ -5636,12 +5640,14 @@ typedef struct J9CInterpreterStackFrame {
 	UDATA currentTOC; /* callee saves own TOC in own frame */
 	UDATA outgoingArguments[J9_INLINE_JNI_MAX_ARG_COUNT];
 	UDATA jitGPRs[32]; /* r0-r31 */
-	U_8 jitFPRs[32 * 8]; /* fp0-fp31 */
 	UDATA jitCR;
 	UDATA jitLR;
+	U_8 jitFPRs[32 * 8]; /* fp0-fp31 */
+	U_8 jitVRs[52 * 16]; /* vsr0-vsr51 */
 	UDATA align[6];
 	UDATA preservedGPRs[18]; /* r14-r31 */
 	U_8 preservedFPRs[18 * 8]; /* fp14-31 */
+	U_8 preservedVRs[12 * 16]; /* vsr52-vsr63 */
 #else /* J9VM_ENV_LITTLE_ENDIAN */
 	/* Linux PPC 64 BE
 	 *
@@ -5655,12 +5661,14 @@ typedef struct J9CInterpreterStackFrame {
 	UDATA currentTOC; /* callee saves own TOC in own frame */
 	UDATA outgoingArguments[J9_INLINE_JNI_MAX_ARG_COUNT];
 	UDATA jitGPRs[32]; /* r0-r31 */
-	U_8 jitFPRs[32 * 8]; /* fp0-fp31 */
 	UDATA jitCR;
 	UDATA jitLR;
+	U_8 jitFPRs[32 * 8]; /* fp0-fp31 */
+	U_8 jitVRs[52 * 16]; /* vsr0-vsr51 */
 	UDATA align[4];
 	UDATA preservedGPRs[18]; /* r14-r31 */
 	U_8 preservedFPRs[18 * 8]; /* fp14-31 */
+	U_8 preservedVRs[12 * 16]; /* vsr52-vsr63 */
 #endif /* J9VM_ENV_LITTLE_ENDIAN */
 #else /* J9VM_ENV_DATA64 */
 #if defined(J9VM_ENV_LITTLE_ENDIAN)
@@ -5675,9 +5683,9 @@ typedef struct J9CInterpreterStackFrame {
 	UDATA preservedLR; /* callee saves in caller frame */
 	UDATA outgoingArguments[J9_INLINE_JNI_MAX_ARG_COUNT];
 	UDATA jitGPRs[32]; /* r0-r31 */
-	U_8 jitFPRs[32 * 8]; /* fp0-fp31 */
 	UDATA jitCR;
 	UDATA jitLR;
+	U_8 jitFPRs[32 * 8]; /* fp0-fp31 */
 	UDATA preservedCR; /* callee saves in own frame */
 	UDATA preservedGPRs[19]; /* r13-r31 */
 	U_8 preservedFPRs[18 * 8]; /* fp14-31 */

--- a/runtime/oti/phelpers.m4
+++ b/runtime/oti/phelpers.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 1991, 2019 IBM Corp. and others
+dnl Copyright (c) 1991, 2021 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -88,6 +88,10 @@ define({fp31},31)
 
 J9CONST({CINTERP_STACK_SIZE},J9TR_cframe_sizeof)
 
+define({CONCAT},$1$2)
+define({SYM_COUNT},0)
+define({INC_SYM_COUNT},{define({SYM_COUNT},eval(1+SYM_COUNT))})
+
 ifdef({ASM_J9VM_ENV_DATA64},{
 
 ifelse(eval(CINTERP_STACK_SIZE % 64),0, ,{ERROR stack size CINTERP_STACK_SIZE is not 64-aligned})
@@ -130,6 +134,10 @@ ifdef({AIXPPC},{
 
 dnl AIX PPC 32 and 64
 
+define({START_FILE},{
+	.file $1
+})
+
 define({FUNC_PTR},{r11})
 
 define({CALL_INDIRECT},{
@@ -144,7 +152,7 @@ dnl inline version of _ptrgl follows
 define({FUNC_LABEL},{.$1})
 
 define({BRANCH_SYMBOL},{FUNC_LABEL($1)[pr]})
-
+	
 define({DECLARE_PUBLIC},{
 	.globl .$1[pr]
 	.globl $1[ds]
@@ -169,6 +177,7 @@ define({START_TEXT},{
 })
 
 define({START_PROC},{
+	INC_SYM_COUNT
 	DECLARE_PUBLIC($1)
 	START_TEXT(CSECT_NAME)
 	.$1:
@@ -193,6 +202,13 @@ J9CONST({CR_SAVE_OFFSET},eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedCR))
 J9CONST({LR_SAVE_OFFSET},eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedLR))
 
 },{ dnl AIXPPC
+
+dnl Linux PPC
+
+define({START_FILE},{
+	.file $1
+	.machine power7
+})
 
 ifdef({ASM_J9VM_ENV_DATA64},{
 
@@ -230,6 +246,7 @@ define({CALL_DIRECT},{
 })
 
 define({START_PROC},{
+	INC_SYM_COUNT
 	DECLARE_PUBLIC($1)
 	START_TEXT(CSECT_NAME)
 	FUNC_LABEL($1):
@@ -295,6 +312,7 @@ define({DECLARE_EXTERN},{
 })
 
 define({START_PROC},{
+	INC_SYM_COUNT
 	DECLARE_PUBLIC($1)
 	START_TEXT(CSECT_NAME)
 	FUNC_LABEL($1):
@@ -341,6 +359,7 @@ define({START_TEXT})
 define({CALL_DIRECT},{bl BRANCH_SYMBOL($1)})
 
 define({START_PROC},{
+	INC_SYM_COUNT
 	DECLARE_PUBLIC($1)
 	START_TEXT(CSECT_NAME)
 	FUNC_LABEL($1):
@@ -445,6 +464,22 @@ define({CALL_C_WITH_VMTHREAD},{
 	CALL_DIRECT($1)
 })
 
+dnl Any helper called at a method invocation point does not
+dnl need to preserve FPR/VR as they are all considered volatile
+dnl in the JIT private linkage.
+dnl
+dnl The exceptions to this are FPRs which represent arguments to
+dnl the called method. These must be stored into the FPR save slots
+dnl in the ELS before calling the helper in case decompilation occurs.
+dnl They must be restored after the helper call as the PicBuilder code
+dnl does not preserve them. If VRs are in used, just restore the VRs
+dnl since they will also restore the contents of the FPRs.
+dnl
+dnl MUST_PRESERVE_FPR indicates that all FPRs must be preserved. If this is
+dnl not defined, then the JIT argument FPRs only must be preserved.
+dnl
+dnl MUST_PRESERVE_VR indicates that VRs must be preserved.
+
 define({SAVE_C_VOLATILE_REGS},{
 	SAVE_CR
 	SAVE_R2_FOR_ALL
@@ -466,15 +501,261 @@ define({SAVE_C_VOLATILE_REGS},{
 	stfd fp5,JIT_FPR_SAVE_SLOT(5)
 	stfd fp6,JIT_FPR_SAVE_SLOT(6)
 	stfd fp7,JIT_FPR_SAVE_SLOT(7)
+ifdef({MUST_PRESERVE_VR},{
+	laddr r4,J9TR_VMThread_javaVM(J9VMTHREAD)
+	lwz r3,J9TR_JavaVM_runtimeFlags(r4)
+	andi. r3,r3,J9TR_J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS
+	beq CONCAT(.L_no_VR_save_,SYM_COUNT)
+	addi r3,r1,J9TR_cframe_jitVRs
+	stxvd2x 0,0,r3
+	addi r3,r3,16
+	stxvd2x 1,0,r3
+	addi r3,r3,16
+	stxvd2x 2,0,r3
+	addi r3,r3,16
+	stxvd2x 3,0,r3
+	addi r3,r3,16
+	stxvd2x 4,0,r3
+	addi r3,r3,16
+	stxvd2x 5,0,r3
+	addi r3,r3,16
+	stxvd2x 6,0,r3
+	addi r3,r3,16
+	stxvd2x 7,0,r3
+	addi r3,r3,16
+	stxvd2x 8,0,r3
+	addi r3,r3,16
+	stxvd2x 9,0,r3
+	addi r3,r3,16
+	stxvd2x 10,0,r3
+	addi r3,r3,16
+	stxvd2x 11,0,r3
+	addi r3,r3,16
+	stxvd2x 12,0,r3
+	addi r3,r3,16
+	stxvd2x 13,0,r3
+	addi r3,r3,16
+	stxvd2x 14,0,r3
+	addi r3,r3,16
+	stxvd2x 15,0,r3
+	addi r3,r3,16
+	stxvd2x 16,0,r3
+	addi r3,r3,16
+	stxvd2x 17,0,r3
+	addi r3,r3,16
+	stxvd2x 18,0,r3
+	addi r3,r3,16
+	stxvd2x 19,0,r3
+	addi r3,r3,16
+	stxvd2x 20,0,r3
+	addi r3,r3,16
+	stxvd2x 21,0,r3
+	addi r3,r3,16
+	stxvd2x 22,0,r3
+	addi r3,r3,16
+	stxvd2x 23,0,r3
+	addi r3,r3,16
+	stxvd2x 24,0,r3
+	addi r3,r3,16
+	stxvd2x 25,0,r3
+	addi r3,r3,16
+	stxvd2x 26,0,r3
+	addi r3,r3,16
+	stxvd2x 27,0,r3
+	addi r3,r3,16
+	stxvd2x 28,0,r3
+	addi r3,r3,16
+	stxvd2x 29,0,r3
+	addi r3,r3,16
+	stxvd2x 30,0,r3
+	addi r3,r3,16
+	stxvd2x 31,0,r3
+	addi r3,r3,16
+	stxvd2x 32,0,r3
+	addi r3,r3,16
+	stxvd2x 33,0,r3
+	addi r3,r3,16
+	stxvd2x 34,0,r3
+	addi r3,r3,16
+	stxvd2x 35,0,r3
+	addi r3,r3,16
+	stxvd2x 36,0,r3
+	addi r3,r3,16
+	stxvd2x 37,0,r3
+	addi r3,r3,16
+	stxvd2x 38,0,r3
+	addi r3,r3,16
+	stxvd2x 39,0,r3
+	addi r3,r3,16
+	stxvd2x 40,0,r3
+	addi r3,r3,16
+	stxvd2x 41,0,r3
+	addi r3,r3,16
+	stxvd2x 42,0,r3
+	addi r3,r3,16
+	stxvd2x 43,0,r3
+	addi r3,r3,16
+	stxvd2x 44,0,r3
+	addi r3,r3,16
+	stxvd2x 45,0,r3
+	addi r3,r3,16
+	stxvd2x 46,0,r3
+	addi r3,r3,16
+	stxvd2x 47,0,r3
+	addi r3,r3,16
+	stxvd2x 48,0,r3
+	addi r3,r3,16
+	stxvd2x 49,0,r3
+	addi r3,r3,16
+	stxvd2x 50,0,r3
+	addi r3,r3,16
+	stxvd2x 51,0,r3
+ifdef({MUST_PRESERVE_FPR},{
+	b CONCAT(.L_save_done_,SYM_COUNT)
+}) dnl MUST_PRESERVE_FPR
+CONCAT(.L_no_VR_save_,SYM_COUNT):	
+}) dnl MUST_PRESERVE_VR
+ifdef({MUST_PRESERVE_FPR},{
 	stfd fp8,JIT_FPR_SAVE_SLOT(8)
 	stfd fp9,JIT_FPR_SAVE_SLOT(9)
 	stfd fp10,JIT_FPR_SAVE_SLOT(10)
 	stfd fp11,JIT_FPR_SAVE_SLOT(11)
 	stfd fp12,JIT_FPR_SAVE_SLOT(12)
 	stfd fp13,JIT_FPR_SAVE_SLOT(13)
+}) dnl MUST_PRESERVE_FPR
+CONCAT(.L_save_done_,SYM_COUNT):	
 })
 
 define({RESTORE_C_VOLATILE_REGS},{
+ifdef({MUST_PRESERVE_VR},{
+	laddr r4,J9TR_VMThread_javaVM(J9VMTHREAD)
+	lwz r3,J9TR_JavaVM_runtimeFlags(r4)
+	andi. r3,r3,J9TR_J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS
+	beq CONCAT(.L_no_VR_restore_,SYM_COUNT)
+	addi r3,r1,J9TR_cframe_jitVRs
+	lxvd2x 0,0,r3
+	addi r3,r3,16
+	lxvd2x 1,0,r3
+	addi r3,r3,16
+	lxvd2x 2,0,r3
+	addi r3,r3,16
+	lxvd2x 3,0,r3
+	addi r3,r3,16
+	lxvd2x 4,0,r3
+	addi r3,r3,16
+	lxvd2x 5,0,r3
+	addi r3,r3,16
+	lxvd2x 6,0,r3
+	addi r3,r3,16
+	lxvd2x 7,0,r3
+	addi r3,r3,16
+	lxvd2x 8,0,r3
+	addi r3,r3,16
+	lxvd2x 9,0,r3
+	addi r3,r3,16
+	lxvd2x 10,0,r3
+	addi r3,r3,16
+	lxvd2x 11,0,r3
+	addi r3,r3,16
+	lxvd2x 12,0,r3
+	addi r3,r3,16
+	lxvd2x 13,0,r3
+	addi r3,r3,16
+	lxvd2x 14,0,r3
+	addi r3,r3,16
+	lxvd2x 15,0,r3
+	addi r3,r3,16
+	lxvd2x 16,0,r3
+	addi r3,r3,16
+	lxvd2x 17,0,r3
+	addi r3,r3,16
+	lxvd2x 18,0,r3
+	addi r3,r3,16
+	lxvd2x 19,0,r3
+	addi r3,r3,16
+	lxvd2x 20,0,r3
+	addi r3,r3,16
+	lxvd2x 21,0,r3
+	addi r3,r3,16
+	lxvd2x 22,0,r3
+	addi r3,r3,16
+	lxvd2x 23,0,r3
+	addi r3,r3,16
+	lxvd2x 24,0,r3
+	addi r3,r3,16
+	lxvd2x 25,0,r3
+	addi r3,r3,16
+	lxvd2x 26,0,r3
+	addi r3,r3,16
+	lxvd2x 27,0,r3
+	addi r3,r3,16
+	lxvd2x 28,0,r3
+	addi r3,r3,16
+	lxvd2x 29,0,r3
+	addi r3,r3,16
+	lxvd2x 30,0,r3
+	addi r3,r3,16
+	lxvd2x 31,0,r3
+	addi r3,r3,16
+	lxvd2x 32,0,r3
+	addi r3,r3,16
+	lxvd2x 33,0,r3
+	addi r3,r3,16
+	lxvd2x 34,0,r3
+	addi r3,r3,16
+	lxvd2x 35,0,r3
+	addi r3,r3,16
+	lxvd2x 36,0,r3
+	addi r3,r3,16
+	lxvd2x 37,0,r3
+	addi r3,r3,16
+	lxvd2x 38,0,r3
+	addi r3,r3,16
+	lxvd2x 39,0,r3
+	addi r3,r3,16
+	lxvd2x 40,0,r3
+	addi r3,r3,16
+	lxvd2x 41,0,r3
+	addi r3,r3,16
+	lxvd2x 42,0,r3
+	addi r3,r3,16
+	lxvd2x 43,0,r3
+	addi r3,r3,16
+	lxvd2x 44,0,r3
+	addi r3,r3,16
+	lxvd2x 45,0,r3
+	addi r3,r3,16
+	lxvd2x 46,0,r3
+	addi r3,r3,16
+	lxvd2x 47,0,r3
+	addi r3,r3,16
+	lxvd2x 48,0,r3
+	addi r3,r3,16
+	lxvd2x 49,0,r3
+	addi r3,r3,16
+	lxvd2x 50,0,r3
+	addi r3,r3,16
+	lxvd2x 51,0,r3
+	b CONCAT(.L_restore_done_,SYM_COUNT)
+CONCAT(.L_no_VR_restore_,SYM_COUNT):	
+}) dnl MUST_PRESERVE_VR
+	lfd fp0,JIT_FPR_SAVE_SLOT(0)
+	lfd fp1,JIT_FPR_SAVE_SLOT(1)
+	lfd fp2,JIT_FPR_SAVE_SLOT(2)
+	lfd fp3,JIT_FPR_SAVE_SLOT(3)
+	lfd fp4,JIT_FPR_SAVE_SLOT(4)
+	lfd fp5,JIT_FPR_SAVE_SLOT(5)
+	lfd fp6,JIT_FPR_SAVE_SLOT(6)
+	lfd fp7,JIT_FPR_SAVE_SLOT(7)
+ifdef({MUST_PRESERVE_FPR},{
+	lfd fp8,JIT_FPR_SAVE_SLOT(8)
+	lfd fp9,JIT_FPR_SAVE_SLOT(9)
+	lfd fp10,JIT_FPR_SAVE_SLOT(10)
+	lfd fp11,JIT_FPR_SAVE_SLOT(11)
+	lfd fp12,JIT_FPR_SAVE_SLOT(12)
+	lfd fp13,JIT_FPR_SAVE_SLOT(13)
+}) dnl MUST_PRESERVE_FPR
+CONCAT(.L_restore_done_,SYM_COUNT):	
 	RESTORE_CR
 	RESTORE_R2_FOR_ALL
 	laddr r3,JIT_GPR_SAVE_SLOT(3)
@@ -487,20 +768,6 @@ define({RESTORE_C_VOLATILE_REGS},{
 	laddr r10,JIT_GPR_SAVE_SLOT(10)
 	laddr r11,JIT_GPR_SAVE_SLOT(11)
 	laddr r12,JIT_GPR_SAVE_SLOT(12)
-	lfd fp0,JIT_FPR_SAVE_SLOT(0)
-	lfd fp1,JIT_FPR_SAVE_SLOT(1)
-	lfd fp2,JIT_FPR_SAVE_SLOT(2)
-	lfd fp3,JIT_FPR_SAVE_SLOT(3)
-	lfd fp4,JIT_FPR_SAVE_SLOT(4)
-	lfd fp5,JIT_FPR_SAVE_SLOT(5)
-	lfd fp6,JIT_FPR_SAVE_SLOT(6)
-	lfd fp7,JIT_FPR_SAVE_SLOT(7)
-	lfd fp8,JIT_FPR_SAVE_SLOT(8)
-	lfd fp9,JIT_FPR_SAVE_SLOT(9)
-	lfd fp10,JIT_FPR_SAVE_SLOT(10)
-	lfd fp11,JIT_FPR_SAVE_SLOT(11)
-	lfd fp12,JIT_FPR_SAVE_SLOT(12)
-	lfd fp13,JIT_FPR_SAVE_SLOT(13)
 })
 
 dnl No need to save/restore fp14-31 - the stack walker will never need to read

--- a/runtime/vm/pcinterp.m4
+++ b/runtime/vm/pcinterp.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 2017, 2018 IBM Corp. and others
+dnl Copyright (c) 2017, 2021 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@ dnl SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exc
 
 include(phelpers.m4)
 
-	.file "pcinterp.s"
+	START_FILE("pcinterp.s")
 
 define({CSECT_NAME},{c_cInterpreter})
 
@@ -77,7 +77,7 @@ ifdef({SAVE_R13},{
 	SAVE_FPR(30)
 	SAVE_FPR(31)
  	mr J9VMTHREAD,r3
-	laddr r4,J9TR_VMThread_entryLocalStorage(r3)
+	laddr r4,J9TR_VMThread_entryLocalStorage(J9VMTHREAD)
 	addi r0,r1,JIT_GPR_SAVE_OFFSET(0)
 	staddr r0,J9TR_ELS_jitGlobalStorageBase(r4)
 	addi r0,r1,JIT_FPR_SAVE_OFFSET(0)
@@ -85,8 +85,36 @@ ifdef({SAVE_R13},{
 	li r3,-1
 ifdef({ASM_J9VM_ENV_DATA64},{
 	staddr r3,JIT_GPR_SAVE_SLOT(17)
-	laddr r3,J9TR_VMThread_javaVM(J9VMTHREAD)
-	laddr r3,J9TR_JavaVMJitConfig(r3)
+	laddr r4,J9TR_VMThread_javaVM(J9VMTHREAD)
+	lwz r3,J9TR_JavaVM_runtimeFlags(r4)
+	andi. r3,r3,J9TR_J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS
+	beq .L_no_VR_save
+	addi r3,r1,J9TR_cframe_preservedVRs
+	stxvd2x 52,0,r3
+	addi r3,r3,16
+	stxvd2x 53,0,r3
+	addi r3,r3,16
+	stxvd2x 54,0,r3
+	addi r3,r3,16
+	stxvd2x 55,0,r3
+	addi r3,r3,16
+	stxvd2x 56,0,r3
+	addi r3,r3,16
+	stxvd2x 57,0,r3
+	addi r3,r3,16
+	stxvd2x 58,0,r3
+	addi r3,r3,16
+	stxvd2x 59,0,r3
+	addi r3,r3,16
+	stxvd2x 60,0,r3
+	addi r3,r3,16
+	stxvd2x 61,0,r3
+	addi r3,r3,16
+	stxvd2x 62,0,r3
+	addi r3,r3,16
+	stxvd2x 63,0,r3
+.L_no_VR_save:
+	laddr r3,J9TR_JavaVMJitConfig(r4)
 	cmpliaddr r3,0
 	beq .L_noJIT
 	laddr r3,J9TR_JitConfig_pseudoTOC(r3)
@@ -114,6 +142,37 @@ ifdef({ASM_J9VM_ENV_DATA64},{
 ifdef({SAVE_R13},{
 	RESTORE_GPR(13)
 })
+ifdef({ASM_J9VM_ENV_DATA64},{
+	laddr r4,J9TR_VMThread_javaVM(J9VMTHREAD)
+	lwz r3,J9TR_JavaVM_runtimeFlags(r4)
+	andi. r3,r3,J9TR_J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS
+	beq .L_no_VR_restore
+	addi r3,r1,J9TR_cframe_preservedVRs
+	lxvd2x 52,0,r3
+	addi r3,r3,16
+	lxvd2x 53,0,r3
+	addi r3,r3,16
+	lxvd2x 54,0,r3
+	addi r3,r3,16
+	lxvd2x 55,0,r3
+	addi r3,r3,16
+	lxvd2x 56,0,r3
+	addi r3,r3,16
+	lxvd2x 57,0,r3
+	addi r3,r3,16
+	lxvd2x 58,0,r3
+	addi r3,r3,16
+	lxvd2x 59,0,r3
+	addi r3,r3,16
+	lxvd2x 60,0,r3
+	addi r3,r3,16
+	lxvd2x 61,0,r3
+	addi r3,r3,16
+	lxvd2x 62,0,r3
+	addi r3,r3,16
+	lxvd2x 63,0,r3
+.L_no_VR_restore:
+}) dnl ASM_J9VM_ENV_DATA64
 	RESTORE_GPR(14)
 	RESTORE_GPR(15)
 	RESTORE_GPR(16)


### PR DESCRIPTION
Optionally preserve the vector registers in the assembly helpers on
Power. This is controlled by the
J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS bit in the J9JavaVM
extendedRuntimeFlags field.

Fixes: #11752

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>