### PR TITLE
Add healthcenter sanity test

### DIFF
--- a/test/functional/HealthCenter/build.xml
+++ b/test/functional/HealthCenter/build.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2021, 2021 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<project name="HealthCenter" default="build" basedir=".">
+	<description>
+		HealthCenter
+	</description>
+
+	<import file="${TEST_ROOT}/functional/build.xml" />
+
+	<!-- set global properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/HealthCenter" />
+	<property name="PROJECT_ROOT" location="." />
+
+	<target name="init">
+		<mkdir dir="${DEST}" />
+	</target>
+
+	<target name="dist" depends="init" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${PROJECT_ROOT}">
+				<include name="*.xml" />
+			</fileset>
+		</copy>
+	</target>
+
+	<target name="build" depends="dist">
+	</target>
+
+	<target name="clean" description="clean up">
+	</target>
+
+</project>

--- a/test/functional/HealthCenter/healthcenter.xml
+++ b/test/functional/HealthCenter/healthcenter.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016, 2021 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<project name="HealthCenter" default="sanity">
+
+	<taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+	<target name="sanity">
+		<if>
+			<resourcecount when="greater" count="0">
+				<fileset dir="${TEST_JDK_HOME}">
+					<include name="**/healthcenter.properties" />
+				</fileset>
+			</resourcecount>
+			<then>
+				<echo>Running 'java -Xhealthcenter -version'</echo>
+				<echo>JAVA_COMMAND:  ${JAVA_COMMAND}</echo>
+				<echo>os.name:       ${os.name}</echo>
+
+				<exec executable="${JAVA_COMMAND}" failonerror="true">
+					<arg value="-Xhealthcenter" />
+					<arg value="-version" />
+				</exec>
+			</then>
+			<else>
+				<echo>File 'healthcenter.properties' not found; assuming JDK '${TEST_JDK_HOME}' does not support HealthCenter.</echo>
+			</else>
+		</if>
+	</target>
+
+</project>

--- a/test/functional/HealthCenter/playlist.xml
+++ b/test/functional/HealthCenter/playlist.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Copyright (c) 2021, 2021 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+	<test>
+		<testCaseName>HealthCenter_sanity</testCaseName>
+		<command>ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_JDK_HOME=${TEST_JDK_HOME} -f $(Q)$(TEST_RESROOT)$(D)healthcenter.xml$(Q); $(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+</playlist>


### PR DESCRIPTION
Run `java -Xhealthcenter -version` if the test JDK appears to include support for healthcenter.