### PR TITLE
Disable Dynamic Breadth First for Balanced

### DIFF
--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -276,8 +276,9 @@ MM_ConfigurationIncrementalGenerational::initialize(MM_EnvironmentBase *env)
 	env->disableHotFieldDepthCopy();
 
 	if (result) {
-		if (extensions->scavengerScanOrdering != MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_BREADTH_FIRST) {
-			extensions->scavengerScanOrdering = MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST;
+		if (MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST != extensions->scavengerScanOrdering) {
+			extensions->scavengerScanOrdering = MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_BREADTH_FIRST;
+		} else {
 			extensions->adaptiveGcCountBetweenHotFieldSort = false;
 		}
 		extensions->setVLHGC(true);

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -1383,7 +1383,9 @@ MM_CopyForwardScheme::mainSetupForCopyForward(MM_EnvironmentVLHGC *env)
 	_phantomReferenceRegionsToProcess = 0;
 
 	/* Sort all hot fields for all classes as dynamicBreadthFirstScanOrdering is enabled */
-	MM_HotFieldUtil::sortAllHotFieldData(_javaVM, _extensions->globalVLHGCStats.gcCount);
+	if (MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST == _extensions->scavengerScanOrdering) {
+		MM_HotFieldUtil::sortAllHotFieldData(_javaVM, _extensions->globalVLHGCStats.gcCount);
+	}
 
 	/* Cache of the mark map */
 	_markMap = env->_cycleState->_markMap;


### PR DESCRIPTION
Disable Dynamic Breadth-First Scan Ordering by default
for the Balanced GC policy in the OpenJ9 master branch and the upcoming release 0.26 branch in light of a newly raised issue (https://github.com/eclipse/openj9/issues/12346). Revert back to Dynamic Breadth-First Scan Ordering by default after the issue is resolved. 

Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>