### PR TITLE
Fix two issues in MethodHandleTransformer

### DIFF
--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -2391,6 +2391,12 @@ J9::TransformUtil::refineMethodHandleInvokeBasic(TR::Compilation* comp, TR::Tree
        (symRef->getOwningMethodIndex(), -1, refinedMethod, TR::MethodSymbol::Static);
 
    TR::Node::recreateWithSymRef(node, refinedMethod->directCallOpCode(), newSymRef);
+   // doNotProfile flag is used to imply whether the bytecode can OSR under voluntary OSR. Above transformation
+   // will set this flag to indicate the node cannot OSR. However, the transformation does not change the operand
+   // stack and local state before the call, hence it can OSR.
+   //
+   node->getByteCodeInfo().setDoNotProfile(false);
+
    return true;
 #else
    return false;
@@ -2522,6 +2528,11 @@ J9::TransformUtil::refineMethodHandleLinkTo(TR::Compilation* comp, TR::TreeTop* 
       node->removeAllChildren();
       // Recreate the node to a indirect call node
       TR::Node::recreateWithoutProperties(node, callOpCode, numArgs, vftLoad, newSymRef);
+      // doNotProfile flag is used to imply whether the bytecode can OSR under voluntary OSR. Above transformation
+      // will set this flag to indicate the node cannot OSR. However, the transformation does not change the operand
+      // stack and local state before the call, hence it can OSR.
+      //
+      node->getByteCodeInfo().setDoNotProfile(false);
 
       for (int32_t i = 0; i < numArgs - 1; i++)
          node->setAndIncChild(i + 1, args[i]);

--- a/runtime/compiler/optimizer/MethodHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/MethodHandleTransformer.cpp
@@ -234,6 +234,18 @@ TR_MethodHandleTransformer::ObjectInfo*
 TR_MethodHandleTransformer::blockStartObjectInfoFromPredecessors(TR::Block* block)
    {
    auto blockNum = block->getNumber();
+   // If there exist an exception edge coming into this block, we don't know the object info at
+   // the time of the exception, thus initialize the object info for all locals to unknown for
+   // this block
+   //
+   if (block->isCatchBlock())
+      {
+      if (trace())
+         traceMsg(comp(), "block_%d has exception predecessor, initialize all local slots to unknown object\n", blockNum);
+
+      return new (comp()->trMemory()->currentStackRegion()) ObjectInfo(_numLocals, static_cast<int>(TR::KnownObjectTable::UNKNOWN), comp()->trMemory()->currentStackRegion());
+      }
+
    // If there exists one or more predecessor unvisited, the unvisited predecessor must be from a back edge.
    // Don't propagate as we don't know what might happen from the predecessor.
    //


### PR DESCRIPTION
This PR does the following things:
1. Don't set `doNotProfile` on refined `invokeBasic`/`linkTo*` calls. The transformation doesn't change the operand stack and local state before the call, thus the call can OSR.
2. Don't propagate any local object info to catch block, as the local object info on exception edges is unknown.