### PR TITLE
JITServer AOT cache storage infrastructure

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -405,6 +405,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/net/ServerStream.cpp \
     compiler/runtime/CompileService.cpp \
     compiler/runtime/JITClientSession.cpp \
+    compiler/runtime/JITServerAOTCache.cpp \
     compiler/runtime/JITServerIProfiler.cpp \
     compiler/runtime/JITServerROMClassHash.cpp \
     compiler/runtime/JITServerSharedROMClassCache.cpp \

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -77,6 +77,7 @@ template <typename T> class TR_PersistentArray;
 typedef J9JITExceptionTable TR_MethodMetaData;
 #if defined(J9VM_OPT_JITSERVER)
 class ClientSessionHT;
+class JITServerAOTCacheMap;
 class JITServerSharedROMClassCache;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
@@ -1071,6 +1072,9 @@ public:
 
    JITServerSharedROMClassCache *getJITServerSharedROMClassCache() const { return _sharedROMClassCache; }
    void setJITServerSharedROMClassCache(JITServerSharedROMClassCache *cache) { _sharedROMClassCache = cache; }
+
+   JITServerAOTCacheMap *getJITServerAOTCacheMap() const { return _JITServerAOTCacheMap; }
+   void setJITServerAOTCacheMap(JITServerAOTCacheMap *map) { _JITServerAOTCacheMap = map; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    static void replenishInvocationCount(J9Method* method, TR::Compilation* comp);
@@ -1291,6 +1295,7 @@ private:
    PersistentVector<std::string> _sslCerts;
    JITServer::CompThreadActivationPolicy _activationPolicy;
    JITServerSharedROMClassCache *_sharedROMClassCache;
+   JITServerAOTCacheMap *_JITServerAOTCacheMap;
 #endif /* defined(J9VM_OPT_JITSERVER) */
    }; // CompilationInfo
 }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1194,6 +1194,7 @@ TR::CompilationInfo::CompilationInfo(J9JITConfig *jitConfig) :
    _localGCCounter = 0;
    _activationPolicy = JITServer::CompThreadActivationPolicy::AGGRESSIVE;
    _sharedROMClassCache = NULL;
+   _JITServerAOTCacheMap = NULL;
 #endif /* defined(J9VM_OPT_JITSERVER) */
    }
 

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -113,10 +113,11 @@
 #include "net/ClientStream.hpp"
 #include "net/LoadSSLLibs.hpp"
 #include "runtime/JITClientSession.hpp"
-#include "runtime/Listener.hpp"
+#include "runtime/JITServerAOTCache.hpp"
+#include "runtime/JITServerIProfiler.hpp"
 #include "runtime/JITServerSharedROMClassCache.hpp"
 #include "runtime/JITServerStatisticsThread.hpp"
-#include "runtime/JITServerIProfiler.hpp"
+#include "runtime/Listener.hpp"
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 extern "C" int32_t encodeCount(int32_t count);
@@ -1753,6 +1754,14 @@ onLoadInternal(
          compInfo->setJITServerSharedROMClassCache(cache);
          }
 
+      //NOTE: This must be done only after the SSL library has been successfully loaded
+      if (compInfo->getPersistentInfo()->getJITServerUseAOTCache())
+         {
+         auto aotCacheMap = new (PERSISTENT_NEW) JITServerAOTCacheMap();
+         if (!aotCacheMap)
+            return -1;
+         compInfo->setJITServerAOTCacheMap(aotCacheMap);
+         }
       }
    else if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
       {

--- a/runtime/compiler/env/PersistentCollections.hpp
+++ b/runtime/compiler/env/PersistentCollections.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,5 +51,18 @@ template<typename T>
 using VectorAllocator = TR::typed_allocator<T, TR::Region&>;
 template<typename T>
 using Vector = std::vector<T, VectorAllocator<T>>;
+
+
+namespace std
+   {
+   template<typename T0, typename T1> struct hash<std::pair<T0, T1>>
+      {
+      size_t operator()(const std::pair<T0, T1> &k) const noexcept
+         {
+         return std::hash<T0>()(k.first) ^ std::hash<T1>()(k.second);
+         }
+      };
+   }
+
 
 #endif

--- a/runtime/compiler/env/PersistentCollections.hpp
+++ b/runtime/compiler/env/PersistentCollections.hpp
@@ -27,30 +27,40 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "env/PersistentAllocator.hpp"
+#include "env/Region.hpp"
+
+
 template<typename T>
-using PersistentVectorAllocator = TR::typed_allocator<T, TR::PersistentAllocator&>;
+using PersistentVectorAllocator = TR::typed_allocator<T, TR::PersistentAllocator &>;
 template<typename T>
 using PersistentVector = std::vector<T, PersistentVectorAllocator<T>>;
 
 template<typename T>
-using PersistentUnorderedSetAllocator = TR::typed_allocator<T, TR::PersistentAllocator&>;
-template<typename T>
-using PersistentUnorderedSet = std::unordered_set<T, std::hash<T>, std::equal_to<T>, PersistentUnorderedSetAllocator<T>>;
+using PersistentUnorderedSetAllocator = TR::typed_allocator<T, TR::PersistentAllocator &>;
+template<typename T, typename H = std::hash<T>, typename E = std::equal_to<T>>
+using PersistentUnorderedSet = std::unordered_set<T, H, E, PersistentUnorderedSetAllocator<T>>;
 
-template<typename T, typename U>
-using PersistentUnorderedMapAllocator = TR::typed_allocator<std::pair<const T, U>, TR::PersistentAllocator&>;
-template<typename T, typename U>
-using PersistentUnorderedMap = std::unordered_map<T, U, std::hash<T>, std::equal_to<T>, PersistentUnorderedMapAllocator<T, U>>;
+template<typename K, typename V>
+using PersistentUnorderedMapAllocator = TR::typed_allocator<std::pair<const K, V>, TR::PersistentAllocator &>;
+template<typename K, typename V, typename H = std::hash<K>, typename E = std::equal_to<K>>
+using PersistentUnorderedMap = std::unordered_map<K, V, H, E, PersistentUnorderedMapAllocator<K, V>>;
 
-template<typename T, typename U>
-using UnorderedMapAllocator = TR::typed_allocator<std::pair<const T, U>, TR::Region&>;
-template<typename T, typename U>
-using UnorderedMap = std::unordered_map<T, U, std::hash<T>, std::equal_to<T>, UnorderedMapAllocator<T, U>>;
 
 template<typename T>
-using VectorAllocator = TR::typed_allocator<T, TR::Region&>;
+using VectorAllocator = TR::typed_allocator<T, TR::Region &>;
 template<typename T>
 using Vector = std::vector<T, VectorAllocator<T>>;
+
+template<typename T>
+using UnorderedSetAllocator = TR::typed_allocator<T, TR::Region &>;
+template<typename T, typename H = std::hash<T>, typename E = std::equal_to<T>>
+using UnorderedSet = std::unordered_set<T, H, E, UnorderedSetAllocator<T>>;
+
+template<typename K, typename V>
+using UnorderedMapAllocator = TR::typed_allocator<std::pair<const K, V>, TR::Region &>;
+template<typename K, typename V, typename H = std::hash<K>, typename E = std::equal_to<K>>
+using UnorderedMap = std::unordered_map<K, V, H, E, UnorderedMapAllocator<K, V>>;
 
 
 namespace std
@@ -62,7 +72,32 @@ namespace std
          return std::hash<T0>()(k.first) ^ std::hash<T1>()(k.second);
          }
       };
+
+   template<typename T0, typename T1> struct hash<std::tuple<T0, T1>>
+      {
+      size_t operator()(const std::tuple<T0, T1> &k) const noexcept
+         {
+         return std::hash<T0>()(std::get<0>(k)) ^ std::hash<T1>()(std::get<1>(k));
+         }
+      };
+
+   template<typename T0, typename T1, typename T2> struct hash<std::tuple<T0, T1, T2>>
+      {
+      size_t operator()(const std::tuple<T0, T1, T2> &k) const noexcept
+         {
+         return std::hash<T0>()(std::get<0>(k)) ^ std::hash<T1>()(std::get<1>(k)) ^ std::hash<T2>()(std::get<2>(k));
+         }
+      };
+
+   template<typename T0, typename T1, typename T2, typename T3> struct hash<std::tuple<T0, T1, T2, T3>>
+      {
+      size_t operator()(const std::tuple<T0, T1, T2, T3> &k) const noexcept
+         {
+         return std::hash<T0>()(std::get<0>(k)) ^ std::hash<T1>()(std::get<1>(k)) ^
+                std::hash<T2>()(std::get<2>(k)) ^ std::hash<T3>()(std::get<3>(k));
+         }
+      };
    }
 
 
-#endif
+#endif /* PERSISTENT_COLLECTIONS_H */

