### PR TITLE
Remove the extra module in error msgs

### DIFF
--- a/runtime/vm/lookupmethod.c
+++ b/runtime/vm/lookupmethod.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1016,10 +1016,8 @@ getModuleNameUTF(J9VMThread *currentThread, j9object_t	moduleObject, char *buffe
 		nameBuffer = buffer;
 #undef	UNNAMED_MODULE
 	} else {
-#define NAMED_MODULE   "module "
 		nameBuffer = copyStringToUTF8WithMemAlloc(
-			currentThread, module->moduleName, J9_STR_NULL_TERMINATE_RESULT, NAMED_MODULE, strlen(NAMED_MODULE), buffer, bufferLength, NULL);
-#undef	NAMED_MODULE
+			currentThread, module->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, buffer, bufferLength, NULL);
 	}
 	return nameBuffer;
 }


### PR DESCRIPTION
Remove the extra module in error msgs

Currently we output messages with "because module module com.test does
not read module module hamcrest.core". We insert the pre-pending
"module" when printing out module names in `getModuleNameUTF`.

Fixes #12315

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>