### PR TITLE
Do not flatten volatile field that is > 8 bytes

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
@@ -212,7 +212,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 					if (modifiers.anyBitsIn(J9FieldFlagObject)) {
 						if (valueTypeHelper.isFlattenableFieldSignature(J9ROMFieldShapeHelper.getSignature(localField))) {
 							J9ClassPointer fieldClass = valueTypeHelper.findJ9ClassInFlattenedClassCacheWithFieldName(instanceClass, J9ROMFieldShapeHelper.getName(localField));
-							if (valueTypeHelper.isJ9ClassIsFlattened(fieldClass)) {
+							if (valueTypeHelper.isJ9FieldIsFlattened(fieldClass, localField)) {
 								UDATA size = null;
 								if (valueTypeHelper.isJ9ClassLargestAlignmentConstraintDouble(fieldClass)) {
 									size = fieldClass.totalInstanceSize();

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
@@ -395,7 +395,7 @@ public class ObjectFieldInfo {
 					if (valueTypeHelper.isFlattenableFieldSignature(J9ROMFieldShapeHelper.getSignature(f))) {
 						int size = 0;
 						J9ClassPointer fieldClass = valueTypeHelper.findJ9ClassInFlattenedClassCacheWithFieldName(containerClazz, J9ROMFieldShapeHelper.getName(f));
-						if (!valueTypeHelper.isJ9ClassIsFlattened(fieldClass)) {
+						if (!valueTypeHelper.isJ9FieldIsFlattened(fieldClass, f)) {
 							instanceObjectCount += 1;
 							totalObjectCount += 1;
 						} else if (valueTypeHelper.isJ9ClassLargestAlignmentConstraintDouble(fieldClass)) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/PrintObjectFieldsHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/PrintObjectFieldsHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -234,7 +234,7 @@ public class PrintObjectFieldsHelper {
 		String className = J9ClassHelper.getName(fromClass);
 		String fieldName = J9UTF8Helper.stringValue(fieldShape.nameAndSignature().name());
 		String fieldSignature = J9UTF8Helper.stringValue(fieldShape.nameAndSignature().signature());
-		boolean fieldIsFlattened = valueTypeHelper.isFieldInClassFlattened(localClazz, fieldName);
+		boolean fieldIsFlattened = valueTypeHelper.isFieldInClassFlattened(localClazz, fieldShape);
 
 		if (containerIsFlatObject && valueTypeHelper.classRequires4BytePrePadding(localClazz)) {
 			/* If container has pre-padding the dataStart was adjusted to reflect this. 
@@ -290,7 +290,7 @@ public class PrintObjectFieldsHelper {
 		boolean isHiddenField = objectFieldOffset.isHidden();
 		String fieldName = J9UTF8Helper.stringValue(fieldShape.nameAndSignature().name());
 		String fieldSignature = J9UTF8Helper.stringValue(fieldShape.nameAndSignature().signature());
-		boolean fieldIsFlattened = valueTypeHelper.isFieldInClassFlattened(localClazz, fieldName);
+		boolean fieldIsFlattened = valueTypeHelper.isFieldInClassFlattened(localClazz, fieldShape);
 		
 		padding(out, tabLevel);
 		

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -316,12 +316,17 @@ static const struct { \
 #define J9CLASS_UNPADDED_INSTANCE_SIZE(clazz) J9_VALUETYPE_FLATTENED_SIZE(clazz)
 #define J9_IS_J9CLASS_VALUETYPE(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassIsValueType)
 #define J9_IS_J9CLASS_FLATTENED(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassIsFlattened)
+/* Disable flattening of volatile field that is > 8 bytes for now, as the current implementation of copyObjectFields() will tear this field. */  
+#define J9_IS_FIELD_FLATTENED(fieldClazz, romFieldShape) \
+	(J9_IS_J9CLASS_FLATTENED(fieldClazz) && \
+	(J9_ARE_NO_BITS_SET((romFieldShape)->modifiers, J9AccVolatile) || (J9CLASS_UNPADDED_INSTANCE_SIZE(fieldClazz) <= sizeof(U_64))))
 #define J9_VALUETYPE_FLATTENED_SIZE(clazz) (J9CLASS_HAS_4BYTE_PREPADDING((clazz)) ? ((clazz)->totalInstanceSize - sizeof(U_32)) : (clazz)->totalInstanceSize)
 #define IS_REF_OR_VAL_SIGNATURE(firstChar) ('L' == (firstChar) || 'Q' == (firstChar))
 #else /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 #define J9CLASS_UNPADDED_INSTANCE_SIZE(clazz) ((clazz)->totalInstanceSize)
 #define J9_IS_J9CLASS_VALUETYPE(clazz) FALSE
 #define J9_IS_J9CLASS_FLATTENED(clazz) FALSE
+#define J9_IS_FIELD_FLATTENED(fieldClazz, romFieldShape) FALSE
 #define J9_VALUETYPE_FLATTENED_SIZE(clazz)((UDATA) 0) /* It is not possible for this macro to be used since we always check J9_IS_J9CLASS_FLATTENED before ever using it. */
 #define IS_REF_OR_VAL_SIGNATURE(firstChar) ('L' == (firstChar))
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */

--- a/runtime/vm/ObjectFieldInfo.cpp
+++ b/runtime/vm/ObjectFieldInfo.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corp. and others
+ * Copyright (c) 2015, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,7 +51,7 @@ ObjectFieldInfo::countInstanceFields(void)
 				if ('Q' == *fieldSigBytes) {
 					J9Class *fieldClass = findJ9ClassInFlattenedClassCache(_flattenedClassCache, fieldSigBytes + 1, J9UTF8_LENGTH(fieldSig) - 2);
 					U_32 size = fieldClass->totalInstanceSize;
-					if (J9_ARE_NO_BITS_SET(fieldClass->classFlags, J9ClassIsFlattened)) {
+					if (!J9_IS_FIELD_FLATTENED(fieldClass, field)) {
 						_instanceObjectCount += 1;
 						_totalObjectCount += 1;
 					} else if (J9_ARE_ALL_BITS_SET(fieldClass->classFlags, J9ClassLargestAlignmentConstraintDouble)) {

--- a/runtime/vm/ValueTypeHelpers.cpp
+++ b/runtime/vm/ValueTypeHelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -85,7 +85,7 @@ defaultValueWithUnflattenedFlattenables(J9VMThread *currentThread, J9Class *claz
 	for (UDATA index = 0; index < length; index++) {
 		entry = J9_VM_FCC_ENTRY_FROM_CLASS(clazz, index);
 		entryClazz = J9_VM_FCC_CLASS_FROM_ENTRY(entry);
-		if (!J9_VM_FCC_ENTRY_IS_STATIC_FIELD(entry) && J9_ARE_NO_BITS_SET(J9ClassIsFlattened, entryClazz->classFlags)) {
+		if (!J9_VM_FCC_ENTRY_IS_STATIC_FIELD(entry) && !J9_IS_FIELD_FLATTENED(entryClazz, entry->field)) {
 			objectAccessBarrier.inlineMixedObjectStoreObject(currentThread,
 												instance,
 												entry->offset + objectHeaderSize,
@@ -179,7 +179,7 @@ isFlattenableFieldFlattened(J9Class *fieldOwner, J9ROMFieldShape *field)
         Assert_VM_notNull(field);
 
         J9Class* clazz = getFlattenableFieldType(fieldOwner, field);
-        BOOLEAN fieldFlattened = J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassIsFlattened);
+        BOOLEAN fieldFlattened = J9_IS_FIELD_FLATTENED(clazz, field);
 
         return fieldFlattened;
 }

--- a/runtime/vm/ValueTypeHelpers.hpp
+++ b/runtime/vm/ValueTypeHelpers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -154,7 +154,7 @@ private:
 					J9Class *fieldClass = findJ9ClassInFlattenedClassCache(clazz->flattenedClassCache, sigChar + 1, J9UTF8_LENGTH(signature) - 2);
 					rc = false;
 
-					if (J9_IS_J9CLASS_FLATTENED(fieldClass)) {
+					if (J9_IS_FIELD_FLATTENED(fieldClass, result->field)) {
 						rc = isSubstitutable(currentThread, objectAccessBarrier, lhs, rhs, startOffset + result->offset, fieldClass);
 					} else {
 						j9object_t lhsFieldObject = objectAccessBarrier.inlineMixedObjectReadObject(currentThread, lhs, startOffset + result->offset);

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -1912,7 +1912,7 @@ loadFlattenableFieldValueClasses(J9VMThread *currentThread, J9ClassLoader *class
 						goto done;
 					}
 
-					if (!J9_IS_J9CLASS_FLATTENED(valueClass)) {
+					if (!J9_IS_FIELD_FLATTENED(valueClass, field)) {
 						*valueTypeFlags |= (J9ClassContainsUnflattenedFlattenables | J9ClassHasReferences);
 						eligibleForFastSubstitutability = false;
 					} else if (J9_ARE_NO_BITS_SET(valueClass->classFlags, J9ClassCanSupportFastSubstitutability)) {

--- a/runtime/vm/description.c
+++ b/runtime/vm/description.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -186,7 +186,9 @@ calculateInstanceDescription( J9VMThread *vmThread, J9Class *ramClass, J9Class *
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 				if ('Q' == *fieldSigBytes) {
 					J9Class *fieldClass = walkResult->flattenedClass;
-					if ((NULL != fieldClass) && J9_ARE_ALL_BITS_SET(fieldClass->classFlags, J9ClassIsFlattened)) {
+					if ((NULL != fieldClass) 
+						&& J9_IS_FIELD_FLATTENED(fieldClass, walkResult->field)
+					) {
 						UDATA size = fieldClass->totalInstanceSize;
 
 						/* positive means the field will spill over to the next slot in the shape array */

--- a/runtime/vm/resolvefield.cpp
+++ b/runtime/vm/resolvefield.cpp
@@ -1090,7 +1090,7 @@ fieldOffsetsFindNext(J9ROMFieldOffsetWalkState *state, J9ROMFieldShape *field)
 						if ('Q' == *fieldSigBytes) {
 							J9Class *fieldClass = NULL;
 							fieldClass = findJ9ClassInFlattenedClassCache(state->flattenedClassCache, fieldSigBytes + 1, J9UTF8_LENGTH(fieldSig) - 2);
-							if (J9_ARE_NO_BITS_SET(fieldClass->classFlags, J9ClassIsFlattened)) {
+							if (!J9_IS_FIELD_FLATTENED(fieldClass, field)) {
 								if (J9_ARE_ALL_BITS_SET(state->walkFlags, J9VM_FIELD_OFFSET_WALK_BACKFILL_OBJECT_FIELD)) {
 									Assert_VM_true(state->backfillOffsetToUse >= 0);
 									state->result.offset = state->backfillOffsetToUse;

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -1076,7 +1076,7 @@ illegalAccess:
 						fieldIndex = findIndexInFlattenedClassCache(flattenedClassCache, nameAndSig);
 						flattenableClass = J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, fieldIndex)->clazz;
 					}
-					if (J9_ARE_ALL_BITS_SET(flattenableClass->classFlags, J9ClassIsFlattened)) {
+					if (J9_IS_FIELD_FLATTENED(flattenableClass, field)) {
 						if (fccEntryFieldNotSet) {
 							J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, fieldIndex)->offset = valueOffset;
 						}

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/DDRValueTypeTest.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/DDRValueTypeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,6 +60,7 @@ public class DDRValueTypeTest {
 		};
 		Object assortedValueWithSingleAlignment = ValueTypeTests.createAssorted(makeAssortedValueWithSingleAlignment, ValueTypeTests.typeWithSingleAlignmentFields);
 		Object assortedValueWithSingleAlignmentAlt = ValueTypeTests.createAssorted(makeAssortedValueWithSingleAlignment, ValueTypeTests.typeWithSingleAlignmentFields, altFields);
+		Object valueTypeWithVolatileFields = ValueTypeTests.createValueTypeWithVolatileFields();
 		
 		Object valArray = Array.newInstance(assortedValueWithSingleAlignmentClass, 2);
 		Array.set(valArray, 0, assortedValueWithSingleAlignment);
@@ -67,6 +68,8 @@ public class DDRValueTypeTest {
 
 		ValueTypeTests.checkObject(assortedValueWithSingleAlignment, 
 				assortedValueWithSingleAlignmentAlt, 
-				valArray);
+				valArray, 
+				valueTypeWithVolatileFields
+				);
 	}
 }

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -204,6 +204,8 @@ public class ValueTypeGenerator extends ClassLoader {
 			} else {
 				if ((nameAndSigValue.length > 2) && nameAndSigValue[2].equals("static")) {
 					fieldModifiers = ACC_PUBLIC + ACC_STATIC;
+				} else if ((nameAndSigValue.length > 2) && nameAndSigValue[2].equals("volatile")) {
+					fieldModifiers = ACC_PUBLIC + ACC_FINAL + ACC_VOLATILE;
 				} else {
 					fieldModifiers = ACC_PUBLIC + ACC_FINAL;
 				}

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -1256,7 +1256,7 @@ public class ValueTypeTests {
 			Assert.fail("shouldn't throw exception. MonitorEnter and MonitorExit should be used with refType");
 		}
 	}
-	
+
 	/*	
 	 * Create a valueType with three valueType members
 	 * 
@@ -1460,6 +1460,27 @@ public class ValueTypeTests {
 
 		valueObject = withObject.invoke(valueObject, valNew);
 		assertEquals(getObject.invoke(valueObject), valNew);
+	}
+	
+	/*	
+	 * Create a valueType with four valueType members including 2 volatile.  
+	 * 
+	 * value valueWithVolatile {
+	 *  flattened Point2D point;   <--- 8 bytes, will be flattened.
+	 *  volatile Point2D vpoint;   <--- volatile 8 bytes, will be flattened.
+	 *  flattened Line2D 1ine;     <--- 16 bytes, will be flattened.
+	 *  volatile Line2D vline;     <--- volatile 16 bytes, will not be flattened.
+	 * }
+	 */
+	@Test(priority=3)
+	static public Object createValueTypeWithVolatileFields() throws Throwable {
+		String fields[] = {"point:QPoint2D;:value", "vpoint:QPoint2D;:volatile", "line:QFlattenedLine2D;:value", "vline:QFlattenedLine2D;:volatile"};
+		Class ValueTypeWithVolatileFieldsClass = ValueTypeGenerator.generateValueClass("ValueTypeWithVolatileFields", fields);
+		MethodHandle valueWithVolatile = lookup.findStatic(ValueTypeWithVolatileFieldsClass, "makeValueGeneric", MethodType.methodType(Object.class, Object.class, Object.class, Object.class, Object.class));
+		MethodHandle[][] getterAndWither = generateGenericGetterAndWither(ValueTypeWithVolatileFieldsClass, fields);
+		Object valueWithVolatileObj = createAssorted(valueWithVolatile, fields);
+		checkFieldAccessMHOfAssortedType(getterAndWither, valueWithVolatileObj, fields, true);
+		return valueWithVolatileObj;
 	}
 
 	/*

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
@@ -72,6 +72,7 @@
 		<output regex="no" type="success" showMatch="yes">!J9IndexableObject 0x</output>
 		<saveoutput regex="no" type="required" saveName="valueAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[0] = !fj9object 0x</saveoutput>
 		<saveoutput regex="no" type="required" saveName="arrayAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[2] = !fj9object 0x</saveoutput>
+		<saveoutput regex="no" type="required" saveName="valueAddr1" splitIndex="1" splitBy="= !j9object " showMatch="yes">[3] = !fj9object 0x</saveoutput>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -146,6 +147,47 @@
 			<input>quit</input>
 		</command>
 		<output regex="no" type="success" showMatch="yes">I i = 0x45456767</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+	
+	<test id="Run !j9object $valueAddr1$ to show the fields of the reference object. Make sure field vline is not flattened">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $valueAddr1$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes"> ValueTypeWithVolatileFields</output>
+		<output regex="no" type="required" showMatch="yes"> point (offset = 4) (Point2D)</output>
+		<output regex="no" type="required" showMatch="yes"> vpoint (offset = 12) (Point2D)</output>
+		<output regex="no" type="required" showMatch="yes"> line (offset = 20) (FlattenedLine2D)</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes"> vline = !fj9object 0x[\w]+ \(offset = 0\)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !flatobject $valueAddr1$ to show the all fields of ValueTypeWithVolatileFields. Make sure all the flattened fields have the correct values">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!flatobject $valueAddr1$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes"> ValueTypeWithVolatileFields</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D point (.)* \(offset = 4\)[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D vpoint (.)* \(offset = 12\)[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D st (.)*[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D en (.)*[\n\r](.)*I x = 0xCCDDCCDD[\n\r](.)*I y = 0x33443344</output>
+		<saveoutput regex="no" type="required" saveName="vlineAddr" splitIndex="1" splitBy="!fj9object " showMatch="yes">= !fj9object 0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+	
+	<test id="Run !flatobject $vlineAddr$ to show the field vline of ValueTypeWithVolatileFields. Make sure it has the correct values">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!flatobject $vlineAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes"> FlattenedLine2D</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D st (.)*[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D en (.)*[\n\r](.)*I x = 0xCCDDCCDD[\n\r](.)*I y = 0x33443344</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 </suite>


### PR DESCRIPTION
1. Disable flattening of volatile field that is > 8 bytes for now, as
the current implementation of copyObjectFields() will tear this field.

2. Add test.

issue #11178

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>