--- a/runtime/compiler/runtime/CMakeLists.txt
+++ b/runtime/compiler/runtime/CMakeLists.txt
@@ -63,6 +63,7 @@ if(J9VM_OPT_JITSERVER)
 	j9jit_files(
 		runtime/CompileService.cpp
 		runtime/JITClientSession.cpp
+		runtime/JITServerAOTCache.cpp
 		runtime/JITServerIProfiler.cpp
 		runtime/JITServerROMClassHash.cpp
 		runtime/JITServerSharedROMClassCache.cpp

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -133,19 +133,6 @@ using TR_FieldAttributesCache = PersistentUnorderedMap<int32_t, TR_J9MethodField
 
 using ClassLoaderStringPair = std::pair<J9ClassLoader *, std::string>;
 
-// custom specializations of std::hash injected in std namespace
-namespace std
-   {
-   template<typename T, typename Q> struct hash<std::pair<T, Q>>
-      {
-      std::size_t operator()(const std::pair<T, Q> &key) const noexcept
-         {
-         return std::hash<T>()(key.first) ^ std::hash<Q>()(key.second);
-         }
-      };
-   }
-
-
 
 struct ClassUnloadedData
    {

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -131,31 +131,11 @@ class TR_J9MethodFieldAttributes
 
 using TR_FieldAttributesCache = PersistentUnorderedMap<int32_t, TR_J9MethodFieldAttributes>;
 
-struct ClassLoaderStringPair
-   {
-   J9ClassLoader *_classLoader;
-   std::string    _className;
-
-   bool operator==(const ClassLoaderStringPair &other) const
-      {
-      return _classLoader == other._classLoader &&  _className == other._className;
-      }
-   };
-
+using ClassLoaderStringPair = std::pair<J9ClassLoader *, std::string>;
 
 // custom specializations of std::hash injected in std namespace
 namespace std
    {
-   template<> struct hash<ClassLoaderStringPair>
-      {
-      typedef ClassLoaderStringPair argument_type;
-      typedef std::size_t result_type;
-      result_type operator()(argument_type const& clsPair) const noexcept
-         {
-         return std::hash<void*>()((void*)(clsPair._classLoader)) ^ std::hash<std::string>()(clsPair._className);
-         }
-      };
-
    template<typename T, typename Q> struct hash<std::pair<T, Q>>
       {
       std::size_t operator()(const std::pair<T, Q> &key) const noexcept

--- a/runtime/compiler/runtime/JITServerAOTCache.cpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.cpp
@@ -1,0 +1,683 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "control/CompilationRuntime.hpp"
+#include "env/StackMemoryRegion.hpp"
+#include "infra/CriticalSection.hpp"
+#include "runtime/JITServerAOTCache.hpp"
+#include "runtime/JITServerSharedROMClassCache.hpp"
+
+
+static void *
+allocate(size_t size)
+   {
+   void *ptr = TR::Compiler->persistentGlobalMemory()->allocatePersistentMemory(size, TR_Memory::JITServerAOTCache);
+   if (!ptr)
+      throw std::bad_alloc();
+   return ptr;
+   }
+
+
+ClassLoaderSerializationRecord::ClassLoaderSerializationRecord(uintptr_t id, const uint8_t *name, size_t nameLength) :
+   AOTSerializationRecord(size(nameLength), id, AOTSerializationRecordType::ClassLoader),
+   _nameLength(nameLength)
+   {
+   memcpy(_name, name, nameLength);
+   }
+
+AOTCacheClassLoaderRecord::AOTCacheClassLoaderRecord(uintptr_t id, const uint8_t *name, size_t nameLength) :
+   _data(id, name, nameLength)
+   {
+   }
+
+AOTCacheClassLoaderRecord *
+AOTCacheClassLoaderRecord::create(uintptr_t id, const uint8_t *name, size_t nameLength)
+   {
+   return new(allocate(size(nameLength))) AOTCacheClassLoaderRecord(id, name, nameLength);
+   }
+
+
+ClassSerializationRecord::ClassSerializationRecord(uintptr_t id, uintptr_t classLoaderId,
+                                                   const JITServerROMClassHash &hash, const J9ROMClass *romClass) :
+   AOTSerializationRecord(size(J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(romClass))), id, AOTSerializationRecordType::Class),
+   _classLoaderId(classLoaderId), _hash(hash), _romClassSize(romClass->romSize),
+   _nameLength(J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(romClass)))
+   {
+   memcpy(_name, J9UTF8_DATA(J9ROMCLASS_CLASSNAME(romClass)), _nameLength);
+   }
+
+AOTCacheClassRecord::AOTCacheClassRecord(uintptr_t id, const AOTCacheClassLoaderRecord *classLoaderRecord,
+                                         const JITServerROMClassHash &hash, const J9ROMClass *romClass) :
+   _classLoaderRecord(classLoaderRecord),
+   _data(id, classLoaderRecord->data().id(), hash, romClass)
+   {
+   }
+
+AOTCacheClassRecord *
+AOTCacheClassRecord::create(uintptr_t id, const AOTCacheClassLoaderRecord *classLoaderRecord,
+                            const JITServerROMClassHash &hash, const J9ROMClass *romClass)
+   {
+   void *ptr = allocate(size(J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(romClass))));
+   return new (ptr) AOTCacheClassRecord(id, classLoaderRecord, hash, romClass);
+   }
+
+void
+AOTCacheClassRecord::subRecordsDo(const std::function<void(const AOTCacheRecord *)> &f) const
+   {
+   f(_classLoaderRecord);
+   }
+
+
+MethodSerializationRecord::MethodSerializationRecord(uintptr_t id, uintptr_t definingClassId, uint32_t index) :
+   AOTSerializationRecord(sizeof(*this), id, AOTSerializationRecordType::Method),
+   _definingClassId(definingClassId), _index(index)
+   {
+   }
+
+AOTCacheMethodRecord::AOTCacheMethodRecord(uintptr_t id, const AOTCacheClassRecord *definingClassRecord,
+                                           uint32_t index) :
+   _definingClassRecord(definingClassRecord),
+   _data(id, definingClassRecord->data().id(), index)
+   {
+   }
+
+AOTCacheMethodRecord *
+AOTCacheMethodRecord::create(uintptr_t id, const AOTCacheClassRecord *definingClassRecord, uint32_t index)
+   {
+   void *ptr = allocate(sizeof(AOTCacheMethodRecord));
+   return new (ptr) AOTCacheMethodRecord(id, definingClassRecord, index);
+   }
+
+void
+AOTCacheMethodRecord::subRecordsDo(const std::function<void(const AOTCacheRecord *)> &f) const
+   {
+   f(_definingClassRecord);
+   }
+
+
+template<class D, class R, typename... Args>
+AOTCacheListRecord<D, R, Args...>::AOTCacheListRecord(uintptr_t id, const R *const *records,
+                                                      size_t length, Args... args) :
+   _data(id, length, args...)
+   {
+   for (size_t i = 0; i < length; ++i)
+      _data.list().ids()[i] = records[i]->data().id();
+   memcpy((void *)this->records(), records, length * sizeof(R *));
+   }
+
+template<class D, class R, typename... Args> void
+AOTCacheListRecord<D, R, Args...>::subRecordsDo(const std::function<void(const AOTCacheRecord *)> &f) const
+   {
+   for (size_t i = 0; i < _data.list().length(); ++i)
+      f(records()[i]);
+   }
+
+
+ClassChainSerializationRecord::ClassChainSerializationRecord(uintptr_t id, size_t length) :
+   AOTSerializationRecord(size(length), id, AOTSerializationRecordType::ClassChain),
+   _list(length)
+   {
+   }
+
+AOTCacheClassChainRecord *
+AOTCacheClassChainRecord::create(uintptr_t id, const AOTCacheClassRecord *const *records, size_t length)
+   {
+   void *ptr = allocate(size(length));
+   return new (ptr) AOTCacheClassChainRecord(id, records, length);
+   }
+
+
+WellKnownClassesSerializationRecord::WellKnownClassesSerializationRecord(uintptr_t id, size_t length,
+                                                                         uintptr_t includedClasses) :
+   AOTSerializationRecord(size(length), id, AOTSerializationRecordType::WellKnownClasses),
+   _includedClasses(includedClasses), _list(length)
+   {
+   }
+
+AOTCacheWellKnownClassesRecord *
+AOTCacheWellKnownClassesRecord::create(uintptr_t id, const AOTCacheClassChainRecord *const *records,
+                                       size_t length, uintptr_t includedClasses)
+   {
+   void *ptr = allocate(size(length));
+   return new (ptr) AOTCacheWellKnownClassesRecord(id, records, length, includedClasses);
+   }
+
+
+AOTHeaderSerializationRecord::AOTHeaderSerializationRecord(uintptr_t id, const TR_AOTHeader *header) :
+   AOTSerializationRecord(sizeof(*this), id, AOTSerializationRecordType::AOTHeader),
+   _header(*header)
+   {
+   }
+
+AOTCacheAOTHeaderRecord::AOTCacheAOTHeaderRecord(uintptr_t id, const TR_AOTHeader *header) :
+   _data(id, header)
+   {
+   }
+
+AOTCacheAOTHeaderRecord *
+AOTCacheAOTHeaderRecord::create(uintptr_t id, const TR_AOTHeader *header)
+   {
+   void *ptr = allocate(sizeof(AOTCacheAOTHeaderRecord));
+   return new (ptr) AOTCacheAOTHeaderRecord(id, header);
+   }
+
+
+SerializedAOTMethod::SerializedAOTMethod(uintptr_t definingClassChainId, uint32_t index,
+                                         TR_Hotness optLevel, uintptr_t aotHeaderId, size_t numRecords,
+                                         const void *code, size_t codeSize, const void *data, size_t dataSize) :
+   _size(size(numRecords, codeSize, dataSize)),
+   _definingClassChainId(definingClassChainId), _index(index),
+   _optLevel(optLevel), _aotHeaderId(aotHeaderId),
+   _numRecords(numRecords), _codeSize(codeSize), _dataSize(dataSize)
+   {
+   memcpy((void *)this->code(), code, codeSize);
+   memcpy((void *)this->data(), data, dataSize);
+   }
+
+CachedAOTMethod::CachedAOTMethod(const AOTCacheClassChainRecord *definingClassChainRecord, uint32_t index,
+                                 TR_Hotness optLevel, const AOTCacheAOTHeaderRecord *aotHeaderRecord,
+                                 const Vector<std::pair<const AOTCacheRecord *, uintptr_t>> &records,
+                                 const void *code, size_t codeSize, const void *data, size_t dataSize) :
+   _data(definingClassChainRecord->data().id(), index, optLevel,
+         aotHeaderRecord->data().id(), records.size(), code, codeSize, data, dataSize),
+   _definingClassChainRecord(definingClassChainRecord)
+   {
+   for (size_t i = 0; i < records.size(); ++i)
+      {
+      const AOTSerializationRecord *record = records[i].first->dataAddr();
+      new (&_data.offsets()[i]) SerializedSCCOffset(record->id(), record->type(), records[i].second);
+      ((const AOTCacheRecord **)this->records())[i] = records[i].first;
+      }
+   }
+
+CachedAOTMethod *
+CachedAOTMethod::create(const AOTCacheClassChainRecord *definingClassChainRecord, uint32_t index,
+                        TR_Hotness optLevel, const AOTCacheAOTHeaderRecord *aotHeaderRecord,
+                        const Vector<std::pair<const AOTCacheRecord *, uintptr_t>> &records,
+                        const void *code, size_t codeSize, const void *data, size_t dataSize)
+   {
+   void *ptr = allocate(size(records.size(), codeSize, dataSize));
+   return new (ptr) CachedAOTMethod(definingClassChainRecord, index, optLevel, aotHeaderRecord,
+                                    records, code, codeSize, data, dataSize);
+   }
+
+
+bool
+JITServerAOTCache::ClassLoaderKey::operator==(const ClassLoaderKey &k) const
+   {
+   return J9UTF8_DATA_EQUALS(_name, _nameLength, k._name, k._nameLength);
+   }
+
+size_t
+JITServerAOTCache::ClassLoaderKey::Hash::operator()(const ClassLoaderKey &k) const noexcept
+   {
+   size_t h = 0;
+   for (size_t i = 0; i < k._nameLength; ++i)
+      h = (h << 5) - h + k._name[i];
+   return h;
+   }
+
+
+bool
+JITServerAOTCache::ClassKey::operator==(const ClassKey &k) const
+   {
+   return (_classLoaderRecord == k._classLoaderRecord) && (*_hash == *k._hash);
+   }
+
+size_t
+JITServerAOTCache::ClassKey::Hash::operator()(const ClassKey &k) const noexcept
+   {
+   // Remove trailing zero bits in aligned pointer for better hash distribution
+   return ((uintptr_t)k._classLoaderRecord << 3) ^ std::hash<JITServerROMClassHash>()(*k._hash);
+   }
+
+
+static size_t recordListHash(const AOTCacheRecord *const *records, size_t length)
+{
+   size_t h = length;
+   for (size_t i = 0; i < length; ++i)
+      h ^= (uintptr_t)records[i] >> 3;// Remove trailing zero bits in aligned pointer for better hash distribution
+   return h;
+}
+
+
+bool
+JITServerAOTCache::ClassChainKey::operator==(const ClassChainKey &k) const
+   {
+   return (_length == k._length) && (memcmp(_records, k._records, _length * sizeof(_records[0])) == 0);
+   }
+
+size_t
+JITServerAOTCache::ClassChainKey::Hash::operator()(const ClassChainKey &k) const noexcept
+   {
+   return recordListHash((const AOTCacheRecord *const *)k._records, k._length);
+   }
+
+
+bool
+JITServerAOTCache::WellKnownClassesKey::operator==(const WellKnownClassesKey &k) const
+   {
+   return (_length == k._length) && (_includedClasses == k._includedClasses) &&
+          (memcmp(_records, k._records, _length * sizeof(_records[0])) == 0);
+   }
+
+size_t
+JITServerAOTCache::WellKnownClassesKey::Hash::operator()(const WellKnownClassesKey &k) const noexcept
+   {
+   return recordListHash((const AOTCacheRecord *const *)k._records, k._length) ^ k._includedClasses;
+   }
+
+
+bool
+JITServerAOTCache::AOTHeaderKey::operator==(const AOTHeaderKey &k) const
+   {
+   return memcmp(_header, k._header, sizeof(*_header)) == 0;
+   }
+
+size_t
+JITServerAOTCache::AOTHeaderKey::Hash::operator()(const AOTHeaderKey &k) const noexcept
+   {
+   // Treat TR_AOTHeader as an array of size_t words (most of its fields are word-sized)
+   size_t h = 0;
+   for (size_t i = 0; i < sizeof(*k._header) / sizeof(size_t); ++i)
+      h ^= ((const size_t *)k._header)[i];
+   return h;
+   }
+
+
+// Insert value (which must be allocated with the global persistent allocator)
+// with the key into the map, avoiding memory leaks in case of exceptions.
+template<typename K, typename V, typename H> static void
+addToMap(PersistentUnorderedMap<K, V *, H> &map,
+         const typename PersistentUnorderedMap<K, V *, H>::const_iterator &it,
+         const K &key, V *value)
+   {
+   try
+      {
+      map.insert(it, { key, value });
+      }
+   catch (...)
+      {
+      TR::Compiler->persistentGlobalMemory()->freePersistentMemory(value);
+      throw;
+      }
+   }
+
+// Free all the values (which must be allocated with the global persistent allocator) in the map
+template<typename K, typename V, typename H> static void
+freeMapValues(const PersistentUnorderedMap<K, V *, H> &map)
+   {
+   for (auto &kv : map)
+      TR::Compiler->persistentGlobalMemory()->freePersistentMemory(kv.second);
+   }
+
+
+JITServerAOTCache::JITServerAOTCache(const std::string &name) :
+   _name(name),
+   _classLoaderMap(decltype(_classLoaderMap)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _classLoaderMonitor(TR::Monitor::create("JIT-JITServerAOTCacheClassLoaderMonitor")),
+   _classMap(decltype(_classMap)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _classMonitor(TR::Monitor::create("JIT-JITServerAOTCacheClassMonitor")),
+   _methodMap(decltype(_methodMap)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _methodMonitor(TR::Monitor::create("JIT-JITServerAOTCacheMethodMonitor")),
+   _classChainMap(decltype(_classChainMap)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _classChainMonitor(TR::Monitor::create("JIT-JITServerAOTCacheClassChainMonitor")),
+   _wellKnownClassesMap(decltype(_wellKnownClassesMap)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _wellKnownClassesMonitor(TR::Monitor::create("JIT-JITServerAOTCacheWellKnownClassesMonitor")),
+   _aotHeaderMap(decltype(_aotHeaderMap)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _aotHeaderMonitor(TR::Monitor::create("JIT-JITServerAOTCacheAOTHeaderMonitor")),
+   _cachedMethodMap(decltype(_cachedMethodMap)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _cachedMethodMonitor(TR::Monitor::create("JIT-JITServerAOTCacheCachedMethodMonitor"))
+   {
+   bool allMonitors = _classLoaderMonitor && _classMonitor && _methodMonitor &&
+                      _classChainMonitor && _wellKnownClassesMonitor &&
+                      _aotHeaderMonitor && _cachedMethodMonitor;
+   if (!allMonitors)
+      throw std::bad_alloc();
+   }
+
+JITServerAOTCache::~JITServerAOTCache()
+   {
+   freeMapValues(_classLoaderMap);
+   freeMapValues(_classMap);
+   freeMapValues(_methodMap);
+   freeMapValues(_classChainMap);
+   freeMapValues(_wellKnownClassesMap);
+   freeMapValues(_aotHeaderMap);
+   freeMapValues(_cachedMethodMap);
+
+   TR::Monitor::destroy(_classMonitor);
+   TR::Monitor::destroy(_classLoaderMonitor);
+   TR::Monitor::destroy(_methodMonitor);
+   TR::Monitor::destroy(_classChainMonitor);
+   TR::Monitor::destroy(_wellKnownClassesMonitor);
+   TR::Monitor::destroy(_aotHeaderMonitor);
+   TR::Monitor::destroy(_cachedMethodMonitor);
+   }
+
+
+// Helper macros to make the code for printing class and method names to vlog more concise
+#define RECORD_NAME(record) (int)(record).nameLength(), (const char *)(record).name()
+#define LENGTH_AND_DATA(str) J9UTF8_LENGTH(str), (const char *)J9UTF8_DATA(str)
+#define ROMMETHOD_NAS(romMethod) \
+   LENGTH_AND_DATA(J9ROMMETHOD_NAME(romMethod)), LENGTH_AND_DATA(J9ROMMETHOD_SIGNATURE(romMethod))
+
+
+const AOTCacheClassLoaderRecord *
+JITServerAOTCache::getClassLoaderRecord(const uint8_t *name, size_t nameLength)
+   {
+   TR_ASSERT(nameLength, "Empty class loader identifying name");
+   OMR::CriticalSection cs(_classLoaderMonitor);
+
+   auto it = _classLoaderMap.find({ name, nameLength });
+   if (it != _classLoaderMap.end())
+      return it->second;
+
+   auto record = AOTCacheClassLoaderRecord::create(_classLoaderMap.size() + 1, name, nameLength);
+   addToMap(_classLoaderMap, it, { record->data().name(), record->data().nameLength() }, record);
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+         "AOT cache %s: created class loader ID %zu -> %.*s",
+         _name.c_str(), record->data().id(), (int)nameLength, (const char *)name
+      );
+
+   return record;
+   }
+
+const AOTCacheClassRecord *
+JITServerAOTCache::getClassRecord(const AOTCacheClassLoaderRecord *classLoaderRecord, const J9ROMClass *romClass)
+   {
+   JITServerROMClassHash hash;
+   if (auto cache = TR::CompilationInfo::get()->getJITServerSharedROMClassCache())
+      hash = cache->getHash(romClass);
+   else
+      hash = JITServerROMClassHash(romClass);
+
+   OMR::CriticalSection cs(_classMonitor);
+
+   auto it = _classMap.find({ classLoaderRecord, &hash });
+   if (it != _classMap.end())
+      return it->second;
+
+   auto record = AOTCacheClassRecord::create(_classMap.size() + 1, classLoaderRecord, hash, romClass);
+   addToMap(_classMap, it, { classLoaderRecord, &record->data().hash() }, record);
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      {
+      const ClassSerializationRecord &c = record->data();
+      char buffer[ROMCLASS_HASH_BYTES * 2 + 1];
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+         "AOT cache %s: created class ID %zu -> %.*s size %u hash %s",
+         _name.c_str(), c.id(), RECORD_NAME(c), romClass->romSize, hash.toString(buffer, sizeof(buffer))
+      );
+      }
+
+   return record;
+   }
+
+const AOTCacheMethodRecord *
+JITServerAOTCache::getMethodRecord(const AOTCacheClassRecord *definingClassRecord,
+                                   uint32_t index, const J9ROMMethod *romMethod)
+   {
+   MethodKey key(definingClassRecord, index);
+   OMR::CriticalSection cs(_methodMonitor);
+
+   auto it = _methodMap.find(key);
+   if (it != _methodMap.end())
+      return it->second;
+
+   auto record = AOTCacheMethodRecord::create(_methodMap.size() + 1, definingClassRecord, index);
+   addToMap(_methodMap, it, key, record);
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      {
+      const ClassSerializationRecord &c = definingClassRecord->data();
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+         "AOT cache %s: created method ID %zu -> %.*s.%.*s%.*s index %u class ID %zu",
+         _name.c_str(), record->data().id(), RECORD_NAME(c), ROMMETHOD_NAS(romMethod), index, c.id()
+      );
+      }
+
+   return record;
+   }
+
+const AOTCacheClassChainRecord *
+JITServerAOTCache::getClassChainRecord(const AOTCacheClassRecord *const *classRecords, size_t length)
+   {
+   OMR::CriticalSection cs(_classChainMonitor);
+
+   auto it = _classChainMap.find({ classRecords, length });
+   if (it != _classChainMap.end())
+      return it->second;
+
+   auto record = AOTCacheClassChainRecord::create(_classChainMap.size() + 1, classRecords, length);
+   addToMap(_classChainMap, it, { record->records(), length }, record);
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      {
+      const ClassSerializationRecord &c = classRecords[0]->data();
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+         "AOT cache %s: created class chain ID %zu -> %.*s ID %zu length %zu",
+         _name.c_str(), record->data().id(), RECORD_NAME(c), c.id(), length
+      );
+      }
+
+   return record;
+   }
+
+const AOTCacheWellKnownClassesRecord *
+JITServerAOTCache::getWellKnownClassesRecord(const AOTCacheClassChainRecord *const *chainRecords,
+                                             size_t length, uintptr_t includedClasses)
+{
+   OMR::CriticalSection cs(_wellKnownClassesMonitor);
+
+   auto it = _wellKnownClassesMap.find({ chainRecords, length, includedClasses });
+   if (it != _wellKnownClassesMap.end())
+      return it->second;
+
+   auto record = AOTCacheWellKnownClassesRecord::create(_wellKnownClassesMap.size() + 1,
+                                                        chainRecords, length, includedClasses);
+   addToMap(_wellKnownClassesMap, it, { record->records(), length, includedClasses }, record);
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+         "AOT cache %s: created well-known classes ID %zu -> length %zu includedClasses %zx",
+         _name.c_str(), record->data().id(), includedClasses, length
+      );
+
+   return record;
+}
+
+const AOTCacheAOTHeaderRecord *
+JITServerAOTCache::getAOTHeaderRecord(const TR_AOTHeader *header, uint64_t clientUID)
+   {
+   OMR::CriticalSection cs(_aotHeaderMonitor);
+
+   auto it = _aotHeaderMap.find({ header });
+   if (it != _aotHeaderMap.end())
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+            "AOT cache %s: using existing AOT header ID %zu for clientUID %llu",
+            _name.c_str(), it->second->data().id(), (unsigned long long)clientUID
+         );
+      return it->second;
+      }
+
+   auto record = AOTCacheAOTHeaderRecord::create(_aotHeaderMap.size() + 1, header);
+   addToMap(_aotHeaderMap, it, { record->data().header() }, record);
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+         "AOT cache %s: created AOT header ID %zu for clientUID %llu",
+         _name.c_str(), record->data().id(), (unsigned long long)clientUID
+      );
+
+   return record;
+   }
+
+
+bool
+JITServerAOTCache::storeMethod(const AOTCacheClassChainRecord *definingClassChainRecord, uint32_t index,
+                               TR_Hotness optLevel, const AOTCacheAOTHeaderRecord *aotHeaderRecord,
+                               const Vector<std::pair<const AOTCacheRecord *, uintptr_t/*reloDataOffset*/>> &records,
+                               const void *code, size_t codeSize, const void *data, size_t dataSize,
+                               const char *signature, uint64_t clientUID)
+   {
+   uintptr_t definingClassId = definingClassChainRecord->records()[0]->data().id();
+   const char *levelName = TR::Compilation::getHotnessName(optLevel);
+
+   CachedMethodKey key(definingClassChainRecord, index, optLevel, aotHeaderRecord);
+   OMR::CriticalSection cs(_cachedMethodMonitor);
+
+   auto it = _cachedMethodMap.find(key);
+   if (it != _cachedMethodMap.end())
+      {
+      //NOTE: Current implementation keeps the first version of the method for this key in the cache.
+      //      If we want to keep the most recent version instead, we will need to synchronize deleting
+      //      the old version with any concurrent threads that could be sending it to other clients.
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+            "AOT cache %s: method %s @ %s index %u class ID %zu AOT header ID %zu already exists",
+            _name.c_str(), signature, levelName, index, definingClassId, aotHeaderRecord->data().id()
+         );
+      return false;
+      }
+
+   auto method = CachedAOTMethod::create(definingClassChainRecord, index, optLevel, aotHeaderRecord,
+                                         records, code, codeSize, data, dataSize);
+   addToMap(_cachedMethodMap, it, key, method);
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+         "AOT cache %s: stored method %s @ %s index %u class ID %zu AOT header ID %zu for clientUID %llu",
+         _name.c_str(), signature, levelName, index, definingClassId,
+         aotHeaderRecord->data().id(), (unsigned long long)clientUID
+      );
+
+   return true;
+   }
+
+const CachedAOTMethod *
+JITServerAOTCache::findMethod(const AOTCacheClassChainRecord *definingClassChainRecord, uint32_t index,
+                              TR_Hotness optLevel, const AOTCacheAOTHeaderRecord *aotHeaderRecord)
+   {
+   CachedMethodKey key(definingClassChainRecord, index, optLevel, aotHeaderRecord);
+   OMR::CriticalSection cs(_cachedMethodMonitor);
+
+   auto it = _cachedMethodMap.find(key);
+   if (it == _cachedMethodMap.end())
+      return NULL;
+
+   return it->second;
+   }
+
+
+Vector<const AOTSerializationRecord *>
+JITServerAOTCache::getSerializationRecords(const CachedAOTMethod *method, const KnownIdSet &knownIds,
+                                           TR_Memory &trMemory) const
+   {
+   VectorAllocator<const AOTSerializationRecord *> resultAllocator(trMemory.heapMemoryRegion());
+   Vector<const AOTSerializationRecord *> result(resultAllocator);
+
+   TR::StackMemoryRegion stackMemoryRegion(trMemory);
+   UnorderedSetAllocator<const AOTCacheRecord *> newRecordsAllocator(trMemory.currentStackRegion());
+   // Keep track of visited records to avoid duplicates
+   UnorderedSet<const AOTCacheRecord *> newRecords(newRecordsAllocator);
+
+   addRecord(method->definingClassChainRecord(), result, newRecords, knownIds);
+   //NOTE: AOT header record doesn't need to be sent to the client.
+   //      If the cached method was found for this client's compilation
+   //      request, its AOT header is already guaranteed to be compatible.
+   for (size_t i = 0; i < method->data().numRecords(); ++i)
+      addRecord(method->records()[i], result, newRecords, knownIds);
+
+   return result;
+   }
+
+void
+JITServerAOTCache::addRecord(const AOTCacheRecord *record, Vector<const AOTSerializationRecord *> &result,
+                             UnorderedSet<const AOTCacheRecord *> &newRecords, const KnownIdSet &knownIds) const
+   {
+   // Check if the record is already known and deserialized at the client
+   const AOTSerializationRecord *data = record->dataAddr();
+   uintptr_t idAndType = AOTSerializationRecord::idAndType(data->id(), data->type());
+   if (knownIds.find(idAndType) != knownIds.end())
+      return;
+
+   // Check if the record was already visited
+   auto it = newRecords.find(record);
+   if (it != newRecords.end())
+      return;
+
+   //NOTE: Using recursion here is reasonable since its depth is limited to a maximum of 3 nested calls:
+   //      wkc record -> class chain record -> class record -> class loader record
+   record->subRecordsDo([&](const AOTCacheRecord *r)
+      {
+      addRecord(r, result, newRecords, knownIds);
+      });
+
+   newRecords.insert(record);
+   result.push_back(data);
+   }
+
+
+JITServerAOTCacheMap::JITServerAOTCacheMap() :
+   _map(decltype(_map)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _monitor(TR::Monitor::create("JIT-JITServerAOTCacheMapMonitor"))
+   {
+   if (!_monitor)
+      throw std::bad_alloc();
+   }
+
+JITServerAOTCacheMap::~JITServerAOTCacheMap()
+   {
+   freeMapValues(_map);
+   TR::Monitor::destroy(_monitor);
+   }
+
+
+JITServerAOTCache *
+JITServerAOTCacheMap::get(const std::string &name, uint64_t clientUID)
+   {
+   OMR::CriticalSection cs(_monitor);
+
+   auto it = _map.find(name);
+   if (it != _map.end())
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Created AOT cache %s for clientUID %llu",
+                                        name.c_str(), (unsigned long long)clientUID);
+      return it->second;
+      }
+
+   auto cache = new (TR::Compiler->persistentGlobalMemory()) JITServerAOTCache(name);
+   if (!cache)
+      throw std::bad_alloc();
+   addToMap(_map, it, name, cache);
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Using existing AOT cache %s for clientUID %llu",
+                                     name.c_str(), (unsigned long long)clientUID);
+   return cache;
+   }

