### PR TITLE
Add more acmp fastpath in the JIT and move the helper call out of line

### DIFF
--- a/runtime/compiler/optimizer/TreeLowering.cpp
+++ b/runtime/compiler/optimizer/TreeLowering.cpp
@@ -57,6 +57,53 @@ TR::TreeLowering::perform()
    return 0;
    }
 
+void
+TR::TreeLowering::moveNodeToEndOfBlock(TR::Block* const block, TR::TreeTop* const tt, TR::Node* const node)
+   {
+   TR::Compilation* comp = self()->comp();
+   TR::TreeTop* blockExit = block->getExit();
+   TR::TreeTop* iterTT = tt->getNextTreeTop();
+
+   if (iterTT != blockExit)
+      {
+      if (trace())
+         {
+         traceMsg(comp, "Moving treetop containing node n%dn [%p] for acmp helper call to end of prevBlock in preparation of final block split\n", tt->getNode()->getGlobalIndex(), tt->getNode());
+         }
+
+      // Remove TreeTop for call node, and gather it and the treetops for stores that
+      // resulted from un-commoning in a TreeTop chain from tt to lastTTForCallBlock
+      tt->unlink(false);
+      TR::TreeTop* lastTTForCallBlock = tt;
+
+      while (iterTT != blockExit)
+         {
+         TR::TreeTop* nextTT = iterTT->getNextTreeTop();
+         TR::ILOpCodes op = iterTT->getNode()->getOpCodeValue();
+
+         if ((op == TR::iRegStore || op == TR::istore) && iterTT->getNode()->getFirstChild() == node)
+            {
+            if (trace())
+               {
+               traceMsg(comp, "Moving treetop containing node n%dn [%p] for store of acmp helper result to end of prevBlock in preparation of final block split\n", iterTT->getNode()->getGlobalIndex(), iterTT->getNode());
+               }
+
+            // Remove store node from prevBlock temporarily
+            iterTT->unlink(false);
+            lastTTForCallBlock->join(iterTT);
+            lastTTForCallBlock = iterTT;
+            }
+
+         iterTT = nextTT;
+         }
+
+      // Move the treetops that were gathered for the call and any stores of the
+      // result to the end of the block in preparation for the split of the call block
+      blockExit->getPrevTreeTop()->join(tt);
+      lastTTForCallBlock->join(blockExit);
+      }
+   }
+
 /**
  * @brief Perform lowering related to Valhalla value types
  *
@@ -313,47 +360,7 @@ TR::TreeLowering::fastpathAcmpHelper(TR::Node * const node, TR::TreeTop * const 
    // to splitPostGRA above.  Move the acmp helper call treetop to the end of prevBlock, along with
    // any stores resulting from un-commoning of the nodes in the helper call tree so that it can be
    // split into its own call block.
-   TR::TreeTop* prevBlockExit = callBlock->getExit();
-   TR::TreeTop* iterTT = tt->getNextTreeTop();
-
-   if (iterTT != prevBlockExit)
-      {
-      if (trace())
-         {
-         traceMsg(comp, "Moving treetop containing node n%dn [%p] for acmp helper call to end of prevBlock in preparation of final block split\n", tt->getNode()->getGlobalIndex(), tt->getNode());
-         }
-
-      // Remove TreeTop for call node, and gather it and the treetops for stores that
-      // resulted from un-commoning in a TreeTop chain from tt to lastTTForCallBlock
-      tt->unlink(false);
-      TR::TreeTop* lastTTForCallBlock = tt;
-
-      while (iterTT != prevBlockExit)
-         {
-         TR::TreeTop* nextTT = iterTT->getNextTreeTop();
-         TR::ILOpCodes op = iterTT->getNode()->getOpCodeValue();
-
-         if ((op == TR::iRegStore || op == TR::istore) && iterTT->getNode()->getFirstChild() == node)
-            {
-            if (trace())
-               {
-               traceMsg(comp, "Moving treetop containing node n%dn [%p] for store of acmp helper result to end of prevBlock in preparation of final block split\n", iterTT->getNode()->getGlobalIndex(), iterTT->getNode());
-               }
-
-            // Remove store node from prevBlock temporarily
-            iterTT->unlink(false);
-            lastTTForCallBlock->join(iterTT);
-            lastTTForCallBlock = iterTT;
-            }
-
-         iterTT = nextTT;
-         }
-
-      // Move the treetops that were gathered for the call and any stores of the
-      // result to the end of the block in preparation for the split of the call block
-      prevBlockExit->getPrevTreeTop()->join(tt);
-      lastTTForCallBlock->join(prevBlockExit);
-      }
+   moveNodeToEndOfBlock(callBlock, tt, node);
 
    if (!performTransformation(comp, "%sInserting fastpath for lhs == rhs\n", optDetailString()))
       return;

--- a/runtime/compiler/optimizer/TreeLowering.hpp
+++ b/runtime/compiler/optimizer/TreeLowering.hpp
@@ -65,7 +65,7 @@ class TreeLowering : public TR::Optimization
 
    // helpers related to Valhalla value type lowering
    void lowerValueTypeOperations(TR::Node* node, TR::TreeTop* tt);
-   void fastpathAcmpHelper(TR::Node* node, TR::TreeTop* tt);
+   void fastpathAcmpHelper(TR::Node* const node, TR::TreeTop* const tt);
    void lowerArrayStoreCHK(TR::Node* node, TR::TreeTop* tt);
    };
 

--- a/runtime/compiler/optimizer/TreeLowering.hpp
+++ b/runtime/compiler/optimizer/TreeLowering.hpp
@@ -64,6 +64,20 @@ class TreeLowering : public TR::Optimization
    private:
 
    /**
+    * @brief Moves a node down to the end of a block
+    *
+    * Any stores of the value of the node are also moved down.
+    *
+    * This can be useful to do after a call to splitPostGRA where, as part of un-commoning,
+    * it is possible that code to store the anchored node into a register or temp-slot is
+    * appended to the original block.
+    *
+    * @param block is the block containing the TreeTop to be moved
+    * @param tt is a pointer to the TreeTop to be moved
+    */
+   void moveNodeToEndOfBlock(TR::Block* const block, TR::TreeTop* const tt, TR::Node* const node);
+
+   /**
     * @brief Split a block after having inserted a fastpath branch
     *
     * The function should be used to split a block after a branch has been inserted.

--- a/runtime/compiler/optimizer/TreeLowering.hpp
+++ b/runtime/compiler/optimizer/TreeLowering.hpp
@@ -27,6 +27,7 @@
 #include "il/Node_inlines.hpp"
 #include "il/TreeTop.hpp"
 #include "il/TreeTop_inlines.hpp"
+#include "infra/ILWalk.hpp"
 #include "optimizer/Optimization.hpp"
 #include "optimizer/Optimization_inlines.hpp"
 #include "optimizer/OptimizationManager.hpp"
@@ -99,8 +100,8 @@ class TreeLowering : public TR::Optimization
    TR::Block* splitForFastpath(TR::Block* const block, TR::TreeTop* const splitPoint, TR::Block* const targetBlock);
 
    // helpers related to Valhalla value type lowering
-   void lowerValueTypeOperations(TR::Node* node, TR::TreeTop* tt);
-   void fastpathAcmpHelper(TR::Node* const node, TR::TreeTop* const tt);
+   void lowerValueTypeOperations(TR::PreorderNodeIterator& nodeIter, TR::Node* node, TR::TreeTop* tt);
+   void fastpathAcmpHelper(TR::PreorderNodeIterator& nodeIter, TR::Node* const node, TR::TreeTop* const tt);
    void lowerArrayStoreCHK(TR::Node* node, TR::TreeTop* tt);
    };
 

--- a/runtime/compiler/optimizer/TreeLowering.hpp
+++ b/runtime/compiler/optimizer/TreeLowering.hpp
@@ -63,6 +63,27 @@ class TreeLowering : public TR::Optimization
 
    private:
 
+   /**
+    * @brief Split a block after having inserted a fastpath branch
+    *
+    * The function should be used to split a block after a branch has been inserted.
+    * After the split, the resulting fall-through block is marked as an extension of
+    * the previous block (the original block that was split), which implies that 
+    * uncommoning is not required. The cfg is also updated with an edge going from
+    * the original block to some target block, which should be the same as the
+    * target of the branch inserted before the split.
+    *
+    * Note that this function does not call TR::CFG::invalidateStructure() as it assumes
+    * the caller is using this function in a context where TR::CFG::invalidateStructure()
+    * is likely to have already been called.
+    *
+    * @param block is the block that will be split
+    * @param splitPoint is the TreeTop within block at which the split must happen
+    * @param targetBlock is the target block of the branch inserted before the split point
+    * @return TR::Block* the (fallthrough) block created from the split
+    */
+   TR::Block* splitForFastpath(TR::Block* const block, TR::TreeTop* const splitPoint, TR::Block* const targetBlock);
+
    // helpers related to Valhalla value type lowering
    void lowerValueTypeOperations(TR::Node* node, TR::TreeTop* tt);
    void fastpathAcmpHelper(TR::Node* const node, TR::TreeTop* const tt);


### PR DESCRIPTION
This PR introduces additional fastpaths for acmp by inlining some of the checks performed by the VM helper. The fastpaths are added in the treeLowering optimizations. A few helper functions are also introduced to make the code more readable.