### PR TITLE
AArch64: Inline direct call for atomic method symbols

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -3366,6 +3366,10 @@ J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
    TR::CodeGenerator *cg = self();
    TR::MethodSymbol * methodSymbol = node->getSymbol()->getMethodSymbol();
 
+   if (OMR::CodeGeneratorConnector::inlineDirectCall(node, resultReg))
+      {
+      return true;
+      }
    if (methodSymbol)
       {
       switch (methodSymbol->getRecognizedMethod())


### PR DESCRIPTION
Call overridden implementation of `inlineDirectCall` method
as inlining of atomic method symbols is implemented in OMR class.

Depends on https://github.com/eclipse/omr/pull/5950

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>