### PR TITLE
Fix object layout if a flattening threshold is set

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corp. and others
+ * Copyright (c) 2015, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -213,8 +213,13 @@ public class ObjectFieldInfo {
 	boolean
 	isBackfillSuitableInstanceSingleAvailable()
 	{
-		return ((0 != getInstanceSingleCount())
-				|| (0 != getFlatAlignedSingleInstanceBackfillSize())
+		return (0 != getInstanceSingleCount());
+	}
+	
+	boolean
+	isBackfillSuitableFlatInstanceSingleAvailable()
+	{
+		return ((0 != getFlatAlignedSingleInstanceBackfillSize())
 				|| (0 != getFlatUnAlignedSingleInstanceBackfillSize()));
 	}
 
@@ -640,7 +645,7 @@ public class ObjectFieldInfo {
 	getNonBackfilledFlatInstanceSingleSize()
 	{
 		int nonBackfilledFlatSinglesSize = totalFlatFieldSingleBytes;
-		if (isBackfillSuitableInstanceSingleAvailable()
+		if (isBackfillSuitableFlatInstanceSingleAvailable()
 			&& isMyBackfillSlotAvailable()
 			&& (0 == getInstanceSingleCount())
 			&& (objectCanUseBackfill && (0 == getInstanceObjectCount()))

--- a/runtime/vm/ObjectFieldInfo.hpp
+++ b/runtime/vm/ObjectFieldInfo.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -308,12 +308,20 @@ public:
 	VMINLINE bool
 	isBackfillSuitableInstanceSingleAvailable(void) const
 	{
-		return ((0 != getInstanceSingleCount())
+		return (0 != getInstanceSingleCount());
+	}
+	
+	VMINLINE bool
+	isBackfillSuitableFlatInstanceSingleAvailable(void) const
+	{
+		
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-				|| (0 != getFlatAlignedSingleInstanceBackfillSize())
-				|| (0 != getFlatUnAlignedSingleInstanceBackfillSize())
+		return ((0 != getFlatAlignedSingleInstanceBackfillSize())
+				|| (0 != getFlatUnAlignedSingleInstanceBackfillSize()));
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+		return false;
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
-		);
+		
 	}
 
 	VMINLINE bool
@@ -732,7 +740,7 @@ public:
 	getNonBackfilledFlatInstanceSingleSize(void) const
 	{
 		U_32 nonBackfilledFlatSinglesSize = _totalFlatFieldSingleBytes;
-		if (isBackfillSuitableInstanceSingleAvailable()
+		if (isBackfillSuitableFlatInstanceSingleAvailable()
 			&& isMyBackfillSlotAvailable()
 			&& (0 == getInstanceSingleCount())
 			&& (_objectCanUseBackfill && (0 == getInstanceObjectCount()))

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -28,6 +28,9 @@
 			<variation> -XX:ValueTypeFlatteningThreshold=99999 -Xgcpolicy:optthruput -XX:-EnableArrayFlattening</variation>
 			<variation>-Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
 			<variation>-Xgcpolicy:gencon -XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+			<!-- Use -XX:-EnableArrayFlattening. testDefaultValueInTriangleArray asserts the fields of each element are not NULL, 
+					which is not true as a FlatteningThreshold is set. -->
+			<variation>-Xgcpolicy:gencon -XX:ValueTypeFlatteningThreshold=12 -XX:-EnableArrayFlattening</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		-Xverify:none \


### PR DESCRIPTION
1. If using an object reference field as backfill, its type should be
Ltype or non-flattened Qtype. So add checks for Qtype and 
J9ClassIsFlattened before using object reference as backfill.

2. From the backfill priority list, instance singles, flat
end-aligned/unaligned singles singles are different.
isBackfillSuitableInstanceSingleAvailable() should not include flat
singles.

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>