### PR TITLE
Include UTC date/time and timezone in javacore files

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -228,7 +228,6 @@ set(J9_CFLAGS
 	${OMR_PLATFORM_C_COMPILE_OPTIONS}
 )
 set(J9_CXXFLAGS
-	${OMR_PLATFORM_COMPILE_OPTIONS}
 	${OMR_PLATFORM_CXX_COMPILE_OPTIONS}
 )
 if(OMR_OS_LINUX OR OMR_OS_OSX)
@@ -297,8 +296,20 @@ else()
 	message(SEND_ERROR "unsupported platform")
 endif()
 
-omr_stringify(J9_CFLAGS_STR ${J9_CFLAGS} ${J9_SHAREDFLAGS})
-omr_stringify(J9_CXXFLAGS_STR ${J9_CXXFLAGS} ${J9_SHAREDFLAGS})
+# Add optional user-specified compiler flags that only apply to the JIT
+list(APPEND J9_CFLAGS ${J9JIT_EXTRA_CFLAGS})
+list(APPEND J9_CXXFLAGS ${J9JIT_EXTRA_CXXFLAGS})
+
+# Note: J9_CFLAGS and J9_CXXFLAGS are appended after J9_SHAREDFLAGS so that
+#       OMR_PLATFORM_C_COMPILE_OPTIONS and OMR_PLATFORM_CXX_COMPILE_OPTIONS
+#       end up after OMR_PLATFORM_COMPILE_OPTIONS, which matches the rest
+#       of the VM build (see cmake/modules/OmrPlatform.cmake in OMR).
+#       This allows the user to pass extra compiler options via
+#       OMR_PLATFORM_C_COMPILE_OPTIONS and OMR_PLATFORM_CXX_COMPILE_OPTIONS
+#       to override the defaults specified by OMR_PLATFORM_COMPILE_OPTIONS,
+#       e.g. in order to produce a debug build.
+omr_stringify(J9_CFLAGS_STR ${J9_SHAREDFLAGS} ${J9_CFLAGS})
+omr_stringify(J9_CXXFLAGS_STR ${J9_SHAREDFLAGS} ${J9_CXXFLAGS})
 
 # Note: This is explicitly overriding what's provided by
 #       the VM CMakeLists, as they pass -fno-exceptions

--- a/runtime/compiler/aarch64/env/J9CPU.hpp
+++ b/runtime/compiler/aarch64/env/J9CPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,7 +52,18 @@ protected:
 
 public:
 
-   OMRProcessorDesc getProcessorDescription();
+   /**
+    * @brief Intialize _supportedFeatureMasks to the list of processor features that will be utilized by the compiler and set _isSupportedFeatureMasksEnabled to true
+    */
+   static void enableFeatureMasks();
+
+   /**
+    * @brief A factory method used to construct a CPU object for portable AOT compilations
+    * @param[in] omrPortLib : the port library
+    * @return TR::CPU
+    */
+   static TR::CPU detectRelocatable(OMRPortLibrary * const omrPortLib);
+
    bool isCompatible(const OMRProcessorDesc& processorDescription);
 
    };

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -5710,9 +5710,10 @@ static int32_t J9THREAD_PROC samplerThreadProc(void * entryarg)
 
    if (TR::Options::isAnyVerboseOptionSet())
       {
+      OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
       char timestamp[32];
       bool incomplete;
-      j9str_ftime(timestamp, sizeof(timestamp), "%b %d %H:%M:%S %Y", persistentInfo->getStartTime());
+      omrstr_ftime_ex(timestamp, sizeof(timestamp), "%b %d %H:%M:%S %Y", persistentInfo->getStartTime(), OMRSTR_FTIME_FLAG_LOCAL);
       TR_VerboseLog::vlogAcquire();
       TR_VerboseLog::writeLine(TR_Vlog_INFO, "StartTime: %s", timestamp);
       uint64_t phMemAvail = compInfo->computeAndCacheFreePhysicalMemory(incomplete);

--- a/runtime/compiler/env/J9CompilerEnv.cpp
+++ b/runtime/compiler/env/J9CompilerEnv.cpp
@@ -30,7 +30,7 @@
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 J9::CompilerEnv::CompilerEnv(J9JavaVM *vm, TR::RawAllocator raw, const TR::PersistentAllocatorKit &persistentAllocatorKit) :
-#if defined(TR_HOST_ARM) || defined(TR_HOST_ARM64)
+#if defined(TR_HOST_ARM)
    OMR::CompilerEnvConnector(raw, persistentAllocatorKit),
 #else
    OMR::CompilerEnvConnector(raw, persistentAllocatorKit, OMRPORT_FROM_J9PORT(vm->portLibrary)),

--- a/runtime/compiler/env/ProcessorDetection.cpp
+++ b/runtime/compiler/env/ProcessorDetection.cpp
@@ -289,13 +289,6 @@ portLibCall_getARMProcessorType()
    return tp;
    }
 