--- a/runtime/compiler/runtime/JITServerAOTCache.cpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.cpp
@@ -254,7 +254,7 @@ size_t
 JITServerAOTCache::ClassKey::Hash::operator()(const ClassKey &k) const noexcept
    {
    // Remove trailing zero bits in aligned pointer for better hash distribution
-   return ((uintptr_t)k._classLoaderRecord << 3) ^ std::hash<JITServerROMClassHash>()(*k._hash);
+   return ((uintptr_t)k._classLoaderRecord >> 3) ^ std::hash<JITServerROMClassHash>()(*k._hash);
    }
 
 

--- a/runtime/compiler/runtime/JITServerAOTCache.hpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.hpp
@@ -61,6 +61,9 @@ public:
    // Calls f(r) for each sub-record r
    virtual void subRecordsDo(const std::function<void(const AOTCacheRecord *)> &f) const { }
 
+   static void *allocate(size_t size);
+   static void free(void *ptr);
+
 protected:
    AOTCacheRecord() = default;
    };

--- a/runtime/compiler/runtime/JITServerAOTCache.hpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.hpp
@@ -1,0 +1,368 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef JITSERVER_AOTCACHE_H
+#define JITSERVER_AOTCACHE_H
+
+#include <functional>
+
+#include "env/TRMemory.hpp"
+#include "env/PersistentCollections.hpp"
+#include "runtime/JITServerAOTSerializationRecords.hpp"
+
+namespace TR { class Monitor; }
+
+
+// Base class for serialization record "wrappers" stored at the server.
+//
+// When a cached serialized method is sent to a client, the server needs
+// to gather all the serialization records that the method refers to.
+// Serialization records refer to their sub-records (e.g. class chain
+// records to class records) by IDs. Mapping IDs to records would require
+// a data structure (e.g. vector or unordered map) synchronized with a lock.
+// To avoid locking while gathering serialization records for a method, we
+// store direct pointers to sub-records in the record wrappers at the server.
+//
+// This class is also used to allow virtual methods which are prohibited
+// in AOTSerializationRecord structs since they are sent over the network.
+//
+// Each AOTCacheRecord is a single contiguous object (variable-sized for most
+// record types) in order to simplify memory management and exception handling.
+// The subclasses store their underlying serialization record data inline
+// (as well as variable-length arrays of subrecord pointers in some cases).
+class AOTCacheRecord
+   {
+public:
+   // Disable copying since instances can be variable-sized
+   AOTCacheRecord(const AOTCacheRecord &) = delete;
+   void operator=(const AOTCacheRecord &) = delete;
+
+   // Returns the address of the underlying serialization record
+   virtual const AOTSerializationRecord *dataAddr() const = 0;
+   // Calls f(r) for each sub-record r
+   virtual void subRecordsDo(const std::function<void(const AOTCacheRecord *)> &f) const { }
+
+protected:
+   AOTCacheRecord() = default;
+   };
+
+
+class AOTCacheClassLoaderRecord final : public AOTCacheRecord
+   {
+public:
+   const ClassLoaderSerializationRecord &data() const { return _data; }
+   const AOTSerializationRecord *dataAddr() const override { return &_data; }
+
+   static AOTCacheClassLoaderRecord *create(uintptr_t id, const uint8_t *name, size_t nameLength);
+
+private:
+   AOTCacheClassLoaderRecord(uintptr_t id, const uint8_t *name, size_t nameLength);
+
+   static size_t size(size_t nameLength)
+      {
+      return offsetof(AOTCacheClassLoaderRecord, _data) + ClassLoaderSerializationRecord::size(nameLength);
+      }
+
+   const ClassLoaderSerializationRecord _data;
+   };
+
+
+class AOTCacheClassRecord final : public AOTCacheRecord
+   {
+public:
+   const AOTCacheClassLoaderRecord *classLoaderRecord() const { return _classLoaderRecord; }
+   const ClassSerializationRecord &data() const { return _data; }
+   const AOTSerializationRecord *dataAddr() const override { return &_data; }
+
+   static AOTCacheClassRecord *create(uintptr_t id, const AOTCacheClassLoaderRecord *classLoaderRecord,
+                                      const JITServerROMClassHash &hash, const J9ROMClass *romClass);
+   void subRecordsDo(const std::function<void(const AOTCacheRecord *)> &f) const override;
+
+private:
+   AOTCacheClassRecord(uintptr_t id, const AOTCacheClassLoaderRecord *classLoaderRecord,
+                       const JITServerROMClassHash &hash, const J9ROMClass *romClass);
+
+   static size_t size(size_t nameLength)
+      {
+      return offsetof(AOTCacheClassRecord, _data) + ClassSerializationRecord::size(nameLength);
+      }
+
+   const AOTCacheClassLoaderRecord *const _classLoaderRecord;
+   const ClassSerializationRecord _data;
+   };
+
+
+class AOTCacheMethodRecord final : public AOTCacheRecord
+   {
+public:
+   const AOTCacheClassRecord *definingClassRecord() const { return _definingClassRecord; }
+   const MethodSerializationRecord &data() const { return _data; }
+   const AOTSerializationRecord *dataAddr() const override { return &_data; }
+
+   static AOTCacheMethodRecord *create(uintptr_t id, const AOTCacheClassRecord *definingClassRecord, uint32_t index);
+   void subRecordsDo(const std::function<void(const AOTCacheRecord *)> &f) const override;
+
+private:
+   AOTCacheMethodRecord(uintptr_t id, const AOTCacheClassRecord *definingClassRecord, uint32_t index);
+
+   const AOTCacheClassRecord *const _definingClassRecord;
+   const MethodSerializationRecord _data;
+   };
+
+
+// Helper template class to avoid duplicating code for class chain records and well-known classes records
+template<class D, class R, typename... Args>
+class AOTCacheListRecord : public AOTCacheRecord
+   {
+public:
+   const D &data() const { return _data; }
+   const AOTSerializationRecord *dataAddr() const override { return &_data; }
+   const R *const *records() const { return (const R *const *)_data.end(); }
+
+   void subRecordsDo(const std::function<void(const AOTCacheRecord *)> &f) const override;
+
+protected:
+   AOTCacheListRecord(uintptr_t id, const R *const *records, size_t length, Args... args);
+
+   static size_t size(size_t length)
+      {
+      return offsetof(AOTCacheListRecord, _data) + D::size(length) + length * sizeof(R *);
+      }
+
+   D _data;
+   // Array of record pointers is stored inline after serialization record data
+   };
+
+
+class AOTCacheClassChainRecord final : public AOTCacheListRecord<ClassChainSerializationRecord, AOTCacheClassRecord>
+   {
+public:
+   static AOTCacheClassChainRecord *create(uintptr_t id, const AOTCacheClassRecord *const *records, size_t length);
+
+private:
+   using AOTCacheListRecord::AOTCacheListRecord;
+   };
+
+
+class AOTCacheWellKnownClassesRecord final :
+   public AOTCacheListRecord<WellKnownClassesSerializationRecord, AOTCacheClassChainRecord, uintptr_t>
+   {
+public:
+   static AOTCacheWellKnownClassesRecord *create(uintptr_t id, const AOTCacheClassChainRecord *const *records,
+                                                 size_t length, uintptr_t includedClasses);
+
+private:
+   using AOTCacheListRecord::AOTCacheListRecord;
+   };
+
+
+class AOTCacheAOTHeaderRecord final : public AOTCacheRecord
+   {
+public:
+   const AOTHeaderSerializationRecord &data() const { return _data; }
+   const AOTSerializationRecord *dataAddr() const override { return &_data; }
+
+   static AOTCacheAOTHeaderRecord *create(uintptr_t id, const TR_AOTHeader *header);
+
+private:
+   AOTCacheAOTHeaderRecord(uintptr_t id, const TR_AOTHeader *header);
+
+   const AOTHeaderSerializationRecord _data;
+   };
+
+
+// Wrapper class for serialized AOT methods stored in the cache at the server.
+// Serves the same purpose as AOTCacheRecord (serialization record wrappers).
+class CachedAOTMethod
+   {
+public:
+   // Disable copying since instances are variable-sized
+   CachedAOTMethod(const CachedAOTMethod &) = delete;
+   void operator=(const CachedAOTMethod &) = delete;
+
+   const AOTCacheClassChainRecord *definingClassChainRecord() const { return _definingClassChainRecord; }
+   const AOTCacheClassRecord *definingClassRecord() const { return _definingClassChainRecord->records()[0]; }
+   const SerializedAOTMethod &data() const { return _data; }
+   SerializedAOTMethod &data() { return _data; }
+   const AOTCacheRecord *const *records() const { return (const AOTCacheRecord *const *)_data.end(); }
+
+   static CachedAOTMethod *create(const AOTCacheClassChainRecord *definingClassChainRecord, uint32_t index,
+                                  TR_Hotness optLevel, const AOTCacheAOTHeaderRecord *aotHeaderRecord,
+                                  const Vector<std::pair<const AOTCacheRecord *, uintptr_t>> &records,
+                                  const void *code, size_t codeSize, const void *data, size_t dataSize);
+
+private:
+   CachedAOTMethod(const AOTCacheClassChainRecord *definingClassChainRecord, uint32_t index,
+                   TR_Hotness optLevel, const AOTCacheAOTHeaderRecord *aotHeaderRecord,
+                   const Vector<std::pair<const AOTCacheRecord *, uintptr_t>> &records,
+                   const void *code, size_t codeSize, const void *data, size_t dataSize);
+
+   static size_t size(size_t numRecords, size_t codeSize, size_t dataSize)
+      {
+      return offsetof(CachedAOTMethod, _data) + SerializedAOTMethod::size(numRecords, codeSize, dataSize) +
+             numRecords * sizeof(AOTCacheRecord *);
+      }
+
+   const AOTCacheClassChainRecord *const _definingClassChainRecord;
+   SerializedAOTMethod _data;
+   // Array of record pointers is stored inline after serialized AOT method data
+   };
+
+
+// Each AOT cache instance at the JITServer is identified by a unique name and stores its
+// own independent set of serialized AOT methods and corresponding serialization records.
+class JITServerAOTCache
+   {
+public:
+   TR_PERSISTENT_ALLOC(TR_Memory::JITServerAOTCache)
+
+   JITServerAOTCache(const std::string &name);
+   ~JITServerAOTCache();
+
+   const std::string &name() const { return _name; }
+
+   const AOTCacheClassLoaderRecord *getClassLoaderRecord(const uint8_t *name, size_t nameLength);
+   const AOTCacheClassRecord *getClassRecord(const AOTCacheClassLoaderRecord *loaderRecord, const J9ROMClass *romClass);
+   const AOTCacheMethodRecord *getMethodRecord(const AOTCacheClassRecord *definingClassRecord,
+                                               uint32_t index, const J9ROMMethod *romMethod);
+   const AOTCacheClassChainRecord *getClassChainRecord(const AOTCacheClassRecord *const *classRecords, size_t length);
+   const AOTCacheWellKnownClassesRecord *getWellKnownClassesRecord(const AOTCacheClassChainRecord *const *chainRecords,
+                                                                   size_t length, uintptr_t includedClasses);
+   const AOTCacheAOTHeaderRecord *getAOTHeaderRecord(const TR_AOTHeader *header, uint64_t clientUID);
+
+   bool storeMethod(const AOTCacheClassChainRecord *definingClassChainRecord, uint32_t index,
+                    TR_Hotness optLevel, const AOTCacheAOTHeaderRecord *aotHeaderRecord,
+                    const Vector<std::pair<const AOTCacheRecord *, uintptr_t/*reloDataOffset*/>> &records,
+                    const void *code, size_t codeSize, const void *data, size_t dataSize,
+                    const char *signature, uint64_t clientUID);
+
+   const CachedAOTMethod *findMethod(const AOTCacheClassChainRecord *definingClassChainRecord, uint32_t index,
+                                     TR_Hotness optLevel, const AOTCacheAOTHeaderRecord *aotHeaderRecord);
+
+   using KnownIdSet = PersistentUnorderedSet<uintptr_t/*recordIdAndType*/>;
+
+   // Get serialization records the method refers to, excluding the ones already
+   // present in the knownIds set (i.e. already deseralized at the client)
+   Vector<const AOTSerializationRecord *>
+   getSerializationRecords(const CachedAOTMethod *method, const KnownIdSet &knownIds, TR_Memory &trMemory) const;
+
+private:
+   struct ClassLoaderKey
+      {
+      bool operator==(const ClassLoaderKey &k) const;
+      struct Hash { size_t operator()(const ClassLoaderKey &k) const noexcept; };
+
+      const uint8_t *const _name;
+      const size_t _nameLength;
+      };
+
+   struct ClassKey
+      {
+      bool operator==(const ClassKey &k) const;
+      struct Hash { size_t operator()(const ClassKey &k) const noexcept; };
+
+      const AOTCacheClassLoaderRecord *const _classLoaderRecord;
+      const JITServerROMClassHash *const _hash;
+      };
+
+   using MethodKey = std::pair<const AOTCacheClassRecord *, uint32_t/*index*/>;
+
+   struct ClassChainKey
+      {
+      bool operator==(const ClassChainKey &k) const;
+      struct Hash { size_t operator()(const ClassChainKey &k) const noexcept; };
+
+      const AOTCacheClassRecord *const *const _records;
+      const size_t _length;
+      };
+
+   struct WellKnownClassesKey
+      {
+      bool operator==(const WellKnownClassesKey &k) const;
+      struct Hash { size_t operator()(const WellKnownClassesKey &k) const noexcept; };
+
+      const AOTCacheClassChainRecord *const *const _records;
+      const size_t _length;
+      const uintptr_t _includedClasses;
+      };
+
+   struct AOTHeaderKey
+      {
+      bool operator==(const AOTHeaderKey &k) const;
+      struct Hash { size_t operator()(const AOTHeaderKey &k) const noexcept; };
+
+      const TR_AOTHeader *const _header;
+      };
+
+   //NOTE: Current implementation doesn't support compatible differences in AOT headers.
+   //      A cached method can only be sent to a client with the exact same AOT header.
+   using CachedMethodKey = std::tuple<const AOTCacheClassChainRecord *, uint32_t/*index*/,
+                                      TR_Hotness, const AOTCacheAOTHeaderRecord *>;
+
+   // Helper method used in getSerializationRecords()
+   void addRecord(const AOTCacheRecord *record, Vector<const AOTSerializationRecord *> &result,
+                  UnorderedSet<const AOTCacheRecord *> &newRecords, const KnownIdSet &knownIds) const;
+
+   const std::string _name;
+
+   PersistentUnorderedMap<ClassLoaderKey, AOTCacheClassLoaderRecord *, ClassLoaderKey::Hash> _classLoaderMap;
+   TR::Monitor *const _classLoaderMonitor;
+
+   PersistentUnorderedMap<ClassKey, AOTCacheClassRecord *, ClassKey::Hash> _classMap;
+   TR::Monitor *const _classMonitor;
+
+   PersistentUnorderedMap<MethodKey, AOTCacheMethodRecord *> _methodMap;
+   TR::Monitor *const _methodMonitor;
+
+   PersistentUnorderedMap<ClassChainKey, AOTCacheClassChainRecord *, ClassChainKey::Hash> _classChainMap;
+   TR::Monitor *const _classChainMonitor;
+
+   PersistentUnorderedMap<WellKnownClassesKey, AOTCacheWellKnownClassesRecord *, WellKnownClassesKey::Hash>
+      _wellKnownClassesMap;
+   TR::Monitor *const _wellKnownClassesMonitor;
+
+   PersistentUnorderedMap<AOTHeaderKey, AOTCacheAOTHeaderRecord *, AOTHeaderKey::Hash> _aotHeaderMap;
+   TR::Monitor *const _aotHeaderMonitor;
+
+   PersistentUnorderedMap<CachedMethodKey, CachedAOTMethod *> _cachedMethodMap;
+   TR::Monitor *const _cachedMethodMonitor;
+   };
+
+
+// Maps AOT cache names to JITServerAOTCache instances
+class JITServerAOTCacheMap
+   {
+public:
+   TR_PERSISTENT_ALLOC(TR_Memory::JITServerAOTCache)
+
+   JITServerAOTCacheMap();
+   ~JITServerAOTCacheMap();
+
+   JITServerAOTCache *get(const std::string &name, uint64_t clientUID);
+
+private:
+   PersistentUnorderedMap<std::string, JITServerAOTCache *> _map;
+   TR::Monitor *const _monitor;
+   };
+
+
+#endif /* defined(JITSERVER_AOTCACHE_H) */

