### PR TITLE
AArch64: Add Allocation Prefetch

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -985,7 +985,7 @@ TR::OptionTable OMR::Options::_feOptions[] = {
    {"timeBetweenPurges=", " \tDefines how often we are willing to scan for old entries to be purged", 
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_timeBetweenPurges,  0, " %d"},
 #endif /* defined(J9VM_OPT_JITSERVER) */
-#if defined(TR_HOST_X86) || defined(TR_HOST_POWER)
+#if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_ARM64)
    {"tlhPrefetchBoundaryLineCount=",    "O<nnn>\tallocation prefetch boundary line for allocation prefetch",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_TLHPrefetchBoundaryLineCount, 0, "P%d", NOT_IN_SUBSET},
    {"tlhPrefetchLineCount=",    "O<nnn>\tallocation prefetch line count for allocation prefetch",
@@ -1862,11 +1862,13 @@ J9::Options::fePreProcess(void * base)
          }
       }
 
-#if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390)
+#if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM64)
    bool preferTLHPrefetch;
 #if defined(TR_HOST_POWER)
    preferTLHPrefetch = TR::Compiler->target.cpu.isAtLeast(OMR_PROCESSOR_PPC_P6) && TR::Compiler->target.cpu.isAtMost(OMR_PROCESSOR_PPC_P7);
 #elif defined(TR_HOST_S390)
+   preferTLHPrefetch = true;
+#elif defined(TR_HOST_ARM64)
    preferTLHPrefetch = true;
 #else // TR_HOST_X86
    preferTLHPrefetch = true;


### PR DESCRIPTION
Generate `PRFM` instruction after each inlined allocation by JIT.
By default, the address to prefetch is 4 cache lines ahead of allocation pointer.

Options to control prefetch parameter:
- tlhPrefetchLineCount: # of lines to prefetch for each allocation. The default value is 1.
- tlhPrefetchLineSize: cache line size. The default value is 64.
- tlhPrefetchStaggeredLineCount: the distance in line count between alloction pointer
                                 to address prefetched. The default value is 4.

Env vars to control prefetch parameter:
- TR_AArch64PrefetchThresholdSize: `PRFM` is not generated if allocation size
                                   is smaller than this threshold. The default value is 64.
- TR_AArch64PrefetchArrayLineCount: # of lines to prefetch for each array allocation.
                                    The default value is 4.
- TR_AArch64PrefetchType: The type of prefetch op. 0 for load, 1 for instruction, 2 for store.
                          The default value is store.
- TR_AArch64PrefetchTarget: The target of prefetch op. 0 for L1, 1 for L2, and 2 for L3.
                            The default value is L3.
- TR_AArch64PrefetchPolicy: The policy of prefetch op. 0 for KEEP, 1 for STRM.
                            The default value is STRM.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>