### PR TITLE
Remove Scavenger shouldYeild()

### DIFF
--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -672,11 +672,6 @@ MM_ScavengerDelegate::private_shouldPercolateGarbageCollect_activeJNICriticalReg
 }
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-bool
-MM_ScavengerDelegate::shouldYield() {
-	return (J9_XACCESS_PENDING == ((J9JavaVM*)_omrVM->_language_vm)->exclusiveAccessState);
-}
-
 void
 MM_ScavengerDelegate::switchConcurrentForThread(MM_EnvironmentBase *env)
 {

--- a/runtime/gc_glue_java/ScavengerDelegate.hpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.hpp
@@ -138,7 +138,6 @@ public:
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	void switchConcurrentForThread(MM_EnvironmentBase *env);
 	void fixupIndirectObjectSlots(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
-	bool shouldYield();
 	void signalThreadsToFlushCaches(MM_EnvironmentBase *env);
 	void cancelSignalToFlushCaches(MM_EnvironmentBase *env);
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */


### PR DESCRIPTION
Not used anymore. It was not a reliable way to determining if we could
yield due to a pending Exclusive Access Request, since when external
threads would request it they would set the state directly to
J9_XACCESS_EXCLUSIVE, skipping over J9_XACCESS_PENDING.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>