--- a/runtime/compiler/runtime/JITServerAOTCache.hpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.hpp
@@ -328,22 +328,28 @@ private:
    const std::string _name;
 
    PersistentUnorderedMap<ClassLoaderKey, AOTCacheClassLoaderRecord *, ClassLoaderKey::Hash> _classLoaderMap;
+   uintptr_t _nextClassLoaderId;
    TR::Monitor *const _classLoaderMonitor;
 
    PersistentUnorderedMap<ClassKey, AOTCacheClassRecord *, ClassKey::Hash> _classMap;
+   uintptr_t _nextClassId;
    TR::Monitor *const _classMonitor;
 
    PersistentUnorderedMap<MethodKey, AOTCacheMethodRecord *> _methodMap;
+   uintptr_t _nextMethodId;
    TR::Monitor *const _methodMonitor;
 
    PersistentUnorderedMap<ClassChainKey, AOTCacheClassChainRecord *, ClassChainKey::Hash> _classChainMap;
+   uintptr_t _nextClassChainId;
    TR::Monitor *const _classChainMonitor;
 
-   PersistentUnorderedMap<WellKnownClassesKey, AOTCacheWellKnownClassesRecord *, WellKnownClassesKey::Hash>
-      _wellKnownClassesMap;
+   PersistentUnorderedMap<WellKnownClassesKey, AOTCacheWellKnownClassesRecord *,
+                          WellKnownClassesKey::Hash> _wellKnownClassesMap;
+   uintptr_t _nextWellKnownClassesId;
    TR::Monitor *const _wellKnownClassesMonitor;
 
    PersistentUnorderedMap<AOTHeaderKey, AOTCacheAOTHeaderRecord *, AOTHeaderKey::Hash> _aotHeaderMap;
