### PR TITLE
Update release notes for 0.26

### DIFF
--- a/doc/release-notes/0.26/0.26.md
+++ b/doc/release-notes/0.26/0.26.md
@@ -50,10 +50,10 @@ The following table covers notable changes in v0.26.0. Further information about
 <tbody>
 
 <tr><td valign="top">
-<a href="https://github.com/eclipse/openj9/issues/7552">#7552</a></td>
-<td valign="top">New default garbage collection (GC) scan ordering mode for the <tt>balanced</tt> policy</td>
+<a href="https://github.com/eclipse/openj9/issues/11278">#11278</a></td>
+<td valign="top">The <strong>jextract</strong> tool is deprecated</td>
 <td valign="top">All versions</td>
-<td valign="top">For performance improvements, GC copy forward operations in the <tt>balanced</tt> policy now use <i>dynamic breadth first scan mode</i>. To revert to the behavior in earlier releases, set <tt>-Xgc:breadthFirstScanOrdering</tt> on the command line when you start your application.</td>
+<td valign="top">The dump extractor tool, <strong>jextract</strong>, is deprecated in this release and is replaced by the <strong>jpackcore</strong> tool. The <strong>jpackcore</strong> tool uses the same syntax and takes the same parameters.</td>
 </tr>
 
 </table>


### PR DESCRIPTION
- Remove change to default scan behavior for the Balanced GC policy
- Add deprecation statement for jextract

[ci skip]

Signed-off-by: SueChaplain <sue_chaplain@uk.ibm.com>