### PR TITLE
(0.26.0) Update GCCheck test to use -Xmx to limit core file size

### DIFF
--- a/test/functional/cmdLineTests/gcCheck/gcchecktests.xml
+++ b/test/functional/cmdLineTests/gcCheck/gcchecktests.xml
@@ -38,7 +38,7 @@
   <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
   <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
   <exec command="rm -f $DUMPFILE$" />
-  <command>$EXE$ $CP$ $XDUMP$ $PROGRAM$</command>
+  <command>$EXE$ -Xmx256m $CP$ $XDUMP$ $PROGRAM$</command>
   <output regex="no" type="success">System dump written</output>
  </test>
 


### PR DESCRIPTION
Fixes https://github.com/eclipse/openj9/issues/12302

Cherry pick of https://github.com/eclipse/openj9/pull/12307 for the 0.26.0 release.