+   uintptr_t _nextAOTHeaderId;
    TR::Monitor *const _aotHeaderMonitor;
 
    PersistentUnorderedMap<CachedMethodKey, CachedAOTMethod *> _cachedMethodMap;

--- a/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
+++ b/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
@@ -60,6 +60,7 @@ public:
    void operator=(const AOTSerializationRecord &) = delete;
 
    size_t size() const { return _size; }
+   //NOTE: 0 signifies an invalid record ID
    uintptr_t id() const { return getId(_idAndType); }
    AOTSerializationRecordType type() const { return getType(_idAndType); }
    const uint8_t *end() const { return (const uint8_t *)this + size(); }
@@ -74,6 +75,7 @@ public:
    // Record ID and type are stored in compact way in a single pointer-sized word
    static uintptr_t idAndType(uintptr_t id, AOTSerializationRecordType type)
       {
+      TR_ASSERT(id, "ID 0 is invalid");
       TR_ASSERT(id <= (UINTPTR_MAX >> idShift), "ID overflow: %zu", id);
       return (id << idShift) | (uintptr_t)type;
       }

--- a/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
+++ b/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
@@ -1,0 +1,332 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef JITSERVER_AOT_SERIALIZATION_RECORDS_H
+#define JITSERVER_AOT_SERIALIZATION_RECORDS_H
+
+#include "OMR/Bytes.hpp"
+#include "runtime/JITServerROMClassHash.hpp"
+#include "runtime/RelocationRuntime.hpp"
+
+
+enum AOTSerializationRecordType
+   {
+   // Not associated with an SCC entity; used for class loader identification (by name of the 1st loaded class)
+   ClassLoader,
+   // Associated with a ROMClass
+   Class,
+   // Associated with a ROMMethod
+   Method,
+   // Associated with an SCC class chain
+   ClassChain,
+   // Associated with an SCC "well-known classes" object
+   WellKnownClasses,
+   // Not associated with an SCC entity; corresponds to TR_AOTHeader struct used for checking AOT code compatibility
+   AOTHeader,
+
+   AOTSerializationRecordType_MAX
+   };
+
+
+// Base class for serialization records used in serialized AOT methods.
+// These records are sent to clients which use them for deserialization.
+// Each record is contiguous, and variable-sized for most record types.
+// Records refer to other records that they depend on via unique record IDs,
+// e.g. a class chain record contains a list of class record IDs.
+struct AOTSerializationRecord
+   {
+public:
+   // Disable copying since instances can be variable-sized
+   AOTSerializationRecord(const AOTSerializationRecord &) = delete;
+   void operator=(const AOTSerializationRecord &) = delete;
+
+   size_t size() const { return _size; }
+   uintptr_t id() const { return getId(_idAndType); }
+   AOTSerializationRecordType type() const { return getType(_idAndType); }
+   const uint8_t *end() const { return (const uint8_t *)this + size(); }
+
+   static const AOTSerializationRecord *get(const std::string &str)
+      {
+      auto record = (const AOTSerializationRecord *)str.data();
+      TR_ASSERT((str.size() >= sizeof(*record)) && (str.size() == record->_size), "Invalid size");
+      return record;
+      }
+
+   // Record ID and type are stored in compact way in a single pointer-sized word
+   static uintptr_t idAndType(uintptr_t id, AOTSerializationRecordType type)
+      {
+      TR_ASSERT(id <= (UINTPTR_MAX >> idShift), "ID overflow: %zu", id);
+      return (id << idShift) | (uintptr_t)type;
+      }
+
+   static uintptr_t getId(uintptr_t idAndType)
+      {
+      return idAndType >> idShift;
+      }
+
+   static AOTSerializationRecordType getType(uintptr_t idAndType)
+      {
+      return (AOTSerializationRecordType)(idAndType & typeMask);
+      }
+
+protected:
+   AOTSerializationRecord(size_t size, uintptr_t id, AOTSerializationRecordType type) :
+      _size(size), _idAndType(idAndType(id, type)) { }
+
+private:
+   static const uintptr_t idShift = 3;
+   static const uintptr_t typeMask = (1 << idShift) - 1;
+   static_assert(AOTSerializationRecordType_MAX <= typeMask + 1, "Too many types");
+
+   const size_t _size;
+   const uintptr_t _idAndType;
+   };
+
+
+struct ClassLoaderSerializationRecord : public AOTSerializationRecord
+   {
+public:
+   size_t nameLength() const { return _nameLength; }
+   const uint8_t *name() const { return _name; }
+
+private:
+   friend class AOTCacheClassLoaderRecord;
+
+   ClassLoaderSerializationRecord(uintptr_t id, const uint8_t *name, size_t nameLength);
+
+   static size_t size(size_t nameLength)
+      {
+      return sizeof(ClassLoaderSerializationRecord) + OMR::alignNoCheck(nameLength, sizeof(size_t));
+      }
+
+   // Name of the 1st class loaded by the class loader
+   const size_t _nameLength;
+   uint8_t _name[];
+   };
+
+
+struct ClassSerializationRecord : public AOTSerializationRecord
+   {
+public:
+   uintptr_t classLoaderId() const { return _classLoaderId; }
+   const JITServerROMClassHash &hash() const { return _hash; }
+   uint32_t romClassSize() const { return _romClassSize; }
+   size_t nameLength() const { return _nameLength; }
+   const uint8_t *name() const { return _name; }
+
+private:
+   friend class AOTCacheClassRecord;
+
+   ClassSerializationRecord(uintptr_t id, uintptr_t classLoaderId,
+                            const JITServerROMClassHash &hash, const J9ROMClass *romClass);
+
+   static size_t size(size_t nameLength)
+      {
+      return sizeof(ClassSerializationRecord) + OMR::alignNoCheck(nameLength, sizeof(size_t));
+      }
+
+   const uintptr_t _classLoaderId;
+   const JITServerROMClassHash _hash;
+   // Used to quickly detect class mismatches (without computing the hash) when ROMClass size is different
+   const uint32_t _romClassSize;
+   // Class name string
+   const uint32_t _nameLength;
+   uint8_t _name[];
+   };
+
+
+struct MethodSerializationRecord : public AOTSerializationRecord
+   {
+public:
+   uintptr_t definingClassId() const { return _definingClassId; }
+   uint32_t index() const { return _index; }
+
+private:
+   friend class AOTCacheMethodRecord;
+
+   MethodSerializationRecord(uintptr_t id, uintptr_t definingClassId, uint32_t index);
+
+   const uintptr_t _definingClassId;
+   // Index in the array of methods of the defining class
+   const uint32_t _index;
+   };
+
+
+struct IdList
+   {
+public:
+   IdList(size_t length) : _length(length) { }
+
+   size_t length() const { return _length; }
+   const uintptr_t *ids() const { return _ids; }
+   uintptr_t *ids() { return _ids; }
+
+   static size_t size(size_t length) { return sizeof(IdList) + length * sizeof(uintptr_t); }
+
+private:
+   const size_t _length;
+   uintptr_t _ids[];
+   };
+
+
+struct ClassChainSerializationRecord : public AOTSerializationRecord
+   {
+public:
+   const IdList &list() const { return _list; }
+
+private:
+   template<class D, class R, typename... Args> friend class AOTCacheListRecord;
+
+   ClassChainSerializationRecord(uintptr_t id, size_t length);
+
+   IdList &list() { return _list; }
+
+   static size_t size(size_t length)
+      {
+      return offsetof(ClassChainSerializationRecord, _list) + IdList::size(length);
+      }
+
+   // List of class IDs
+   IdList _list;
+   };
+
+
+struct WellKnownClassesSerializationRecord : public AOTSerializationRecord
+   {
+public:
+   uintptr_t includedClasses() const { return _includedClasses; }
+   const IdList &list() const { return _list; }
+
+private:
+   template<class D, class R, typename... Args> friend class AOTCacheListRecord;
+
+   WellKnownClassesSerializationRecord(uintptr_t id, size_t length, uintptr_t includedClasses);
+
+   IdList &list() { return _list; }
+
+   static size_t size(size_t length)
+      {
+      return offsetof(WellKnownClassesSerializationRecord, _list) + IdList::size(length);
+      }
+
+   // Bit mask representing which classes out of the predefined well-known set are included
+   const uintptr_t _includedClasses;
+   // List of class chain IDs
+   IdList _list;
+   };
+
+
+struct AOTHeaderSerializationRecord : public AOTSerializationRecord
+   {
+public:
+   const TR_AOTHeader *header() const { return &_header; }
+
+private:
+   friend class AOTCacheAOTHeaderRecord;
+
+   AOTHeaderSerializationRecord(uintptr_t id, const TR_AOTHeader *header);
+
+   const TR_AOTHeader _header;
+   };
+
+
+// Represents an SCC offset stored in AOT method relocation data that will be updated during deserialization
+struct SerializedSCCOffset
+   {
+public:
+   SerializedSCCOffset(uintptr_t recordId, AOTSerializationRecordType recordType, uintptr_t reloDataOffset) :
+      _recordIdAndType(AOTSerializationRecord::idAndType(recordId, recordType)), _reloDataOffset(reloDataOffset)
+      {
+      TR_ASSERT((recordType > AOTSerializationRecordType::ClassLoader) &&
+                (recordType < AOTSerializationRecordType::AOTHeader), "Invalid record type: %u", recordType);
+      }
+
+   uintptr_t recordId() const { return AOTSerializationRecord::getId(_recordIdAndType); }
+   AOTSerializationRecordType recordType() const { return AOTSerializationRecord::getType(_recordIdAndType); }
+   uintptr_t reloDataOffset() const { return _reloDataOffset; }
+
+private:
+   // ID and type of the corresponding serialization record
+   const uintptr_t _recordIdAndType;
+   // Offset into AOT method relocation data where the SCC offset to be updated is stored
+   const uintptr_t _reloDataOffset;
+   };
+
+
+struct SerializedAOTMethod
+   {
+public:
+   SerializedAOTMethod(const SerializedAOTMethod &) = delete;
+   void operator=(const SerializedAOTMethod &) = delete;
+
+   size_t size() const { return _size; }
+   uintptr_t definingClassChainId() const { return _definingClassChainId; }
+   uint32_t index() const { return _index; }
+   TR_Hotness optLevel() const { return _optLevel; }
+   uintptr_t aotHeaderId() const { return _aotHeaderId; }
+   size_t numRecords() const { return _numRecords; }
+   size_t codeSize() const { return _codeSize; }
+   size_t dataSize() const { return _dataSize; }
+   const SerializedSCCOffset *offsets() const { return (const SerializedSCCOffset *)_varSizedData; }
+   SerializedSCCOffset *offsets() { return (SerializedSCCOffset *)_varSizedData; }
+   const uint8_t *code() const { return (const uint8_t *)(offsets() + _numRecords); }
+   const uint8_t *data() const { return code() + _codeSize; }
+   uint8_t *data() { return (uint8_t *)(code() + _codeSize); }
+   const uint8_t *end() const { return (const uint8_t *)this + size(); }
+
+   static SerializedAOTMethod *get(std::string &str)
+      {
+      auto method = (SerializedAOTMethod *)str.data();
+      TR_ASSERT((str.size() >= sizeof(*method)) && (str.size() == method->_size), "Invalid size");
+      return method;
+      }
+
+private:
+   friend class CachedAOTMethod;
+
+   SerializedAOTMethod(uintptr_t definingClassChainId, uint32_t index,
+                       TR_Hotness optLevel, uintptr_t aotHeaderId, size_t numRecords,
+                       const void *code, size_t codeSize, const void *data, size_t dataSize);
+
+   static size_t size(size_t numRecords, size_t codeSize, size_t dataSize)
+      {
+      return sizeof(SerializedAOTMethod) + numRecords * sizeof(SerializedSCCOffset) +
+             OMR::alignNoCheck(codeSize + dataSize, sizeof(size_t));
+      }
+
+   const size_t _size;
+   const uintptr_t _definingClassChainId;
+   // Index in the array of methods of the defining class
+   const uint32_t _index;
+   const TR_Hotness _optLevel;
+   // Represents the TR_AOTHeader of the client JVM that this method was originally compiled for
+   const uintptr_t _aotHeaderId;
+   // Number of serialization records and corresponding SCC offsets
+   const size_t _numRecords;
+   const size_t _codeSize;
+   const size_t _dataSize;
+   // Layout: SerializedSCCOffset offsets[_numRecords], uint8_t code[_codeSize], uint8_t data[_dataSize]
+   uint8_t _varSizedData[];
+   };
+
+
+#endif /* defined(JITSERVER_AOT_SERIALIZATION_RECORDS_H) */

