### PR TITLE
Fix uses of flags which were not always defined

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/OptInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/OptInfo.java
@@ -27,7 +27,6 @@ import static com.ibm.j9ddr.vm29.structure.J9NonbuilderConstants.J9_ROMCLASS_OPT
 import static com.ibm.j9ddr.vm29.structure.J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_ENCLOSING_METHOD;
 import static com.ibm.j9ddr.vm29.structure.J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_GENERIC_SIGNATURE;
 import static com.ibm.j9ddr.vm29.structure.J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_PERMITTEDSUBCLASSES_ATTRIBUTE;
-import static com.ibm.j9ddr.vm29.structure.J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_INJECTED_INTERFACE_INFO;
 import static com.ibm.j9ddr.vm29.structure.J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_SIMPLE_NAME;
 import static com.ibm.j9ddr.vm29.structure.J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_SOURCE_DEBUG_EXTENSION;
 import static com.ibm.j9ddr.vm29.structure.J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_SOURCE_FILE_NAME;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCSegmentIterator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCSegmentIterator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,8 +60,8 @@ public class GCSegmentIterator extends GCIterator
 	public boolean hasNext() 
 	{
 		try {
-			while(memorySegment.notNull()) {
-				if(memorySegment.type().allBitsIn(flags)) {
+			while (memorySegment.notNull()) {
+				if ((0 == flags) || memorySegment.type().allBitsIn(flags)) {
 					return true;
 				}
 				memorySegment = memorySegment.nextSegment();

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/AbstractPointer.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/AbstractPointer.java
@@ -82,7 +82,18 @@ public abstract class AbstractPointer extends DataType {
 	public abstract AbstractPointer untag(long tagBits);
 	public abstract AbstractPointer untag();
 
-	public boolean allBitsIn(long bitmask) {
+	public final boolean allBitsIn(long bitmask) {
+		if (0 == bitmask) {
+			/*
+			 * In the vast majority of situations, the caller supplies a non-zero
+			 * argument. However, in backwards-compatibility cases the argument
+			 * may be derived from a constant which has not always been present.
+			 * The behavior we want is for such tests to return false (such a bit
+			 * could never have been set in core dumps generated before the constant
+			 * existed).
+			 */
+			return false;
+		}
 		return bitmask == (address & bitmask);
 	}
 	
@@ -108,7 +119,8 @@ public abstract class AbstractPointer extends DataType {
 	public boolean eq(Object obj) {
 		return equals(obj);
 	}
-	
+
+	@Override
 	public boolean equals(Object obj) {
 		if (obj == null) {
 			return false;
@@ -120,7 +132,8 @@ public abstract class AbstractPointer extends DataType {
 		
 		return address == ((AbstractPointer) obj).address;
 	}
-	
+
+	@Override
 	public int hashCode() {
 		return (int)((0xFFFFFFFFL & address) ^ ((0xFFFFFFFF00000000L & address) >> 32));
 	}
@@ -138,7 +151,7 @@ public abstract class AbstractPointer extends DataType {
 	}
 
 	public String getHexAddress() {
-		return String.format("0x%0" + UDATA.SIZEOF * 2 + "X", address);
+		return String.format("0x%0" + (UDATA.SIZEOF * 2) + "X", address);
 	}
 	
 	/**

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ValueTypeHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ValueTypeHelper.java
@@ -215,18 +215,12 @@ public class ValueTypeHelper {
 
 		@Override
 		public boolean isRomClassAValueType(J9ROMClassPointer romClass) throws CorruptDataException {
-			if (J9JavaAccessFlags.J9AccValueType != 0) {
-				return romClass.modifiers().allBitsIn(J9JavaAccessFlags.J9AccValueType);
-			}
-			return false;
+			return romClass.modifiers().allBitsIn(J9JavaAccessFlags.J9AccValueType);
 		}
 
 		@Override
 		public boolean isJ9ClassAValueType(J9ClassPointer clazz) throws CorruptDataException {
-			if (J9JavaClassFlags.J9ClassIsValueType != 0) {
-				return clazz.classFlags().allBitsIn(J9JavaClassFlags.J9ClassIsValueType);
-			}
-			return false;
+			return clazz.classFlags().allBitsIn(J9JavaClassFlags.J9ClassIsValueType);
 		}
 
 		@Override
@@ -254,34 +248,22 @@ public class ValueTypeHelper {
 
 		@Override
 		public boolean isJ9ClassLargestAlignmentConstraintDouble(J9ClassPointer clazz) throws CorruptDataException {
-			if (J9JavaClassFlags.J9ClassLargestAlignmentConstraintDouble != 0) {
-				return J9ClassHelper.extendedClassFlags(clazz).allBitsIn(J9JavaClassFlags.J9ClassLargestAlignmentConstraintDouble);
-			}
-			return false;
+			return J9ClassHelper.extendedClassFlags(clazz).allBitsIn(J9JavaClassFlags.J9ClassLargestAlignmentConstraintDouble);
 		}
 
 		@Override
 		public boolean isJ9ClassLargestAlignmentConstraintReference(J9ClassPointer clazz) throws CorruptDataException {
-			if (J9JavaClassFlags.J9ClassLargestAlignmentConstraintReference != 0) {
-				return J9ClassHelper.extendedClassFlags(clazz).allBitsIn(J9JavaClassFlags.J9ClassLargestAlignmentConstraintReference);
-			}
-			return false;
+			return J9ClassHelper.extendedClassFlags(clazz).allBitsIn(J9JavaClassFlags.J9ClassLargestAlignmentConstraintReference);
 		}
 
 		@Override
 		public boolean isJ9ClassIsFlattened(J9ClassPointer clazz) throws CorruptDataException {
-			if (J9JavaClassFlags.J9ClassIsFlattened != 0) {
-				return J9ClassHelper.extendedClassFlags(clazz).allBitsIn(J9JavaClassFlags.J9ClassIsFlattened);
-			}
-			return false;
+			return J9ClassHelper.extendedClassFlags(clazz).allBitsIn(J9JavaClassFlags.J9ClassIsFlattened);
 		}
-		
+
 		@Override
 		public boolean classRequires4BytePrePadding(J9ClassPointer clazz) throws CorruptDataException {
-			if (J9JavaClassFlags.J9ClassRequiresPrePadding != 0) {
-				return J9ClassHelper.extendedClassFlags(clazz).allBitsIn(J9JavaClassFlags.J9ClassRequiresPrePadding);
-			}
-			return false;
+			return J9ClassHelper.extendedClassFlags(clazz).allBitsIn(J9JavaClassFlags.J9ClassRequiresPrePadding);
 		}
 
 		@Override

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/Scalar.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/Scalar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,7 +68,7 @@ public abstract class Scalar extends DataType {
 	}
 
 	public String getHexValue() {
-		return String.format("0x%0" + sizeof() * 2 + "X", data);
+		return String.format("0x%0" + (sizeof() * 2) + "X", data);
 	}
 
 	protected String toStringPattern;
@@ -217,7 +217,18 @@ public abstract class Scalar extends DataType {
 		return new UDATA(result);
 	}
 
-	public boolean allBitsIn(long bitmask) {
+	public final boolean allBitsIn(long bitmask) {
+		if (0 == bitmask) {
+			/*
+			 * In the vast majority of situations, the caller supplies a non-zero
+			 * argument. However, in backwards-compatibility cases the argument
+			 * may be derived from a constant which has not always been present.
+			 * The behavior we want is for such tests to return false (such a bit
+			 * could never have been set in core dumps generated before the constant
+			 * existed).
+			 */
+			return false;
+		}
 		return bitmask == (data & bitmask);
 	}
 


### PR DESCRIPTION
The two implementations of `allBitsIn()` have been updated to return `false` when the argument is zero. The one caller that relied on the old behavior of `allBitsIn(0)` has been updated. Other redundant checks at call sites have been removed.

See https://github.com/eclipse/openj9/issues/12312#issuecomment-809752178.