### PR TITLE
Increase nightly build history to 40

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -92,7 +92,7 @@ test_dependencies_job_name: 'test.getDependency'
 slack_channel: '#jenkins'
 build_discarder:
   logs:
-    Nightly: 35
+    Nightly: 40
     Release: 5
     OMR: 15
     OpenJDK8: 5


### PR DESCRIPTION
This value is used for build logs as well as Artifactory binaries

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>