### PR TITLE
Add JavaLangAccess.join(prefix, suffix, delimiter, elements, size)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -476,6 +476,14 @@ final class Access implements JavaLangAccess {
 	public void inflateBytesToChars(byte[] srcBytes, int srcOffset, char[] dstChars, int dstOffset, int length) {
 		StringLatin1.inflate(srcBytes, srcOffset, dstChars, dstOffset, length);
 	}
+
+	/*[IF OPENJDK_METHODHANDLES]*/
+	// This JPP flag is used to workaround the issue that latest 
+	// String update hasn't been promoted into openj9 branch. 
+	public String join(String prefix, String suffix, String delimiter, String[] elements, int size) {
+		return String.join(prefix, suffix, delimiter, elements, size);
+	}
+	/*[ENDIF] OPENJDK_METHODHANDLES*/
 /*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 
 /*[ENDIF] Sidecar19-SE */


### PR DESCRIPTION
Invoke `String` package private method `join(prefix, suffix, delimiter,elements, size)`.

depends on https://github.com/eclipse/openj9/pull/12209

With this PR and https://github.com/eclipse/openj9/pull/12209, `java -version` output is:
```
openjdk version "17-internal" 2021-09-14
OpenJDK Runtime Environment (build 17-internal+0-adhoc.fengjcaibmcom.openj9-openjdk-jdk)
Eclipse OpenJ9 VM (build jdk17ristr-jlajoin-c2d8cf4dd9, JRE 17 Mac OS X amd64-64-Bit Compressed References 20210423_000000 (JIT enabled, AOT enabled)
OpenJ9   - c2d8cf4dd9
OMR      - 22a4853ac
JCL      - bcdde3be245 based on jdk-17+19)
```

fixes https://github.com/eclipse/openj9/issues/12545

Signed-off-by: Jason Feng <fengj@ca.ibm.com>