### PR TITLE
Fix JitDump timing hole when resuming diagnostic thread

### DIFF
--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -332,11 +332,11 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
       return OMR_ERROR_INTERNAL;
       }
 
-   recompilationThreadInfo->resumeCompilationThread();
-
    compInfo->acquireCompMonitor(crashedThread);
    compInfo->purgeMethodQueue(compilationFailure);
    compInfo->releaseCompMonitor(crashedThread);
+
+   recompilationThreadInfo->resumeCompilationThread();
 
    TR::FILE *jitdumpFile = trfopen(label, "ab", false);
    if (NULL == jitdumpFile)


### PR DESCRIPTION
There is a small timing hole which I haven't observed yet but it is
possible that in the time between resuming the diagnostic thread and
purging the method queue we might pick up an OrdinaryMethod compile
on the diagnostic thread.

The fix here is to simply purge the queue and then enable the
diagnostic thread.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>