### PR TITLE
Optimize object equality comparisons in Simplifier if value types support is enabled

### DIFF
--- a/runtime/compiler/optimizer/J9Simplifier.cpp
+++ b/runtime/compiler/optimizer/J9Simplifier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -240,6 +240,14 @@ J9::Simplifier::isRecognizedAbsMethod(TR::Node * node)
              methodSymbol->getRecognizedMethod() == TR::java_lang_Math_abs_I));
    }
 
+bool
+J9::Simplifier::isObjectEqualityComparison(TR::Node *node)
+   {
+   return node->getOpCode().isCall()
+          && comp()->getSymRefTab()->isNonHelper(node->getSymbolReference(),
+                   TR::SymbolReferenceTable::objectEqualityComparisonSymbol);
+   }
+
 TR::Node *
 J9::Simplifier::foldAbs(TR::Node *node)
    {
@@ -298,6 +306,36 @@ J9::Simplifier::simplifyiCallMethods(TR::Node * node, TR::Block * block)
           valueNode->getDouble() == 10.0 && expNode->getDouble() == 4.0)
          {
          foldDoubleConstant(node, 10000.0, (TR::Simplifier *) this);
+         }
+      }
+   else if (isObjectEqualityComparison(node))
+      {
+      TR::Node *lhs = node->getChild(0);
+      const bool lhsNull =
+         lhs->getOpCodeValue() == TR::aconst
+         && lhs->getConstValue() == 0;
+
+      TR::Node *rhs = node->getChild(1);
+      const bool rhsNull =
+         rhs->getOpCodeValue() == TR::aconst
+         && rhs->getConstValue() == 0;
+
+      // If either operand is null, no need to use the equality comparison helper,
+      // as value types cannot have null references.  Also, if both operands
+      // are the same node, no need to use the comparison helper - the comparison
+      // must be true.  Fold both cases to use acmpeq which might be further simplified
+      //
+      if (lhsNull || rhsNull || lhs == rhs)
+         {
+         if (performTransformation(
+               comp(),
+               "%sChanging n%un from <isObjectEqualityComparison> to acmpeq\n",
+               optDetailString(),
+               node->getGlobalIndex()))
+            {
+            TR::Node::recreate(node, TR::acmpeq);
+            node = simplify(node, block);
+            }
          }
       }
 

--- a/runtime/compiler/optimizer/J9Simplifier.cpp
+++ b/runtime/compiler/optimizer/J9Simplifier.cpp
@@ -333,6 +333,10 @@ J9::Simplifier::simplifyiCallMethods(TR::Node * node, TR::Block * block)
                optDetailString(),
                node->getGlobalIndex()))
             {
+            const char *counterName = TR::DebugCounter::debugCounterName(comp(), "vt-helper/simplifier-xformed/acmp/(%s)/bc=%d",
+                                                            comp()->signature(), node->getByteCodeIndex());
+            TR::DebugCounter::incStaticDebugCounter(comp(), counterName);
+
             TR::Node::recreate(node, TR::acmpeq);
             node = simplify(node, block);
             }

--- a/runtime/compiler/optimizer/J9Simplifier.hpp
+++ b/runtime/compiler/optimizer/J9Simplifier.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,6 +56,16 @@ class Simplifier : public OMR::Simplifier
 
    bool isRecognizedPowMethod(TR::Node *node);
    bool isRecognizedAbsMethod(TR::Node *node);
+
+   /**
+    * \brief Checks whether this node represents a call to the value
+    * comparison non-helper
+    * \param node Call node to check
+    * \return \c true if \c node is a call to the value
+    *         comparison non-helper;
+    *         \c false, otherwise.
+    */
+   bool isObjectEqualityComparison(TR::Node *node);
 
    TR::Node *getUnsafeIorByteChild(TR::Node * child, TR::ILOpCodes b2iOpCode, int32_t mulConst);
    TR::Node *getLastUnsafeIorByteChild(TR::Node * child);


### PR DESCRIPTION
During IL generation with value type support enabled, the JIT generates calls to an equality comparison non-helper to compare objects, as simple address comparisons are not sufficient for comparison of value type instances in general.  Certain object equality comparisons can be simplified by decaying the non-helper call into an ordinary `acmpeq` node.
These cases are:

- if either argument to the compare is a null reference
- if the same node appears as both operands of the compare

Further possible simplifications are done by recursively simplifying the `acmpeq` node, if transformed.