-static TR_Processor
-portLibCall_getARM64ProcessorType()
-   {
-   // ToDo: Add code for detecting processor type (Issue #6637)
-   return TR_DefaultARM64Processor;
-   }
-
 // -----------------------------------------------------------------------------
 
 // For Verbose Log
@@ -389,6 +382,25 @@ int32_t TR_J9VM::getCompInfo(char *processorName, int32_t stringLength)
    if (TR::Compiler->target.cpu.isARM())
       {
       sourceString = "Unknown ARM processor";
+      returnValue = strlen(sourceString);
+      strncpy(processorName, sourceString, stringLength);
+      return returnValue;
+      }
+
+   if (TR::Compiler->target.cpu.isARM64())
+      {
+      switch (TR::Compiler->target.cpu.getProcessorDescription().processor)
+         {
+         case OMR_PROCESSOR_ARM64_UNKNOWN:
+            sourceString = "Unknown ARM64 processor";
+            break;
+         case OMR_PROCESSOR_ARM64_V8_A:
+            sourceString = "ARMv8-A processor";
+            break;
+         default:
+            sourceString = "Unknown ARM64 processor";
+            break;
+         }
       returnValue = strlen(sourceString);
       strncpy(processorName, sourceString, stringLength);
       return returnValue;
@@ -593,10 +605,8 @@ TR_J9VM::initializeProcessorType()
       }
    else if (TR::Compiler->target.cpu.isARM64())
       {
-      TR::Compiler->target.cpu.setProcessor(portLibCall_getARM64ProcessorType());
-
-      TR_ASSERT(TR::Compiler->target.cpu.id() >= TR_FirstARM64Processor
-             && TR::Compiler->target.cpu.id() <= TR_LastARM64Processor, "Not a valid ARM64 Processor Type");
+      OMRProcessorDesc processorDescription = TR::Compiler->target.cpu.getProcessorDescription();
+      TR::Compiler->target.cpu = TR::CPU::customize(processorDescription);
       }
    else
       {

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9401,7 +9401,8 @@ void TR_VerboseLog::writeTimeStamp()
       char timestamp[32];
       TR::CompilationInfo *compInfo = TR::CompilationInfo::get();
       PORT_ACCESS_FROM_JITCONFIG(compInfo->getJITConfig());
-      j9str_ftime(timestamp, sizeof(timestamp), "%b-%d-%Y_%H:%M:%S ", j9time_current_time_millis());
+      OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
+      omrstr_ftime_ex(timestamp, sizeof(timestamp), "%b-%d-%Y_%H:%M:%S ", j9time_current_time_millis(), OMRSTR_FTIME_FLAG_LOCAL);
       write(timestamp);
       }
    }

--- a/runtime/compiler/optimizer/StaticFinalFieldFolding.hpp
+++ b/runtime/compiler/optimizer/StaticFinalFieldFolding.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,6 +29,69 @@
 #include "optimizer/OptimizationManager.hpp"
 
 namespace TR { class NodeChecklist; }
