### PR TITLE
JIT CMake build improvements to enable debug build

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -296,6 +296,10 @@ else()
 	message(SEND_ERROR "unsupported platform")
 endif()
 
+# Add optional user-specified compiler flags that only apply to the JIT
+list(APPEND J9_CFLAGS ${J9JIT_EXTRA_CFLAGS})
+list(APPEND J9_CXXFLAGS ${J9JIT_EXTRA_CXXFLAGS})
+
 # Note: J9_CFLAGS and J9_CXXFLAGS are appended after J9_SHAREDFLAGS so that
 #       OMR_PLATFORM_C_COMPILE_OPTIONS and OMR_PLATFORM_CXX_COMPILE_OPTIONS
 #       end up after OMR_PLATFORM_COMPILE_OPTIONS, which matches the rest

--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -228,7 +228,6 @@ set(J9_CFLAGS
 	${OMR_PLATFORM_C_COMPILE_OPTIONS}
 )
 set(J9_CXXFLAGS
-	${OMR_PLATFORM_COMPILE_OPTIONS}
 	${OMR_PLATFORM_CXX_COMPILE_OPTIONS}
 )
 if(OMR_OS_LINUX OR OMR_OS_OSX)
@@ -297,8 +296,16 @@ else()
 	message(SEND_ERROR "unsupported platform")
 endif()
 
-omr_stringify(J9_CFLAGS_STR ${J9_CFLAGS} ${J9_SHAREDFLAGS})
-omr_stringify(J9_CXXFLAGS_STR ${J9_CXXFLAGS} ${J9_SHAREDFLAGS})
+# Note: J9_CFLAGS and J9_CXXFLAGS are appended after J9_SHAREDFLAGS so that
+#       OMR_PLATFORM_C_COMPILE_OPTIONS and OMR_PLATFORM_CXX_COMPILE_OPTIONS
+#       end up after OMR_PLATFORM_COMPILE_OPTIONS, which matches the rest
+#       of the VM build (see cmake/modules/OmrPlatform.cmake in OMR).
+#       This allows the user to pass extra compiler options via
+#       OMR_PLATFORM_C_COMPILE_OPTIONS and OMR_PLATFORM_CXX_COMPILE_OPTIONS
+#       to override the defaults specified by OMR_PLATFORM_COMPILE_OPTIONS,
+#       e.g. in order to produce a debug build.
+omr_stringify(J9_CFLAGS_STR ${J9_SHAREDFLAGS} ${J9_CFLAGS})
+omr_stringify(J9_CXXFLAGS_STR ${J9_SHAREDFLAGS} ${J9_CXXFLAGS})
 
 # Note: This is explicitly overriding what's provided by
 #       the VM CMakeLists, as they pass -fno-exceptions


### PR DESCRIPTION
This PR makes the following changes:

- Allow passing extra compiler flags to the JIT CMake build via `OMR_PLATFORM_C_COMPILE_OPTIONS` and `OMR_PLATFORM_CXX_COMPILE_OPTIONS` by changing the order in which compiler flags are appended in the JIT's `CMakeLists.txt`. This change makes the behaviour consistent with the rest of the VM.
- Add CMake options `J9JIT_EXTRA_CFLAGS` and `J9JIT_EXTRA_CXXFLAGS` that can be used to pass extra compiler flags that are only used when building the JIT. This is useful e.g. when one wants to define the `DEBUG` flag only for the JIT.

With these changes it becomes easier to produce a debug build, without having to hack the makefiles as described in https://blog.openj9.org/2020/11/19/setting-up-an-openj9-development-environment-with-visual-studio-code-docker-cmake/.

One can use something like this to produce a debug build of the whole VM (assuming GCC toolchain):

```
cflags="-Og -ggdb3 -fno-inline -DDEBUG"
export EXTRA_CMAKE_ARGS="-DOMR_PLATFORM_C_COMPILE_OPTIONS=\"$cflags\" -DOMR_PLATFORM_CXX_COMPILE_OPTIONS=\"$cflags\" -DOMR_SEPARATE_DEBUG_INFO=OFF"
make all
```

Or if one wants a debug version of the JIT only:
```
export EXTRA_CMAKE_ARGS="-DJ9JIT_EXTRA_CFLAGS=\"$cflags\" -DJ9JIT_EXTRA_CXXFLAGS=\"$cflags\" -DOMR_SEPARATE_DEBUG_INFO=OFF"
```

Note that this works because the extra compiler flags passed to the build this way end up after the default `-O` and `-g` options, overriding them. While not a perfect solution, this is better than the current situation (having to hack the makefiles).

Two separate PRs in OpenJ9 (#12475) and OMR (https://github.com/eclipse/omr/pull/5940) fix compiler errors when `DEBUG` is defined.