### PR TITLE
Disable testIdentityObjectOnAbstract VTTest

### DIFF
--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -3038,7 +3038,8 @@ public class ValueTypeTests {
 		assertFalse(Arrays.asList(valueClass.getInterfaces()).contains(IdentityInterface.class));
 	}
 
-	@Test(priority = 1)
+	/* Temporarily disabled due IdentityObject currently not being injected in correct cases */
+	@Test(enabled=false, priority=1)
 	static public void testIdentityObjectOnAbstract() throws Throwable {
 		assertFalse(Arrays.asList(AbstractClass.class.getInterfaces()).contains(IdentityInterface.class));
 	}


### PR DESCRIPTION
Test is disabled as it assumes only concrete types have the
IdentityObject interface injected. The new specification adds
more cases that this test does not cover for.

Relates to: https://github.com/eclipse/openj9/issues/12039

Signed-off-by: Oussama Saoudi <oussama.saoudi@ibm.com>