### PR TITLE
Fix TR_J9ServerVM::getClassLoader()

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -309,10 +309,13 @@ TR_J9ServerVM::getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer)
    }
 
 void *
-TR_J9ServerVM::getClassLoader(TR_OpaqueClassBlock * classPointer)
+TR_J9ServerVM::getClassLoader(TR_OpaqueClassBlock *clazz)
    {
-   TR_ASSERT(false, "The server vm should not call getClassLoader.");
-   return NULL;
+   void *loader = NULL;
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream,
+                                             JITServerHelpers::CLASSINFO_CLASS_LOADER, &loader);
+   return loader;
    }
 
 TR_OpaqueClassBlock *


### PR DESCRIPTION
This PR fixes the issue that was first described but not fully fixed in https://github.com/eclipse/omr/issues/5837 and https://github.com/eclipse/omr/pull/5839.

In some rare circumstances, `TR_J9ServerVM::getClassLoader()` ends up being called by the optimizer through `OMR::SymbolReferenceTable::findOrCreateClassSymbol()` at the JITServer. The current implementation of `TR_J9ServerVM::getClassLoader()` erroneously assumes that it can never be called on the server side, and returns `NULL` after a non-fatal assertion. This PR fixes this issue by providing the correct implementation.