### PR TITLE
Force RB in String Comparator

### DIFF
--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -4171,8 +4171,24 @@ MM_CopyForwardScheme::workThreadGarbageCollect(MM_EnvironmentVLHGC *env)
 	/* ensure that all buffers have been flushed before we start reference processing */
 	env->getGCEnvironment()->_referenceObjectBuffer->flush(env);
 	
+	UDATA preservedGcReadBarrierType = 0;
 	if(env->_currentTask->synchronizeGCThreadsAndReleaseSingleThread(env, UNIQUE_ID)) {
 		_clearableProcessingStarted = true;
+
+		/* During clearable pass, GC threads can access clearable slots other than the one they are directly processing.
+		 * Such other slots could still point to fowarded objects and forwarded pointer needs to be
+		 * resolved (at least in thread local sense) to be able to access the object.
+		 * An example of that is string comparator, that may be used when removing
+		 * an entry from the string table, as part of AVL rebalancing.
+		 * String comparator happens to be used also in  the context of mutator thread when adding new elements,
+		 * and it already uses Read Barrier (to support concurrent evacuating GCs).
+		 * That read barrier will do exactly what we need for our clearable pass (well it will do more,
+		 * not just locally resolve FP, but even fix the slot, but it's correct for this pass, too). We just need
+		 * to enable the RB, if not already enabled.
+		 */
+		preservedGcReadBarrierType = _javaVM->gcReadBarrierType;
+		_javaVM->gcReadBarrierType = J9_GC_READ_BARRIER_TYPE_ALWAYS;
+
 		/* Soft and weak references resurrected by finalization need to be cleared immediately since weak and soft processing has already completed.
 		 * This has to be set before unfinalizable (and phantom) processing, because it can copy object to a tail filled region, in which case we do
 		 * not want to put GMP refs to REMEMBERED state (we want have a chance to put it back to INITIAL state).
@@ -4199,7 +4215,10 @@ MM_CopyForwardScheme::workThreadGarbageCollect(MM_EnvironmentVLHGC *env)
 	/* Clearable must not uncover any new work */
 	Assert_MM_true(NULL == env->_workStack.popNoWait(env));
 
-	env->_currentTask->synchronizeGCThreads(env, UNIQUE_ID);
+	if(env->_currentTask->synchronizeGCThreadsAndReleaseSingleThread(env, UNIQUE_ID)) {
+		_javaVM->gcReadBarrierType = preservedGcReadBarrierType;
+		env->_currentTask->releaseSynchronizedGCThreads(env);
+	}
 
 	if(!abortFlagRaised()) {
 		clearCardTableForPartialCollect(env);

--- a/runtime/vm/montable.c
+++ b/runtime/vm/montable.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,7 +78,9 @@ hashMonitorCompare(void *tableEntryKey, void *userKey, void *userData)
 	/* In a Concurrent GC where monitor object can *move* in a middle of GC cycle,
 	 * we need a proper barrier to get an up-to-date location of the monitor object
 	 * Only access to the table entry needs the barrier. The user provided key should already have an updated location of the objects,
-	 * since a read barrier had to be executed some time prior to the construction of the key, wherever the value is read from */
+	 * since a read barrier had to be executed some time prior to the construction of the key, wherever the value is read from
+	 * In theory (if collision list is ever converted to AVL), this can be called from GC threads during monitor table pruning,
+	 * in which case this has to be unconditionally fixed up, even if read barrier is not active */
 	j9object_t tableEntryObject = J9WEAKROOT_OBJECT_LOAD_VM((J9JavaVM *)userData, &(tableEntryMonitor->userData));
 
 	return tableEntryObject == (j9object_t)userMonitor->userData;


### PR DESCRIPTION
String comparator, while mostly used during insertion into the string
table, in the context of mutator threads, it can also be used during
deletion in the context of GC threads when pruning string table.

With moving collectors, before the comparison, string table slot needs
to be fixed up, first. Previous change
(#9330) generalized this access,
so it goes through read barrier API, rather than directly dealing with
lower level GC concepts (Forwarding Pointer).

However, that change neglected the pruning in GC thread scenario, which
would be indirectly inhibited by RB in Balanced GC, since it does not
have active read barrier.

This change is forcing RB fixup during clearable phase of Balanced
CopyFoward.

Testing tip: Comparisons in deletion scenario occurs when String table
uses AVL (over list) for collided entries. List to AVL conversion will
occur with fairly high list size threshold. So, for stability testing of
this path, it's recommended to significantly reduce that threshold, so
that AVL deletion far more frequently occurs.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>