### PR TITLE
Increase OS stackspace on PPC64

### DIFF
--- a/runtime/oti/j9cfg_builder.h
+++ b/runtime/oti/j9cfg_builder.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,14 +92,23 @@
 #define J9_JIT_DATA_CACHE_SIZE (8 * 1024 * 1024)
 #endif /* J9VM_ARCH_X86 && !J9VM_ENV_DATA64 */
 
-#if defined(J9ZOS390) && defined(J9VM_ENV_DATA64)
+
+#define J9_OS_STACK_GUARD (16 * 1024)
+
+#if defined(J9VM_ENV_DATA64) && defined(J9ZOS390)
 /* Use a 1MB OS stack on z/OS 64-bit as this is what the OS
  * allocates anyway, using IARV64 GETSTOR to allocate a segment.
  */
 #define J9_OS_STACK_SIZE (1024 * 1024)
-#else /* J9ZOS390 && J9VM_ENV_DATA64 */
+#elif defined(J9VM_ENV_DATA64) && defined(J9VM_ARCH_POWER)
+/* increase stack space on PPC64 (AIX & Linux) since we are now preserving the
+ * 32 128-bit Vector (VSCR) registers.
+ */
+#define J9_OS_STACK_SIZE (512 * 1024)
+#else /* defined(J9VM_ENV_DATA64) && defined(J9ZOS390) */
 #define J9_OS_STACK_SIZE (256 * 1024)
-#endif
+#endif /* defined(J9VM_ENV_DATA64) && defined(J9ZOS390) */
+
 
 /* Unused constants, kept here in case the JCL compiles use them */
 

--- a/runtime/vm/callin.cpp
+++ b/runtime/vm/callin.cpp
@@ -299,7 +299,7 @@ buildCallInStackFrame(J9VMThread *currentThread, J9VMEntryLocalStorage *newELS, 
 		UDATA usedBytes = ((UDATA)oldELS - (UDATA)newELS);
 		freeBytes -= usedBytes;
 		currentThread->currentOSStackFree = freeBytes;
-		if ((IDATA)freeBytes < 0) {
+		if ((IDATA)freeBytes < J9_OS_STACK_GUARD) {
 			if (J9_ARE_NO_BITS_SET(currentThread->privateFlags, J9_PRIVATE_FLAGS_CONSTRUCTING_EXCEPTION)) {
 				setCurrentExceptionNLS(currentThread, J9VMCONSTANTPOOL_JAVALANGSTACKOVERFLOWERROR, J9NLS_VM_OS_STACK_OVERFLOW);
 				currentThread->currentOSStackFree += usedBytes;


### PR DESCRIPTION
We are now preserving vector registers on PPC64between JIT runtime helper
calls. This is believed to be the cause of StackOverflowError failures seen on
PPC64. This PR increases the default stack size on PPC64 from 256kb to
512kb. This PR also introduces a stack guard to protect from overflows
between call-in frames.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>