### PR TITLE
Optimize locking in persistent allocator

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -142,7 +142,6 @@ cgOnClassUnloading(void *loaderPtr)
    #endif
    }
 
-extern TR::Monitor *memoryAllocMonitor;
 extern TR::Monitor *assumptionTableMutex;
 
 extern volatile bool shutdownSamplerThread;

--- a/runtime/compiler/env/PersistentAllocator.cpp
+++ b/runtime/compiler/env/PersistentAllocator.cpp
@@ -374,11 +374,12 @@ PersistentAllocator::freeVariableSizeBlock(Block * block)
    }
 
 #if defined(J9VM_OPT_JITSERVER)
-size_t 
+size_t
 PersistentAllocator::getInterval(size_t blockSize)
    {  
    // Find the power-of-two interval that this block size belongs to
-   TR_ASSERT(blockSize >= PERSISTANT_BLOCK_SIZE_BUCKETS * sizeof(void *), "getInterval should be used only on big blocks. blockSize=%zu", blockSize);
+   TR_ASSERT(blockSize >= PERSISTENT_BLOCK_SIZE_BUCKETS * sizeof(void *),
+             "getInterval should be used only on big blocks. blockSize=%zu", blockSize);
    // If very large block
    if (blockSize >= (1 << (BITS_TO_SHIFT_FIRST_INTERVAL + NUM_INTERVALS - 1)))
       return NUM_INTERVALS - 1; // last one

--- a/runtime/compiler/env/PersistentAllocator.hpp
+++ b/runtime/compiler/env/PersistentAllocator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -89,12 +89,13 @@ private:
       void setNext(Block *b) { _next = b; }
       };
 
-   // Monitor to protect access to the linked lists of (small) fixed-size blocks
-   // The variable-size block list (which takes longer to access) will continue
-   // to be protected by memoryAllocMonitor. This arrangement prevents a fast
-   // fixed-size block list access to be delayed by a slow variable-size block
-   // list access
-   J9ThreadMonitor * _smallBlockListsMonitor;
+   // Use separate monitors to protect access to each data structure:
+   // - the lists of small fixed-size blocks;
+   // - the (indexed) list of vartiable-sized large blocks; and
+   // - the deque of segments.
+   J9ThreadMonitor *_smallBlockMonitor;
+   J9ThreadMonitor *_largeBlockMonitor;
+   J9ThreadMonitor *_segmentMonitor;
 
    static const size_t PERSISTANT_BLOCK_SIZE_BUCKETS = 16;
    // first list/bucket is for large blocks of variable size

--- a/runtime/compiler/env/PersistentAllocator.hpp
+++ b/runtime/compiler/env/PersistentAllocator.hpp
@@ -97,16 +97,14 @@ private:
    J9ThreadMonitor *_largeBlockMonitor;
    J9ThreadMonitor *_segmentMonitor;
 
-   static const size_t PERSISTANT_BLOCK_SIZE_BUCKETS = 16;
+   static const size_t PERSISTENT_BLOCK_SIZE_BUCKETS = 16;
    // first list/bucket is for large blocks of variable size
    static const size_t LARGE_BLOCK_LIST_INDEX = 0;
    static size_t freeBlocksIndex(size_t const blockSize)
       {
       size_t const adjustedBlockSize = blockSize - sizeof(Block);
       size_t const candidateBucket = adjustedBlockSize / sizeof(void *);
-      return candidateBucket < PERSISTANT_BLOCK_SIZE_BUCKETS ?
-         candidateBucket :
-         LARGE_BLOCK_LIST_INDEX;
+      return candidateBucket < PERSISTENT_BLOCK_SIZE_BUCKETS ? candidateBucket : LARGE_BLOCK_LIST_INDEX;
       }
 
    void * allocateInternal(size_t);
@@ -123,7 +121,7 @@ private:
 
    size_t const _minimumSegmentSize;
    SegmentAllocator _segmentAllocator;
