### PR TITLE
Support lookupMode argument in Java16+ & add CL constraint check

### DIFF
--- a/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
+++ b/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
@@ -56,6 +56,12 @@ extern "C" {
 #define MN_SEARCH_SUPERCLASSES	0x00100000
 #define MN_SEARCH_INTERFACES	0x00200000
 
+#if JAVA_SPEC_VERSION >= 16
+#define MN_MODULE_MODE			0x00000010
+#define MN_UNCONDITIONAL_MODE	0x00000020
+#define MN_TRUSTED_MODE			-1
+#endif /* JAVA_SPEC_VERSION >= 16 */
+
 /* Private MemberName object init helper 
  *
  * Set the MemberName fields based on the refObject given:
@@ -262,16 +268,17 @@ getClassSignature(J9VMThread *currentThread, J9Class * clazz)
 	return sig;
 }
 
-static char *
-getSignatureFromMethodType(J9VMThread *currentThread, j9object_t typeObject, UDATA *signatureLength)
+static J9UTF8 *
+getJ9UTF8SignatureFromMethodType(J9VMThread *currentThread, j9object_t typeObject)
 {
 	J9JavaVM *vm = currentThread->javaVM;
 	j9object_t ptypes = J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(currentThread, typeObject);
 	U_32 numArgs = J9INDEXABLEOBJECT_SIZE(currentThread, ptypes);
 
-	char* methodDescriptor = NULL;
+	J9UTF8* methodDescriptor = NULL;
 	char* cursor = NULL;
 	char* rSignature = NULL;
+	UDATA signatureLength = 2; /* space for '(', ')' */
 
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
@@ -282,7 +289,6 @@ getSignatureFromMethodType(J9VMThread *currentThread, j9object_t typeObject, UDA
 
 	memset(signatures, 0, (numArgs) * sizeof(char*));
 
-	*signatureLength = 2; /* space for '(', ')' */
 	for (U_32 i = 0; i < numArgs; i++) {
 		j9object_t pObject = J9JAVAARRAYOFOBJECT_LOAD(currentThread, ptypes, i);
 		J9Class *pclass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, pObject);
@@ -291,7 +297,7 @@ getSignatureFromMethodType(J9VMThread *currentThread, j9object_t typeObject, UDA
 			goto done;
 		}
 
-		*signatureLength += strlen(signatures[i]);
+		signatureLength += strlen(signatures[i]);
 	}
 
 	{
@@ -304,13 +310,14 @@ getSignatureFromMethodType(J9VMThread *currentThread, j9object_t typeObject, UDA
 		}
 	}
 
-	*signatureLength += strlen(rSignature);
+	signatureLength += strlen(rSignature);
 
-	methodDescriptor = (char*)j9mem_allocate_memory(*signatureLength+1, OMRMEM_CATEGORY_VM);
+	methodDescriptor = (J9UTF8*)j9mem_allocate_memory(signatureLength + sizeof(J9UTF8) + 1, OMRMEM_CATEGORY_VM);
 	if (NULL == methodDescriptor) {
 		goto done;
 	}
-	cursor = methodDescriptor;
+	J9UTF8_SET_LENGTH(methodDescriptor, (U_16)signatureLength);
+	cursor = (char*)J9UTF8_DATA(methodDescriptor);
 	*cursor++ = '(';
 
 	/* Copy class signatures to descriptor string */
@@ -442,21 +449,23 @@ done:
 }
 
 J9Method *
