### PR TITLE
Handle InjectedInvoker class name mismatch during ROM class creation

### DIFF
--- a/runtime/bcutil/ROMClassCreationContext.hpp
+++ b/runtime/bcutil/ROMClassCreationContext.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -402,6 +402,7 @@ public:
 				U_16 classNameLenToCompare0 = (U_16)_classNameLength;
 				U_16 classNameLenToCompare1 = classNameLength;
 				BOOLEAN misMatch = FALSE;
+				BOOLEAN isInjectedInvoker = FALSE;
 				if (isClassHidden()) {
 					if (isROMClassShareable()) {
 						U_8* lambdaClass0 = (U_8*)getLastDollarSignOfLambdaClassName((const char*)_className, _classNameLength);
@@ -425,9 +426,33 @@ public:
 						/* for hidden class className has ROM address appended at the end, _className does not have that */
 						classNameLenToCompare1 = (U_16)_classNameLength;
 					}
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+#define J9_INJECTED_INVOKER_CLASSNAME_BYTECODE "InjectedInvoker/0x0"
+#define J9_INJECTED_INVOKER_CLASSNAME_ROMCLASS "$$InjectedInvoker"
+					if (0 == memcmp(
+							className, J9_INJECTED_INVOKER_CLASSNAME_BYTECODE,
+							LITERAL_STRLEN(J9_INJECTED_INVOKER_CLASSNAME_BYTECODE))
+					) {
+						/* className has InjectedInvoker/0x0000000000000000. */
+						U_8 *start = _className + _classNameLength
+								- LITERAL_STRLEN(J9_INJECTED_INVOKER_CLASSNAME_ROMCLASS);
+						if (0 == memcmp(
+								start, J9_INJECTED_INVOKER_CLASSNAME_ROMCLASS,
+								LITERAL_STRLEN(J9_INJECTED_INVOKER_CLASSNAME_ROMCLASS))
+						) {
+#undef J9_INJECTED_INVOKER_CLASSNAME_ROMCLASS
+#undef J9_INJECTED_INVOKER_CLASSNAME_BYTECODE
+							/* _className has $$InjectedInvoker at the end. */
+							isInjectedInvoker = TRUE;
+						} else {
+							misMatch = TRUE;
+						}
+					}
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 				}
-				if (misMatch || 
-					(!J9UTF8_DATA_EQUALS(_className, classNameLenToCompare0, className, classNameLenToCompare1))
+				if (!isInjectedInvoker
+					&& (misMatch
+						|| (!J9UTF8_DATA_EQUALS(_className, classNameLenToCompare0, className, classNameLenToCompare1)))
 				) {
 #define J9WRONGNAME " (wrong name: "
 					PORT_ACCESS_FROM_PORT(_portLibrary);


### PR DESCRIPTION
To identify a valid `InjectedInvoker` class, check if
- `className` has `InjectedInvoker/0x0000000000000000`; and
- `_className` has `$$InjectedInvoker` at the end.

These changes are only enabled for OJDK MHs.

Fixes: https://github.com/eclipse/openj9/issues/11926

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>