-   Block * _freeBlocks[PERSISTANT_BLOCK_SIZE_BUCKETS];
+   Block *_freeBlocks[PERSISTENT_BLOCK_SIZE_BUCKETS];
    typedef TR::typed_allocator<TR::reference_wrapper<J9MemorySegment>, TR::RawAllocator> SegmentContainerAllocator;
    typedef std::deque<TR::reference_wrapper<J9MemorySegment>, SegmentContainerAllocator> SegmentContainer;
    SegmentContainer _segments;
@@ -178,7 +176,7 @@ private:
    // will point to the same block. If there is no block in an interval, these
    // two pointers are NULL.
    static const size_t NUM_INTERVALS = 8;
-   static const size_t SIZE_FIRST_LARGE_BLOCK = PERSISTANT_BLOCK_SIZE_BUCKETS * sizeof(void *);
+   static const size_t SIZE_FIRST_LARGE_BLOCK = PERSISTENT_BLOCK_SIZE_BUCKETS * sizeof(void *);
    static const size_t BITS_TO_SHIFT_FIRST_INTERVAL = floorLog2(SIZE_FIRST_LARGE_BLOCK);
    ExtendedBlock * _startInterval[NUM_INTERVALS] = {}; // Acts like an index to help us find faster the block of appropriate size
                                                        // First shortcut points to blocks that are [128, 256) bytes in size

--- a/runtime/compiler/infra/J9Monitor.cpp
+++ b/runtime/compiler/infra/J9Monitor.cpp
@@ -31,8 +31,6 @@
 
 TR::MonitorTable *OMR::MonitorTable::_instance = 0;
 
-TR::Monitor *memoryAllocMonitor = NULL;
-
 TR::Monitor *
 J9::Monitor::create(char *name)
    {

--- a/runtime/compiler/infra/J9MonitorTable.hpp
+++ b/runtime/compiler/infra/J9MonitorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -83,7 +83,6 @@ class OMR_EXTENSIBLE MonitorTable : public OMR::MonitorTableConnector
    TR_LinkHead0<TR::Monitor> _monitors;
 
    TR::Monitor _tableMonitor;
-   TR::Monitor _j9MemoryAllocMonitor;
    TR::Monitor _j9ScratchMemoryPoolMonitor;
    J9::RWMonitor _classUnloadMonitor;
    TR::Monitor _classTableMutex;  // JavaVM's class table mutex

--- a/runtime/compiler/ras/DebugExt.cpp
+++ b/runtime/compiler/ras/DebugExt.cpp
@@ -2506,7 +2506,6 @@ TR_DebugExt::dxPrintJ9MonitorTable(TR::MonitorTable *remoteMonTable)
 
    _dbgPrintf("\tJ9MonitorTable at 0x%p\n", remoteMonTable);
    _dbgPrintf("\tTR::Monitor * _tableMonitor = 0x%p\n", &(remoteMonTable->_tableMonitor));
-   _dbgPrintf("\tTR::Monitor * _j9MemoryAllocMonitor = 0x%p\n", &(remoteMonTable->_j9MemoryAllocMonitor));
    _dbgPrintf("\tTR::Monitor * _j9ScratchMemoryPoolMonitor = 0x%p\n", &(remoteMonTable->_j9ScratchMemoryPoolMonitor));
    _dbgPrintf("\tTR::Monitor * _classUnloadMonitor = 0x%p\n", &(remoteMonTable->_classUnloadMonitor));
    _dbgPrintf("\tTR::Monitor * _classTableMutex = 0x%p\n", &(remoteMonTable->_classTableMutex));


### PR DESCRIPTION
Even though JITServer uses per-client persistent allocator instances, they all use the same global `memoryAllocMonitor` to synchronize access to their lists of large variable-sized free blocks and deques of currently used segments. This global monitor can limit scalability when JITServer is used by a large number of concurrent clients.

This PR modifies the persistent allocator implementation to use separate monitors to protect access to each data structure:
- the lists of small fixed-size blocks;
- the (indexed) list of variable-sized large blocks; and
- the deque of segments.

It also removes all other references to the now unused global `memoryAllocMonitor`, which is defined in OMR and can be removed from there after this PR is merged.