-lookupMethod(J9VMThread *currentThread, J9Class *resolvedClass, J9JNINameAndSignature *nas, J9Class *callerClass, UDATA lookupOptions)
+lookupMethod(J9VMThread *currentThread, J9Class *resolvedClass, J9NameAndSignature *nas, J9Class *callerClass, UDATA lookupOptions)
 {
 	J9Method *result = NULL;
 
 	/* If looking for a MethodHandle polymorphic INL method, allow any caller signature. */
 	if (resolvedClass == J9VMJAVALANGINVOKEMETHODHANDLE(currentThread->javaVM)) {
-		if ((0 == strcmp(nas->name, "linkToVirtual"))
-		|| (0 == strcmp(nas->name, "linkToStatic"))
-		|| (0 == strcmp(nas->name, "linkToSpecial"))
-		|| (0 == strcmp(nas->name, "linkToInterface"))
-		|| (0 == strcmp(nas->name, "invokeBasic"))
-		) {
-			nas->signature = NULL;
-			nas->signatureLength = 0;
+		J9UTF8 *nameUTF = nas->name;
+		U_8 *nameData = J9UTF8_DATA(nameUTF);
+		U_16 nameLength = J9UTF8_LENGTH(nameUTF);
 
+		if ((J9UTF8_LITERAL_EQUALS(nameData, nameLength, "linkToVirtual"))
+		|| (J9UTF8_LITERAL_EQUALS(nameData, nameLength, "linkToStatic"))
+		|| (J9UTF8_LITERAL_EQUALS(nameData, nameLength, "linkToSpecial"))
+		|| (J9UTF8_LITERAL_EQUALS(nameData, nameLength, "linkToInterface"))
+		|| (J9UTF8_LITERAL_EQUALS(nameData, nameLength, "invokeBasic"))
+		) {
+			J9UTF8_SET_LENGTH(nas->signature, 0);
 			/* Set flag for partial signature lookup. Signature length is already initialized to 0. */
 			lookupOptions |= J9_LOOK_PARTIAL_SIGNATURE;
 		}
@@ -630,15 +639,20 @@ Java_java_lang_invoke_MethodHandleNatives_expand(JNIEnv *env, jclass clazz, jobj
  * Throw NoSuchMethodError for method/constructor MemberName
  * Throw LinkageError for other
  */
+#if JAVA_SPEC_VERSION >= 16
+jobject JNICALL
+Java_java_lang_invoke_MethodHandleNatives_resolve(JNIEnv *env, jclass clazz, jobject self, jclass caller, jint lookupMode, jboolean speculativeResolve)
+#else /* JAVA_SPEC_VERSION >= 16 */
 jobject JNICALL
 Java_java_lang_invoke_MethodHandleNatives_resolve(JNIEnv *env, jclass clazz, jobject self, jclass caller, jboolean speculativeResolve)
+#endif /* JAVA_SPEC_VERSION >= 16 */
 {
 	J9VMThread *currentThread = (J9VMThread*)env;
 	J9JavaVM *vm = currentThread->javaVM;
 	const J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	jobject result = NULL;
-	char *name = NULL;
-	char *signature = NULL;
+	J9UTF8 *name = NULL;
+	J9UTF8 *signature = NULL;
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 
@@ -667,8 +681,6 @@ Java_java_lang_invoke_MethodHandleNatives_resolve(JNIEnv *env, jclass clazz, job
 
 			jint ref_kind = (flags >> MN_REFERENCE_KIND_SHIFT) & MN_REFERENCE_KIND_MASK;
 
-			UDATA nameLength = 0;
-			UDATA signatureLength = 0;
 			J9Class *typeClass = J9OBJECT_CLAZZ(currentThread, typeObject);
 
 			/* The type field of a MemberName could be in:
@@ -679,18 +691,24 @@ Java_java_lang_invoke_MethodHandleNatives_resolve(JNIEnv *env, jclass clazz, job
 			if (J9VMJAVALANGINVOKEMETHODTYPE(vm) == typeClass) {
 				j9object_t sigString = J9VMJAVALANGINVOKEMETHODTYPE_METHODDESCRIPTOR(currentThread, typeObject);
 				if (NULL != sigString) {
-					signature = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, sigString, J9_STR_NULL_TERMINATE_RESULT | J9_STR_XLAT, "", 0, NULL, 0, &signatureLength);
+					signature = vmFuncs->copyStringToJ9UTF8WithMemAlloc(currentThread, sigString, J9_STR_XLAT, "", 0, NULL, 0);
 				} else {
-					signature = getSignatureFromMethodType(currentThread, typeObject, &signatureLength);
-					// TODO store this signature as j.l.String in MT
+					signature = getJ9UTF8SignatureFromMethodType(currentThread, typeObject);
 				}
 			} else if (J9VMJAVALANGSTRING_OR_NULL(vm) == typeClass) {
-				signature = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, typeObject, J9_STR_NULL_TERMINATE_RESULT | J9_STR_XLAT, "", 0, NULL, 0, &signatureLength);
+				signature = vmFuncs->copyStringToJ9UTF8WithMemAlloc(currentThread, typeObject, J9_STR_XLAT, "", 0, NULL, 0);
 			} else if (J9VMJAVALANGCLASS(vm) == typeClass) {
 				J9Class *rclass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, typeObject);
-				signature = getClassSignature(currentThread, rclass);
-				if (NULL != signature) {
-					signatureLength = strlen(signature);
+				char *classSignature = getClassSignature(currentThread, rclass);
+				if (NULL != classSignature) {
+					UDATA signatureLength = strlen(classSignature);
+					PORT_ACCESS_FROM_JAVAVM(vm);
+					signature = (J9UTF8*)j9mem_allocate_memory(signatureLength + sizeof(J9UTF8), OMRMEM_CATEGORY_VM);
+					if (NULL != signature) {
+						J9UTF8_SET_LENGTH(signature, (U_16)signatureLength);
+						memcpy(J9UTF8_DATA(signature), classSignature, signatureLength);
+					}
+					j9mem_free_memory(classSignature);
 				}
 			} else {
 				vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
@@ -708,24 +726,39 @@ Java_java_lang_invoke_MethodHandleNatives_resolve(JNIEnv *env, jclass clazz, job
 			/* Refetch reference after GC point */
 			membernameObject = J9_JNI_UNWRAP_REFERENCE(self);
 			nameObject = J9VMJAVALANGINVOKEMEMBERNAME_NAME(currentThread, membernameObject);
-			name = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, nameObject, J9_STR_NULL_TERMINATE_RESULT, "", 0, NULL, 0, &nameLength);
+			name = vmFuncs->copyStringToJ9UTF8WithMemAlloc(currentThread, nameObject, 0, "", 0, NULL, 0);
 			if (NULL == name) {
 				vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 				goto done;
 			}
 
-			Trc_JCL_java_lang_invoke_MethodHandleNatives_resolve_NAS(env, name, signature);
+			j9object_t callerObject = (NULL == caller) ? NULL : J9_JNI_UNWRAP_REFERENCE(caller);
+			J9Class *callerClass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, callerObject);
+
+			Trc_JCL_java_lang_invoke_MethodHandleNatives_resolve_NAS(env, J9UTF8_LENGTH(name), J9UTF8_DATA(name), J9UTF8_LENGTH(signature), J9UTF8_DATA(signature));
 
 			if (J9_ARE_ANY_BITS_SET(flags, MN_IS_METHOD | MN_IS_CONSTRUCTOR)) {
-				j9object_t callerObject = (NULL == caller) ? NULL : J9_JNI_UNWRAP_REFERENCE(caller);
-				J9Class *callerClass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, callerObject);
-
-				J9JNINameAndSignature nas;
-				UDATA lookupOptions = J9_LOOK_JNI;
+				J9NameAndSignature nas;
+				UDATA lookupOptions = J9_LOOK_DIRECT_NAS;
 
 				if (JNI_TRUE == speculativeResolve) {
 					lookupOptions |= J9_LOOK_NO_THROW;
 				}
+
+#if JAVA_SPEC_VERSION >= 16
+				/* Check CL constraint only for lookup that is not trusted (with caller) and not public (UNCONDITIONAL mode not set)
+				 * Note: UNCONDITIONAL lookupMode can only access unconditionally exported public members which assumes readablity
+				 * ie lookup class not used to determine lookup context
+				 * See java.lang.invoke.MethodHandles$Lookup.publicLookup()
+				 */
+				if ((NULL != callerClass) && J9_ARE_NO_BITS_SET(lookupMode, MN_UNCONDITIONAL_MODE)) {
+					lookupOptions |= J9_LOOK_CLCONSTRAINTS;
+				}
+#else
+				if (NULL != callerClass) {
+					lookupOptions |= J9_LOOK_CLCONSTRAINTS;
+				}
+#endif
 
 				/* Determine the lookup type based on reference kind and resolved class flags */
 				switch (ref_kind)
@@ -749,8 +782,6 @@ Java_java_lang_invoke_MethodHandleNatives_resolve(JNIEnv *env, jclass clazz, job
 
 				nas.name = name;
 				nas.signature = signature;
-				nas.nameLength = (U_32)nameLength;
-				nas.signatureLength = (U_32)signatureLength;
 
 				/* Check if signature polymorphic native calls */
 				J9Method *method = lookupMethod(currentThread, resolvedClass, &nas, callerClass, lookupOptions);
@@ -788,8 +819,8 @@ Java_java_lang_invoke_MethodHandleNatives_resolve(JNIEnv *env, jclass clazz, job
 				 */
 				offset = vmFuncs->instanceFieldOffset(currentThread,
 					resolvedClass,
-					(U_8*)name, strlen(name),
-					(U_8*)signature, strlen(signature),
+					J9UTF8_DATA(name), J9UTF8_LENGTH(name),
+					J9UTF8_DATA(signature), J9UTF8_LENGTH(signature),
 					&declaringClass, (UDATA*)&romField,
 					lookupOptions);
 
@@ -802,8 +833,8 @@ Java_java_lang_invoke_MethodHandleNatives_resolve(JNIEnv *env, jclass clazz, job
 
 					void* fieldAddress = vmFuncs->staticFieldAddress(currentThread,
 						resolvedClass,
-						(U_8*)name, strlen(name),
-						(U_8*)signature, strlen(signature),
+						J9UTF8_DATA(name), J9UTF8_LENGTH(name),
+						J9UTF8_DATA(signature), J9UTF8_LENGTH(signature),
 						&declaringClass, (UDATA*)&romField,
 						lookupOptions,
 						NULL);
@@ -816,6 +847,39 @@ Java_java_lang_invoke_MethodHandleNatives_resolve(JNIEnv *env, jclass clazz, job
 				}
 
 				if (NULL != declaringClass) {
+					if ((NULL != callerClass)
+#if JAVA_SPEC_VERSION >= 16
+					 && (J9_ARE_NO_BITS_SET(lookupMode, MN_UNCONDITIONAL_MODE))
+#endif
+					) {
+						if (callerClass->classLoader != declaringClass->classLoader) {
+							J9BytecodeVerificationData *verifyData = vm->bytecodeVerificationData;
+							U_16 sigOffset = 0;
+
+							/* Skip the '[', 'L' prefix */
+							while ('[' == J9UTF8_DATA(signature)[sigOffset]) {
+								sigOffset += 1;
+							}
+							if ('L' == J9UTF8_DATA(signature)[sigOffset]) {
+								sigOffset += 1;
+								omrthread_monitor_enter(vm->classTableMutex);
+								UDATA clConstraintResult = verifyData->checkClassLoadingConstraintForNameFunction(
+																currentThread,
+																declaringClass->classLoader,
+																callerClass->classLoader,
+																J9UTF8_DATA(signature) + sigOffset,
+																J9UTF8_DATA(signature) + sigOffset,
+																J9UTF8_LENGTH(signature) - sigOffset - 1, /* -1 to remove the trailing ;*/
+																true);
+								omrthread_monitor_exit(vm->classTableMutex);
+								if (0 != clConstraintResult) {
+									vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGLINKAGEERROR, NULL);
+									goto done;
+								}
+							}
+						}
+					}
+
 					UDATA inconsistentData = 0;
 					J9JNIFieldID *fieldID = vmFuncs->getJNIFieldID(currentThread, declaringClass, romField, offset, &inconsistentData);
 					vmindex = (jlong)(UDATA)fieldID;

--- a/runtime/jcl/j9jcl.tdf
+++ b/runtime/jcl/j9jcl.tdf
@@ -656,7 +656,7 @@ TraceExit=Trc_JCL_java_lang_invoke_MethodHandleNatives_expand_Exit Overhead=1 Le
 
 TraceEntry=Trc_JCL_java_lang_invoke_MethodHandleNatives_resolve_Entry Overhead=1 Level=3 Template="MethodHandleNatives_resolve Enter: self = %p, caller = %p, speculativeResolve = %s"
 TraceEvent=Trc_JCL_java_lang_invoke_MethodHandleNatives_resolve_Data Overhead=1 Level=3 Template="MethodHandleNatives_resolve Data: membername = %p, caller = %p, flags = 0x%08X, vmindex = %lld, target = %lld"
-TraceEvent=Trc_JCL_java_lang_invoke_MethodHandleNatives_resolve_NAS Overhead=1 Level=3 Template="MethodHandleNatives_resolve NAS: name = %s, signature = %s"
+TraceEvent=Trc_JCL_java_lang_invoke_MethodHandleNatives_resolve_NAS Overhead=1 Level=3 Template="MethodHandleNatives_resolve NAS: name = %.*s, signature = %.*s"
 TraceEvent=Trc_JCL_java_lang_invoke_MethodHandleNatives_resolve_resolved Overhead=1 Level=3 Template="MethodHandleNatives_resolve Resolved to: vmindex = %lld, target = %lld, class = %p, flags = 0x%08X"
 TraceExit=Trc_JCL_java_lang_invoke_MethodHandleNatives_resolve_Exit Overhead=1 Level=3 Template="MethodHandleNatives_resolve Exit"
 

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -956,7 +956,11 @@ jobject JNICALL Java_java_lang_invoke_MethodType_makeTenured(JNIEnv *env, jclass
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 void JNICALL Java_java_lang_invoke_MethodHandleNatives_init(JNIEnv *env, jclass clazz, jobject self, jobject ref);
 void JNICALL Java_java_lang_invoke_MethodHandleNatives_expand(JNIEnv *env, jclass clazz, jobject self);
+#if JAVA_SPEC_VERSION >= 16
+jobject JNICALL Java_java_lang_invoke_MethodHandleNatives_resolve(JNIEnv *env, jclass clazz, jobject self, jclass caller, jint lookupMode, jboolean speculativeResolve);
+#else /* JAVA_SPEC_VERSION >= 16 */
 jobject JNICALL Java_java_lang_invoke_MethodHandleNatives_resolve(JNIEnv *env, jclass clazz, jobject self, jclass caller, jboolean speculativeResolve);
+#endif /* JAVA_SPEC_VERSION >= 16 */
 jint JNICALL Java_java_lang_invoke_MethodHandleNatives_getMembers(JNIEnv *env, jclass clazz, jclass defc, jstring matchName, jstring matchSig, jint matchFlags, jclass caller, jint skip, jobjectArray results);
 jlong JNICALL Java_java_lang_invoke_MethodHandleNatives_objectFieldOffset(JNIEnv *env, jclass clazz, jobject self);
 jlong JNICALL Java_java_lang_invoke_MethodHandleNatives_staticFieldOffset(JNIEnv *env, jclass clazz, jobject self);


### PR DESCRIPTION
- change J9JNI-NAS to J9NAS to use J9_LOOK_DIRECT_NAS and J9_LOOK_CLCONSTRAINTS
- Add CL constraint check to field resolution

Fixes: #11925, Fixes: #11928, Fixes: #11964 

Co-authored-by: Babneet Singh <sbabneet@ca.ibm.com>
Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>