### PR TITLE
CleanWs after bootjdk download

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -58,14 +58,14 @@ def get_sources_with_authentication() {
 def get_sources() {
     // Temp workaround for Windows clones
     // See #3633 and JENKINS-54612
-    if (NODE_LABELS.contains("windows") || NODE_LABELS.contains("zos")) {
+    if (SPEC.contains("win") || SPEC.contains("zos")) {
 
         CLONE_CMD = "git clone -b ${OPENJDK_BRANCH} ${OPENJDK_REPO} ."
         if (OPENJDK_REFERENCE_REPO) {
             CLONE_CMD += " --reference ${OPENJDK_REFERENCE_REPO}"
         }
 
-        if (USER_CREDENTIALS_ID && NODE_LABELS.contains("windows")) {
+        if (USER_CREDENTIALS_ID && SPEC.contains("win")) {
             sshagent(credentials:["${USER_CREDENTIALS_ID}"]) {
                 sh "${CLONE_CMD}"
             }

--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -1589,9 +1589,9 @@ def download_boot_jdk(bootJDKVersion, bootJDK) {
                 gzip -cd "\$sdkFile" | tar xof - -C ${bootJDK} --strip=${dirStrip}
             fi
             ${bootJDK}/bin/java -version
-            rm -f "\$sdkFile"
         """
     }
+    buildFile.cleanWorkspace(false)
 }
 
 def set_build_custom_options() {


### PR DESCRIPTION
Fixes #11486

Also
Check SPEC rather than NODE_LABELS.
SPEC is more reliable. Node labels can
change, especially when debugging on
specific machines

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>

CleanWs after bootjdk download

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>