### PR TITLE
(0.26.0) Update accessCheckArgRetTypes to always check array component type

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -1065,11 +1065,17 @@ public class MethodHandles {
 			if (INTERNAL_PRIVILEGED != accessMode) {
 				for (Class<?> para : type.ptypes()) {
 					if (!para.isPrimitive()) {
+						while (para.isArray()) {
+							para = para.getComponentType();
+						}
 						checkClassAccess(para);
 					}
 				}
 				Class<?> rType = type.returnType();
 				if (!rType.isPrimitive()) {
+					while (rType.isArray()) {
+						rType = rType.getComponentType();
+					}
 					checkClassAccess(rType);
 				}
 			}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -1062,6 +1062,11 @@ public class MethodHandles {
 		 * Check access to the parameter and return classes within incoming MethodType
 		 */
 		final void accessCheckArgRetTypes(MethodType type) throws IllegalAccessException {
+			/* OpenJ9 Github issue #12285
+			 * Protected array innerclass should not throw IllegalAccessException
+			 * TODO: revert the arrayClass unwrapping code below and properly handle it in checkClassAccess()
+			 * 		once this has been updated in OpenJDK
+			 */
 			if (INTERNAL_PRIVILEGED != accessMode) {
 				for (Class<?> para : type.ptypes()) {
 					if (!para.isPrimitive()) {


### PR DESCRIPTION
Port of #12371 to 0.26 release.

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>