### PR TITLE
Import antcontrib tasks consistently

### DIFF
--- a/test/functional/DDR_Test/tck_ddrext.xml
+++ b/test/functional/DDR_Test/tck_ddrext.xml
@@ -21,7 +21,7 @@ OpenJDK Assembly Exception [2].
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <project name="DDR Extension Test" default="clean">
-	<taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 
 	<property name="JAVA_COMMAND" value="${JAVA_COMMAND}" />
 	<property name="TEST_ROOT" value="${TEST_ROOT}" />

--- a/test/functional/HealthCenter/healthcenter.xml
+++ b/test/functional/HealthCenter/healthcenter.xml
@@ -22,7 +22,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 -->
 <project name="HealthCenter" default="sanity">
 
-	<taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 
 	<target name="sanity">
 		<if>


### PR DESCRIPTION
Use `antlib.xml` like all other ant scripts, as advised at http://ant-contrib.sourceforge.net/tasks/index.html.