### PR TITLE
Don't set build unstable if commit status setter fails

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions.groovy
+++ b/buildenv/jenkins/common/pipeline-functions.groovy
@@ -163,7 +163,7 @@ def set_build_status(REPO, CONTEXT, SHA, URL, STATE, MESSAGE) {
         $class: "GitHubCommitStatusSetter",
         reposSource: [$class: "ManuallyEnteredRepositorySource", url: REPO],
         contextSource: [$class: "ManuallyEnteredCommitContextSource", context: CONTEXT],
-        errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+        errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "SUCCESS"]],
         commitShaSource: [$class: "ManuallyEnteredShaSource", sha: SHA ],
         statusBackrefSource: [$class: "ManuallyEnteredBackrefSource", backref: URL],
         statusResultSource: [$class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: MESSAGE, state: STATE]] ]


### PR DESCRIPTION
The usefulness of setting UNSTABLE is likely unessary and
it is currently causing an issue on internal builds trying
to update external repos.
Setting to SUCCESS will have no effect as Jenkins will always
retain the worst status.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>