### PR TITLE
Restrict the -Xhealthcenter test to z/OS

### DIFF
--- a/test/functional/HealthCenter/playlist.xml
+++ b/test/functional/HealthCenter/playlist.xml
@@ -24,6 +24,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test>
 		<testCaseName>HealthCenter_sanity</testCaseName>
 		<command>ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_JDK_HOME=${TEST_JDK_HOME} -f $(Q)$(TEST_RESROOT)$(D)healthcenter.xml$(Q); $(TEST_STATUS)</command>
+		<platformRequirements>os.zos</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
z/OS is where the test is most needed. Since libhealthcenter.so isn't
linked with libstdc++ it fails on machines without this library. It
doesn't seem necessary to require all test machines to install this just
for this test wanted for z/OS.
```
JVMJ9TI001E Agent library healthcenter could not be opened
(/usr/lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found
```

See https://github.com/eclipse/openj9/pull/12290
and https://github.com/eclipse/openj9/pull/12298

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>