### PR TITLE
Include types from omrmem32struct.h in legacy DDR

### DIFF
--- a/runtime/ddr/j9portddrstructs.properties
+++ b/runtime/ddr/j9portddrstructs.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010, 2017 IBM Corp. and others
+# Copyright (c) 2010, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,6 +40,7 @@ ddrblob.name=J9Port
 ddrblob.headers=\
 portpriv.h,\
 j9port.h,\
+omrmem32struct.h,\
 omrportptb.h,\
 j9port_generated.h,\
 edcwccwi.h,\


### PR DESCRIPTION
Make types `J9HeapWrapper` and `J9SubAllocateHeapMem32` available to DDR in IBM builds.