### PR TITLE
Add support for sun.stderr.encoding and sun.stdout.encoding

### DIFF
--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_console.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_console.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2021, 2021 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 Command-Line Option Tests" timeout="180">
+  <variable name="CP" value="-cp $Q$$JARPATH$$Q$" />
+  <variable name="TARGET" value="GetConsoleCharset" />
+  <variable name="OPENS" value="--add-opens=java.base/java.io=ALL-UNNAMED"/>
+  <if testVariable="JDK_VERSION" testValue="8" resultVariable="OPENS" resultValue=" "/>
+  <variable name="DEFAULT_ENCODING_PROP" value="file.encoding" />
+  <variable name="DEFAULT_ENCODING_PROP" value="ibm.system.encoding" platforms="zos.*" />
+  <!-- Use an encoding supported by Java 8 and in the java.base module -->
+  <variable name="ENCODING1" value="ISO8859_2" />
+  <!-- Use an encoding supported by Java 8 and in the jdk.charsets module -->
+  <variable name="ENCODING2" value="Cp948" />
+
+  <test id="$DEFAULT_ENCODING_PROP$ System.out $ENCODING1$">
+    <command>$EXE$ $OPENS$ $CP$ -D$DEFAULT_ENCODING_PROP$=$ENCODING1$ $TARGET$ out $ENCODING1$</command>
+    <return type="success" value="0" />
+  </test>
+
+  <test id="$DEFAULT_ENCODING_PROP$ System.err $ENCODING1$">
+    <command>$EXE$ $OPENS$ $CP$ -D$DEFAULT_ENCODING_PROP$=$ENCODING1$ $TARGET$ err $ENCODING1$</command>
+    <return type="success" value="0" />
+  </test>
+
+  <test id="sun.stdout.encoding $ENCODING1$">
+    <command>$EXE$ $OPENS$ $CP$ -D$DEFAULT_ENCODING_PROP$=$ENCODING2$ -Dsun.stdout.encoding=$ENCODING1$ $TARGET$ out $ENCODING1$</command>
+    <return type="success" value="0" />
+  </test>
+
+  <test id="sun.stderr.encoding $ENCODING1$">
+    <command>$EXE$ $OPENS$ $CP$ -D$DEFAULT_ENCODING_PROP$=$ENCODING2$ -Dsun.stderr.encoding=$ENCODING1$ $TARGET$ err $ENCODING1$</command>
+    <return type="success" value="0" />
+  </test>
+
+  <test id="$DEFAULT_ENCODING_PROP$ System.out $ENCODING2$">
+    <command>$EXE$ $OPENS$ $CP$ -D$DEFAULT_ENCODING_PROP$=$ENCODING2$ $TARGET$ out $ENCODING2$</command>
+    <return type="success" value="0" />
+  </test>
+
+  <test id="$DEFAULT_ENCODING_PROP$ System.err $ENCODING2$">
+    <command>$EXE$ $OPENS$ $CP$ -D$DEFAULT_ENCODING_PROP$=$ENCODING2$ $TARGET$ err $ENCODING2$</command>
+    <return type="success" value="0" />
+  </test>
+
+  <test id="sun.stdout.encoding $ENCODING2$">
+    <command>$EXE$ $OPENS$ $CP$ -Dsun.stdout.encoding=$ENCODING2$ $TARGET$ out $ENCODING2$</command>
+    <return type="success" value="0" />
+  </test>
+
+  <test id="sun.stderr.encoding $ENCODING2$">
+    <command>$EXE$ $OPENS$ $CP$ -Dsun.stderr.encoding=$ENCODING2$ $TARGET$ err $ENCODING2$</command>
+    <return type="success" value="0" />
+  </test>
+
+</suite>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
@@ -140,4 +140,51 @@
 			<impl>openj9</impl>
 		</impls>
 	</test>
+	<test>
+		<testCaseName>cmdLineTest_J9test_console</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-DJARPATH=$(Q)$(TEST_RESROOT)$(D)cmdLineTest_J9tests.jar$(Q) -DJDK_VERSION=$(JDK_VERSION) \
+	-DJVMLIBPATH=$(Q)$(J9VM_PATH)$(Q) \
+	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)j9tests_console.xml$(Q) \
+	-xids all,$(PLATFORM) -plats all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)j9tests_exclude.xml$(Q) \
+	-explainExcludes -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>cmdLineTest_J9test_console_zos</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-DJARPATH=$(Q)$(TEST_RESROOT)$(D)cmdLineTest_J9tests.jar$(Q) -DJDK_VERSION=$(JDK_VERSION) \
+	-DJVMLIBPATH=$(Q)$(J9VM_PATH)$(Q) \
+	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)j9tests_console.xml$(Q) \
+	-xids all,$(PLATFORM) -plats all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)j9tests_exclude.xml$(Q) \
+	-explainExcludes -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<platformRequirements>os.zos</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>11+</version>
+		</versions>
+		<impls>
+			<impl>ibm</impl>
+			<impl>openj9</impl>
+		</impls>
+	</test>
 </playlist>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/src/GetConsoleCharset.java
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/src/GetConsoleCharset.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import java.io.*;
+import java.lang.reflect.*;
+import java.nio.charset.*;
+
+/**
+ * @file GetConsoleCharset.java
+ * @brief Compare the System.err or System.out Charset name to a provided name and
+ * return the result via the exit code, 0 meaning there is a match.
+ */
+
+public class GetConsoleCharset {
+	public static void main(String[] args) throws Exception {
+		OutputStream stream;
+		if (args.length < 2) {
+			System.out.println("Provide two arguments, the first is either 'out' or 'err', and the second is the expected Charset name.");
+			System.exit(1);
+		}
+		if ("out".equals(args[0])) {
+			stream = System.out;
+		} else {
+			stream = System.err;
+		}
+		Field charOutField = PrintStream.class.getDeclaredField("charOut");
+		charOutField.setAccessible(true);
+		String encoding = ((OutputStreamWriter)charOutField.get(stream)).getEncoding();
+		System.out.println("System." + args[0] + " encoding: " + encoding);
+		if (args.length > 2) {
+			FileOutputStream out = new FileOutputStream("GetConsoleCharset-result.txt");
+			out.write(encoding.getBytes("ISO-8859-1"));
+			out.close();
+		}
+		if (encoding.equals(args[1])) {
+			System.out.println("SUCCESS");
+			System.exit(0);
+		}
+		System.out.println("FAILED");
+		System.exit(1);
+	}
+}


### PR DESCRIPTION
Also support setting extended Charset's in the jdk.charsets module.

See https://github.com/eclipse/openj9/pull/11387

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>