### PR TITLE
Use getCPIndexForVM inside trampoline code

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5454,7 +5454,7 @@ TR_J9VMBase::reserveTrampolineIfNecessary(TR::Compilation * comp, TR::SymbolRefe
    else if (symRef->isUnresolved() || isAOT_DEPRECATED_DO_NOT_USE())
       {
       void *cp = (void *)symRef->getOwningMethod(comp)->constantPool();
-      I_32 cpIndex = symRef->getCPIndex();
+      I_32 cpIndex = symRef->getCPIndexForVM();
 
 #if 0
       if (isAOT_DEPRECATED_DO_NOT_USE() && (comp->getOption(TR_TraceRelocatableDataCG) || comp->getOption(TR_TraceRelocatableDataDetailsCG)) )


### PR DESCRIPTION
Replaces the call to getCPIndex with a call to getCPIndexForVM inside
reserveTrampolineIfNecessary. This is done to get the non-sign extended
version of the cpIndex. This is required to generate the key when adding the
unresolved method to the _unresolvedMethodHT hashtable in a code cache.

Issue: #12120
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>