### PR TITLE
CMake: disable add_custom_ascii_command

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -141,10 +141,12 @@ add_custom_target(j9vm_nlsgen
 set(J9VM_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/include")
 file(MAKE_DIRECTORY "${J9VM_INCLUDE_DIR}")
 
+
+# Note: the following does not appear to be needed anymore. It is left here in case we need it in the future.
 # On z/OS, some generated files must be converted to EBCDIC for consistency.
 # This macro is intended to be used as a replacement for add_custom_command
 # for those files.
-if(OMR_OS_ZOS)
+if("FALSE" AND OMR_OS_ZOS)
 	macro(add_custom_ascii_command)
 		set(options)
 		set(singleValueArgs OUTPUT WORKING_DIRECTORY)


### PR DESCRIPTION
Functionality seems to no longer be required. However, code left in place
should we need to re-enable it in the future.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>