### PR TITLE
Updates for setting System.err and out, fix z/OS and streamline code

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -98,7 +98,7 @@ public final class System {
 	private static volatile boolean consoleInitialized;
 
 	private static String lineSeparator;
-		
+
 	private static boolean propertiesInitialized = false;
 
 	private static String platformEncoding;
@@ -115,13 +115,13 @@ public final class System {
 /*[IF Sidecar19-SE]*/
 	static java.lang.ModuleLayer	bootLayer;
 /*[ENDIF]*/
-	
+
 	// Initialize all the slots in System on first use.
 	static {
-		initEncodings();		
+		initEncodings();
 	}
-	
-	//	get following system properties in clinit and make it available via static variables 
+
+	//	get following system properties in clinit and make it available via static variables
 	//	at early boot stage in which System is not fully initialized
 	//	os.encoding, ibm.system.encoding/sun.jnu.encoding, file.encoding
 	private static void initEncodings() {
@@ -230,7 +230,7 @@ public final class System {
 	static void afterClinitInitialization() {
 		/*[PR CMVC 189091] Perf: EnumSet.allOf() is slow */
 		/*[PR CMVC 191554] Provide access to ClassLoader methods to improve performance */
-		/* Multitenancy change: only initialize VMLangAccess once as it's non-isolated */ 
+		/* Multitenancy change: only initialize VMLangAccess once as it's non-isolated */
 		if (null == com.ibm.oti.vm.VM.getVMLangAccess()) {
 			com.ibm.oti.vm.VM.setVMLangAccess(new VMAccess());
 		}
@@ -240,26 +240,26 @@ public final class System {
 
 		/*[PR CMVC 150472] sun.misc.SharedSecrets needs access to java.lang. */
 		SharedSecrets.setJavaLangAccess(new Access());
-		
+
 		/*[REM] Initialize the JITHelpers needed in J9VMInternals since the class can't do it itself */
 		try {
 			java.lang.reflect.Field f1 = J9VMInternals.class.getDeclaredField("jitHelpers"); //$NON-NLS-1$
 			java.lang.reflect.Field f2 = String.class.getDeclaredField("helpers"); //$NON-NLS-1$
-			
+
 			Unsafe unsafe = Unsafe.getUnsafe();
-			
+
 			unsafe.putObject(unsafe.staticFieldBase(f1), unsafe.staticFieldOffset(f1), com.ibm.jit.JITHelpers.getHelpers());
 			unsafe.putObject(unsafe.staticFieldBase(f2), unsafe.staticFieldOffset(f2), com.ibm.jit.JITHelpers.getHelpers());
 		} catch (NoSuchFieldException e) { }
-		
+
 		/**
-		 * When the System Property == true, then disable sharing (i.e. arraycopy the underlying value array) in 
-		 * String.substring(int) and String.substring(int, int) methods whenever offset is zero. Otherwise, enable 
+		 * When the System Property == true, then disable sharing (i.e. arraycopy the underlying value array) in
+		 * String.substring(int) and String.substring(int, int) methods whenever offset is zero. Otherwise, enable
 		 * sharing of the underlying value array.
 		 */
 		String enableSharingInSubstringWhenOffsetIsZeroProperty = internalGetProperties().getProperty("java.lang.string.substring.nocopy"); //$NON-NLS-1$
 		String.enableSharingInSubstringWhenOffsetIsZero = enableSharingInSubstringWhenOffsetIsZeroProperty == null || enableSharingInSubstringWhenOffsetIsZeroProperty.equalsIgnoreCase("false"); //$NON-NLS-1$
-		
+
 		// Set up standard in, out, and err.
 		/*[PR CMVC 193070] - OTT:Java 8 Test_JITHelpers test_getSuperclass NoSuchMet*/
 		/*[PR JAZZ 58297] - continue with the rules defined by JAZZ 57070 - Build a Java 8 J9 JCL using the SIDECAR18 preprocessor configuration */
@@ -355,9 +355,9 @@ public final class System {
 	}
 
 native static void startSNMPAgent();
-	
+
 static void completeInitialization() {
-	/*[IF !Sidecar19-SE_RAWPLUSJ9]*/	
+	/*[IF !Sidecar19-SE_RAWPLUSJ9]*/
 	/*[IF !Sidecar18-SE-OpenJ9]*/
 	Class<?> systemInitialization = null;
 	Method hook;
@@ -372,7 +372,7 @@ static void completeInitialization() {
 		// Assume this is a raw configuration and suppress the exception
 	} catch (Exception e) {
 		throw new InternalError(e.toString());
-	} 	
+	}
 	try {
 		if (null != systemInitialization) {
 			hook = systemInitialization.getMethod("firstChanceHook");	//$NON-NLS-1$
@@ -382,7 +382,7 @@ static void completeInitialization() {
 		throw new InternalError(e.toString());
 	}
 	/*[ENDIF]*/ // Sidecar18-SE-OpenJ9
-	
+
 	/*[IF (Sidecar18-SE-OpenJ9|Sidecar19-SE)&!(PLATFORM-mz31|PLATFORM-mz64)]*/
 	setIn(new BufferedInputStream(new FileInputStream(FileDescriptor.in)));
 	/*[ELSE]*/
@@ -390,7 +390,7 @@ static void completeInitialization() {
 	setIn(com.ibm.jvm.io.ConsoleInputStream.localize(new BufferedInputStream(new FileInputStream(FileDescriptor.in))));
 	/*[ENDIF]*/ //Sidecar18-SE-OpenJ9|Sidecar19-SE
 	/*[ENDIF]*/ //!Sidecar19-SE_RAWPLUSJ9
-		
+
 	/*[PR 102344] call Terminator.setup() after Thread init */
 	Terminator.setup();
 
@@ -456,7 +456,7 @@ public static void setIn(InputStream newIn) {
 	if (security != null)	{
 		security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionSetIO);
 	}
-	
+
 	setFieldImpl("in", newIn); //$NON-NLS-1$
 }
 
@@ -485,10 +485,10 @@ public static void setErr(java.io.PrintStream newErr) {
 	if (security != null)	{
 		security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionSetIO);
 	}
-	
+
 	setFieldImpl("err", newErr); //$NON-NLS-1$
 }
-	
+
 /**
  * Prevents this class from being instantiated.
  */
@@ -514,10 +514,10 @@ public static native void arraycopy(Object array1, int start1, Object array2, in
 private static void arraycopy(Object[] A1, int offset1, Object[] A2, int offset2, int length) {
 	if (A1 == null || A2 == null) throw new NullPointerException();
 	if (offset1 >= 0 && offset2 >= 0 && length >= 0 &&
-		length <= A1.length - offset1 && length <= A2.length - offset2) 
+		length <= A1.length - offset1 && length <= A2.length - offset2)
 	{
 		// Check if this is a forward or backwards arraycopy
-		if (A1 != A2 || offset1 > offset2 || offset1+length <= offset2) { 
+		if (A1 != A2 || offset1 > offset2 || offset1+length <= offset2) {
 			for (int i = 0; i < length; ++i) {
 				A2[offset2+i] = A1[offset1+i];
 			}
@@ -555,7 +555,7 @@ private static native Properties initProperties(Properties props);
 /*[ENDIF] OpenJ9-RawBuild */
 
 /**
- * If systemProperties is unset, then create a new one based on the values 
+ * If systemProperties is unset, then create a new one based on the values
  * provided by the virtual machine.
  */
 @SuppressWarnings("nls")
@@ -564,7 +564,7 @@ private static void ensureProperties(boolean isInitialization) {
 	// invoke JCL native to initialize platform encoding
 	initProperties(new Properties());
 /*[ENDIF] OpenJ9-RawBuild */
-	
+
 /*[IF JAVA_SPEC_VERSION >= 12]*/
 	Map<String, String> initializedProperties = new Hashtable<String, String>();
 /*[ELSE] JAVA_SPEC_VERSION >= 12
@@ -595,7 +595,7 @@ private static void ensureProperties(boolean isInitialization) {
 		}
 		initializedProperties.put(key, list[i+1]);
 	}
-	
+
 	/* java.lang.VersionProps.init() eventually calls into System.setProperty() where propertiesInitialized needs to be true */
 	propertiesInitialized = true;
 
@@ -659,7 +659,7 @@ private static void ensureProperties(boolean isInitialization) {
 }
 
 /* Converts a Map<String, String> to a properties object.
- * 
+ *
  * The system properties will be initialized as a Map<String, String> type to be compatible
  * with jdk.internal.misc.VM and java.lang.VersionProps APIs.
  */
@@ -676,7 +676,7 @@ private static native void rasInitializeVersion(String javaRuntimeVersion);
  * Causes the virtual machine to stop running, and the
  * program to exit. If runFinalizersOnExit(true) has been
  * invoked, then all finalizers will be run first.
- * 
+ *
  * @param		code		the return code.
  *
  * @throws		SecurityException 	if the running thread is not allowed to cause the vm to exit.
@@ -699,7 +699,7 @@ public static void gc() {
 /*[PR 127013] [JCL Desktop]VM throws runtime exception(no such method signature) when calling System.getenv() function (SPR MXZU76W5R5)*/
 /**
  * Returns an environment variable.
- * 
+ *
  * @param 		var			the name of the environment variable
  * @return		the value of the specified environment variable
  */
@@ -709,7 +709,7 @@ public static String getenv(String var) {
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPermission(new RuntimePermission("getenv." + var)); //$NON-NLS-1$
-	
+
 	return ProcessEnvironment.getenv(var);
 }
 
@@ -729,7 +729,7 @@ public static Properties getProperties() {
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPropertiesAccess();
-	
+
 	return systemProperties;
 }
 
@@ -746,7 +746,7 @@ static Properties internalGetProperties() {
 }
 /**
  * Answers the value of a particular system property.
- * Answers null if no such property exists, 
+ * Answers null if no such property exists,
  * <p>
  * The properties currently provided by the virtual
  * machine are:
@@ -794,7 +794,7 @@ public static String getProperty(String prop, String defaultValue) {
 	if (security != null)
 		security.checkPropertyAccess(prop);
 
-	if (!propertiesInitialized 
+	if (!propertiesInitialized
 			&& !prop.equals("com.ibm.IgnoreMalformedInput") //$NON-NLS-1$
 			&& !prop.equals("file.encoding.pkg") //$NON-NLS-1$
 			&& !prop.equals("sun.nio.cs.map")) { //$NON-NLS-1$
@@ -807,7 +807,7 @@ public static String getProperty(String prop, String defaultValue) {
 		}
 		throw new Error("bootstrap error, system property access before init: " + prop); //$NON-NLS-1$
 	}
-		
+
 	return systemProperties.getProperty(prop, defaultValue);
 }
 
@@ -815,20 +815,20 @@ public static String getProperty(String prop, String defaultValue) {
  * Sets the value of a particular system property.
  *
  * @param		prop		the system property to change
- * @param		value		the value to associate with prop 
+ * @param		value		the value to associate with prop
  * @return		the old value of the property, or null
  */
 public static String setProperty(String prop, String value) {
 	if (!propertiesInitialized) throw new Error("bootstrap error, system property access before init: " + prop); //$NON-NLS-1$
-	
+
 	/*[PR CMVC 80288] should check for empty key */
 	if (prop.length() == 0) throw new IllegalArgumentException();
-	
+
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPermission(
 			new PropertyPermission(prop, "write")); //$NON-NLS-1$
-	
+
 	return (String)systemProperties.setProperty(prop, value);
 }
 
@@ -882,7 +882,7 @@ public static int identityHashCode(Object anObject) {
 
 /**
  * Loads the specified file as a dynamic library.
- * 
+ *
  * @param 		pathName	the path of the file to be loaded
  */
 @CallerSensitive
@@ -957,13 +957,13 @@ public static void runFinalizersOnExit(boolean flag) {
 
 /**
  * Answers the system properties. Note that the object
- * which is passed in not copied, so that subsequent 
+ * which is passed in not copied, so that subsequent
  * changes made to the object will be reflected in
  * calls to getProperty and getProperties.
  * <p>
  * Security managers should restrict access to this
  * API if possible.
- * 
+ *
  * @param		p			the property to set
  */
 public static void setProperties(Properties p) {
@@ -984,7 +984,7 @@ public static void setProperties(Properties p) {
  * exception.
  *
  * @param		s			the new security manager
- * 
+ *
  * @throws		SecurityException 	if the security manager has already been set and its checkPermission method doesn't allow it to be replaced.
  /*[IF JAVA_SPEC_VERSION >= 12]
  * @throws		UnsupportedOperationException 	if s is non-null and a special token "disallow" has been set for system property "java.security.manager"
@@ -994,7 +994,7 @@ public static void setProperties(Properties p) {
 public static void setSecurityManager(final SecurityManager s) {
 	/*[PR 113606] security field could be modified by another Thread */
 	final SecurityManager currentSecurity = security;
-	
+
 	if (s != null) {
 		/*[IF JAVA_SPEC_VERSION >= 12]*/
 		if ("disallow".equals(systemProperties.getProperty("java.security.manager"))) { //$NON-NLS-1$ //$NON-NLS-2$
@@ -1008,21 +1008,21 @@ public static void setSecurityManager(final SecurityManager s) {
 			try {
 				/*[PR 95057] preload classes required for checkPackageAccess() */
 				// Preload classes used for checkPackageAccess(),
-				// otherwise we could go recursive 
+				// otherwise we could go recursive
 				s.checkPackageAccess("java.lang"); //$NON-NLS-1$
 			} catch (Exception e) {
 				// ignore any potential exceptions
 			}
 		}
-		
+
 		try {
 			/*[PR 97686] Preload the policy permission */
 			AccessController.doPrivileged(new PrivilegedAction<Void>() {
 				@Override
 				public Void run() {
 					if (currentSecurity == null) {
-						// initialize external messages and 
-						// also load security sensitive classes 
+						// initialize external messages and
+						// also load security sensitive classes
 						com.ibm.oti.util.Msg.getString("K002c"); //$NON-NLS-1$
 					}
 					ProtectionDomain pd = s.getClass().getPDImpl();
@@ -1068,10 +1068,10 @@ static Class getCallerClass() {
 
 /**
  * Return the channel inherited by the invocation of the running vm. The channel is
- * obtained by calling SelectorProvider.inheritedChannel(). 
- * 
+ * obtained by calling SelectorProvider.inheritedChannel().
+ *
  * @return the inherited channel or null
- * 
+ *
  * @throws IOException if an IO error occurs getting the inherited channel
  */
 public static java.nio.channels.Channel inheritedChannel() throws IOException {
@@ -1081,20 +1081,20 @@ public static java.nio.channels.Channel inheritedChannel() throws IOException {
 /**
  * Returns the current tick count in nanoseconds. The tick count
  * only reflects elapsed time.
- * 
+ *
  * @return		the current nanosecond tick count, which may be negative
  */
 public static native long nanoTime();
 
 /**
  * Removes the property.
- * 
+ *
  * @param 		prop		the name of the property to remove
  * @return		the value of the property removed
  */
 public static String clearProperty(String prop) {
 	if (!propertiesInitialized) throw new Error("bootstrap error, system property access before init: " + prop); //$NON-NLS-1$
-	
+
 	if (prop.length() == 0) throw new IllegalArgumentException();
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
@@ -1104,20 +1104,20 @@ public static String clearProperty(String prop) {
 
 /**
  * Returns all of the system environment variables in an unmodifiable Map.
- * 
+ *
  * @return	an unmodifiable Map containing all of the system environment variables.
  */
 public static Map<String, String> getenv() {
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPermission(new RuntimePermission("getenv.*")); //$NON-NLS-1$
-		
+
 	return ProcessEnvironment.getenv();
 }
 
 /**
  * Return the Console or null.
- * 
+ *
  * @return the Console or null
  */
 public static Console console() {
@@ -1166,7 +1166,7 @@ private static void longMultiLeafArrayCopy(Object src, int srcPos,
 
 	srcLeafPos = newSrcPos % numOfElemsPerLeaf;
 	destLeafPos = newDestPos % numOfElemsPerLeaf;
-	if (srcLeafPos < destLeafPos) 
+	if (srcLeafPos < destLeafPos)
 	{
 		if (isFwd)
 		{
@@ -1179,8 +1179,8 @@ private static void longMultiLeafArrayCopy(Object src, int srcPos,
 			L1 = srcLeafPos + 1;
 			L2 = destLeafPos - srcLeafPos;
 		}
-	} 
-	else 
+	}
+	else
 	{
 		if (isFwd)
 		{
@@ -1240,17 +1240,17 @@ private static void longMultiLeafArrayCopy(Object src, int srcPos,
 /**
  * JIT Helper method
  */
-private static void simpleMultiLeafArrayCopy(Object src, int srcPos, 
-		Object dest, int destPos, int length, int elementSize, int leafSize) 
+private static void simpleMultiLeafArrayCopy(Object src, int srcPos,
+		Object dest, int destPos, int length, int elementSize, int leafSize)
 {
 	int count = 0;
 
 	// Check if this is a forward or backwards arraycopy
 	boolean isFwd;
-	if (src != dest || srcPos > destPos || srcPos+length <= destPos) 
+	if (src != dest || srcPos > destPos || srcPos+length <= destPos)
 		isFwd = true;
 	else
-		isFwd = false; 
+		isFwd = false;
 
 	int newSrcPos;
 	int newDestPos;
@@ -1317,29 +1317,29 @@ private static void simpleMultiLeafArrayCopy(Object src, int srcPos,
 /**
  * JIT Helper method
  */
-private static void multiLeafArrayCopy(Object src, int srcPos, Object dest, 
+private static void multiLeafArrayCopy(Object src, int srcPos, Object dest,
 		int destPos, int length, int elementSize, int leafSize) {
 	int count = 0;
 
 	// Check if this is a forward or backwards arraycopy
 	boolean isFwd;
-	if (src != dest || srcPos > destPos || srcPos+length <= destPos) 
+	if (src != dest || srcPos > destPos || srcPos+length <= destPos)
 		isFwd = true;
 	else
-		isFwd = false; 
+		isFwd = false;
 
 	int newSrcPos;
 	int newDestPos;
 	int numOfElemsPerLeaf = leafSize / elementSize;
 	int srcLeafPos;
 	int destLeafPos;
-	
-	if (isFwd) 
+
+	if (isFwd)
 	{
 		newSrcPos = srcPos;
 		newDestPos = destPos;
-	} 
-	else 
+	}
+	else
 	{
 		 newSrcPos = srcPos + length - 1;
 		 newDestPos = destPos + length - 1;
@@ -1347,7 +1347,7 @@ private static void multiLeafArrayCopy(Object src, int srcPos, Object dest,
 
 	int iterLength1 = 0;
 	int iterLength2 = 0;
-	while (count < length) 
+	while (count < length)
 	{
 		srcLeafPos = (newSrcPos % numOfElemsPerLeaf);
 		destLeafPos = (newDestPos % numOfElemsPerLeaf);
@@ -1355,12 +1355,12 @@ private static void multiLeafArrayCopy(Object src, int srcPos, Object dest,
 		int firstPos, secondPos;
 
 		if ((isFwd && (srcLeafPos >= destLeafPos)) ||
-				(!isFwd && (srcLeafPos < destLeafPos))) 
+				(!isFwd && (srcLeafPos < destLeafPos)))
 		{
 			firstPos = srcLeafPos;
 			secondPos = newDestPos;
-		} 
-		else 
+		}
+		else
 		{
 			firstPos = destLeafPos;
 			secondPos = newSrcPos;
@@ -1377,7 +1377,7 @@ private static void multiLeafArrayCopy(Object src, int srcPos, Object dest,
 
 		if (isFwd)
 			iterLength2 = numOfElemsPerLeaf - ((secondPos + iterLength1) % numOfElemsPerLeaf);
-		else 
+		else
 		{
 			iterLength2 = ((secondPos - iterLength1) % numOfElemsPerLeaf) + 1;
 			offset = iterLength1 - 1;
@@ -1389,12 +1389,12 @@ private static void multiLeafArrayCopy(Object src, int srcPos, Object dest,
 		System.arraycopy(src, newSrcPos - offset, dest, newDestPos - offset, iterLength1);
 
 		offset = 0;
-		if (isFwd) 
+		if (isFwd)
 		{
 			newSrcPos += iterLength1;
 			newDestPos += iterLength1;
-		} 
-		else 
+		}
+		else
 		{
 			newSrcPos -= iterLength1;
 			newDestPos -= iterLength1;
@@ -1405,12 +1405,12 @@ private static void multiLeafArrayCopy(Object src, int srcPos, Object dest,
 
 		System.arraycopy(src, newSrcPos - offset, dest, newDestPos - offset, iterLength2);
 
-		if (isFwd) 
+		if (isFwd)
 		{
 			newSrcPos += iterLength2;
 			newDestPos += iterLength2;
-		} 
-		else 
+		}
+		else
 		{
 			newSrcPos -= iterLength2;
 			newDestPos -= iterLength2;
@@ -1423,8 +1423,8 @@ private static void multiLeafArrayCopy(Object src, int srcPos, Object dest,
 
 /**
  * Return platform specific line separator character(s)
- * Unix is \n while Windows is \r\n as per the prop set by the VM 
- *  
+ * Unix is \n while Windows is \r\n as per the prop set by the VM
+ *
  * @return platform specific line separator character(s)
  */
 //  Refer to Jazz 30875
@@ -1435,7 +1435,7 @@ public static String lineSeparator() {
 /*[IF Sidecar19-SE]*/
 /**
  * Return an instance of Logger.
- * 
+ *
  * @param loggerName The name of the logger to return
  * @return An instance of the logger.
  * @throws NullPointerException if the loggerName is null
@@ -1455,7 +1455,7 @@ public static Logger getLogger(String loggerName) {
  * @throws NullPointerException if the loggerName or bundle is null
  */
 @CallerSensitive
-public static Logger getLogger(String loggerName, ResourceBundle bundle) { 
+public static Logger getLogger(String loggerName, ResourceBundle bundle) {
 	loggerName = Objects.requireNonNull(loggerName);
 	bundle = Objects.requireNonNull(bundle);
 	Class<?> caller = Reflection.getCallerClass();
@@ -1468,10 +1468,10 @@ public static Logger getLogger(String loggerName, ResourceBundle bundle) {
  */
 public abstract static class LoggerFinder {
 	private static volatile LoggerFinder loggerFinder = null;
-	
+
 	/**
 	 * Checks needed runtime permissions
-	 * 
+	 *
 	 * @throws SecurityException if RuntimePermission("loggerFinder") is not allowed
 	 */
 	protected LoggerFinder() {
@@ -1480,7 +1480,7 @@ public abstract static class LoggerFinder {
 
 	/**
 	 * Returns a localizable instance of Logger for the given module
-	 * 
+	 *
 	 * @param loggerName The name of the logger
 	 * @param bundle A resource bundle; can be null
 	 * @param callerModule The module for which the logger is being requested
@@ -1496,10 +1496,10 @@ public abstract static class LoggerFinder {
 		Logger localizedLogger = new jdk.internal.logger.LocalizedLoggerWrapper(logger, bundle);
 		return localizedLogger;
 	}
-	
+
 	/**
 	 * Returns an instance of Logger for the given module
-	 * 
+	 *
 	 * @param loggerName The name of the logger
 	 * @param callerModule The module for which the logger is being requested
 	 * @return a Logger suitable for use within the given module
@@ -1510,7 +1510,7 @@ public abstract static class LoggerFinder {
 
 	/**
 	 * Returns the LoggerFinder instance
-	 * 
+	 *
 	 * @return the LoggerFinder instance.
 	 * @throws SecurityException if RuntimePermission("loggerFinder") is not allowed
 	 */
@@ -1524,7 +1524,7 @@ public abstract static class LoggerFinder {
 		}
 		return loggerFinder;
 	}
-	
+
 	private static void verifyPermissions() {
 		SecurityManager securityManager = System.getSecurityManager();
 		if (securityManager != null)	{
@@ -1534,7 +1534,7 @@ public abstract static class LoggerFinder {
 }
 
 /**
- * Logger logs messages that will be routed to the underlying logging framework 
+ * Logger logs messages that will be routed to the underlying logging framework
  * that LoggerFinder uses.
  */
 public interface Logger {
@@ -1568,53 +1568,53 @@ public interface Logger {
 		ERROR(1000),
 		/**
 		 *
-		 * Disable logging 
+		 * Disable logging
 		 */
 		OFF(Integer.MAX_VALUE);
-		
+
 		final int severity;
 		Level(int value) {
 			severity = value;
 		}
-	
+
 		/**
 		 * Returns the name of this level
-		 * 
+		 *
 		 * @return name of this level
 		 */
 		public final java.lang.String getName() {
 			return name();
 		}
-		
+
 		/**
 		 * Returns severity of this level
-		 * 
-		 * @return severity of this level 
+		 *
+		 * @return severity of this level
 		 */
 		public final int getSeverity() {
 			return severity;
 		}
 	}
-	
+
 	/**
 	 * Returns the name of this logger
-	 * 
+	 *
 	 * @return the logger name
 	 */
 	public String getName();
-	
+
 	/**
 	 * Checks if a message of the given level will be logged
-	 * 
+	 *
 	 * @param level The log message level
 	 * @return true if the given log message level is currently being logged
 	 * @throws NullPointerException if level is null
 	 */
 	public boolean isLoggable(Level level);
-	
+
 	/**
 	 * Logs a message
-	 * 
+	 *
 	 * @param level The log message level
 	 * @param msg The log message
 	 * @throws NullPointerException if level is null
@@ -1623,10 +1623,10 @@ public interface Logger {
 		level = Objects.requireNonNull(level);
 		log(level, (ResourceBundle)null, msg, (Object[])null);
 	}
-	
+
 	/**
 	 * Logs a lazily supplied message
-	 * 
+	 *
 	 * @param level The log message level
 	 * @param supplier Supplier function that produces a message
 	 * @throws NullPointerException if level or supplier is null
@@ -1638,10 +1638,10 @@ public interface Logger {
 			log(level, (ResourceBundle)null, supplier.get(), (Object[])null);
 		}
 	}
-	
+
 	/**
 	 * Logs a message produced from the give object
-	 * 
+	 *
 	 * @param level The log message level
 	 * @param value The object to log
 	 * @throws NullPointerException if level or value is null
@@ -1653,10 +1653,10 @@ public interface Logger {
 			log(level, (ResourceBundle)null, value.toString(), (Object[])null);
 		}
 	}
-	
+
 	/**
 	 * Log a message associated with a given throwable
-	 * 
+	 *
 	 * @param level The log message level
 	 * @param msg The log message
 	 * @param throwable Throwable associated with the log message
@@ -1666,10 +1666,10 @@ public interface Logger {
 		level = Objects.requireNonNull(level);
 		log(level, (ResourceBundle)null, msg, throwable);
 	}
-	
+
 	/**
 	 * Logs a lazily supplied message associated with a given throwable
-	 * 
+	 *
 	 * @param level The log message level
 	 * @param supplier Supplier function that produces a message
 	 * @param throwable Throwable associated with the log message
@@ -1682,10 +1682,10 @@ public interface Logger {
 			log(level, (ResourceBundle)null, supplier.get(), throwable);
 		}
 	}
-	
+
 	/**
 	 * Logs a message with an optional list of parameters
-	 * 
+	 *
 	 * @param level The log message level
 	 * @param msg The log message
 	 * @param values Optional list of parameters
@@ -1695,10 +1695,10 @@ public interface Logger {
 		level = Objects.requireNonNull(level);
 		log(level, (ResourceBundle)null, msg, values);
 	}
-	
+
 	/**
 	 * Logs a localized message associated with a given throwable
-	 * 
+	 *
 	 * @param level The log message level
 	 * @param bundle A resource bundle to localize msg
 	 * @param msg The log message
@@ -1706,10 +1706,10 @@ public interface Logger {
 	 * @throws NullPointerException if level is null
 	 */
 	public void log(Level level, ResourceBundle bundle, String msg, Throwable throwable);
-	
+
 	/**
 	 * Logs a message with resource bundle and an optional list of parameters
-	 * 
+	 *
 	 * @param level The log message level
 	 * @param bundle A resource bundle to localize msg
 	 * @param msg The log message

--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -230,15 +230,9 @@ void completeInitialization() {
 	 * encodings can be used for System.err and System.out.
 	 */
 	Properties props = System.internalGetProperties();
-	/*[IF PLATFORM-mz31|PLATFORM-mz64]*/
-	String consoleEncoding = props.getProperty("ibm.system.encoding"); //$NON-NLS-1$
-	/*[ELSE]*/
-	String consoleEncoding = props.getProperty("file.encoding"); //$NON-NLS-1$
-	/*[ENDIF] PLATFORM-mz31|PLATFORM-mz64 */
-
 	// If the sun.stderr.encoding was already set in System, don't change the encoding
 	if (!System.hasSetErrEncoding()) {
-		Charset stderrCharset = System.getCharset(props.getProperty("sun.stderr.encoding"), consoleEncoding); //$NON-NLS-1$
+		Charset stderrCharset = System.getCharset(props.getProperty("sun.stderr.encoding"), true); //$NON-NLS-1$
 		if (stderrCharset != null) {
 			System.err.flush();
 			/*[IF PLATFORM-mz31|PLATFORM-mz64]*/
@@ -251,7 +245,7 @@ void completeInitialization() {
 
 	// If the sun.stdout.encoding was already set in System, don't change the encoding
 	if (!System.hasSetOutEncoding()) {
-		Charset stdoutCharset = System.getCharset(props.getProperty("sun.stdout.encoding"), consoleEncoding); //$NON-NLS-1$
+		Charset stdoutCharset = System.getCharset(props.getProperty("sun.stdout.encoding"), true); //$NON-NLS-1$
 		if (stdoutCharset != null) {
 			System.out.flush();
 			/*[IF PLATFORM-mz31|PLATFORM-mz64]*/

--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -28,10 +28,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import sun.security.util.SecurityConstants;
 /*[IF JAVA_SPEC_VERSION >= 11]*/
-import java.io.BufferedOutputStream;
 import java.io.FileDescriptor;
-import java.io.FileOutputStream;
-import java.io.PrintStream;
 import java.nio.charset.Charset;
 import java.util.Properties;
 import jdk.internal.misc.TerminatingThreadLocal;
@@ -235,11 +232,7 @@ void completeInitialization() {
 		Charset stderrCharset = System.getCharset(props.getProperty("sun.stderr.encoding"), true); //$NON-NLS-1$
 		if (stderrCharset != null) {
 			System.err.flush();
-			/*[IF PLATFORM-mz31|PLATFORM-mz64]*/
-			System.setErr(com.ibm.jvm.io.ConsolePrintStream.localize(new BufferedOutputStream(new FileOutputStream(FileDescriptor.err)), true, stderrCharset));
-			/*[ELSE]*/
-			System.setErr(new PrintStream(new BufferedOutputStream(new FileOutputStream(FileDescriptor.err)), true, stderrCharset));
-			/*[ENDIF] PLATFORM-mz31|PLATFORM-mz64 */
+			System.setErr(System.createConsole(FileDescriptor.err, stderrCharset));
 		}
 	}
 
@@ -248,11 +241,7 @@ void completeInitialization() {
 		Charset stdoutCharset = System.getCharset(props.getProperty("sun.stdout.encoding"), true); //$NON-NLS-1$
 		if (stdoutCharset != null) {
 			System.out.flush();
-			/*[IF PLATFORM-mz31|PLATFORM-mz64]*/
-			System.setOut(com.ibm.jvm.io.ConsolePrintStream.localize(new BufferedOutputStream(new FileOutputStream(FileDescriptor.out)), true, stdoutCharset));
-			/*[ELSE]*/
-			System.setOut(new PrintStream(new BufferedOutputStream(new FileOutputStream(FileDescriptor.out)), true, stdoutCharset));
-			/*[ENDIF] PLATFORM-mz31|PLATFORM-mz64 */
+			System.setOut(System.createConsole(FileDescriptor.out, stdoutCharset));
 		}
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 11 */

--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -71,7 +71,7 @@ public class Thread implements Runnable {
 	 */
 	public final static int NORM_PRIORITY = 5;		// Normal priority for a thread
 	/*[PR 97331] Initial thread name should be Thread-0 */
-	private static int createCount = -1;					// Used internally to compute Thread names that comply with the Java specification	
+	private static int createCount = -1;					// Used internally to compute Thread names that comply with the Java specification
 	/*[PR 122459] LIR646 - Remove use of generic object for synchronization */
 	private static final class TidLock {
 		TidLock() {}
@@ -86,8 +86,8 @@ public class Thread implements Runnable {
 	private long threadRef;									// Used by the VM
 	long stackSize = 0;
 	/*[IF JAVA_SPEC_VERSION >= 14]*/
-	/* deadInterrupt tracks the thread interrupt state when threadRef has no reference (ie thread is not alive). 
-	 * Note that this value need not be updated while the thread is running since the interrupt state will be 
+	/* deadInterrupt tracks the thread interrupt state when threadRef has no reference (ie thread is not alive).
+	 * Note that this value need not be updated while the thread is running since the interrupt state will be
 	 * tracked by the vm during that time. Because of this the value should not be used over calling
 	 * isInterrupted() or interrupted().
 	 */
@@ -113,7 +113,7 @@ public class Thread implements Runnable {
 
 	ThreadLocal.ThreadLocalMap inheritableThreadLocals;
 	private volatile sun.nio.ch.Interruptible blockOn;
-	
+
 	int threadLocalsIndex;
 	int inheritableThreadLocalsIndex;
 
@@ -125,10 +125,10 @@ public class Thread implements Runnable {
 
 	private static ThreadGroup systemThreadGroup;		// Assigned by the vm
 	private static ThreadGroup mainGroup;				// ThreadGroup where the "main" Thread starts
-	
+
 	/*[PR 113602] Thread fields should be volatile */
 	private volatile static UncaughtExceptionHandler defaultExceptionHandler;
-	
+
 	/*[PR CMVC 196696] Build error:java.lang.Thread need extra fields */
 	long threadLocalRandomSeed;
 	int threadLocalRandomProbe;
@@ -166,7 +166,7 @@ private Thread(String vmName, Object vmThreadGroup, int vmPriority, boolean vmIs
 	setNameImpl(threadRef, threadName);
 	/*[ENDIF] JAVA_SPEC_VERSION < 15 */
 	name = threadName;
-	
+
 	isDaemon = vmIsDaemon;
 	priority = vmPriority;	// If we called setPriority(), it would have to be after setting the ThreadGroup (further down),
 							// because of the checkAccess() call (which requires the ThreadGroup set). However, for the main
@@ -184,18 +184,18 @@ private Thread(String vmName, Object vmThreadGroup, int vmPriority, boolean vmIs
 		/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 	}
 	threadGroup = vmThreadGroup == null ? mainGroup : (ThreadGroup)vmThreadGroup;
-	
+
 	/*[PR 1FEVFSU] The rest of the configuration/initialization is shared between this constructor and the public one */
 	initialize(booting, threadGroup, null, null, true);	// no parent Thread
 	/*[PR 115667, CMVC 94448] In 1.5 and CDC/Foundation 1.1, thread is added to ThreadGroup when started */
  	this.group.add(this);
- 	
+
 	/*[PR 100718] Initialize System.in after the main thread */
 	if (booting) {
 		/*[IF JAVA_SPEC_VERSION >= 15]*/
 		/* JDK15+ native method binding uses java.lang.ClassLoader.findNative():bootstrapClassLoader.nativelibs.find(entryName)
 		 * to lookup native address when not found within systemClassLoader native libraries.
-		 * This requires bootstrapClassLoader is initialized via initialize(booting, threadGroup, null, null, true) above before 
+		 * This requires bootstrapClassLoader is initialized via initialize(booting, threadGroup, null, null, true) above before
 		 * invoking a native method not present within systemClassLoader native libraries such as following setNameImpl modified
 		 * via JVMTI agent SetNativeMethodPrefix (https://github.com/eclipse/openj9/issues/11181).
 		 * After bootstrapClassLoader initialization, setNameImpl can be invoked before initialize() to set thread name earlier.
@@ -335,7 +335,7 @@ public Thread(String threadName) {
  *					if <code>group.destroy()</code> has already been done
  *
  * @see			java.lang.ThreadGroup
- * @see			java.lang.Runnable 
+ * @see			java.lang.Runnable
  * @see			java.lang.SecurityException
  * @see			java.lang.SecurityManager
  */
@@ -360,7 +360,7 @@ public Thread(ThreadGroup group, Runnable runnable) {
  * @since 1.4
  *
  * @see			java.lang.ThreadGroup
- * @see			java.lang.Runnable 
+ * @see			java.lang.Runnable
  * @see			java.lang.SecurityException
  * @see			java.lang.SecurityManager
  */
@@ -407,7 +407,7 @@ public Thread(ThreadGroup group, Runnable runnable, String threadName, long stac
  *					if <code>group.destroy()</code> has already been done
  *
  * @see			java.lang.ThreadGroup
- * @see			java.lang.Runnable 
+ * @see			java.lang.Runnable
  * @see			java.lang.SecurityException
  * @see			java.lang.SecurityManager
  */
@@ -429,9 +429,9 @@ private Thread(ThreadGroup group, Runnable runnable, String threadName, AccessCo
 	this.name = threadName;		// We avoid the public API 'setName', since it does redundant work (checkAccess)
 	this.runnable = runnable;	// No API available here, so just direct access to inst. var.
 	Thread currentThread  = currentThread();
-	
+
 	this.isDaemon = currentThread.isDaemon(); // We avoid the public API 'setDaemon', since it does redundant work (checkAccess)
-	
+
 /*[PR 1FEO92F] (dup of 1FC0TRN) */
 	if (group == null) {
 		SecurityManager currentManager = System.getSecurityManager();
@@ -444,11 +444,11 @@ private Thread(ThreadGroup group, Runnable runnable, String threadName, AccessCo
 	if (group == null)
 		// Same group as Thread that created us
 		group = currentThread.getThreadGroup();
-	
+
 
 	/*[PR 1FEVFSU] The rest of the configuration/initialization is shared between this constructor and the private one */
 	initialize(false, group, currentThread, acc, inheritThreadLocals);
-	
+
 	setPriority(currentThread.getPriority());	// In this case we can call the public API according to the spec - 20.20.10
 }
 
@@ -470,26 +470,26 @@ private void initialize(boolean booting, ThreadGroup threadGroup, Thread parentT
 
 	/*[PR 96408]*/
 	this.group = threadGroup;
-	
-	
+
+
 	if (booting) {
 		System.afterClinitInitialization();
 	}
-	
-	
+
+
 	// initialize the thread local storage before making other calls
 	if (parentThread != null) { // Non-main thread
 		if (inheritThreadLocals && (null != parentThread.inheritableThreadLocals)) {
 			inheritableThreadLocals = ThreadLocal.createInheritedMap(parentThread.inheritableThreadLocals);
 		}
-		
+
 		/*[PR CMVC 90230] enableContextClassLoaderOverride check added in 1.5 */
 		final SecurityManager sm = System.getSecurityManager();
 		final Class implClass = getClass();
 		final Class thisClass = Thread.class;
 		if (sm != null && implClass != thisClass) {
 			boolean override = ((Boolean)AccessController.doPrivileged(new PrivilegedAction() {
-				public Object run() {			
+				public Object run() {
 					try {
 						java.lang.reflect.Method method = implClass.getMethod("getContextClassLoader", new Class[0]); //$NON-NLS-1$
 						if (method.getDeclaringClass() != thisClass) {
@@ -526,12 +526,12 @@ private void initialize(boolean booting, ThreadGroup threadGroup, Thread parentT
 			}
 
 			// Explicitly initialize ClassLoaders, so ClassLoader methods (such as
-			// ClassLoader.callerClassLoader) can be used before System is initialized 
+			// ClassLoader.callerClassLoader) can be used before System is initialized
 			ClassLoader.initializeClassLoaders();
 		}
 		// Just set the context class loader
 		contextClassLoader = ClassLoader.getSystemClassLoader();
-	}	
+	}
 
 	threadGroup.checkAccess();
 	/*[PR 115667, CMVC 94448] In 1.5 and CDC/Foundation 1.1, thread is added to ThreadGroup when started */
@@ -563,12 +563,12 @@ public Thread(ThreadGroup group, String threadName) {
 /**
  * Returns how many threads are active in the <code>ThreadGroup</code>
  * which the current thread belongs to.
- * 
+ *
  * @return Number of Threads
  */
 public static int activeCount(){
 	/*[PR CMVC 93001] changed in 1.5 to only count active threads */
-	return currentThread().getThreadGroup().activeCount();	
+	return currentThread().getThreadGroup().activeCount();
 }
 
 
@@ -590,7 +590,7 @@ public final void checkAccess() {
  * 	Returns the number of stack frames in this thread.
  *
  * @return		Number of stack frames
- * 
+ *
 /*[IF JAVA_SPEC_VERSION >= 14]
  * @exception	UnsupportedOperationException
 /*[ENDIF] JAVA_SPEC_VERSION >= 14
@@ -621,7 +621,7 @@ public static native Thread currentThread();
 /*[IF JAVA_SPEC_VERSION < 11]*/
 /**
  * 	Destroys the receiver without any monitor cleanup. Not implemented.
- * 
+ *
  * @deprecated May cause deadlocks.
  */
 /*[IF Sidecar19-SE]*/
@@ -652,7 +652,7 @@ public static void dumpStack() {
  *
  * @return		How many Threads were copied over
  *
- * @exception	SecurityException	
+ * @exception	SecurityException
  *					if the installed SecurityManager fails <code>checkAccess(Ljava.lang.Thread;)</code>
  *
  * @see			java.lang.SecurityException
@@ -681,8 +681,8 @@ public ClassLoader getContextClassLoader() {
 		ClassLoader callerClassLoader = ClassLoader.callerClassLoader();
 		if (ClassLoader.needsClassLoaderPermissionCheck(callerClassLoader, contextClassLoader)) {
 			currentManager.checkPermission(SecurityConstants.GET_CLASSLOADER_PERMISSION);
-		}	
-	}	
+		}
+	}
 	return contextClassLoader;
 }
 
@@ -719,7 +719,7 @@ public final ThreadGroup getThreadGroup() {
 
 /**
  * Posts an interrupt request to the receiver
- * 
+ *
 /*[IF JAVA_SPEC_VERSION >= 14]
  * From Java 14, the interrupt state for threads that are not alive is tracked.
 /*[ENDIF] JAVA_SPEC_VERSION >= 14
@@ -730,7 +730,7 @@ public final ThreadGroup getThreadGroup() {
  * @see			java.lang.SecurityException
  * @see			java.lang.SecurityManager
  * @see			Thread#interrupted
- * @see			Thread#isInterrupted 
+ * @see			Thread#isInterrupted
  */
 public void interrupt() {
 	SecurityManager currentManager = System.getSecurityManager();
@@ -740,7 +740,7 @@ public void interrupt() {
 			currentManager.checkAccess(this);
 		}
 	}
-	
+
 	synchronized(lock) {
 		interruptImpl();
 		sun.nio.ch.Interruptible localBlockOn = blockOn;
@@ -759,21 +759,21 @@ public void interrupt() {
  *
  * @return		a <code>boolean</code>
  *
- * @see			Thread#currentThread 
- * @see			Thread#interrupt 
+ * @see			Thread#currentThread
+ * @see			Thread#interrupt
  * @see			Thread#isInterrupted
  */
 public static native boolean interrupted();
 
 /**
  * Posts an interrupt request to the receiver
- * 
+ *
 /*[IF JAVA_SPEC_VERSION >= 14]
  * From Java 14, the interrupt state for threads that are not alive is tracked.
 /*[ENDIF] JAVA_SPEC_VERSION >= 14
  *
  * @see			Thread#interrupted
- * @see			Thread#isInterrupted 
+ * @see			Thread#isInterrupted
  */
 private native void interruptImpl();
 
@@ -821,7 +821,7 @@ private boolean isDead() {
  *
  * @return		a <code>boolean</code>
  *
- * @see			Thread#setDaemon 
+ * @see			Thread#setDaemon
  */
 public final boolean isDaemon() {
 	return this.isDaemon;
@@ -833,7 +833,7 @@ public final boolean isDaemon() {
  *
  * @return		a <code>boolean</code>
  *
- * @see			Thread#interrupt 
+ * @see			Thread#interrupt
  * @see			Thread#interrupted
  */
 public boolean isInterrupted() {
@@ -852,7 +852,7 @@ private native boolean isInterruptedImpl();
  * @exception	InterruptedException
  *					if <code>interrupt()</code> was called for the receiver while
  *					it was in the <code>join()</code> call
- * 
+ *
  * @see			Object#notifyAll
  * @see			java.lang.ThreadDeath
  */
@@ -872,7 +872,7 @@ public final synchronized void join() throws InterruptedException {
  * @exception	InterruptedException
  *					if <code>interrupt()</code> was called for the receiver while
  *					it was in the <code>join()</code> call
- * 
+ *
  * @see			Object#notifyAll
  * @see			java.lang.ThreadDeath
  */
@@ -891,7 +891,7 @@ public final void join(long timeoutInMilliseconds) throws InterruptedException {
  * @exception	InterruptedException
  *					if <code>interrupt()</code> was called for the receiver while
  *					it was in the <code>join()</code> call
- * 
+ *
  * @see			Object#notifyAll
  * @see			java.lang.ThreadDeath
  */
@@ -902,7 +902,7 @@ public final synchronized void join(long timeoutInMilliseconds, int nanos) throw
 	if (!started || isDead()) return;
 
 	// No nanosecond precision for now, we would need something like 'currentTimenanos'
-	
+
 	long totalWaited = 0;
 	long toWait = timeoutInMilliseconds;
 	boolean timedOut = false;
@@ -926,7 +926,7 @@ public final synchronized void join(long timeoutInMilliseconds, int nanos) throw
 		// less than the timeout, we must check if the thread really died
 		timedOut = (totalWaited >= timeoutInMilliseconds);
 	}
-	
+
 }
 
 /**
@@ -945,7 +945,7 @@ private synchronized static String newName() {
 		return "main"; //$NON-NLS-1$
 	} else {
 		return "Thread-" + createCount++; //$NON-NLS-1$
-	}	
+	}
 }
 
 /**
@@ -1003,13 +1003,13 @@ public void run() {
  * @see			#getContextClassLoader()
  */
 public void setContextClassLoader(ClassLoader cl) {
-/*[PR 1FCA807]*/	
+/*[PR 1FCA807]*/
 	SecurityManager currentManager = System.getSecurityManager();
 	 // if there is a security manager...
 	if (currentManager != null) {
 		// then check permission
 		currentManager.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionSetContextClassLoader);
-	}	
+	}
 	contextClassLoader = cl;
 }
 
@@ -1018,11 +1018,11 @@ public void setContextClassLoader(ClassLoader cl) {
  * before the Thread starts running.
  *
  * @param		isDaemon		A boolean indicating if the Thread should be daemon or not
- * 
+ *
  * @exception	SecurityException
  *					if <code>checkAccess()</code> fails with a SecurityException
  *
- * @see			Thread#isDaemon 
+ * @see			Thread#isDaemon
  */
 public final void setDaemon(boolean isDaemon) {
 	checkAccess();
@@ -1046,7 +1046,7 @@ public final void setDaemon(boolean isDaemon) {
  * @exception	SecurityException
  *					if <code>checkAccess()</code> fails with a SecurityException
  *
- * @see			Thread#getName 
+ * @see			Thread#getName
  */
 public final void setName(String threadName) {
 	checkAccess();
@@ -1095,7 +1095,7 @@ public final void setPriority(int requestedPriority){
 					setPriorityNoVMAccessImpl(threadRef, finalPriority);
 				}
 			}
-		} 
+		}
 		return;
 	}
 	throw new IllegalArgumentException();
@@ -1122,7 +1122,7 @@ private native void setPriorityNoVMAccessImpl(long threadRef, int priority);
  *
  * @see			Thread#interrupt()
  */
- 
+
 public static void sleep(long time) throws InterruptedException {
 	sleep(time, 0);
 }
@@ -1144,9 +1144,9 @@ public static native void sleep(long time, int nanos) throws InterruptedExceptio
 
 /*[IF Sidecar19-SE]*/
 /**
- * Hints to the run-time that a spin loop is being performed 
+ * Hints to the run-time that a spin loop is being performed
  * which helps the thread in the spin loop not to use as much power.
- * 
+ *
  */
 public static native void onSpinWait();
 /*[ENDIF]*/
@@ -1162,29 +1162,29 @@ public static native void onSpinWait();
  */
 public synchronized void start() {
 	boolean success = false;
-	
+
 	/*[PR CMVC 189553] Deadlock when a thread fails to start and another thread is ins */
 	/*[IF]
 	 * Deadlock happens when a thread is added to the ThreadGroup
 	 * and its start method fails and calls its ThreadGroup's remove method for this thread to be removed while holding this thread's lock.
 	 * If there is another call which is holding ThreadGroup's child lock and waiting for this thread's lock,
-	 * then deadlock occurs since ThreadGroup's remove method is waiting for its child lock. 
+	 * then deadlock occurs since ThreadGroup's remove method is waiting for its child lock.
 	 *
 	 * Release the lock before calling threadgroup's remove method for this thread.
 	/*[ENDIF]*/
-	 
+
 	try {
 		synchronized(lock) {
 			if (started) {
-				/*[MSG "K0341", "Thread is already started"]*/ 
+				/*[MSG "K0341", "Thread is already started"]*/
 				throw new IllegalThreadStateException(com.ibm.oti.util.Msg.getString("K0341")); //$NON-NLS-1$
 			}
- 		
+
 			/*[PR 115667, CMVC 94448] In 1.5, thread is added to ThreadGroup when started */
 			group.add(this);
-		
+
 			startImpl();
- 		 	
+
 			success = true;
 		}
  	} finally {
@@ -1193,8 +1193,8 @@ public synchronized void start() {
  		}
  	}
 }
- 
-private native void startImpl(); 
+
+private native void startImpl();
 
 /**
  * Requests the receiver Thread to stop and throw ThreadDeath.
@@ -1251,7 +1251,7 @@ private final synchronized void stopWithThrowable(Throwable throwable) {
 		if (throwable != null){
 			if (!started){
 				/* [PR CMVC 179978] Java7:JCK:java_lang.Thread fails in all plat*/
-				/* 
+				/*
 				 * if the thread has not yet been simply store the fact that stop has been called
 				 * The JVM uses this to determine if stop has been called before start
 				 */
@@ -1294,12 +1294,12 @@ private native void stopImpl(Throwable throwable);
 /*[ELSE] JAVA_SPEC_VERSION >= 11 */
 @Deprecated
 /*[ENDIF] JAVA_SPEC_VERSION >= 11 */
-public final void suspend() { 
+public final void suspend() {
 	checkAccess();
 	/*[PR 106321]*/
 	if (currentThread() == this) suspendImpl();
 	else {
-		synchronized( lock ) { 
+		synchronized( lock ) {
 			suspendImpl();
 		}
 	}
@@ -1323,7 +1323,7 @@ private native void suspendImpl();
 public String toString() {
 	/*[PR JAZZ 85499] : NullPointerException from Thread.toString() */
 	ThreadGroup localGroup = getThreadGroup();
-	
+
 	return "Thread[" + this.getName() + "," + this.getPriority() + "," + //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		/*[PR 97317] Handle a null thread group */
 		(null == localGroup ? "" : localGroup.getName()) + "]" ; //$NON-NLS-1$ //$NON-NLS-2$
@@ -1335,14 +1335,14 @@ public String toString() {
  *
  * @version		initial
  */
-public static native void yield(); 
+public static native void yield();
 
 /**
  * Returns whether the current thread has a monitor lock on the specified object.
  *
  * @param object the object to test for the monitor lock
  * @return true when the current thread has a monitor lock on the specified object
- * 
+ *
  * @since 1.4
  */
 public static native boolean holdsLock(Object object);
@@ -1367,12 +1367,12 @@ private native Throwable getStackTraceImpl();
 
 /**
  * Returns an array of StackTraceElement, where each element of the array represents a frame
- * on the Java stack. 
- * 
+ * on the Java stack.
+ *
  * @return an array of StackTraceElement
- * 
+ *
  * @throws SecurityException if the RuntimePermission "getStackTrace" is not allowed
- * 
+ *
  * @see java.lang.StackTraceElement
  */
 public StackTraceElement[] getStackTrace() {
@@ -1395,12 +1395,12 @@ public StackTraceElement[] getStackTrace() {
 /**
  * Returns a Map containing Thread keys, and values which are arrays of StackTraceElement. The Map contains
  * all Threads which were alive at the time this method was called.
- * 
+ *
  * @return an array of StackTraceElement
- * 
+ *
  * @throws SecurityException if the RuntimePermission "getStackTrace" is not allowed, or the
  * 		RuntimePermission "modifyThreadGroup" is not allowed
- * 
+ *
  * @see #getStackTrace()
  */
 public static Map<Thread, StackTraceElement[]> getAllStackTraces() {
@@ -1422,7 +1422,7 @@ public static Map<Thread, StackTraceElement[]> getAllStackTraces() {
 
 /**
  * Return a unique id for this Thread.
- * 
+ *
  * @return a positive unique id for this Thread.
  */
 public long getId() {
@@ -1436,7 +1436,7 @@ public long getId() {
 public static interface UncaughtExceptionHandler {
 	/**
 	 * The method invoked when an uncaught exception occurs in a Thread.
-	 * 
+	 *
 	 * @param thread the Thread where the uncaught exception occurred
 	 * @param throwable the uncaught exception
 	 */
@@ -1445,9 +1445,9 @@ public static interface UncaughtExceptionHandler {
 
 /**
  * Return the UncaughtExceptionHandler for this Thread.
- * 
+ *
  * @return the UncaughtExceptionHandler for this Thread
- * 
+ *
  * @see UncaughtExceptionHandler
  */
 public UncaughtExceptionHandler getUncaughtExceptionHandler() {
@@ -1458,9 +1458,9 @@ public UncaughtExceptionHandler getUncaughtExceptionHandler() {
 
 /**
  * Set the UncaughtExceptionHandler for this Thread.
- * 
+ *
  * @param handler the UncaughtExceptionHandler to set
- * 
+ *
  * @see UncaughtExceptionHandler
  */
 public void setUncaughtExceptionHandler(UncaughtExceptionHandler handler) {
@@ -1469,9 +1469,9 @@ public void setUncaughtExceptionHandler(UncaughtExceptionHandler handler) {
 
 /**
  * Return the default UncaughtExceptionHandler used for new Threads.
- * 
+ *
  * @return the default UncaughtExceptionHandler for new Threads
- * 
+ *
  * @see UncaughtExceptionHandler
  */
 public static UncaughtExceptionHandler getDefaultUncaughtExceptionHandler() {
@@ -1480,9 +1480,9 @@ public static UncaughtExceptionHandler getDefaultUncaughtExceptionHandler() {
 
 /**
  * Set the UncaughtExceptionHandler used for new  Threads.
- * 
+ *
  * @param handler the UncaughtExceptionHandler to set
- * 
+ *
  * @see UncaughtExceptionHandler
  */
 public static void setDefaultUncaughtExceptionHandler(UncaughtExceptionHandler handler) {
@@ -1495,7 +1495,7 @@ public static void setDefaultUncaughtExceptionHandler(UncaughtExceptionHandler h
 /**
  * The possible Thread states.
  */
-// The order of the States is known by the getStateImpl() native 
+// The order of the States is known by the getStateImpl() native
 public static enum State {
 	/**
 	 * A Thread which has not yet started.
@@ -1508,7 +1508,7 @@ public static enum State {
 	/**
 	 * A Thread which is blocked on a monitor.
 	 */
-	BLOCKED, 
+	BLOCKED,
 	/**
 	 * A Thread which is waiting with no timeout.
 	 */
@@ -1516,7 +1516,7 @@ public static enum State {
 	/**
 	 * A Thread which is waiting with a timeout.
 	 */
-	TIMED_WAITING, 
+	TIMED_WAITING,
 	/**
 	 * A thread which is no longer alive.
 	 */
@@ -1524,9 +1524,9 @@ public static enum State {
 
 /**
  * Returns the current Thread state.
- * 
+ *
  * @return the current Thread state constant.
- * 
+ *
  * @see State
  */
 public State getState() {
@@ -1570,7 +1570,7 @@ void uncaughtException(Throwable e) {
  */
 void cleanup() {
 /*[IF JAVA_SPEC_VERSION >= 14]*/
-	/* Refresh deadInterrupt value so it is accurate when thread reference is removed. */	
+	/* Refresh deadInterrupt value so it is accurate when thread reference is removed. */
 	deadInterrupt = interrupted();
 /*[ENDIF] JAVA_SPEC_VERSION >= 14 */
 


### PR DESCRIPTION
- Take console.encoding into account for System.out and err on z/OS
- Remove trailing whitespace from System and Thread.java 
- Add a createConsole() helper to init System.err and out