+
+/** \brief
+ *
+ * This opt walks the trees and folds direct loads of static final fields.
+ *
+ * \details
+ *
+ * This opt walks the trees and tries to fold direct loads of static final fields.
+ * For a primitive type, it will be folded into a primitive constant. For a reference
+ * type, a known object index is assigned to the referenced object, the symref on
+ * the load node is improved to one with the known object index.
+ *
+ * There are two types of static final fields this opt is trying to fold:
+ *  1. Fields in special JCL classes that are closely tied to VM core implementation,
+ *     these fields are not expected to be modified once initialized.
+ *     `J9::TransformUtil::foldFinalFieldsIn` contains a list of such classes.
+ *
+ *  2. Other fields that may be modified through reflection or Unsafe APIs.
+ *
+ * For 1, they're always directly folded into a constant. The folding doesn't require any
+ * analysis or protection.
+ *
+ * For 2, they can only be folded with the assumption that they're not to be modified.
+ * However, when modification happens, the JIT code with the invalid folded value must
+ * not be executed. Thus, the folding of type 2 final statics requires guards. We use
+ * OSR guards to protect ourselves in such situations. When modification happens, the
+ * OSR guard will be patched to induce OSR transition to the interpreter.
+ *
+ * To be able to do guarded static final field folding (to fold the second type of fields),
+ * we have to make sure that an OSR guard can be added after any yield point (place where
+ * invaliation of assumptions can happen) that can reach the folded field. This is because
+ * if invalidation happens, we have to get out of the JIT body before running into the code
+ * with the invalid folded value.
+ *
+ * However, only yield points with OSR support can have OSR guard added after. They are places
+ * where we have the bookkeeping to reconstruct the operand stack and local slots such that
+ * the interpreter can resume the execution from where the JIT code left. If a type 2 static
+ * final field can be reached by a yield point without OSR support, it can't be folded, as
+ * there exists a path where invalidation happens but we can't avoid running into the invalid
+ * code.
+ *
+ * Whether a load of type 2 static final field can be folded can be determined by data flow
+ * analysis, which is expensive. To avoid doing the analysis, there are a few simple checks we
+ * do, which is done in `safeToAddFearPointAt` in J9TransformUtil.cpp. The result of these
+ * checks is more conservative than that from a data flow analysis, but it will guarantee
+ * functional correctness.
+ *
+ * After a type 2 field is folded, a call to `osrFearPointHelper` is inserted before the tree
+ * with the load of the field. The helper call marks where a type 2 field is folded and is
+ * a fear point in FearPointAnalysis, which runs in OSRGuardInsertion to decide the placement
+ * of OSR guards.
+ *
+ * The folding is done in a transform util `J9::TransformUtil::attemptGenericStaticFinalFieldFolding`.
+ * It will always fold type 1 final statics, and type 2 final statics when it is safe to do so.
+ * Type 2 field folding requires OSR guards to be inserted, so it can only run before OSRGuardInsertion.
+ *
+ * Type 1 final statics are folded by default in all compilations at any opt level.
+ *
+ * For type 2 final statics folding, it is only enabled when voluntary OSR is on, which is turned
+ * on by nextGenHCR. nextGenHCR is on by default except in a small number of compiles when the
+ * compiled method has been redefined too many times or during startup time where nextGenHCR
+ * is considered too expensive.
+ */
 
 class TR_StaticFinalFieldFolding : public TR::Optimization
    {

--- a/runtime/gc_trace/TgcCardCleaning.cpp
+++ b/runtime/gc_trace/TgcCardCleaning.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,12 +52,13 @@ printCardCleaningStats(OMR_VMThread *omrVMThread)
 	J9VMThread *currentThread = (J9VMThread *)MM_EnvironmentBase::getEnvironment(omrVMThread)->getLanguageVMThread();
 	MM_TgcExtensions *tgcExtensions = MM_TgcExtensions::getExtensions(currentThread);
 	PORT_ACCESS_FROM_VMC(currentThread);
+	OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
 	char timestamp[32];
 	
 	U_64 totalTime = 0;
 	UDATA totalCardsCleaned = 0;
 	
-	j9str_ftime(timestamp, sizeof(timestamp), "%b %d %H:%M:%S %Y", j9time_current_time_millis());
+	omrstr_ftime_ex(timestamp, sizeof(timestamp), "%b %d %H:%M:%S %Y", j9time_current_time_millis(), OMRSTR_FTIME_FLAG_LOCAL);
 	tgcExtensions->printf("<cardcleaning timestamp=\"%s\">\n", timestamp);
 	
 	GC_VMThreadListIterator threadIterator(currentThread);

--- a/runtime/gc_trace/TgcParallel.cpp
+++ b/runtime/gc_trace/TgcParallel.cpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright (c) 1991, 2021 IBM Corp. and others
  *
@@ -248,10 +247,11 @@ tgcHookLocalGcEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData, v
 	J9VMThread *walkThread;
 	uint64_t scavengeTotalTime;
 	PORT_ACCESS_FROM_VMC(vmThread);
-	
+	OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
+
 	char timestamp[32];
 	int64_t timeInMillis = j9time_current_time_millis();
-	j9str_ftime(timestamp, sizeof(timestamp), "%Y-%m-%dT%H:%M:%S", timeInMillis);
+	omrstr_ftime_ex(timestamp, sizeof(timestamp), "%Y-%m-%dT%H:%M:%S", timeInMillis, OMRSTR_FTIME_FLAG_LOCAL);
 	tgcExtensions->printf("\n");
 	tgcExtensions->printf("Scavenger parallel and progress stats, timestamp=\"%s.%ld\"\n", timestamp, timeInMillis % 1000);
 

--- a/runtime/gc_trace/TgcRootScanner.cpp
+++ b/runtime/gc_trace/TgcRootScanner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -104,7 +104,8 @@ printRootScannerStats(OMR_VMThread *omrVMThread)
 	
 	/* print only if at least one thread reported stats on at least one of its roots */
 	if (extensions->rootScannerStatsUsed) {
-		j9str_ftime(timestamp, sizeof(timestamp), "%b %d %H:%M:%S %Y", j9time_current_time_millis());
+		OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
+		omrstr_ftime_ex(timestamp, sizeof(timestamp), "%b %d %H:%M:%S %Y", j9time_current_time_millis(), OMRSTR_FTIME_FLAG_LOCAL);
 		tgcExtensions->printf("<scan timestamp=\"%s\">\n", timestamp);
 
 		GC_VMThreadListIterator threadIterator(currentThread);

--- a/runtime/gc_verbose_old_events/VerboseEventAFStart.cpp
+++ b/runtime/gc_verbose_old_events/VerboseEventAFStart.cpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,12 +66,13 @@ void
 MM_VerboseEventAFStart::formattedOutput(MM_VerboseOutputAgent *agent)
 {
 	PORT_ACCESS_FROM_JAVAVM(((J9VMThread*)_omrThread->_language_vmthread)->javaVM);
+	OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
 	char timestamp[32];
 	UDATA indentLevel = _manager->getIndentLevel();
-	U_64 timeInMicroSeconds;
-	U_64 prevTime;	
-	
-	j9str_ftime(timestamp, sizeof(timestamp), VERBOSEGC_DATE_FORMAT, _timeInMilliSeconds);
+	U_64 timeInMicroSeconds = 0;
+	U_64 prevTime = 0;
+
+	omrstr_ftime_ex(timestamp, sizeof(timestamp), VERBOSEGC_DATE_FORMAT, _timeInMilliSeconds, OMRSTR_FTIME_FLAG_LOCAL);
 	switch(_subSpaceType) {
 		case 0:
 			agent->formatAndOutput(static_cast<J9VMThread*>(_omrThread->_language_vmthread), indentLevel, "<af type=\"UNKNOWN!!\" />");

--- a/runtime/oti/j9port_generated.h
+++ b/runtime/oti/j9port_generated.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -680,7 +680,6 @@ extern J9_CFUNC int32_t j9port_isCompatible(struct J9PortLibraryVersion *expecte
 #define j9sock_getaddrinfo_length(param1,param2) privatePortLibrary->sock_getaddrinfo_length(privatePortLibrary,param1,param2)
 #define j9sock_getaddrinfo_name(param1,param2,param3) privatePortLibrary->sock_getaddrinfo_name(privatePortLibrary,param1,param2,param3)
 #define j9sock_error_message() privatePortLibrary->sock_error_message(privatePortLibrary)
-#define j9str_ftime(param1,param2,param3,param4) OMRPORT_FROM_J9PORT(privatePortLibrary)->str_ftime(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2,param3,param4)
 #define j9mmap_startup() OMRPORT_FROM_J9PORT(privatePortLibrary)->mmap_startup(OMRPORT_FROM_J9PORT(privatePortLibrary))
 #define j9mmap_shutdown() OMRPORT_FROM_J9PORT(privatePortLibrary)->mmap_shutdown(OMRPORT_FROM_J9PORT(privatePortLibrary))
 #define j9mmap_capabilities() OMRPORT_FROM_J9PORT(privatePortLibrary)->mmap_capabilities(OMRPORT_FROM_J9PORT(privatePortLibrary))

--- a/runtime/rasdump/trigger.c
+++ b/runtime/rasdump/trigger.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1035,8 +1035,9 @@ triggerDumpAgents(struct J9JavaVM *vm, struct J9VMThread *self, UDATA eventFlags
 							((node->stopOnCount < node->startOnCount) || (newCount <= node->stopOnCount))) {
 						if (printed == 0) {
 							if (node->dumpFn != doSilentDump) {
+								OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
 								char dateStamp[64];
-								j9str_ftime(dateStamp, sizeof(dateStamp), "%Y/%m/%d %H:%M:%S", now);
+								omrstr_ftime_ex(dateStamp, sizeof(dateStamp), "%Y/%m/%d %H:%M:%S", now, OMRSTR_FTIME_FLAG_LOCAL);
 								j9nls_printf(PORTLIB, J9NLS_INFO | J9NLS_STDERR | J9NLS_VITAL, J9NLS_DMP_PROCESSING_EVENT_TIME, mapDumpEvent(eventFlags), detailLength, detailData, dateStamp);
 								printed = 1;
 							}

--- a/runtime/shared_common/CacheLifecycleManager.cpp
+++ b/runtime/shared_common/CacheLifecycleManager.cpp
@@ -332,17 +332,12 @@ printSharedCache(void* element, void* param)
 			if (J9SH_OSCACHE_UNKNOWN == currentItem->lastdetach) {
 				j9tty_printf(PORTLIB, "%s\n", "Unknown");
 			} else {
-				time_t t;
-
-				t = (time_t) (currentItem->lastdetach/1000);
-
-				/*
-				 *	For now we will use ctime function - we need to modify str_ftime to take in the time at some point
-				 *	j9str_ftime(formatted, 30, "%d %b %Y %H:%m", currentItem->lastdetach * 1000);
-				 *  j9tty_printf(PORTLIB, "%-15s", formatted);
-				 */
-
-				j9tty_printf(PORTLIB, "%s", ctime(&t));
+				OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
+#define FORMAT "%a %b %d %H:%M:%S %Y"
+				char buffer[sizeof(FORMAT) + 1 + 1 + 2]; /* %a and %b expand to 1 extra char each, %Y to 2 extra */
+				omrstr_ftime_ex(buffer, sizeof(buffer), FORMAT, currentItem->lastdetach, OMRSTR_FTIME_FLAG_LOCAL);
+				j9tty_printf(PORTLIB, "%s\n", buffer);
+#undef FORMAT
 			}
 		} else if ((currentItem->nattach == J9SH_OSCACHE_UNKNOWN) || (currentItem->lastdetach == J9SH_OSCACHE_UNKNOWN)) {
 			if (J9PORT_SHR_CACHE_TYPE_SNAPSHOT == currentItem->versionData.cacheType) {

--- a/runtime/shared_common/CacheLifecycleManager.cpp
+++ b/runtime/shared_common/CacheLifecycleManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -239,8 +239,6 @@ printSharedCache(void* element, void* param)
 	SH_OSCache_Info* currentItem = (SH_OSCache_Info*) element;
 	if (((state->printCompatibleCache == true) && (currentItem->isCompatible))
 			|| ((state->printIncompatibleCache == true) && (!currentItem->isCompatible))) {
-		char addrmodeStr[10];
-
 		PORT_ACCESS_FROM_JAVAVM(state->vm);
 
 		Trc_SHR_CLM_printSharedCache_Entry();
@@ -257,16 +255,16 @@ printSharedCache(void* element, void* param)
 		}
 
 		if (state->printHeader) {
-			j9tty_printf(PORTLIB, "%-16s\t", "Cache name");
-			j9tty_printf(PORTLIB, "%-14s", "level");
+			j9tty_printf(PORTLIB, "%-20s", "Cache name");
+			j9tty_printf(PORTLIB, "%-15s", "level");
 			j9tty_printf(PORTLIB, "%-16s", "cache-type");
-			j9tty_printf(PORTLIB, "%-16s", "feature");
-			j9tty_printf(PORTLIB, "%-12s", "layer");
+			j9tty_printf(PORTLIB, "%-9s", "feature");
+			j9tty_printf(PORTLIB, "%-7s", "layer");
 #if !defined(WIN32)
 			j9tty_printf(PORTLIB, "%-15s", "OS shmid");
 			j9tty_printf(PORTLIB, "%-15s", "OS semid");
 #endif
-			j9tty_printf(PORTLIB, "%-15s", "last detach time\n");
+			j9tty_printf(PORTLIB, "%s", "last detach time\n");
 			state->printHeader = 0;
 			if (currentItem->isCompatible) {
 				state->printCompatibleHeader = 1;
@@ -274,7 +272,7 @@ printSharedCache(void* element, void* param)
 				state->printIncompatibleHeader = 1;
 			}
 		}
-		
+
 		if (!currentItem->isCompatible && state->printIncompatibleHeader == 0) {
 			state->printIncompatibleHeader = 1;
 		}
@@ -288,12 +286,15 @@ printSharedCache(void* element, void* param)
 			j9tty_printf(PORTLIB, "\nIncompatible shared caches\n");
 			state->printIncompatibleHeader = 2;
 		}
-		j9tty_printf(PORTLIB, "%-16s\t", currentItem->name);
+		j9tty_printf(PORTLIB, "%-20s", currentItem->name);
 		char jclLevelStr[10];
 		memset(jclLevelStr, 0, sizeof(jclLevelStr));
 		getStringForShcModlevel(PORTLIB, currentItem->versionData.modlevel, jclLevelStr, sizeof(jclLevelStr));
+		char addrmodeStr[10];
 		getStringForShcAddrmode(PORTLIB, currentItem->versionData.addrmode, addrmodeStr);
-		j9tty_printf(PORTLIB, "%s %s  ", jclLevelStr, addrmodeStr);
+		char levelStr[20];
+		j9str_printf(PORTLIB, levelStr, sizeof(levelStr), "%s %s", jclLevelStr, addrmodeStr);
+		j9tty_printf(PORTLIB, "%-15s", levelStr);
 		if (J9PORT_SHR_CACHE_TYPE_PERSISTENT == currentItem->versionData.cacheType) {
 			j9tty_printf(PORTLIB, "%-16s", "persistent");
 		} else if (J9PORT_SHR_CACHE_TYPE_SNAPSHOT == currentItem->versionData.cacheType) {
@@ -304,16 +305,16 @@ printSharedCache(void* element, void* param)
 			j9tty_printf(PORTLIB, "%-16s", "non-persistent");
 		}
 		if (J9_ARE_ALL_BITS_SET(currentItem->versionData.feature, J9SH_FEATURE_COMPRESSED_POINTERS)) {
-			j9tty_printf(PORTLIB, "%-16s", "cr");
+			j9tty_printf(PORTLIB, "%-9s", "cr");
 		} else if (J9_ARE_ALL_BITS_SET(currentItem->versionData.feature, J9SH_FEATURE_NON_COMPRESSED_POINTERS)) {
-			j9tty_printf(PORTLIB, "%-16s", "non-cr");
+			j9tty_printf(PORTLIB, "%-9s", "non-cr");
 		} else {
-			j9tty_printf(PORTLIB, "%-16s", "default");
+			j9tty_printf(PORTLIB, "%-9s", "default");
 		}
 		if (currentItem->layer >= 0) {
-			j9tty_printf(PORTLIB, "%-12d", currentItem->layer);
+			j9tty_printf(PORTLIB, "%-7d", currentItem->layer);
 		} else {
-			j9tty_printf(PORTLIB, "%-12s", "");
+			j9tty_printf(PORTLIB, "%-7s", "");
 		}
 #if !defined(WIN32)
 		if (currentItem->os_shmid != (UDATA)J9SH_OSCACHE_UNKNOWN) {
@@ -329,7 +330,7 @@ printSharedCache(void* element, void* param)
 #endif
 		if (currentItem->nattach == 0) {
 			if (J9SH_OSCACHE_UNKNOWN == currentItem->lastdetach) {
-				j9tty_printf(PORTLIB, "%-15s\n", "Unknown");
+				j9tty_printf(PORTLIB, "%s\n", "Unknown");
 			} else {
 				time_t t;
 
@@ -341,17 +342,17 @@ printSharedCache(void* element, void* param)
 				 *  j9tty_printf(PORTLIB, "%-15s", formatted);
 				 */
 
-				j9tty_printf(PORTLIB, "%-15s", ctime(&t));
+				j9tty_printf(PORTLIB, "%s", ctime(&t));
 			}
 		} else if ((currentItem->nattach == J9SH_OSCACHE_UNKNOWN) || (currentItem->lastdetach == J9SH_OSCACHE_UNKNOWN)) {
 			if (J9PORT_SHR_CACHE_TYPE_SNAPSHOT == currentItem->versionData.cacheType) {
 				/* no last detach time for snapshot,  currentItem->nattach and currentItem->lastdetach are both J9SH_OSCACHE_UNKNOWN */
-				j9tty_printf(PORTLIB,"\n");
+				j9tty_printf(PORTLIB, "\n");
 			} else {
-				j9tty_printf(PORTLIB, "%-15s\n", "Unknown");
+				j9tty_printf(PORTLIB, "%s\n", "Unknown");
 			}
 		} else {
-			j9tty_printf(PORTLIB, "%-15s\n", "In use");
+			j9tty_printf(PORTLIB, "%s\n", "In use");
 		}
 	}
 	Trc_SHR_CLM_printSharedCache_Exit();

--- a/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2001, 2020 IBM Corp. and others
+  Copyright (c) 2001, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,7 @@
  
  <!-- Arguments specific to the class unloading tests -->
  <variable name="PROGRAM" value="com.ibm.tests.garbagecollector.TestClassLoaderMain" />
- <variable name="MEM" value="4m" />
+ <variable name="MEM" value="8m" />
  <variable name="VMARGS" value="-Xmx$MEM$ -Xms$MEM$ -Xalwaysclassgc -Xdisableexcessivegc" />
  <variable name="EXTRAVMARG" value="-Xgc:fvtest=forceFinalizeClassLoaders" />
  <variable name="EXCESSIVE_STRING" value="excessive gc activity detected, will fail on allocate" />


### PR DESCRIPTION
Issue: #12397.
Depends on eclipse/omr#5945.

The first and third of the following lines are new:
```
1TIDATETIMEUTC Date: 2021/04/14 at 18:51:14:126 (UTC)
1TIDATETIME    Date: 2021/04/14 at 14:51:14:126
1TITIMEZONE    Timezone: UTC-4 (EDT)
```