### PR TITLE
(v0.26.0)Fix NoSuchFieldError in SCC DDR command

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ShrCCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ShrCCommand.java
@@ -1202,9 +1202,14 @@ public class ShrCCommand extends Command
 					/*  _ccHead -------------> ccNext ---------> ccNext --------> ........---------> ccTail
 					 * (top layer)         (middle layer)     (middle layer)      ........         (layer 0)
 					 */
-					SH_CompositeCacheImplPointer compositeCacheImpl = cacheMap._ccTail();
-					for (int tmplayer = 0; tmplayer < layer; tmplayer++) {
-						compositeCacheImpl = compositeCacheImpl._previous();
+					SH_CompositeCacheImplPointer compositeCacheImpl;
+					try {
+						compositeCacheImpl = cacheMap._ccTail();
+						for (int tmplayer = 0; tmplayer < layer; tmplayer++) {
+							compositeCacheImpl = compositeCacheImpl._previous();
+						}
+					} catch (NoSuchFieldError | NoSuchMethodError e) {
+						compositeCacheImpl = cacheMap._cc();
 					}
 					if (compositeCacheImpl.notNull()) {
 						cacheStartAddress[layer] = compositeCacheImpl._theca();


### PR DESCRIPTION
Catch NoSuchFieldError and NoSuchMethodError when running on an old core
where SH_CacheMap does not have field _ccTail. Fall back to code before
#6883 i.e. use cacheMap._cc() to set compositeCacheImpl in this case.

Fixes #12357

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>