### PR TITLE
(0.26.0) AArch64: Add class unloading pic site to address constant for instanceof/checkcast

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -1120,13 +1120,24 @@ void genInstanceOfOrCheckCastArbitraryClassTest(TR::Node *node, TR::Register *in
    {
    TR::Compilation *comp = cg->comp();
    TR::Register *arbitraryClassReg = srm->findOrCreateScratchRegister();
+   TR_J9VMBase *fej9 = static_cast<TR_J9VMBase *>(comp->fe());
+
    if (comp->compileRelocatableCode())
       {
       loadAddressConstantInSnippet(cg, node, reinterpret_cast<intptr_t>(arbitraryClass), arbitraryClassReg, TR_ClassPointer);
       }
    else
       {
-      loadAddressConstant(cg, node, reinterpret_cast<intptr_t>(arbitraryClass), arbitraryClassReg, NULL, true);
+      bool isUnloadAssumptionRequired = fej9->isUnloadAssumptionRequired(arbitraryClass, comp->getCurrentMethod());
+
+      if (isUnloadAssumptionRequired)
+         {
+         loadAddressConstantInSnippet(cg, node, reinterpret_cast<intptr_t>(arbitraryClass), arbitraryClassReg, TR_NoRelocation, true);
+         }
+      else
+         {
+         loadAddressConstant(cg, node, reinterpret_cast<intptr_t>(arbitraryClass), arbitraryClassReg, NULL, true);
+         }
       }
    generateCompareInstruction(cg, node, instanceClassReg, arbitraryClassReg, true);
    


### PR DESCRIPTION
This commit changes `genInstanceOfOrCheckCastArbitraryClassTest` to load
address constant with `ConstantDataSnippet` if class unload assumption is required.
This fixes intermittent javac error while building OpenJ9.

Master PR: https://github.com/eclipse/openj9/pull/12279
Depends on: https://github.com/eclipse/openj9-omr/pull/105

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>