### PR TITLE
Consume OMR Optimizer_inlines.hpp

### DIFF
--- a/runtime/compiler/optimizer/J9Optimizer.cpp
+++ b/runtime/compiler/optimizer/J9Optimizer.cpp
@@ -83,6 +83,7 @@
 #include "optimizer/HandleRecompilationOps.hpp"
 #include "optimizer/MethodHandleTransformer.hpp"
 
+#include "optimizer/Optimizer_inlines.hpp"
 
 static const OptimizationStrategy J9EarlyGlobalOpts[] =
    {
@@ -908,11 +909,6 @@ J9::Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *method
       self()->setRequestOptimization(OMR::sequentialLoadAndStoreColdGroup, true);
    }
 
-inline
-TR::Optimizer *J9::Optimizer::self()
-   {
-   return (static_cast<TR::Optimizer *>(this));
-   }
 
 OMR_InlinerPolicy *J9::Optimizer::getInlinerPolicy()
    {

--- a/runtime/compiler/optimizer/J9Optimizer.hpp
+++ b/runtime/compiler/optimizer/J9Optimizer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,10 +62,6 @@ class Optimizer : public OMR::OptimizerConnector
 
    static const OptimizationStrategy *optimizationStrategy(TR::Compilation *c);
    static ValueNumberInfoBuildType valueNumberInfoBuildType();
-
-   private:
-
-   TR::Optimizer *self();
    };
 
 }


### PR DESCRIPTION
* Include the Optimizer_inlines.hpp in the appropriate implementation file
* Remove redundant self() call from J9 Optimizer class

Signed-off-by: Daryl Maier <maier@ca.ibm.com>