### PR TITLE
AArch64: Properly find compressed refs sequence in implicit NULLCHK

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -3301,13 +3301,11 @@ J9::ARM64::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node *node, boo
       // pattern match the sequence under the l2a
       // NULLCHK        NULLCHK                     <- node
       //    aloadi f      l2a
-      //       aload O       ladd
-      //                       lshl
-      //                          i2l
-      //                            iloadi/irdbari f <- n
-      //                               aload O        <- reference
-      //                          iconst shftKonst
-      //                       lconst HB
+      //       aload O      lshl
+      //                       iu2l
+      //                          iloadi/irdbari f <- n
+      //                             aload O        <- reference
+      //                       iconst shftKonst
       //
       hasCompressedPointers = true;
       TR::ILOpCodes loadOp = cg->comp()->il.opCodeForIndirectLoad(TR::Int32);
@@ -3331,6 +3329,7 @@ J9::ARM64::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node *node, boo
 
    bool needExplicitCheck  = true;
    bool needLateEvaluation = true;
+   bool firstChildEvaluated = false;
 
    // Add the explicit check after this instruction
    //
@@ -3339,9 +3338,8 @@ J9::ARM64::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node *node, boo
    // determine if an explicit check is needed
    if (cg->getHasResumableTrapHandler())
       {
-      if (opCode.isLoadVar()
-            || (opCode.getOpCodeValue() == TR::l2i)
-            || (hasCompressedPointers && firstChild->getFirstChild()->getOpCode().getOpCodeValue() == TR::i2l))
+      if (n->getOpCode().isLoadVar()
+            || (opCode.getOpCodeValue() == TR::l2i))
          {
          TR::SymbolReference *symRef = NULL;
 
@@ -3362,19 +3360,29 @@ J9::ARM64::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node *node, boo
 
             // at this point, n is the raw iloadi (created by lowerTrees) and
             // reference is the aload of the object. node->getFirstChild is the
-            // l2a sequence; as a result, n's refCount will always be 1
-            // and node->getFirstChild's refCount will be at least 2 (one under the nullchk
-            // and the other under the translate treetop)
+            // l2a sequence; as a result, n's refCount will always be 1.
             //
             if (hasCompressedPointers
-                  && node->getFirstChild()->getReferenceCount() > 2)
+                  && node->getFirstChild()->getReferenceCount() >= 2)
+               {
+               // In this case, the result of load is used in other places, so we need to evaluate it here
+               //
                needLateEvaluation = true;
+
+               // Check if offset from a NULL reference will fall into the inaccessible bytes,
+               // resulting in an implicit trap being raised.
+               if (symRef
+                   && ((symRef->getSymbol()->getOffset() + symRef->getOffset()) < cg->getNumberBytesReadInaccessible()))
+                  {
+                  needExplicitCheck = false;
+                  }
+               }
             }
 
          // Check if offset from a NULL reference will fall into the inaccessible bytes,
          // resulting in an implicit trap being raised.
          else if (symRef
-               && ((symRef->getSymbol()->getOffset() + symRef->getOffset()) < cg->getNumberBytesReadInaccessible()))
+                  && ((symRef->getSymbol()->getOffset() + symRef->getOffset()) < cg->getNumberBytesReadInaccessible()))
             {
             needExplicitCheck = false;
 
@@ -3407,7 +3415,6 @@ J9::ARM64::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node *node, boo
                      {
                      needLateEvaluation = false;
                      needExplicitCheck = true;
-                     reference->incReferenceCount(); // will be decremented again later
                      }
                   }
                }
@@ -3461,17 +3468,15 @@ J9::ARM64::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node *node, boo
          // The child may generate inline code that provides an implicit null check
          // but we won't know until the child is evaluated.
          //
-         reference->incReferenceCount(); // will be decremented again later
          needLateEvaluation = false;
          cg->evaluate(reference);
          appendTo = cg->getAppendInstruction();
          cg->evaluate(firstChild);
-
+         firstChildEvaluated = true;
          if (cg->getImplicitExceptionPoint()
                && (cg->getNumberBytesReadInaccessible() > cg->fe()->getOffsetOfContiguousArraySizeField()))
             {
             needExplicitCheck = false;
-            cg->decReferenceCount(reference);
             }
          }
       }
@@ -3503,12 +3508,19 @@ J9::ARM64::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node *node, boo
    if (needLateEvaluation)
       {
       cg->evaluate(firstChild);
+      firstChildEvaluated = true;
       }
-   else if (needExplicitCheck)
+   // If the firstChild is evaluated, we simply call decReferenceCount.
+   // Otherwise, we need to call recursivelyDecReferenceCount so that the ref count of
+   // child nodes of the firstChild is properly decremented when the ref count of the firstChild is 1.
+   if (firstChildEvaluated)
       {
-      cg->decReferenceCount(reference);
+      cg->decReferenceCount(firstChild);
       }
-   cg->decReferenceCount(firstChild);
+   else
+      {
+      cg->recursivelyDecReferenceCount(firstChild);
+      }
 
    // If an explicit check has not been generated for the null check, there is
    // an instruction that will cause a hardware trap if the exception is to be


### PR DESCRIPTION
`evaluateNULLCHKWithPossibleResolve` does pattern matching to
find load operation in compressed references sequences, but it searches for
`TR::i2l` instead of correct opcode `TR::iu2l`.
Also, if it is a load operation and the reference count of the load node
under the compressed refs sequence is 1, explicit NULLCHK is used
even if the reference count of `TR::l2a` node is more than 2.
This commit changes `evaluateNULLCHKWithPossibleResolve` to
- Use opcode value of the parent of the reference node for judging
   whether it is a load operation instead of searching `TR::iu2l`.
- Use implicit NULLCHK if `TR::l2a` node's reference count > 2.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>