### PR TITLE
Update GCCheck test to use -Xmx to limit core file size

### DIFF
--- a/test/functional/cmdLineTests/gcCheck/gcchecktests.xml
+++ b/test/functional/cmdLineTests/gcCheck/gcchecktests.xml
@@ -38,7 +38,7 @@
   <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
   <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
   <exec command="rm -f $DUMPFILE$" />
-  <command>$EXE$ $CP$ $XDUMP$ $PROGRAM$</command>
+  <command>$EXE$ -Xmx256m $CP$ $XDUMP$ $PROGRAM$</command>
   <output regex="no" type="success">System dump written</output>
  </test>
 


### PR DESCRIPTION
Fixes https://github.com/eclipse/openj9/issues/12302

Checking the heap usage on xlinux jdk11 with compressedrefs, I saw 

- ~175mb used without any -Xmx
- ~157mb used with -Xmx256m
- ~174mb used with -Xmx512m

I've set -Xmx256m, but if this is a concern for the test I can set -Xmx512m or higher instead. The XL build is even more restricted with -Xmx256m.

Tested on jdk11 AIX via grinder https://ci.eclipse.org/openj9/view/Test/job/Grinder/1624/ which passed.