### PR TITLE
AArch64: Replace CPU APIs

### DIFF
--- a/runtime/compiler/aarch64/env/J9CPU.hpp
+++ b/runtime/compiler/aarch64/env/J9CPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,7 +52,18 @@ protected:
 
 public:
 
-   OMRProcessorDesc getProcessorDescription();
+   /**
+    * @brief Intialize _supportedFeatureMasks to the list of processor features that will be utilized by the compiler and set _isSupportedFeatureMasksEnabled to true
+    */
+   static void enableFeatureMasks();
+
+   /**
+    * @brief A factory method used to construct a CPU object for portable AOT compilations
+    * @param[in] omrPortLib : the port library
+    * @return TR::CPU
+    */
+   static TR::CPU detectRelocatable(OMRPortLibrary * const omrPortLib);
+
    bool isCompatible(const OMRProcessorDesc& processorDescription);
 
    };

--- a/runtime/compiler/env/J9CompilerEnv.cpp
+++ b/runtime/compiler/env/J9CompilerEnv.cpp
@@ -30,7 +30,7 @@
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 J9::CompilerEnv::CompilerEnv(J9JavaVM *vm, TR::RawAllocator raw, const TR::PersistentAllocatorKit &persistentAllocatorKit) :
-#if defined(TR_HOST_ARM) || defined(TR_HOST_ARM64)
+#if defined(TR_HOST_ARM)
    OMR::CompilerEnvConnector(raw, persistentAllocatorKit),
 #else
    OMR::CompilerEnvConnector(raw, persistentAllocatorKit, OMRPORT_FROM_J9PORT(vm->portLibrary)),

--- a/runtime/compiler/env/ProcessorDetection.cpp
+++ b/runtime/compiler/env/ProcessorDetection.cpp
@@ -289,13 +289,6 @@ portLibCall_getARMProcessorType()
    return tp;
    }
 
-static TR_Processor
-portLibCall_getARM64ProcessorType()
-   {
-   // ToDo: Add code for detecting processor type (Issue #6637)
-   return TR_DefaultARM64Processor;
-   }
-
 // -----------------------------------------------------------------------------
 
 // For Verbose Log
@@ -389,6 +382,25 @@ int32_t TR_J9VM::getCompInfo(char *processorName, int32_t stringLength)
    if (TR::Compiler->target.cpu.isARM())
       {
       sourceString = "Unknown ARM processor";
+      returnValue = strlen(sourceString);
+      strncpy(processorName, sourceString, stringLength);
+      return returnValue;
+      }
+
+   if (TR::Compiler->target.cpu.isARM64())
+      {
+      switch (TR::Compiler->target.cpu.getProcessorDescription().processor)
+         {
+         case OMR_PROCESSOR_ARM64_UNKNOWN:
+            sourceString = "Unknown ARM64 processor";
+            break;
+         case OMR_PROCESSOR_ARM64_V8_A:
+            sourceString = "ARMv8-A processor";
+            break;
+         default:
+            sourceString = "Unknown ARM64 processor";
+            break;
+         }
       returnValue = strlen(sourceString);
       strncpy(processorName, sourceString, stringLength);
       return returnValue;
@@ -593,10 +605,8 @@ TR_J9VM::initializeProcessorType()
       }
    else if (TR::Compiler->target.cpu.isARM64())
       {
-      TR::Compiler->target.cpu.setProcessor(portLibCall_getARM64ProcessorType());
-
-      TR_ASSERT(TR::Compiler->target.cpu.id() >= TR_FirstARM64Processor
-             && TR::Compiler->target.cpu.id() <= TR_LastARM64Processor, "Not a valid ARM64 Processor Type");
+      OMRProcessorDesc processorDescription = TR::Compiler->target.cpu.getProcessorDescription();
+      TR::Compiler->target.cpu = TR::CPU::customize(processorDescription);
       }
    else
       {


### PR DESCRIPTION
Implement new CPU APIs on aarch64 as other platforms.

Depends on:
https://github.com/eclipse/omr/pull/5932
https://github.com/eclipse/omr/pull/5934

See OpenJ9 #10594.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>