### PR TITLE
Add object header size to correctly locate the CallSite.target field

### DIFF
--- a/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
+++ b/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
@@ -487,6 +487,7 @@ setCallSiteTargetImpl(J9VMThread *currentThread, jobject callsite, jobject targe
 			(U_8*)"Ljava/lang/invoke/MethodHandle;",
 			LITERAL_STRLEN("Ljava/lang/invoke/MethodHandle;"),
 			NULL, NULL, 0);
+		offset += J9VMTHREAD_OBJECT_HEADER_SIZE(currentThread);
 		MM_ObjectAccessBarrierAPI objectAccessBarrier = MM_ObjectAccessBarrierAPI(currentThread);
 		objectAccessBarrier.inlineMixedObjectStoreObject(currentThread, callsiteObject, offset, targetObject, isVolatile);
 	}


### PR DESCRIPTION
Fixes: https://github.com/eclipse/openj9/issues/12404

Co-authored-by: Dan Heidinga <heidinga@redhat.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>