### PR TITLE
Fix invalid memory access when getting a ROM class

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -877,7 +877,12 @@ TR::CompilationInfoPerThread::getAndCacheRemoteROMClass(J9Class *clazz, TR_Memor
       romClass = JITServerHelpers::getRemoteROMClass(clazz, getStream(), currentMemory, &classInfoTuple);
       bool cached = JITServerHelpers::cacheRemoteROMClass(getClientData(), clazz, romClass, &classInfoTuple);
       if (!cached)
+         {
          currentMemory->trPersistentMemory()->freePersistentMemory(romClass);
+         // return the ROM class from cache
+         romClass = getRemoteROMClassIfCached(clazz);
+         }
+      TR_ASSERT_FATAL(romClass, "ROM class of J9Class=%p must be cached at this point", clazz);
       }
    return romClass;
    }

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -639,7 +639,11 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
             }
          bool cached = JITServerHelpers::cacheRemoteROMClass(getClientData(), clazz, romClass, &classInfoTuple);
          if (!cached)
+            {
             clientSession->persistentMemory()->freePersistentMemory(romClass);
+            romClass = JITServerHelpers::getRemoteROMClassIfCached(clientSession, clazz);
+            }
+         TR_ASSERT_FATAL(romClass, "ROM class of J9Class=%p must be cached at this point", clazz);
          }
 
       J9ROMMethod *romMethod = (J9ROMMethod*)((uint8_t*)romClass + romMethodOffset);


### PR DESCRIPTION
PR #12180 introduced a bug: when we try to cache a newly
received ROM class but find that it's already been cached,
we deallocate it but still return the pointer to the ROM class
that now contains invalid memory.
The fix is to update the class pointer with the cached value
and return that.

Closes: #12468, #12442