### PR TITLE
Increase cmdLineTester_XcheckJNI timeout

### DIFF
--- a/test/functional/cmdLineTests/xcheckjni/xcheckjni.xml
+++ b/test/functional/cmdLineTests/xcheckjni/xcheckjni.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2009, 2020 IBM Corp. and others
+  Copyright (c) 2009, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,7 @@
 
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
-<suite id="J9 XCheck JNI tests" timeout="120">
+<suite id="J9 XCheck JNI tests" timeout="180">
 <variable name="CP" value="-cp $Q$$RESJAR$$Q$" />
 
 <variable name="TYPE1" value="boolean" />


### PR DESCRIPTION
Various sub tests are intermittently timing out on z/OS, which seems due
to infra issues. Increase the timeout in an attempt to reduce the
occurrences.