### PR TITLE
AArch64: Fix wrtbarEvaluator to kill scratch registers

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -651,6 +651,7 @@ static void wrtbarEvaluator(TR::Node *node, TR::Register *srcReg, TR::Register *
    srm->addScratchRegistersToDependencyList(conditions);
    generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions, NULL);
 
+   srm->stopUsingRegisters();
    }
 
 TR::Register *


### PR DESCRIPTION
Fix `wrtbarEvaluator` to call srm->stopUsingRegister().

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>