### PR TITLE
Change TR_ASSERT_FATAL into failCompilation call in SymRefTab

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -189,12 +189,7 @@ J9::Compilation::Compilation(int32_t id,
    _perClientMemory(_trMemory),
    _methodsRequiringTrampolines(getTypedAllocator<TR_OpaqueMethodBlock *>(self()->allocator())),
 #endif /* defined(J9VM_OPT_JITSERVER) */
-   _osrProhibitedOverRangeOfTrees(false),
-   _useTracingBuffer(false),
-   _tracingBufferStart(NULL),
-   _tracingBufferCursor(NULL),
-   _tracingBufferSize(0),
-   _tracingBufferFreeSpace(0)
+   _osrProhibitedOverRangeOfTrees(false)
    {
    _symbolValidationManager = new (self()->region()) TR::SymbolValidationManager(self()->region(), compilee);
 
@@ -236,14 +231,6 @@ J9::Compilation::Compilation(int32_t id,
 J9::Compilation::~Compilation()
    {
    _profileInfo->~TR_AccessedProfileInfo();
-   }
-
-void
-J9::Compilation::allocateTracingBuffer()
-   {
-   const int32_t size = TRACING_BUFFER_CAPACITY;
-   _tracingBufferStart = (char *)self()->region().allocate(size);
-   _tracingBufferSize = size;
    }
 
 TR_J9VMBase *

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -75,22 +75,6 @@ class ClientSessionData;
 #define COMPILATION_RESERVE_NTRAMPOLINES_ERROR_INBINARYENCODING -19
 #define COMPILATION_AOT_RELOCATION_FAILED -20
 
-#define TRACING_BUFFER_CAPACITY 10*1024
-#define TRACING_BUFFER_SEGMENT_SIZE 128
-#define ADD_TRACING_BUFFER_MESSAGE(comp, fmt, ...) \
-   do \
-      { \
-      if (comp->useTracingBuffer()) \
-         { \
-         char *buffer = comp->getTracingBufferCursor(); \
-         if (comp->getTracingBufferFreeSpace() >= TRACING_BUFFER_SEGMENT_SIZE) \
-            { \
-            snprintf(buffer, TRACING_BUFFER_SEGMENT_SIZE, fmt, ##__VA_ARGS__); \
-            comp->incTracingBuffer(TRACING_BUFFER_SEGMENT_SIZE); \
-            } \
-         } \
-      } while (false)
-
 
 
 namespace J9
@@ -367,23 +351,6 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    void setOSRProhibitedOverRangeOfTrees() { _osrProhibitedOverRangeOfTrees = true; }
    bool isOSRProhibitedOverRangeOfTrees() { return _osrProhibitedOverRangeOfTrees; }
 
-   void setUseTracingBuffer(bool use) { _useTracingBuffer = use; }
-   bool useTracingBuffer() { return _useTracingBuffer; }
-   char *getTracingBufferStart() { return _tracingBufferStart; }
-   char *getTracingBufferCursor() { return _tracingBufferCursor; }
-   void incTracingBuffer(size_t size)
-      {
-      _tracingBufferCursor += size;
-      _tracingBufferFreeSpace -= size;
-      }
-   void allocateTracingBuffer();
-   void resetTracingBuffer()
-      {
-      _tracingBufferCursor = _tracingBufferStart;
-      _tracingBufferFreeSpace = _tracingBufferSize;
-      }
-   int32_t getTracingBufferFreeSpace() { return _tracingBufferFreeSpace; }
-
 private:
    enum CachedClassPointerId
       {
@@ -492,12 +459,6 @@ private:
 
    TR::SymbolValidationManager *_symbolValidationManager;
    bool _osrProhibitedOverRangeOfTrees;
-
-   bool _useTracingBuffer;
-   char *_tracingBufferStart;
-   char *_tracingBufferCursor;
-   int32_t _tracingBufferSize;
-   int32_t _tracingBufferFreeSpace;
    };
 
 }

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -889,29 +889,21 @@ J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * ow
       containingClass =
          owningMethod->definingClassFromCPFieldRef(comp(), cpIndex, isStatic, &fromResolvedJ9Method);
 
-      if (comp()->compileRelocatableCode())
-         {
-         TR_ASSERT_FATAL(
-            containingClass != NULL,
-            "failed to get defining class of field ref cpIndex=%d in owning method J9Method=%p\n"
-            "\tTR_ResolvedJ9Method::definingClassFromCPFieldRef=%p, TR_ResolvedRelocatableJ9Method::definingClassFromCPFieldRef=%p\n"
-            "\tfromResolvedJ9Method=%p\n"
-            "\tTR_UseSymbolValidationManager=%d",
-            cpIndex,
-            owningMethod->getNonPersistentIdentifier(),
-            owningMethod->TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp(), owningMethod->cp(), cpIndex, isStatic),
-            static_cast<TR_ResolvedRelocatableJ9Method *>(owningMethod)->definingClassFromCPFieldRef(comp(), cpIndex, isStatic),
-            fromResolvedJ9Method,
-            comp()->getOption(TR_UseSymbolValidationManager));
-         }
-      else
-         {
-         TR_ASSERT_FATAL(
-            containingClass != NULL,
-            "failed to get defining class of field ref cpIndex=%d in owning method J9Method=%p",
+      // Normally, the expectation is that if a cp field ref is resolved, then the cp ref pointing
+      // to the containing class must also be resolved. However, in #9416, it was discovered that
+      // this assumption does not hold in some cases. Under AOT, loading class data from the SCC
+      // using findSharedData() may fail, which is propagated to the JIT as a NULL containing class.
+      // In addition, if a class is redefined between the point where a field is looked up and
+      // where the defining class is looked, the latter may become NULL.
+      //
+      // Having a NULL containing class would imply two fields from different classes could have
+      // the same lookup key, which is a problem. So, until the above issues are resolved, the
+      // safe thing to do is to abort compilation in these (rare) cases.
+      if (containingClass == NULL)
+         comp()->failCompilation<TR::CompilationException>(
+            "failed to get defining class of resolved field ref cpIndex=%d in owning method J9Method=%p",
             cpIndex,
             owningMethod->getNonPersistentIdentifier());
-         }
 
       ResolvedFieldShadowKey key(containingClass, offset, type);
       TR::SymbolReference *symRef =

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -866,14 +866,6 @@ J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * ow
    TR_ResolvedJ9Method * owningMethod =
       static_cast<TR_ResolvedJ9Method*>(owningMethodSymbol->getResolvedMethod());
 
-   if (comp()->compileRelocatableCode())
-      {
-      comp()->setUseTracingBuffer(true);
-      if (comp()->getTracingBufferStart() == NULL)
-         comp()->allocateTracingBuffer();
-      comp()->resetTracingBuffer();
-      }
-
    bool isVolatile = true, isFinal = false, isPrivate = false, isUnresolvedInCP;
    TR::DataType type = TR::NoType;
    uint32_t offset = 0;
@@ -899,22 +891,6 @@ J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * ow
 
       if (comp()->compileRelocatableCode())
          {
-         if (comp()->useTracingBuffer())
-            {
-            if (containingClass == NULL)
-               {
-               const char *bufferPtr = comp()->getTracingBufferCursor();
-               for (char *cursor = comp()->getTracingBufferStart(); cursor < bufferPtr; cursor += TRACING_BUFFER_SEGMENT_SIZE)
-                  {
-                  J9VMThread *vmThread = comp()->fej9()->getCurrentVMThread();
-                  // each subsection *should* be NULL terminated
-                  fprintf(stderr, "%p: %s", vmThread, cursor);
-                  }
-               fprintf(stderr, "End (%d)\n", comp()->getTracingBufferFreeSpace());
-               }
-            comp()->setUseTracingBuffer(false);
-            }
-
          TR_ASSERT_FATAL(
             containingClass != NULL,
             "failed to get defining class of field ref cpIndex=%d in owning method J9Method=%p\n"
@@ -942,13 +918,8 @@ J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * ow
          findResolvedFieldShadow(key, isVolatile, isPrivate, isFinal);
 
       if (symRef != NULL)
-         {
-         comp()->setUseTracingBuffer(false);
          return symRef;
-         }
       }
-
-   comp()->setUseTracingBuffer(false);
 
    TR::Symbol * sym = 0;
 

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -182,7 +182,6 @@ public:
       }
 
    virtual UDATA *rememberClass(J9Class *clazz, bool create=true);
-   virtual UDATA *rememberClass(bool create, TR::Compilation *comp, J9Class *clazz);
 
    virtual UDATA rememberDebugCounterName(const char *name);
    virtual const char *getDebugCounterName(UDATA offset);
@@ -393,7 +392,7 @@ private:
                          uint32_t numSuperclasses, uint32_t numInterfaces);
 
    bool romclassMatchesCachedVersion(J9ROMClass *romClass, UDATA * & chainPtr, UDATA *chainEnd);
-   UDATA *findChainForClass(J9Class *clazz, const char *key, uint32_t keyLength, TR::Compilation *comp=NULL, J9ROMClass *romClass=NULL);
+   UDATA *findChainForClass(J9Class *clazz, const char *key, uint32_t keyLength);
 
    /**
     * \brief Helper Method; Converts an offset into the ROMClass section into a pointer.

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1725,9 +1725,6 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
       {
       if (aotStats)
          aotStats->numDefiningClassNotFound++;
-
-      ADD_TRACING_BUFFER_MESSAGE(comp, "relo::storeValRecordIfNec, definingClass NULL, %p, %d, %p\n", constantPool, cpIndex, ramMethod);
-
       return false;
       }
 
@@ -1739,10 +1736,7 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
    // all kinds of validations may need to rely on the entire class chain, so make sure we can build one first
    classChain = fej9->sharedCache()->rememberClass(true, comp, definingClass);
    if (!classChain)
-      {
-      ADD_TRACING_BUFFER_MESSAGE(comp, "relo::storeValRecordIfNec, classChain NULL, %p, %p, %d, %p\n", definingClass, constantPool, cpIndex, ramMethod);
       return false;
-      }
 
    bool inLocalList = false;
    TR::list<TR::AOTClassInfo*>* aotClassInfo = comp->_aotClassInfo;
@@ -1774,7 +1768,6 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
    if (inLocalList)
       {
       traceMsg(comp, "\tFound in local list, nothing to do\n");
-      ADD_TRACING_BUFFER_MESSAGE(comp, "relo::storeValRecordIfNec, Found in local list, nothing to do (%p, %d, %p)\n", constantPool, cpIndex, ramMethod);
       if (aotStats)
          {
          if (isStatic)
@@ -1798,13 +1791,10 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
             aotStats->numNewCHEntriesInLocalList++;
          }
 
-      ADD_TRACING_BUFFER_MESSAGE(comp, "relo::storeValRecordIfNec, Created new AOT class info %p\n", classInfo);
-
       return true;
       }
 
    // should only be a native OOM that gets us here...
-   ADD_TRACING_BUFFER_MESSAGE(comp, "relo::storeValRecordIfNec, native OOM?\n");
    return false;
    }
 
@@ -1857,7 +1847,6 @@ TR_ResolvedRelocatableJ9Method::fieldAttributes(TR::Compilation * comp, int32_t 
                }
             else
                {
-               ADD_TRACING_BUFFER_MESSAGE(comp, "relo::fieldAttrib, %d, %p, %p\n", cpIndex, constantPool, ramMethod());
                fieldInfoCanBeUsed = storeValidationRecordIfNecessary(comp, constantPool, cpIndex, TR_ValidateInstanceField, ramMethod());
                }
             }
@@ -1910,8 +1899,6 @@ TR_ResolvedRelocatableJ9Method::fieldAttributes(TR::Compilation * comp, int32_t 
 #if defined(DEBUG_LOCAL_CLASS_OPT)
       unresolvedCtr++;
 #endif
-
-      ADD_TRACING_BUFFER_MESSAGE(comp, "relo::fieldAttrib, theFieldIsFromLocalClass will be false (%p, %d, %p)\n", constantPool, cpIndex, ramMethod());
       }
 
    if (unresolvedInCP)
@@ -2056,10 +2043,7 @@ TR_ResolvedRelocatableJ9Method::definingClassFromCPFieldRef(
       valid = storeValidationRecordIfNecessary(comp, cp(), cpIndex, isStatic ? TR_ValidateStaticField : TR_ValidateInstanceField, ramMethod());
 
    if (!valid)
-      {
-      ADD_TRACING_BUFFER_MESSAGE(comp, "relo::definingClassFromCPFieldRef !valid, %p, %d, %p\n", cp(), cpIndex, ramMethod());
       clazz = NULL;
-      }
 
    return clazz;
    }

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1734,7 +1734,7 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
    void *classChain = NULL;
 
    // all kinds of validations may need to rely on the entire class chain, so make sure we can build one first
-   classChain = fej9->sharedCache()->rememberClass(true, comp, definingClass);
+   classChain = fej9->sharedCache()->rememberClass(definingClass);
    if (!classChain)
       return false;
 


### PR DESCRIPTION
`findOrCreateShadowSymbol()` tries to reuse symrefs produced by `findOrFabricateShadowSymbol()` when the shadow corresponds to the same field. Detecting that the fields are in fact the same requires checking that the defining class is the same. Normally, the expectation is that if a cp field ref is resolved, then the cp ref pointing to the defining class must also be resolved. However, in #9416, it was discovered that this assumption does not hold in some cases. Under AOT, loading class data from the SCC using `findSharedData()` may fail, which is propagated to the JIT as a NULL defining class. In addition, if a class is redefined between the point where a field is looked up and where the defining class is looked, the latter may become NULL.

Since the code in question will not work correctly if the defining class is null, this PR tactically replaces the assert with a call to `failCompilation()`.

In addition, this PR also reverts commits that introduced temporary instrumentation that helped diagnose the issue.

Fixes #9416