### PR TITLE
Groundwork changes for some expected performance improvements with value types enabled

### DIFF
--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -2760,7 +2760,11 @@ TR_J9ByteCodeIlGenerator::genIfAcmpEqNe(TR::ILOpCodes ifacmpOp)
       TR::Node::createWithSymRef(TR::icall, 2, 2, lhs, rhs, comparisonNonHelper);
 
    substitutabilityTest->getByteCodeInfo().setDoNotProfile(true);
-   genTreeTop(substitutabilityTest);
+   TR::TreeTop* callTree = genTreeTop(substitutabilityTest);
+
+   const char *counterName = TR::DebugCounter::debugCounterName(comp(), "vt-helper/generated/acmp/(%s)/bc=%d",
+                                                      comp()->signature(), currentByteCodeIndex());
+   TR::DebugCounter::prependDebugCounter(comp(), counterName, callTree);
 
    push(substitutabilityTest);
    push(TR::Node::iconst(0));
@@ -6255,6 +6259,13 @@ TR_J9ByteCodeIlGenerator::loadArrayElement(TR::DataType dataType, TR::ILOpCodes 
          }
       auto* helperSymRef = comp()->getSymRefTab()->findOrCreateLoadFlattenableArrayElementSymbolRef();
       auto* helperCallNode = TR::Node::createWithSymRef(TR::acall, 2, 2, elementIndex, arrayBaseAddress, helperSymRef);
+
+      TR::TreeTop *loadHelperCallTT = genTreeTop(helperCallNode);
+
+      const char *counterName = TR::DebugCounter::debugCounterName(comp(), "vt-helper/generated/aaload/(%s)/bc=%d",
+                                                      comp()->signature(), currentByteCodeIndex());
+      TR::DebugCounter::prependDebugCounter(comp(), counterName, loadHelperCallTT);
+
       push(helperCallNode);
       return;
       }
@@ -7708,7 +7719,12 @@ TR_J9ByteCodeIlGenerator::storeArrayElement(TR::DataType dataType, TR::ILOpCodes
          genTreeTop(nullchk);
          }
       auto* helperSymRef = comp()->getSymRefTab()->findOrCreateStoreFlattenableArrayElementSymbolRef();
-      genTreeTop(TR::Node::createWithSymRef(TR::acall, 3, 3, value, elementIndex, arrayBaseAddress, helperSymRef));
+      TR::TreeTop *storeHelperCallTT = genTreeTop(TR::Node::createWithSymRef(TR::acall, 3, 3, value, elementIndex, arrayBaseAddress, helperSymRef));
+
+      const char *counterName = TR::DebugCounter::debugCounterName(comp(), "vt-helper/generated/aastore/(%s)/bc=%d",
+                                                      comp()->signature(), currentByteCodeIndex());
+      TR::DebugCounter::prependDebugCounter(comp(), counterName, storeHelperCallTT);
+
       return;
       }
 

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -6247,7 +6247,12 @@ TR_J9ByteCodeIlGenerator::loadFromCallSiteTable(int32_t callSiteIndex)
 void
 TR_J9ByteCodeIlGenerator::loadArrayElement(TR::DataType dataType, TR::ILOpCodes nodeop, bool checks)
    {
-   if (TR::Compiler->om.areValueTypesEnabled() && dataType == TR::Address)
+   // Value types prototype for flattened array elements does not yet support
+   // GC policies that allow arraylets.  If arraylets are required, assume
+   // we won't have flattening, so no call to flattenable array element access
+   // helper is needed.
+   //
+   if (TR::Compiler->om.areValueTypesEnabled() && !TR::Compiler->om.canGenerateArraylets() && dataType == TR::Address)
       {
       TR::Node* elementIndex = pop();
       TR::Node* arrayBaseAddress = pop();
@@ -7708,7 +7713,12 @@ TR_J9ByteCodeIlGenerator::storeArrayElement(TR::DataType dataType, TR::ILOpCodes
 
    handlePendingPushSaveSideEffects(value);
 
-   if (TR::Compiler->om.areValueTypesEnabled() && dataType == TR::Address)
+   // Value types prototype for flattened array elements does not yet support
+   // GC policies that allow arraylets.  If arraylets are required, assume
+   // we won't have flattening, so no call to flattenable array element access
+   // helper is needed.
+   //
+   if (TR::Compiler->om.areValueTypesEnabled() && !TR::Compiler->om.canGenerateArraylets() && dataType == TR::Address)
       {
       TR::Node* elementIndex = pop();
       TR::Node* arrayBaseAddress = pop();


### PR DESCRIPTION
This makes some simple changes to IL generation for array element access with value types enabled:

- Disable generation of calls to `jit{Load|Store}FlattenableArrayElement` helpers if arraylets are supported, as garbage collection policies that use arraylets do not yet work with flattenable array elements.  That will avoid having optimizations that operate on such calls having to worry about handling arraylets.
- Added debug counters to track calls to the array element helpers in order to track calls to them as well as allowing subsequent optimizations that might be able to eliminate such calls to track such elimination.