### PR TITLE
Fix x86 macOS compilation error in SignalHandler.c

### DIFF
--- a/runtime/compiler/runtime/SignalHandler.c
+++ b/runtime/compiler/runtime/SignalHandler.c
@@ -23,6 +23,7 @@
 #include "j9protos.h"
 #include "j9cfg.h"
 #include <assert.h>
+#include <stdlib.h>
 
 #if defined(TR_TARGET_S390) && defined(LINUX)
 #define FPE_DECDATA 86


### PR DESCRIPTION
`getenv` requires `stdlib.h` to be included.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>