--- a/runtime/compiler/runtime/JITServerSharedROMClassCache.cpp
+++ b/runtime/compiler/runtime/JITServerSharedROMClassCache.cpp
@@ -224,9 +224,9 @@ JITServerSharedROMClassCache::release(J9ROMClass *romClass)
 
 const JITServerROMClassHash &
 JITServerSharedROMClassCache::getHash(const J9ROMClass *romClass)
-{
+   {
    return *Entry::get(romClass)->_hash;
-}
+   }
 
 JITServerSharedROMClassCache::Partition &
 JITServerSharedROMClassCache::getPartition(const JITServerROMClassHash &hash)

--- a/runtime/compiler/runtime/JITServerSharedROMClassCache.cpp
+++ b/runtime/compiler/runtime/JITServerSharedROMClassCache.cpp
@@ -37,7 +37,7 @@ struct JITServerSharedROMClassCache::Entry
       }
 
    // The ROMClass is embedded in this structure in order to avoid exposing it in the API
-   static Entry *get(J9ROMClass *romClass)
+   static Entry *get(const J9ROMClass *romClass)
       {
       auto entry = (Entry *)((uint8_t *)romClass - offsetof(Entry, _data));
       TR_ASSERT_FATAL(entry->_eyeCatcher == JITSERVER_SHARED_ROMCLASS_EYECATCHER,
@@ -221,6 +221,12 @@ JITServerSharedROMClassCache::release(J9ROMClass *romClass)
    if (entry->release() == 0)
       getPartition(*entry->_hash).release(entry);
    }
+
+const JITServerROMClassHash &
+JITServerSharedROMClassCache::getHash(const J9ROMClass *romClass)
+{
+   return *Entry::get(romClass)->_hash;
+}
 
 JITServerSharedROMClassCache::Partition &
 JITServerSharedROMClassCache::getPartition(const JITServerROMClassHash &hash)

--- a/runtime/compiler/runtime/JITServerSharedROMClassCache.hpp
+++ b/runtime/compiler/runtime/JITServerSharedROMClassCache.hpp
@@ -47,6 +47,9 @@ public:
    J9ROMClass *getOrCreate(const J9ROMClass *packedROMClass);
    void release(J9ROMClass *romClass);
 
+   // Get precomputed hash of a shared ROMClass
+   static const JITServerROMClassHash &getHash(const J9ROMClass *romClass);
+
 private:
    struct Entry;
    struct Partition;


### PR DESCRIPTION
This PR defines AOT serialization records and serialized AOT method format, and adds the infrastructure needed to store and lookup serialized AOT methods in the JITServer AOT cache. See #12153 for a high-level description of the design.

`JITServerAOTCacheRecords.hpp` contains the definitions of data structures that will be used by both the server and the client, including serialized AOT methods and AOT serialization records. `JITServerAOTCache.hpp` defines the data structures used only on the server side. `JITServerAOTCache` is the main class that implements creation, storage and lookup of serialization records (which will be performed during AOT compilations) and caching of serialized AOT methods. While the current implementation only supports "private" in-memory storage (using the persistent allocator), in the future the cache can potentially be persisted and shared between multiple JITServer instances.

JITServer can maintain multiple AOT cache instances identified by name, e.g. corresponding to the SCC names used by its clients. Each client that has AOT cache enabled will be using a single `JITServerAOTCache` instance. The name-to-cache mapping is implemented in the `JITServerAOTCacheMap` class.

Note that it would be difficult to use the existing AOT relocation/validation record infrastructure for AOT serialization records since it assumes fixed-size records and doesn't have the notion of dependencies between records. AOT serialization records are variable-sized (e.g. contain class names) and can refer to other records.