### PR TITLE
31-bit shim library for z/OS

### DIFF
--- a/buildspecs/j9.flags
+++ b/buildspecs/j9.flags
@@ -1450,6 +1450,10 @@ Only available on zOS</description>
 		<description>Enables compilation of the j9vm module.</description>
 		<ifRemoved>The module will not be compiled.</ifRemoved>
 	</flag>
+	<flag id="module_j9vm31">
+		<description>Enables compilation of the j9vm31 module.</description>
+		<ifRemoved>The module will not be compiled.</ifRemoved>
+	</flag>
 	<flag id="module_j9vmtest">
 		<description>Enables compilation of the j9vmtest module.</description>
 		<ifRemoved>The module will not be compiled.</ifRemoved>

--- a/buildspecs/j9.flags
+++ b/buildspecs/j9.flags
@@ -1442,6 +1442,10 @@ Only available on zOS</description>
 		<description>Enables compilation of the include module.</description>
 		<ifRemoved>The module will not be compiled.</ifRemoved>
 	</flag>
+	<flag id="module_include31">
+		<description>Enables compilation of the include module.</description>
+		<ifRemoved>The module will not be compiled.</ifRemoved>
+	</flag>
 	<flag id="module_j9vm">
 		<description>Enables compilation of the j9vm module.</description>
 		<ifRemoved>The module will not be compiled.</ifRemoved>

--- a/buildspecs/zos_390-64.spec
+++ b/buildspecs/zos_390-64.spec
@@ -193,6 +193,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flag id="module_gptest" value="true"/>
 		<flag id="module_include31" value="true"/>
 		<flag id="module_j9vm" value="true"/>
+		<flag id="module_j9vm31" value="true"/>
 		<flag id="module_j9vmtest" value="true"/>
 		<flag id="module_jextractnatives" value="true"/>
 		<flag id="module_jit_common" value="true"/>

--- a/buildspecs/zos_390-64.spec
+++ b/buildspecs/zos_390-64.spec
@@ -191,6 +191,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flag id="module_codert_vm" value="true"/>
 		<flag id="module_ddr" value="true"/>
 		<flag id="module_gptest" value="true"/>
+		<flag id="module_include31" value="true"/>
 		<flag id="module_j9vm" value="true"/>
 		<flag id="module_j9vmtest" value="true"/>
 		<flag id="module_jextractnatives" value="true"/>

--- a/buildspecs/zos_390-64_cmprssptrs.spec
+++ b/buildspecs/zos_390-64_cmprssptrs.spec
@@ -193,6 +193,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flag id="module_gptest" value="true"/>
 		<flag id="module_include31" value="true"/>
 		<flag id="module_j9vm" value="true"/>
+		<flag id="module_j9vm31" value="true"/>
 		<flag id="module_j9vmtest" value="true"/>
 		<flag id="module_jextractnatives" value="true"/>
 		<flag id="module_jit_common" value="true"/>

--- a/buildspecs/zos_390-64_cmprssptrs.spec
+++ b/buildspecs/zos_390-64_cmprssptrs.spec
@@ -191,6 +191,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flag id="module_codert_vm" value="true"/>
 		<flag id="module_ddr" value="true"/>
 		<flag id="module_gptest" value="true"/>
+		<flag id="module_include31" value="true"/>
 		<flag id="module_j9vm" value="true"/>
 		<flag id="module_j9vmtest" value="true"/>
 		<flag id="module_jextractnatives" value="true"/>

--- a/runtime/buildtools.mk
+++ b/runtime/buildtools.mk
@@ -1,7 +1,7 @@
 # buildtools Makefile
 
 ###############################################################################
-# Copyright (c) 1998, 2020 IBM Corp. and others
+# Copyright (c) 1998, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -173,6 +173,7 @@ OMRGLUE_INCLUDES = \
 
 j9includegen : uma
 	$(MAKE) -C include j9include_generate
+	$(MAKE) -C include31 j9include31_generate
 
 configure : j9includegen
 	$(MAKE) -C omr -f run_configure.mk 'SPEC=$(SPEC)' 'OMRGLUE=$(OMRGLUE)' 'CONFIG_INCL_DIR=$(CONFIG_INCL_DIR)' 'OMRGLUE_INCLUDES=$(OMRGLUE_INCLUDES)' 'EXTRA_CONFIGURE_ARGS=$(EXTRA_CONFIGURE_ARGS)'

--- a/runtime/include/jni.h.m4
+++ b/runtime/include/jni.h.m4
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -79,6 +79,23 @@ typedef double jdouble;
 typedef jint jsize;
 
 #ifdef __cplusplus
+ifdef(`J9_ZOS_3164_INTEROPERABILITY',`dnl
+typedef long long jobject;
+typedef long long jweak;
+typedef long long jclass;
+typedef long long jstring;
+typedef long long jthrowable;
+typedef long long jarray;
+typedef long long jobjectArray;
+typedef long long jbooleanArray;
+typedef long long jbyteArray;
+typedef long long jcharArray;
+typedef long long jshortArray;
+typedef long long jintArray;
+typedef long long jlongArray;
+typedef long long jfloatArray;
+typedef long long jdoubleArray;
+',`dnl
 class _jobject {};
 class _jweak : public _jobject {};
 class _jclass : public _jobject {};
@@ -109,9 +126,14 @@ typedef _jintArray * jintArray;
 typedef _jlongArray * jlongArray;
 typedef _jfloatArray * jfloatArray;
 typedef _jdoubleArray * jdoubleArray;
+')dnl
 #else
+ifdef(`J9_ZOS_3164_INTEROPERABILITY',`dnl
+typedef long long jobject;
+',`dnl
 struct _jobject;
 typedef struct _jobject * jobject;
+')dnl
 typedef jobject jweak;
 typedef jobject jclass;
 typedef jobject jstring;
@@ -128,10 +150,15 @@ typedef jarray jfloatArray;
 typedef jarray jdoubleArray;
 #endif
 
+ifdef(`J9_ZOS_3164_INTEROPERABILITY',`dnl
+typedef long long jfieldID;
+typedef long long jmethodID;
+',`dnl
 struct _jfieldID;
 typedef struct _jfieldID *jfieldID;
 struct _jmethodID;
 typedef struct _jmethodID *jmethodID;
+')dnl
 
 /* Used for CallXXXMethodA API */
 typedef union jvalue {
@@ -672,16 +699,21 @@ ifelse(eval(JAVA_SPEC_VERSION >= 9), 1, `	jobject GetModule(jclass clazz) { retu
 /* 1.1 Args */
 typedef struct JDK1_1InitArgs {
 	jint version;
+ifdef(`J9_ZOS_3164_INTEROPERABILITY',`	void *reservedPropertiesPadding;')
 	char **properties;
-	jint checkSource; 
+	jint checkSource;
 	jint nativeStackSize;
 	jint javaStackSize;
 	jint minHeapSize;
 	jint maxHeapSize;
 	jint verifyMode;
+ifdef(`J9_ZOS_3164_INTEROPERABILITY',`	void *reservedClasspathPadding;')
 	const char *classpath;
+ifdef(`J9_ZOS_3164_INTEROPERABILITY',`	void *reservedVfprintfHookPadding;')
 	jint (JNICALL * vfprintf)(FILE *fp, const char *format, va_list args);
+ifdef(`J9_ZOS_3164_INTEROPERABILITY',`	void *reservedExitHookPadding;')
 	void (JNICALL * exit)(jint code);
+ifdef(`J9_ZOS_3164_INTEROPERABILITY',`	void *reservedAbortHookPadding;')
 	void (JNICALL * abort)(void);
 	jint enableClassGC;
 	jint enableVerboseGC;
@@ -696,18 +728,23 @@ typedef struct JDK1_1AttachArgs {
 
 /* 1.2 args */
 typedef struct JavaVMOption {
+ifdef(`J9_ZOS_3164_INTEROPERABILITY',`	void *reservedOptionStringPadding;')
 	char *optionString;
+ifdef(`J9_ZOS_3164_INTEROPERABILITY',`	void *reservedExtraInfoPadding;')
 	void *extraInfo;
 } JavaVMOption;
 typedef struct JavaVMInitArgs {
 	jint version;
 
 	jint nOptions;
+ifdef(`J9_ZOS_3164_INTEROPERABILITY',`	void *reservedOptionsPadding;')
 	JavaVMOption *options;
 	jboolean ignoreUnrecognized;
+ifdef(`J9_ZOS_3164_INTEROPERABILITY',`	void *reservedAlignmentPadding;')
 } JavaVMInitArgs;
 typedef struct {
 	jint version;
+ifdef(`J9_ZOS_3164_INTEROPERABILITY',`	void *reservedNamePadding;')
 	char *name;
 	jobject group;
 } JavaVMAttachArgs;
@@ -736,6 +773,7 @@ struct JavaVM_ {
 #endif
 };
 
+ifdef(`J9_ZOS_3164_INTEROPERABILITY',`',`dnl
 struct JVMExtensionInterface_ {
 	char eyecatcher[4];
 	jint length;
@@ -761,6 +799,7 @@ typedef  JVMExt_ JVMExt;
 #else
 typedef const struct JVMExtensionInterface_ *JVMExt;
 #endif
+')dnl
 
 jint JNICALL JNI_GetDefaultJavaVMInitArgs(void *);
 jint JNICALL JNI_CreateJavaVM(JavaVM **, void **, void *);

--- a/runtime/include31/module.xml
+++ b/runtime/include31/module.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2021, 2021 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<module>
+
+	<artifact type="reference" name="j9include31">
+	</artifact>
+
+	<artifact type="target" name="j9include31-jni_convert.h" all="false">
+		<dependencies>
+				<dependency name="../include/jni_convert.h"/>
+		</dependencies>
+		<commands>
+				<command type="all" line="cp ../include/jni_convert.h ."/>
+				<command type="clean" line="$(RM) jni_convert.h"/>
+		</commands>
+	</artifact>
+
+	<artifact type="target" name="j9include31-jniport.h" all="false">
+		<dependencies>
+				<dependency name="../include/jniport.h"/>
+		</dependencies>
+		<commands>
+				<command type="all" line="cp ../include/jniport.h ."/>
+				<command type="clean" line="$(RM) jniport.h"/>
+		</commands>
+	</artifact>
+
+	<artifact type="target" name="j9include31-jni.h" all="false">
+		<dependencies>
+			<dependency name="../include/jni.h.m4"/>
+		</dependencies>
+		<commands>
+			<command type="all" line="m4 -D J9_ZOS_3164_INTEROPERABILITY=1 -D JAVA_SPEC_VERSION=$(VERSION_MAJOR) ../include/jni.h.m4 > jni.h $(call CONVERT_ASCII_TO_NATIVE, jni.h)"/>
+			<command type="clean" line="$(RM) jni.h"/>
+		</commands>
+	</artifact>
+
+	<artifact type="target" name="j9include31_generate" all="false">
+		<dependencies>
+			<dependency name="j9include31-jni_convert.h"/>
+			<dependency name="j9include31-jniport.h"/>
+			<dependency name="j9include31-jni.h"/>
+		</dependencies>
+	</artifact>
+</module>

--- a/runtime/j9vm31/j9cel4ro64.c
+++ b/runtime/j9vm31/j9cel4ro64.c
@@ -1,0 +1,365 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9cel4ro64.h"
+#include <assert.h> /* Required for __gtca() */
+
+/* Function descriptor of CEL4RO64 runtime call from GTCA control block */
+typedef void cel4ro64_cwi_func(void*);
+#pragma linkage (cel4ro64_cwi_func,OS_UPSTACK)
+#define CEL4RO64_FNPTR ((cel4ro64_cwi_func *)(*(int*)((char*)(*(int*)(((char*)__gtca())+1024))+8)))
+
+#pragma linkage (J9VM_STE,OS)
+float J9VM_STE(void);
+#pragma linkage (J9VM_STD,OS)
+double J9VM_STD(void);
+#pragma linkage (J9VM_LE,OS)
+void J9VM_LE(float);
+#pragma linkage (J9VM_LD,OS)
+void J9VM_LD(double);
+
+/**
+ * Populate the arguments from argValues in outgoing 64-bit representation based on the types provided.
+ * This routine will zero extend upper 32-bits as necessary.
+ *
+ * @param[in] outgoingArgs The outgoing argument storage area with first 4-bytes as length.
+ * @param[in] argTypes An array of argument types for call.
+ * @param[in] argsValues An uint64_t array of argument values.
+ * @param[in] numArgs Number of arguments.
+ */
+static void
+populateArguments(uint64_t *outgoingArgs, J9_CEL4RO64_ArgType *argTypes, uint64_t *argValues, uint32_t numArgs)
+{
+	/* First field of outgoingArgs is length member - each argument on 64-bit side is
+	 * in an 8-byte slot. Bump outgoingArgs by 4-bytes afterwards.
+	 */
+	uint32_t *lengthPtr = (uint32_t*)outgoingArgs;
+	*lengthPtr = sizeof(uint64_t) * numArgs;
+	outgoingArgs = (uint64_t *)&(lengthPtr[1]);
+
+	for (uint32_t i = 0; i < numArgs; i++) {
+		J9_CEL4RO64_ArgType argType = argTypes[i];
+		jfloat floatArg;
+		jdouble doubleArg;
+
+		switch(argType) {
+		case CEL4RO64_type_jboolean:
+		case CEL4RO64_type_jbyte:
+		case CEL4RO64_type_jchar:
+		case CEL4RO64_type_jshort:
+		case CEL4RO64_type_jint:
+		case CEL4RO64_type_jsize:
+		case CEL4RO64_type_uint32_ptr:
+			outgoingArgs[i] = argValues[i] & 0xFFFFFFFF;
+			break;
+		case CEL4RO64_type_jfloat:
+			/* Note: Float argument requires special handling as the value needs to be loaded into FPR0.
+			 * Only set*FloatField JNI functions have a jfloat parameter, so only need to handle
+			 * one instance.
+			 */
+			floatArg = *(jfloat *)(&(argValues[i]));
+			/* Ideally, we could have used the following inline asm
+			 * but V2R1 xlc does not support that yet.
+			 * __asm(" LE 0,%0" : : "m"(floatArg));
+			 */
+			J9VM_LE(floatArg);
+			break;
+		case CEL4RO64_type_jdouble:
+			/* Note: Double argument requires special handling as the value needs to be loaded into FPR0.
+			 * Only set*DoubleField JNI functions have a jdouble parameter, so only need to handle
+			 * one instance.
+			 */
+			doubleArg = *(jdouble *)(&(argValues[i]));
+			/* Ideally, we could have used the following inline asm
+			 * but V2R1 xlc does not support that yet.
+			 * __asm(" LD 0,%0" : : "m"(doubleArg));
+			 */
+			J9VM_LD(doubleArg);
+			break;
+		case CEL4RO64_type_jlong:
+		case CEL4RO64_type_jobject:
+		case CEL4RO64_type_jweak:
+		case CEL4RO64_type_jclass:
+		case CEL4RO64_type_jstring:
+		case CEL4RO64_type_jthrowable:
+		case CEL4RO64_type_jarray:
+		case CEL4RO64_type_jmethodID:
+		case CEL4RO64_type_jfieldID:
+		case CEL4RO64_type_JNIEnv64:
+		case CEL4RO64_type_JavaVM64:
+			outgoingArgs[i] = argValues[i];
+			break;
+		default:
+			break;
+		}
+	}
+}
+
+/**
+ * Populate the return storage buffer with the appropriate return value from CEL4RO64 call.
+ *
+ * @param[in] controlBlock The outgoing argument storage area.
+ * @param[in] returnType The return type of target function.
+ * @param[in] returnStorage The storage location to store return value.
+ */
+static void
+populateReturnValue(J9_CEL4RO64_controlBlock *controlBlock, J9_CEL4RO64_ArgType returnType, void *returnStorage)
+{
+	/* Integral and pointer data types <= 64 bits in length are widened to 64 bits and returned in GPR3. */
+	uint64_t GPR3returnValue = controlBlock->gpr3ReturnValue;
+
+	/* Cannot initialize these floating point variables, as it might kill FPR0 which contains the real
+	 * return value.
+	 */
+	jfloat floatReturnValue;
+	jdouble doubleReturnValue;
+
+	switch(returnType) {
+	case CEL4RO64_type_jboolean:
+		*((jboolean *)returnStorage) = (jboolean)GPR3returnValue;
+		break;
+	case CEL4RO64_type_jbyte:
+		*((jbyte *)returnStorage) = (jbyte)GPR3returnValue;
+		break;
+	case CEL4RO64_type_jchar:
+		*((jchar *)returnStorage) = (jchar)GPR3returnValue;
+		break;
+	case CEL4RO64_type_jshort:
+		*((jshort *)returnStorage) = (jshort)GPR3returnValue;
+		break;
+	case CEL4RO64_type_jint:
+	case CEL4RO64_type_jsize:
+		*((jint *)returnStorage) = (jint)GPR3returnValue;
+		break;
+	case CEL4RO64_type_jfloat:
+		/* Float return values are returned via FPR0.
+		 * Ideally, we could have used the following inline asm
+		 * but V2R1 xlc does not support that yet.
+		 * __asm(" STE 0,%0" : "=m"(floatReturnValue));
+		 */
+		floatReturnValue = J9VM_STE();
+		*((jfloat *)returnStorage) = floatReturnValue;
+		break;
+	case CEL4RO64_type_jdouble:
+		/* Double return values are returned via FPR0.
+		 * Ideally, we could have used the following inline asm
+		 * but V2R1 xlc does not support that yet.
+		 * __asm(" STD 0,%0" : "=m"(doubleReturnValue));
+		 */
+		doubleReturnValue = J9VM_STD();
+		*((jdouble *)returnStorage) = doubleReturnValue;
+		break;
+	case CEL4RO64_type_jlong:
+	case CEL4RO64_type_jobject:
+	case CEL4RO64_type_jweak:
+	case CEL4RO64_type_jclass:
+	case CEL4RO64_type_jstring:
+	case CEL4RO64_type_jthrowable:
+	case CEL4RO64_type_jarray:
+	case CEL4RO64_type_jmethodID:
+	case CEL4RO64_type_jfieldID:
+	case CEL4RO64_type_JNIEnv64:
+	case CEL4RO64_type_JavaVM64:
+		/* These are all 64-bit types. */
+		*((uint64_t*)returnStorage) = GPR3returnValue;
+		break;
+	case CEL4RO64_type_uint32_ptr:
+		*((uint32_t *)returnStorage) = (uint32_t)GPR3returnValue;
+		break;
+	default:
+		break;
+	}
+}
+
+uint32_t
+j9_cel4ro64_call_function(
+	uint64_t functionDescriptor, J9_CEL4RO64_ArgType *argTypes, uint64_t *argValues, uint32_t numArgs,
+	J9_CEL4RO64_ArgType returnType, void *returnStorage)
+{
+	uint32_t retcode = J9_CEL4RO64_RETCODE_OK;
+	uint32_t argumentAreaInBytes = (0 == numArgs) ? 0 : (sizeof(uint64_t) * numArgs + sizeof(uint32_t));  /* 8 byte slots + 4 byte length member. */
+	J9_CEL4RO64_controlBlock *controlBlock = NULL;
+
+	/* The CEL4RO64 function may not be available if the LE ++APAR is not installed. */
+	if (!j9_cel4ro64_isSupported()) {
+		fprintf(stderr, "CEL4RO64: %s\n", j9_cel4ro64_get_error_message(J9_CEL4RO64_RETCODE_ERROR_LE_RUNTIME_SUPPORT_NOT_FOUND));
+		return J9_CEL4RO64_RETCODE_ERROR_LE_RUNTIME_SUPPORT_NOT_FOUND;
+	}
+
+	controlBlock = (J9_CEL4RO64_controlBlock *)malloc(sizeof(J9_CEL4RO64_controlBlock) + argumentAreaInBytes);
+
+	if (NULL == controlBlock) {
+		retcode = J9_CEL4RO64_RETCODE_ERROR_STORAGE_ISSUE;
+		fprintf(stderr, "CEL4RO64: malloc failed: %s\n", j9_cel4ro64_get_error_message(retcode));
+		return retcode;
+	}
+
+	/* Initialize the control block members and calculate the various offsets. */
+	controlBlock->version = 1;
+	controlBlock->flags = J9_CEL4RO64_FLAG_EXECUTE_TARGET_FUNC;
+	controlBlock->moduleOffset = sizeof(J9_CEL4RO64_controlBlock);
+	controlBlock->functionOffset = sizeof(J9_CEL4RO64_controlBlock);
+	controlBlock->dllHandle = 0;
+	controlBlock->functionDescriptor = functionDescriptor;
+
+	/* If no arguments, the argumentOffset must be zero. */
+	if (0 == numArgs) {
+		controlBlock->argumentsOffset = 0;
+	} else {
+		uint64_t *argumentsArea = (uint64_t *)((char *)(controlBlock) + sizeof(J9_CEL4RO64_controlBlock));
+		controlBlock->argumentsOffset = sizeof(J9_CEL4RO64_controlBlock);
+		populateArguments(argumentsArea, argTypes, argValues, numArgs);
+	}
+
+	CEL4RO64_FNPTR(controlBlock);
+	retcode = controlBlock->retcode;
+	if ((J9_CEL4RO64_RETCODE_OK == retcode) && (CEL4RO64_type_void != returnType)) {
+		populateReturnValue(controlBlock, returnType, returnStorage);
+	}
+
+	free(controlBlock);
+	return retcode;
+}
+
+uint32_t
+j9_cel4ro64_load_query_call_function(
+	const char* moduleName, const char* functionName, J9_CEL4RO64_ArgType *argTypes,
+	uint64_t *argValues, uint32_t numArgs, J9_CEL4RO64_ArgType returnType, void *returnStorage)
+{
+	uint32_t retcode = J9_CEL4RO64_RETCODE_OK;
+	uint32_t IPBLength = 0;
+	uint32_t moduleNameLength = strlen(moduleName);
+	uint32_t functionNameLength = strlen(functionName);
+	uint32_t argsLength = sizeof(uint64_t) * numArgs + sizeof(uint32_t); /* 8 byte slots + 4 byte length member. */
+	J9_CEL4RO64_infoBlock *infoBlock = NULL;
+	J9_CEL4RO64_controlBlock *controlBlock = NULL;
+	J9_CEL4RO64_module *moduleBlock = NULL;
+	J9_CEL4RO64_function *functionBlock = NULL;
+
+	/* The CEL4RO64 function may not be available if the LE ++APAR is not installed. */
+	if (!j9_cel4ro64_isSupported()) {
+		fprintf(stderr, "CEL4RO64: %s\n", j9_cel4ro64_get_error_message(J9_CEL4RO64_RETCODE_ERROR_LE_RUNTIME_SUPPORT_NOT_FOUND));
+		return J9_CEL4RO64_RETCODE_ERROR_LE_RUNTIME_SUPPORT_NOT_FOUND;
+	}
+
+	IPBLength = sizeof(J9_CEL4RO64_infoBlock) + moduleNameLength + functionNameLength + argsLength +
+	            sizeof(moduleBlock->length) + sizeof(functionBlock->length);
+	infoBlock = (J9_CEL4RO64_infoBlock *) malloc(IPBLength);
+	if (NULL == infoBlock) {
+		retcode = J9_CEL4RO64_RETCODE_ERROR_STORAGE_ISSUE;
+		fprintf(stderr, "CEL4RO64: malloc failed: %s\n", j9_cel4ro64_get_error_message(retcode));
+		return retcode;
+	}
+
+	controlBlock = &(infoBlock->ro64ControlBlock);
+
+	/* Initialize the control block members and calculate the various offsets. */
+	controlBlock->version = 1;
+	controlBlock->flags = J9_CEL4RO64_FLAG_ALL_LOAD_QUERY_EXECUTE;
+	controlBlock->moduleOffset = sizeof(J9_CEL4RO64_controlBlock);
+	if (0 == moduleNameLength) {
+		controlBlock->functionOffset = controlBlock->moduleOffset;
+	} else {
+		controlBlock->functionOffset = controlBlock->moduleOffset + moduleNameLength + sizeof(moduleBlock->length);
+	}
+
+	/* For execute target function operations, we need to ensure args reference is set
+	 * up appropriately. If no arguments, argumentsOffset needs to be 0.
+	 */
+	if (0 == argsLength) {
+		controlBlock->argumentsOffset = 0;
+	} else if (0 == functionNameLength) {
+		controlBlock->argumentsOffset = controlBlock->functionOffset;
+	} else {
+		controlBlock->argumentsOffset = controlBlock->functionOffset + functionNameLength + sizeof(functionBlock->length);
+	}
+
+	/* For DLL load operations, we need a module name specified. */
+	moduleBlock = (J9_CEL4RO64_module *)((char *)(controlBlock) + controlBlock->moduleOffset);
+	infoBlock->ro64Module = moduleBlock;
+	moduleBlock->length = moduleNameLength;
+	strncpy(moduleBlock->moduleName, moduleName, moduleNameLength);
+
+	/* For DLL query operations, we need a function name specified. */
+	functionBlock = (J9_CEL4RO64_function *)((char *)(controlBlock) + controlBlock->functionOffset);
+	infoBlock->ro64Function = functionBlock;
+	functionBlock->length = functionNameLength;
+	strncpy(functionBlock->functionName, functionName, functionNameLength);
+
+	/* For execute target function operations, we need to ensure args is set
+	 * up appropriately. If no arguments, argumentsOffset needs to be 0.
+	 */
+	if (0 == numArgs) {
+		controlBlock->argumentsOffset = 0;
+	} else {
+		uint64_t *argumentsArea = (uint64_t *)((char *)(controlBlock) + controlBlock->argumentsOffset);
+		populateArguments(argumentsArea, argTypes, argValues, numArgs);
+	}
+
+	CEL4RO64_FNPTR(controlBlock);
+	retcode = controlBlock->retcode;
+	if ((J9_CEL4RO64_RETCODE_OK == retcode) && (CEL4RO64_type_void != returnType)) {
+		populateReturnValue(controlBlock, returnType, returnStorage);
+	}
+
+	free(infoBlock);
+	return retcode;
+}
+
+jboolean
+j9_cel4ro64_isSupported(void)
+{
+	return (NULL != CEL4RO64_FNPTR);
+}
+
+const char*
+j9_cel4ro64_get_error_message(int retCode)
+{
+	const char* errorMessage;
+	switch(retCode) {
+	case J9_CEL4RO64_RETCODE_OK:
+		errorMessage = "No errors detected.";
+		break;
+	case J9_CEL4RO64_RETCODE_ERROR_MULTITHREAD_INVOCATION:
+		errorMessage = "Multi-threaded invocation not supported.";
+		break;
+	case J9_CEL4RO64_RETCODE_ERROR_STORAGE_ISSUE:
+		errorMessage = "Storage issue detected.";
+		break;
+	case J9_CEL4RO64_RETCODE_ERROR_FAILED_AMODE64_ENV:
+		errorMessage = "Failed to initialize AMODE64 environment.";
+		break;
+	case J9_CEL4RO64_RETCODE_ERROR_FAILED_LOAD_TARGET_DLL:
+		errorMessage = "DLL module not found.";
+		break;
+	case J9_CEL4RO64_RETCODE_ERROR_FAILED_QUERY_TARGET_FUNC:
+		errorMessage = "Target function not found.";
+		break;
+	case J9_CEL4RO64_RETCODE_ERROR_LE_RUNTIME_SUPPORT_NOT_FOUND:
+		errorMessage = "CEL4RO64 runtime support not found.";
+		break;
+	default:
+		errorMessage = "Unexpected return code.";
+		break;
+	}
+	return errorMessage;
+}

--- a/runtime/j9vm31/j9cel4ro64.h
+++ b/runtime/j9vm31/j9cel4ro64.h
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef j9cel4ro64_h
+#define j9cel4ro64_h
+
+#include <stdint.h>
+#include <string.h>
+#include "jni.h" /* Needed for return argument type handling */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Flags to control the behaviour of CEL4RO64. Used by controlBlock->flags */
+#define J9_CEL4RO64_FLAG_LOAD_DLL               0x80000000
+#define J9_CEL4RO64_FLAG_QUERY_TARGET_FUNC      0x40000000
+#define J9_CEL4RO64_FLAG_EXECUTE_TARGET_FUNC    0x20000000
+#define J9_CEL4RO64_FLAG_ALL_LOAD_QUERY_EXECUTE (J9_CEL4RO64_FLAG_LOAD_DLL | J9_CEL4RO64_FLAG_QUERY_TARGET_FUNC | J9_CEL4RO64_FLAG_EXECUTE_TARGET_FUNC)
+
+/* Return codes for CEL4RO64 */
+#define J9_CEL4RO64_RETCODE_OK                                   0x0
+#define J9_CEL4RO64_RETCODE_ERROR_MULTITHREAD_INVOCATION         0x1
+#define J9_CEL4RO64_RETCODE_ERROR_STORAGE_ISSUE                  0x2
+#define J9_CEL4RO64_RETCODE_ERROR_FAILED_AMODE64_ENV             0x3
+#define J9_CEL4RO64_RETCODE_ERROR_FAILED_LOAD_TARGET_DLL         0x4
+#define J9_CEL4RO64_RETCODE_ERROR_FAILED_QUERY_TARGET_FUNC       0x5
+#define J9_CEL4RO64_RETCODE_ERROR_LE_RUNTIME_SUPPORT_NOT_FOUND   0x6
+
+/* Fixed length Control Block structure RO64_CB */
+typedef struct J9_CEL4RO64_controlBlock {
+	uint32_t version;            /**< (Input) A integer which contains the version of RO64_INFO. */
+	uint32_t length;             /**< (Input) A integer which contains the total length of RO64_INFO. */
+	uint32_t flags;              /**< (Input) Flags to control the behavior of CEL4RO64. */
+	uint32_t moduleOffset;       /**< (Input) Offset to RO64_module part from start of RO64_CB. Req'd for DLL load flag. */
+	uint32_t functionOffset;     /**< (Input) Offset to RO64_function part from start of RO64_CB. Req'd for DLL query flag. */
+	uint32_t argumentsOffset;    /**< (Input) Offset to RO64_args part from start of RO64_CB. Req'd for function execution flag. */
+	uint64_t dllHandle;          /**< DLL handle of target program (Input) if DLL query flag. (Output) if DLL load flag. */
+	uint64_t functionDescriptor; /**< Function descriptor of target function (Input) if function exection flag. (Output) if DLL query flag. */
+	uint64_t gpr1ReturnValue;    /**< (Output) Return buffer containing 64-bit GPR1 value of target program after execution. */
+	uint64_t gpr2ReturnValue;    /**< (Output) Return buffer containing 64-bit GPR2 value of target program after execution. */
+	uint64_t gpr3ReturnValue;    /**< (Output) Return buffer containing 64-bit GPR3 value of target program after execution. */
+	int32_t retcode;             /**< (Output) Return code of CEL4RO64. */
+} J9_CEL4RO64_controlBlock;
+
+/* Module name to load */
+typedef struct J9_CEL4RO64_module {
+	int32_t length;         /**< Length of the module name. */
+	char moduleName[1];     /**< Pointer to variable length module name. */
+} J9_CEL4RO64_module;
+
+/* Internal struct to map function name definition in control block. */
+typedef struct J9_CEL4RO64_function {
+	int32_t length;          /**< Length of the function name. */
+	char functionName[1];    /**< Pointer to variable length function name. */
+} J9_CEL4RO64_function;
+
+/* Internal struct to track the RO64 control block and related variable length structures. */
+typedef struct J9_CEL4RO64_infoBlock {
+	J9_CEL4RO64_module *ro64Module;             /**< Pointer to the start of the module section of the control block. */
+	J9_CEL4RO64_function *ro64Function;         /**< Pointer to the start of the function section of the control block. */
+	uint32_t *ro64Arguments;                    /**< Pointer to the start of the outgoing arguments section of the control block. */
+	J9_CEL4RO64_controlBlock ro64ControlBlock;  /**< Pointer to the control block for CEL4RO64. */
+} J9_CEL4RO64_infoBlock;
+
+/**
+ * Types to facilitate argument construction and return values for calls to 64-bit.
+ */
+typedef enum J9_CEL4RO64_ArgType {
+	CEL4RO64_type_void,
+	CEL4RO64_type_jboolean,
+	CEL4RO64_type_jbyte,
+	CEL4RO64_type_jchar,
+	CEL4RO64_type_jshort,
+	CEL4RO64_type_jint,
+	CEL4RO64_type_jlong,
+	CEL4RO64_type_jfloat,
+	CEL4RO64_type_jdouble,
+	CEL4RO64_type_jsize,
+	CEL4RO64_type_jobject,
+	CEL4RO64_type_jweak,
+	CEL4RO64_type_jclass,
+	CEL4RO64_type_jstring,
+	CEL4RO64_type_jthrowable,
+	CEL4RO64_type_jarray,
+	CEL4RO64_type_uint32_ptr,
+	CEL4RO64_type_jmethodID,
+	CEL4RO64_type_jfieldID,
+	CEL4RO64_type_JNIEnv64,
+	CEL4RO64_type_JavaVM64,
+	CEL4RO64_type_EnsureWideEnum = 0x1000000 /* force 4-byte enum */
+} J9_CEL4RO64_ArgType;
+
+/**
+ * A helper routine to invoke a target function with outgoing arguments and return values.
+ * @param[in] functionDescriptor The 64-bit function descriptor of target function to invoke.
+ * @param[in] argTypes An array of argument types for call.
+ * @param[in] argsValues An uint64_t array of argument values.
+ * @param[in] numArgs Number of arguments.
+ * @param[in] returnType The return type of target function.
+ * @param[in] returnStorage The storage location to store return value.
+ *
+ * @return The return code of the CEL4RO64 call - 0 implies success.
+ */
+uint32_t
+j9_cel4ro64_call_function(
+	uint64_t functionDescriptor, J9_CEL4RO64_ArgType *argTypes, uint64_t *argValues, uint32_t numArgs,
+	J9_CEL4RO64_ArgType returnType, void *returnStorage);
+
+/**
+ * A helper routine to allocate the CEL4RO64 control blocks and related structures
+ * for module, function and arguments.
+ * @param[in] moduleName The name of the target library to load.
+ * @param[in] functionName The name of the target function to lookup.
+ * @param[in] argTypes An array of argument types for call.
+ * @param[in] argsValues An uint64_t array of argument values.
+ * @param[in] numArgs Number of arguments.
+ * @param[in] returnType The return type of target function.
+ * @param[in] returnStorage The storage location to store return value.
+ *
+ * @return The return code of the CEL4RO64 call - 0 implies success.
+ */
+uint32_t
+j9_cel4ro64_load_query_call_function(
+	const char* moduleName, const char* functionName, J9_CEL4RO64_ArgType *argTypes,
+	uint64_t *argValues, uint32_t numArgs, J9_CEL4RO64_ArgType returnType, void *returnStorage);
+
+/**
+ * A helper routine to confirm LE support of CEL4RO64
+ * @return whether CEL4RO64 runtime support is available.
+ */
+jboolean
+j9_cel4ro64_isSupported(void);
+
+/**
+ * A helper routine to return an error message associated with the CEL4RO64 return code.
+ * @param[in] retCode A CEL4RO64 return code.
+ *
+ * @return A message describing the conditions of the given error.
+ */
+const char *
+j9_cel4ro64_get_error_message(int32_t retCode);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* j9cel4ro64_h */

--- a/runtime/j9vm31/j9vm31.h
+++ b/runtime/j9vm31/j9vm31.h
@@ -1,0 +1,343 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef j9vm31_h
+#define j9vm31_h
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+#include "j9cel4ro64.h"
+#include "jni.h"
+
+/* High tag bits to signify 31-bit function handles that are passed to 64-bit. */
+#define HANDLE31_HIGHTAG 0x31000000
+
+/* Macro to look up 64-bit function descriptors from JNINativeInterface_. */
+#define FUNCTION_DESCRIPTOR_FROM_JNIENV31(jniEnv, functionX) \
+		jlong functionDescriptor = ((JNIEnv31 *)jniEnv)->functions64[offsetof(struct JNINativeInterface_, functionX) / sizeof(intptr_t)]; \
+		j9vm31TrcJNIMethodEntry(jniEnv, #functionX);
+
+/* Utility macros to extract corresponding 64-bit handle. */
+#define JNIENV64_FROM_JNIENV31(jniEnv) ((JNIEnv31 *)jniEnv)->jniEnv64
+#define JAVAVM64_FROM_JAVAVM31(javaVM) ((JavaVM31 *)javaVM)->javaVM64
+
+/* We need to do DLL query on libjvm.so (sidecar redirector), which will load the appropriate VM module. */
+#define LIBJVM_NAME "libjvm.so"
+#define LIBJ9VM29_NAME "libj9vm29.so"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* A 31-bit JavaVM struct, instances of which are used by 31-bit native code.
+ * Each instance should always have a matching 64-bit JavaVM * isntance from the JVM.
+ */
+typedef struct JavaVM31 {
+	struct JNIInvokeInterface_ *functions;
+	void *reserved0;
+	void *reserved1;
+	void *reserved2;
+	JavaVM31 *next;             /**< Next JavaVM31 instance in global list. */
+	jlong javaVM64;             /**< Handle to corresponding 64-bit JavaVM* instance from JVM. */
+	const jlong *functions64;   /**< Reference to 64-bit JNIInvokeInterface_ function descriptors to invoke. */
+} JavaVM31;
+
+/* A 31-bit JNIEnv struct, instances of which are used by 31-bit native code.
+ * Each instance should always have a matching 64-bit JNIEnv * isntance from the JVM.
+ */
+typedef struct JNIEnv31 {
+	struct JNINativeInterface_ *functions;
+	void *reserved0;
+	void *reserved1[6];
+	JavaVM31 *javaVM31;         /**< A handle to the matching JavaVM31 instance. */
+	JNIEnv31 *next;             /**< Next JNIEnv31 instance in global list. */
+	jlong jniEnv64;             /**< Handle to corresponding 64-bit JNIEnv* instance from JVM. */
+	const jlong *functions64;   /**< Reference to 64-bit JNINativeInterface_ function descriptors to invoke. */
+} JNIEnv31;
+
+/**
+ * Typedefs to wrap the arguments of a va_list to the 64-bit representation.
+ * The actual parameter data itself is still in 31-bit, and those are interpreted on
+ * the 64-bit side with recognition that they are being invoked by 31-bit caller, as
+ * the parameters interpretation require understanding of the specifiers from the
+ * method signature.
+ */
+typedef char  *___valist64[4];    // 64-bit uses char *[2].
+typedef ___valist64  va_list_64;
+
+/**
+ * A helper function that can be also invoked by 64-bit JVM to return the respective 31-bit
+ * JavaVM instance for the given 64-bit JavaVM reference. When invoked by the JVM, this
+ * allows 64-bit JVM to directly invoke 31-bit target functions passing a valid 31-bit JavaVM*
+ * parameter.
+ *
+ * @param[in] JavaVM64Ptr The 64-bit JavaVM reference.
+ *
+ * @return The 31-bit corresponding JavaVM instance.
+ */
+JavaVM31 *
+JNICALL getJavaVM31(uint64_t JavaVM64Ptr);
+
+/**
+ * A helper function that can be also invoked by 64-bit JVM to return the respective 31-bit
+ * JNIEnv instance for the given 64-bit JNIEnv reference. When invoked by the JVM, this
+ * allows 64-bit JVM to directly invoke 31-bit target functions passing a valid 31-bit JNIEnv*
+ * parameter.
+ *
+ * @param[in] JNIEnv64Ptr The 64-bit JNIEnv reference.
+ *
+ * @return The 31-bit corresponding JNIEnv instance.
+ */
+JNIEnv31 *
+JNICALL getJNIEnv31(uint64_t JNIEnv64Ptr);
+
+/**
+ * A debugging routine that outputs method entry statements to stderr. While there
+ * are trace points in 64-bit JVM for most of the JNI methods, this routine
+ * supports diagnostics on 31-bit side.
+ * @Todo: Should consider how to improve this RAS support.
+ *
+ * @param[in] JNIEnv The 31-bit JNIEnv instance.
+ * @param[in] functionName The JNI function to invoke.
+ */
+void
+j9vm31TrcJNIMethodEntry(JNIEnv* env, const char *functionName);
+
+/* The Java Invocation API functions that the shim library will implement. */
+jint JNICALL JNI_GetDefaultJavaVMInitArgs(void *);
+jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args);
+jint JNICALL JNI_GetCreatedJavaVMs(JavaVM **, jsize, jsize *);
+jint JNICALL DestroyJavaVM(JavaVM *vm);
+jint JNICALL AttachCurrentThread(JavaVM *vm, void **penv, void *args);
+jint JNICALL DetachCurrentThread(JavaVM *vm);
+jint JNICALL GetEnv(JavaVM *vm, void **penv, jint version);
+jint JNICALL AttachCurrentThreadAsDaemon(JavaVM *vm, void **penv, void *args);
+
+/* The Java Native Interface API functions that the shim library will implement. */
+jint JNICALL GetVersion(JNIEnv *env);
+jclass JNICALL DefineClass(JNIEnv *env, const char *name, jobject loader, const jbyte *buf, jsize bufLen);
+jclass JNICALL FindClass(JNIEnv *env, const char *name);
+jmethodID JNICALL FromReflectedMethod(JNIEnv *env, jobject method);
+jfieldID JNICALL FromReflectedField(JNIEnv *env, jobject field);
+jobject JNICALL ToReflectedMethod(JNIEnv *env, jclass cls, jmethodID methodID, jboolean isStatic);
+jclass JNICALL GetSuperclass(JNIEnv *env, jclass clazz);
+jboolean JNICALL IsAssignableFrom(JNIEnv *env, jclass clazz1, jclass clazz2);
+jobject JNICALL ToReflectedField(JNIEnv *env, jclass cls, jfieldID fieldID, jboolean isStatic);
+jint JNICALL Throw(JNIEnv *env, jthrowable obj);
+jint JNICALL ThrowNew(JNIEnv *env, jclass clazz, const char *message);
+jthrowable JNICALL ExceptionOccurred(JNIEnv *env);
+void JNICALL ExceptionDescribe(JNIEnv *env);
+void JNICALL ExceptionClear(JNIEnv *env);
+void JNICALL FatalError(JNIEnv *env, const char *msg);
+jint JNICALL PushLocalFrame(JNIEnv *env, jint capacity);
+jobject JNICALL PopLocalFrame(JNIEnv *env, jobject result);
+jobject JNICALL NewGlobalRef(JNIEnv *env, jobject obj);
+void JNICALL DeleteGlobalRef(JNIEnv *env, jobject gref);
+void JNICALL DeleteLocalRef(JNIEnv *env, jobject localRef);
+jboolean JNICALL IsSameObject(JNIEnv *env, jobject ref1, jobject ref2);
+jobject JNICALL NewLocalRef(JNIEnv *env, jobject ref);
+jint JNICALL EnsureLocalCapacity(JNIEnv *env, jint capacity);
+jobject JNICALL AllocObject(JNIEnv *env, jclass clazz);
+jobject JNICALL NewObject(JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+jobject JNICALL NewObjectV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+jobject JNICALL NewObjectA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue *args);
+jclass JNICALL GetObjectClass(JNIEnv *env, jobject obj);
+jboolean JNICALL IsInstanceOf(JNIEnv *env, jobject obj, jclass clazz);
+jmethodID JNICALL GetMethodID(JNIEnv *env, jclass clazz, const char *name, const char *sig);
+jobject JNICALL CallObjectMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...);
+jobject JNICALL CallObjectMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+jobject JNICALL CallObjectMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue * args);
+jboolean JNICALL CallBooleanMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...);
+jboolean JNICALL CallBooleanMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+jboolean JNICALL CallBooleanMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue * args);
+jbyte JNICALL CallByteMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...);
+jbyte JNICALL CallByteMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+jbyte JNICALL CallByteMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue *args);
+jchar JNICALL CallCharMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...);
+jchar JNICALL CallCharMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+jchar JNICALL CallCharMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue *args);
+jshort JNICALL CallShortMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...);
+jshort JNICALL CallShortMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+jshort JNICALL CallShortMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue *args);
+jint JNICALL CallIntMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...);
+jint JNICALL CallIntMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+jint JNICALL CallIntMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue *args);
+jlong JNICALL CallLongMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...);
+jlong JNICALL CallLongMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+jlong JNICALL CallLongMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue *args);
+jfloat JNICALL CallFloatMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...);
+jfloat JNICALL CallFloatMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+jfloat JNICALL CallFloatMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue *args);
+jdouble JNICALL CallDoubleMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...);
+jdouble JNICALL CallDoubleMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+jdouble JNICALL CallDoubleMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue *args);
+void JNICALL CallVoidMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...);
+void JNICALL CallVoidMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list args);
+void JNICALL CallVoidMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue * args);
+jobject JNICALL CallNonvirtualObjectMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+jobject JNICALL CallNonvirtualObjectMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+jobject JNICALL CallNonvirtualObjectMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue * args);
+jboolean JNICALL CallNonvirtualBooleanMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+jboolean JNICALL CallNonvirtualBooleanMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+jboolean JNICALL CallNonvirtualBooleanMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue * args);
+jbyte JNICALL CallNonvirtualByteMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+jbyte JNICALL CallNonvirtualByteMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+jbyte JNICALL CallNonvirtualByteMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue *args);
+jchar JNICALL CallNonvirtualCharMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+jchar JNICALL CallNonvirtualCharMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+jchar JNICALL CallNonvirtualCharMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue *args);
+jshort JNICALL CallNonvirtualShortMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+jshort JNICALL CallNonvirtualShortMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+jshort JNICALL CallNonvirtualShortMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue *args);
+jint JNICALL CallNonvirtualIntMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+jint JNICALL CallNonvirtualIntMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+jint JNICALL CallNonvirtualIntMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue *args);
+jlong JNICALL CallNonvirtualLongMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+jlong JNICALL CallNonvirtualLongMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+jlong JNICALL CallNonvirtualLongMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue *args);
+jfloat JNICALL CallNonvirtualFloatMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+jfloat JNICALL CallNonvirtualFloatMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+jfloat JNICALL CallNonvirtualFloatMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue *args);
+jdouble JNICALL CallNonvirtualDoubleMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+jdouble JNICALL CallNonvirtualDoubleMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+jdouble JNICALL CallNonvirtualDoubleMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue *args);
+void JNICALL CallNonvirtualVoidMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...);
+void JNICALL CallNonvirtualVoidMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list args);
+void JNICALL CallNonvirtualVoidMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue * args);
+jfieldID JNICALL GetFieldID(JNIEnv *env, jclass clazz, const char *name, const char *sig);
+jobject JNICALL GetObjectField(JNIEnv *env, jobject obj, jfieldID fieldID);
+jboolean JNICALL GetBooleanField(JNIEnv *env, jobject obj, jfieldID fieldID);
+jbyte JNICALL GetByteField(JNIEnv *env, jobject obj, jfieldID fieldID);
+jchar JNICALL GetCharField(JNIEnv *env, jobject obj, jfieldID fieldID);
+jshort JNICALL GetShortField(JNIEnv *env, jobject obj, jfieldID fieldID);
+jint JNICALL GetIntField(JNIEnv *env, jobject obj, jfieldID fieldID);
+jlong JNICALL GetLongField(JNIEnv *env, jobject obj, jfieldID fieldID);
+jfloat JNICALL GetFloatField(JNIEnv *env, jobject obj, jfieldID fieldID);
+jdouble JNICALL GetDoubleField(JNIEnv *env, jobject obj, jfieldID fieldID);
+void JNICALL SetObjectField(JNIEnv *env, jobject obj, jfieldID fieldID, jobject value);
+void JNICALL SetBooleanField(JNIEnv *env, jobject obj, jfieldID fieldID, jboolean value);
+void JNICALL SetByteField(JNIEnv *env, jobject obj, jfieldID fieldID, jbyte value);
+void JNICALL SetCharField(JNIEnv *env, jobject obj, jfieldID fieldID, jchar value);
+void JNICALL SetShortField(JNIEnv *env, jobject obj, jfieldID fieldID, jshort value);
+void JNICALL SetIntField(JNIEnv *env, jobject obj, jfieldID fieldID, jint value);
+void JNICALL SetLongField(JNIEnv *env, jobject obj, jfieldID fieldID, jlong value);
+void JNICALL SetFloatField(JNIEnv *env, jobject obj, jfieldID fieldID, jfloat value);
+void JNICALL SetDoubleField(JNIEnv *env, jobject obj, jfieldID fieldID, jdouble value);
+jmethodID JNICALL GetStaticMethodID(JNIEnv *env, jclass clazz, const char *name, const char *sig);
+jobject JNICALL CallStaticObjectMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+jobject JNICALL CallStaticObjectMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+jobject JNICALL CallStaticObjectMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue *args);
+jboolean JNICALL CallStaticBooleanMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+jboolean JNICALL CallStaticBooleanMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+jboolean JNICALL CallStaticBooleanMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue *args);
+jbyte JNICALL CallStaticByteMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+jbyte JNICALL CallStaticByteMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+jbyte JNICALL CallStaticByteMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue *args);
+jchar JNICALL CallStaticCharMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+jchar JNICALL CallStaticCharMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+jchar JNICALL CallStaticCharMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue *args);
+jshort JNICALL CallStaticShortMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+jshort JNICALL CallStaticShortMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+jshort JNICALL CallStaticShortMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue *args);
+jint JNICALL CallStaticIntMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+jint JNICALL CallStaticIntMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+jint JNICALL CallStaticIntMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue *args);
+jlong JNICALL CallStaticLongMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+jlong JNICALL CallStaticLongMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+jlong JNICALL CallStaticLongMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue *args);
+jfloat JNICALL CallStaticFloatMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+jfloat JNICALL CallStaticFloatMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+jfloat JNICALL CallStaticFloatMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue *args);
+jdouble JNICALL CallStaticDoubleMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+jdouble JNICALL CallStaticDoubleMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+jdouble JNICALL CallStaticDoubleMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue *args);
+void JNICALL CallStaticVoidMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...);
+void JNICALL CallStaticVoidMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list args);
+void JNICALL CallStaticVoidMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue * args);
+jfieldID JNICALL GetStaticFieldID(JNIEnv *env, jclass clazz, const char *name, const char *sig);
+jobject JNICALL GetStaticObjectField(JNIEnv *env, jclass clazz, jfieldID fieldID);
+jboolean JNICALL GetStaticBooleanField(JNIEnv *env, jclass clazz, jfieldID fieldID);
+jbyte JNICALL GetStaticByteField(JNIEnv *env, jclass clazz, jfieldID fieldID);
+jchar JNICALL GetStaticCharField(JNIEnv *env, jclass clazz, jfieldID fieldID);
+jshort JNICALL GetStaticShortField(JNIEnv *env, jclass clazz, jfieldID fieldID);
+jint JNICALL GetStaticIntField(JNIEnv *env, jclass clazz, jfieldID fieldID);
+jlong JNICALL GetStaticLongField(JNIEnv *env, jclass clazz, jfieldID fieldID);
+jfloat JNICALL GetStaticFloatField(JNIEnv *env, jclass clazz, jfieldID fieldID);
+jdouble JNICALL GetStaticDoubleField(JNIEnv *env, jclass clazz, jfieldID fieldID);
+void JNICALL SetStaticObjectField(JNIEnv *env, jclass clazz, jfieldID fieldID, jobject value);
+void JNICALL SetStaticBooleanField(JNIEnv *env, jclass clazz, jfieldID fieldID, jboolean value);
+void JNICALL SetStaticByteField(JNIEnv *env, jclass clazz, jfieldID fieldID, jbyte value);
+void JNICALL SetStaticCharField(JNIEnv *env, jclass clazz, jfieldID fieldID, jchar value);
+void JNICALL SetStaticShortField(JNIEnv *env, jclass clazz, jfieldID fieldID, jshort value);
+void JNICALL SetStaticIntField(JNIEnv *env, jclass clazz, jfieldID fieldID, jint value);
+void JNICALL SetStaticLongField(JNIEnv *env, jclass clazz, jfieldID fieldID, jlong value);
+void JNICALL SetStaticFloatField(JNIEnv *env, jclass clazz, jfieldID fieldID, jfloat value);
+void JNICALL SetStaticDoubleField(JNIEnv *env, jclass clazz, jfieldID fieldID, jdouble value);
+jstring JNICALL NewString(JNIEnv *env, const jchar *unicodeChars, jsize len);
+jsize JNICALL GetStringLength(JNIEnv *env, jstring string);
+const jchar *JNICALL GetStringChars(JNIEnv *env, jstring string, jboolean *isCopy);
+void JNICALL ReleaseStringChars(JNIEnv *env, jstring string, const jchar *utf);
+jstring JNICALL NewStringUTF(JNIEnv *env, const char *bytes);
+jsize JNICALL GetStringUTFLength(JNIEnv *env, jstring string);
+const char* JNICALL GetStringUTFChars(JNIEnv *env, jstring string, jboolean *isCopy);
+void JNICALL ReleaseStringUTFChars(JNIEnv *env, jstring string, const char* utf);
+jsize JNICALL GetArrayLength(JNIEnv *env, jarray array);
+jobjectArray JNICALL NewObjectArray(JNIEnv *env, jsize length, jclass clazz, jobject initialElement);
+jobject JNICALL GetObjectArrayElement(JNIEnv *env, jobjectArray array, jsize index);
+void JNICALL SetObjectArrayElement(JNIEnv *env, jobjectArray array, jsize index, jobject value);
+jbooleanArray JNICALL NewBooleanArray(JNIEnv *env, jsize length);
+jbyteArray JNICALL NewByteArray(JNIEnv *env, jsize length);
+jcharArray JNICALL NewCharArray(JNIEnv *env, jsize length);
+jshortArray JNICALL NewShortArray(JNIEnv *env, jsize length);
+jintArray JNICALL NewIntArray(JNIEnv *env, jsize length);
+jlongArray JNICALL NewLongArray(JNIEnv *env, jsize length);
+jfloatArray JNICALL NewFloatArray(JNIEnv *env, jsize length);
+jdoubleArray JNICALL NewDoubleArray(JNIEnv *env, jsize length);
+void * JNICALL getArrayElements(JNIEnv *env, jdoubleArray array, jboolean *isCopy);
+void JNICALL releaseArrayElements(JNIEnv *env, jarray array, void *elems, jint mode);
+void JNICALL getArrayRegion(JNIEnv *env, jarray array, jsize start, jsize len, void *buf);
+void JNICALL setArrayRegion(JNIEnv *env, jarray array, jsize start, jsize len, void *buf);
+jint JNICALL RegisterNatives(JNIEnv *env, jclass clazz, const JNINativeMethod *methods, jint nMethods);
+jint JNICALL UnregisterNatives(JNIEnv *env, jclass clazz);
+jint JNICALL MonitorEnter(JNIEnv *env, jobject obj);
+jint JNICALL MonitorExit(JNIEnv *env, jobject obj);
+jint JNICALL GetJavaVM(JNIEnv *env, JavaVM **vm);
+void JNICALL GetStringRegion(JNIEnv *env, jstring str, jsize start, jsize len, jchar *buf);
+void JNICALL GetStringUTFRegion(JNIEnv *env, jstring str, jsize start, jsize len, char *buf);
+jweak JNICALL NewWeakGlobalRef(JNIEnv *env, jobject obj);
+void JNICALL DeleteWeakGlobalRef(JNIEnv *env, jweak obj);
+jboolean JNICALL ExceptionCheck(JNIEnv *env);
+jobject JNICALL NewDirectByteBuffer(JNIEnv *env, void *address, jlong capacity);
+void * JNICALL GetDirectBufferAddress(JNIEnv *env, jobject buf);
+jlong JNICALL GetDirectBufferCapacity(JNIEnv *env, jobject buf);
+jobjectRefType JNICALL GetObjectRefType(JNIEnv* env, jobject obj);
+#if JAVA_SPEC_VERSION >= 9
+jobject JNICALL GetModule(JNIEnv *env, jclass clazz);
+#endif /* JAVA_SPEC_VERSION >= 9 */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* j9vm31_h */

--- a/runtime/j9vm31/j9vm31floatstubs.s
+++ b/runtime/j9vm31/j9vm31floatstubs.s
@@ -1,0 +1,74 @@
+*
+* Copyright (c) 2021, 2021 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache License,
+* Version 2.0 which accompanies this distribution and is available
+* at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code is also Distributed under one or more
+* Secondary Licenses, as those terms are defined by the
+* Eclipse Public License, v. 2.0: GNU General Public License,
+* version 2 with the GNU Classpath Exception [1] and GNU
+* General Public License, version 2 with the OpenJDK Assembly
+* Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+         TITLE 'j9vm31floatstubs'
+**********************************************************************
+* This file contains a set of stub functions with the sole
+* intention of loading and storing float/double from/to FPR0.
+* However, since the OS Linkage dictates FPR0 is the incoming
+* param and outgoing return floating point register, these
+* functions are actually NOPs.  Ideally, we just generate
+* inline assembly code from the C code (j9cel4ro64 in this case)
+* once build compiler is upgraded.
+
+J9VM_STE CSECT
+J9VM_STE AMODE ANY
+J9VM_STE RMODE ANY
+         EDCPRLG
+* This routine is to extract FPR0 as a float
+* however, since OS linkage returns FPR0 anyways
+* this is a nop routine to trick compiler in
+* extracting return value from FPR0.
+         EDCEPIL
+         END
+
+J9VM_STD CSECT
+J9VM_STD AMODE ANY
+J9VM_STD RMODE ANY
+         EDCPRLG
+* This routine is to extract FPR0 as a double
+* however, since OS linkage returns FPR0 anyways
+* this is a nop routine to trick compiler in
+* extracting return value from FPR0.
+         EDCEPIL
+         END
+
+J9VM_LE CSECT
+J9VM_LE AMODE ANY
+J9VM_LE RMODE ANY
+         EDCPRLG
+* This routine is to store FPR0 with a float
+* parameter.  However, since OS linkage uses
+* FPR0 as the parm, this is a nop routine
+* to trick the compiler in doing it for us.
+         EDCEPIL
+         END
+
+J9VM_LD CSECT
+J9VM_LD AMODE ANY
+J9VM_LD RMODE ANY
+         EDCPRLG
+* This routine is to store FPR0 with a double
+* parameter.  However, since OS linkage uses
+* FPR0 as the parm, this is a nop routine
+* to trick the compiler in doing it for us.
+         EDCEPIL
+         END
+

--- a/runtime/j9vm31/j9vm31natives.xml
+++ b/runtime/j9vm31/j9vm31natives.xml
@@ -1,0 +1,30 @@
+<!--
+Copyright (c) 2021, 2021 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<exportlists>
+	<exports group="all">
+		<export name="JNI_CreateJavaVM" />
+		<export name="JNI_GetCreatedJavaVMs" />
+		<export name="JNI_GetDefaultJavaVMInitArgs" />
+		<export name="getJNIEnv31" />
+		<export name="getJavaVM31" />
+	</exports>
+</exportlists>

--- a/runtime/j9vm31/jnicgen.cpp
+++ b/runtime/j9vm31/jnicgen.cpp
@@ -1,0 +1,1342 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9vm31.h"
+
+static jobject
+CallObjectMethodV_64(JNIEnv *env, jobject obj, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)parms };
+	jobject returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallObjectMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+jobject JNICALL
+CallObjectMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallObjectMethodV_64(env, obj, methodID, parms);
+}
+
+jobject JNICALL
+CallObjectMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallObjectMethodV_64(env, obj, methodID, parms);
+}
+
+jobject JNICALL
+CallObjectMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)args };
+	jobject returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallObjectMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+static jboolean
+CallBooleanMethodV_64(JNIEnv *env, jobject obj, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)parms };
+	jboolean returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallBooleanMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jboolean, &returnValue);
+	return returnValue;
+}
+
+jboolean JNICALL
+CallBooleanMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallBooleanMethodV_64(env, obj, methodID, parms);
+}
+
+jboolean JNICALL
+CallBooleanMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallBooleanMethodV_64(env, obj, methodID, parms);
+}
+
+jboolean JNICALL
+CallBooleanMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)args };
+	jboolean returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallBooleanMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jboolean, &returnValue);
+	return returnValue;
+}
+
+static jbyte
+CallByteMethodV_64(JNIEnv *env, jobject obj, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)parms };
+	jbyte returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallByteMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jbyte, &returnValue);
+	return returnValue;
+}
+
+jbyte JNICALL
+CallByteMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallByteMethodV_64(env, obj, methodID, parms);
+}
+
+jbyte JNICALL
+CallByteMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallByteMethodV_64(env, obj, methodID, parms);
+}
+
+jbyte JNICALL
+CallByteMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)args };
+	jbyte returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallByteMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jbyte, &returnValue);
+	return returnValue;
+}
+
+static jchar
+CallCharMethodV_64(JNIEnv *env, jobject obj, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)parms };
+	jchar returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallCharMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jchar, &returnValue);
+	return returnValue;
+}
+
+jchar JNICALL
+CallCharMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallCharMethodV_64(env, obj, methodID, parms);
+}
+
+jchar JNICALL
+CallCharMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallCharMethodV_64(env, obj, methodID, parms);
+}
+
+jchar JNICALL
+CallCharMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)args };
+	jchar returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallCharMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jchar, &returnValue);
+	return returnValue;
+}
+
+static jshort
+CallShortMethodV_64(JNIEnv *env, jobject obj, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)parms };
+	jshort returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallShortMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jshort, &returnValue);
+	return returnValue;
+}
+
+jshort JNICALL
+CallShortMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallShortMethodV_64(env, obj, methodID, parms);
+}
+
+jshort JNICALL
+CallShortMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallShortMethodV_64(env, obj, methodID, parms);
+}
+
+jshort JNICALL
+CallShortMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)args };
+	jshort returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallShortMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jshort, &returnValue);
+	return returnValue;
+}
+
+static jint
+CallIntMethodV_64(JNIEnv *env, jobject obj, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)parms };
+	jint returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallIntMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+jint JNICALL
+CallIntMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallIntMethodV_64(env, obj, methodID, parms);
+}
+
+jint JNICALL
+CallIntMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallIntMethodV_64(env, obj, methodID, parms);
+}
+
+jint JNICALL
+CallIntMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)args };
+	jint returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallIntMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+static jlong
+CallLongMethodV_64(JNIEnv *env, jobject obj, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)parms };
+	jlong returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallLongMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jlong, &returnValue);
+	return returnValue;
+}
+
+jlong JNICALL
+CallLongMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallLongMethodV_64(env, obj, methodID, parms);
+}
+
+jlong JNICALL
+CallLongMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallLongMethodV_64(env, obj, methodID, parms);
+}
+
+jlong JNICALL
+CallLongMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)args };
+	jlong returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallLongMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jlong, &returnValue);
+	return returnValue;
+}
+
+static jfloat
+CallFloatMethodV_64(JNIEnv *env, jobject obj, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)parms };
+	jfloat returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallFloatMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jfloat, &returnValue);
+	return returnValue;
+}
+
+jfloat JNICALL
+CallFloatMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallFloatMethodV_64(env, obj, methodID, parms);
+}
+
+jfloat JNICALL
+CallFloatMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallFloatMethodV_64(env, obj, methodID, parms);
+}
+
+jfloat JNICALL
+CallFloatMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)args };
+	jfloat returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallFloatMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jfloat, &returnValue);
+	return returnValue;
+}
+
+static jdouble
+CallDoubleMethodV_64(JNIEnv *env, jobject obj, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)parms };
+	jdouble returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallDoubleMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jdouble, &returnValue);
+	return returnValue;
+}
+
+jdouble JNICALL
+CallDoubleMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallDoubleMethodV_64(env, obj, methodID, parms);
+}
+
+jdouble JNICALL
+CallDoubleMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallDoubleMethodV_64(env, obj, methodID, parms);
+}
+
+jdouble JNICALL
+CallDoubleMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)args };
+	jdouble returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallDoubleMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jdouble, &returnValue);
+	return returnValue;
+}
+
+static void
+CallVoidMethodV_64(JNIEnv *env, jobject obj, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)parms };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallVoidMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+CallVoidMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	CallVoidMethodV_64(env, obj, methodID, parms);
+	return;
+}
+
+void JNICALL
+CallVoidMethodV(JNIEnv *env, jobject obj, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	CallVoidMethodV_64(env, obj, methodID, parms);
+	return;
+}
+
+void JNICALL
+CallVoidMethodA(JNIEnv *env, jobject obj, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, methodID, (uint64_t)args };
+
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallVoidMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+static jobject
+CallNonvirtualObjectMethodV_64(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)parms };
+	jobject returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualObjectMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+jobject JNICALL
+CallNonvirtualObjectMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualObjectMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jobject JNICALL
+CallNonvirtualObjectMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualObjectMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jobject JNICALL
+CallNonvirtualObjectMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)args };
+	jobject returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualObjectMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+static jboolean
+CallNonvirtualBooleanMethodV_64(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)parms };
+	jboolean returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualBooleanMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jboolean, &returnValue);
+	return returnValue;
+}
+
+jboolean JNICALL
+CallNonvirtualBooleanMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualBooleanMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jboolean JNICALL
+CallNonvirtualBooleanMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualBooleanMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jboolean JNICALL
+CallNonvirtualBooleanMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)args };
+	jboolean returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualBooleanMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jboolean, &returnValue);
+	return returnValue;
+}
+
+static jbyte
+CallNonvirtualByteMethodV_64(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)parms };
+	jbyte returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualByteMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jbyte, &returnValue);
+	return returnValue;
+}
+
+jbyte JNICALL
+CallNonvirtualByteMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualByteMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jbyte JNICALL
+CallNonvirtualByteMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualByteMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jbyte JNICALL
+CallNonvirtualByteMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)args };
+	jbyte returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualByteMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jbyte, &returnValue);
+	return returnValue;
+}
+
+static jchar
+CallNonvirtualCharMethodV_64(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)parms };
+	jchar returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualCharMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jchar, &returnValue);
+	return returnValue;
+}
+
+jchar JNICALL
+CallNonvirtualCharMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualCharMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jchar JNICALL
+CallNonvirtualCharMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualCharMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jchar JNICALL
+CallNonvirtualCharMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)args };
+	jchar returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualCharMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jchar, &returnValue);
+	return returnValue;
+}
+
+static jshort
+CallNonvirtualShortMethodV_64(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)parms };
+	jshort returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualShortMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jshort, &returnValue);
+	return returnValue;
+}
+
+jshort JNICALL
+CallNonvirtualShortMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualShortMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jshort JNICALL
+CallNonvirtualShortMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualShortMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jshort JNICALL
+CallNonvirtualShortMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)args };
+	jshort returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualShortMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jshort, &returnValue);
+	return returnValue;
+}
+
+static jint
+CallNonvirtualIntMethodV_64(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)parms };
+	jint returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualIntMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+jint JNICALL
+CallNonvirtualIntMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualIntMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jint JNICALL
+CallNonvirtualIntMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualIntMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jint JNICALL
+CallNonvirtualIntMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)args };
+	jint returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualIntMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+static jlong
+CallNonvirtualLongMethodV_64(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)parms };
+	jlong returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualLongMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jlong, &returnValue);
+	return returnValue;
+}
+
+jlong JNICALL
+CallNonvirtualLongMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualLongMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jlong JNICALL
+CallNonvirtualLongMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualLongMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jlong JNICALL
+CallNonvirtualLongMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)args };
+	jlong returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualLongMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jlong, &returnValue);
+	return returnValue;
+}
+
+static jfloat
+CallNonvirtualFloatMethodV_64(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)parms };
+	jfloat returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualFloatMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jfloat, &returnValue);
+	return returnValue;
+}
+
+jfloat JNICALL
+CallNonvirtualFloatMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualFloatMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jfloat JNICALL
+CallNonvirtualFloatMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualFloatMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jfloat JNICALL
+CallNonvirtualFloatMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)args };
+	jfloat returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualFloatMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jfloat, &returnValue);
+	return returnValue;
+}
+
+static jdouble
+CallNonvirtualDoubleMethodV_64(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)parms };
+	jdouble returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualDoubleMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jdouble, &returnValue);
+	return returnValue;
+}
+
+jdouble JNICALL
+CallNonvirtualDoubleMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualDoubleMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jdouble JNICALL
+CallNonvirtualDoubleMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallNonvirtualDoubleMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+jdouble JNICALL
+CallNonvirtualDoubleMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)args };
+	jdouble returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualDoubleMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jdouble, &returnValue);
+	return returnValue;
+}
+
+static void
+CallNonvirtualVoidMethodV_64(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)parms };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualVoidMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+CallNonvirtualVoidMethod(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	CallNonvirtualVoidMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+void JNICALL
+CallNonvirtualVoidMethodV(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	CallNonvirtualVoidMethodV_64(env, obj, clazz, methodID, parms);
+}
+
+void JNICALL
+CallNonvirtualVoidMethodA(JNIEnv *env, jobject obj, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz, methodID, (uint64_t)args };
+
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallNonvirtualVoidMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+static jobject
+CallStaticObjectMethodV_64(JNIEnv *env, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)parms };
+	jobject returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticObjectMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+jobject JNICALL
+CallStaticObjectMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticObjectMethodV_64(env, clazz, methodID, parms);
+}
+
+jobject JNICALL
+CallStaticObjectMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticObjectMethodV_64(env, clazz, methodID, parms);
+}
+
+jobject JNICALL
+CallStaticObjectMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)args };
+	jobject returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticObjectMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+static jboolean
+CallStaticBooleanMethodV_64(JNIEnv *env, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)parms };
+	jboolean returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticBooleanMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jboolean, &returnValue);
+	return returnValue;
+}
+
+jboolean JNICALL
+CallStaticBooleanMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticBooleanMethodV_64(env, clazz, methodID, parms);
+}
+
+jboolean JNICALL
+CallStaticBooleanMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticBooleanMethodV_64(env, clazz, methodID, parms);
+}
+
+jboolean JNICALL
+CallStaticBooleanMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)args };
+	jboolean returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticBooleanMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jboolean, &returnValue);
+	return returnValue;
+}
+
+static jbyte
+CallStaticByteMethodV_64(JNIEnv *env, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)parms };
+	jbyte returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticByteMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jbyte, &returnValue);
+	return returnValue;
+}
+
+jbyte JNICALL
+CallStaticByteMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticByteMethodV_64(env, clazz, methodID, parms);
+}
+
+jbyte JNICALL
+CallStaticByteMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticByteMethodV_64(env, clazz, methodID, parms);
+}
+
+jbyte JNICALL
+CallStaticByteMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)args };
+	jbyte returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticByteMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jbyte, &returnValue);
+	return returnValue;
+}
+
+static jchar
+CallStaticCharMethodV_64(JNIEnv *env, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)parms };
+	jchar returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticCharMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jchar, &returnValue);
+	return returnValue;
+}
+
+jchar JNICALL
+CallStaticCharMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticCharMethodV_64(env, clazz, methodID, parms);
+}
+
+jchar JNICALL
+CallStaticCharMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticCharMethodV_64(env, clazz, methodID, parms);
+}
+
+jchar JNICALL
+CallStaticCharMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)args };
+	jchar returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticCharMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jchar, &returnValue);
+	return returnValue;
+}
+
+static jshort
+CallStaticShortMethodV_64(JNIEnv *env, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)parms };
+	jshort returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticShortMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jshort, &returnValue);
+	return returnValue;
+}
+
+jshort JNICALL
+CallStaticShortMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticShortMethodV_64(env, clazz, methodID, parms);
+}
+
+jshort JNICALL
+CallStaticShortMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticShortMethodV_64(env, clazz, methodID, parms);
+}
+
+jshort JNICALL
+CallStaticShortMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)args };
+	jshort returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticShortMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jshort, &returnValue);
+	return returnValue;
+}
+
+static jint
+CallStaticIntMethodV_64(JNIEnv *env, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)parms };
+	jint returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticIntMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+jint JNICALL
+CallStaticIntMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticIntMethodV_64(env, clazz, methodID, parms);
+}
+
+jint JNICALL
+CallStaticIntMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticIntMethodV_64(env, clazz, methodID, parms);
+}
+
+jint JNICALL
+CallStaticIntMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)args };
+	jint returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticIntMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+static jlong
+CallStaticLongMethodV_64(JNIEnv *env, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)parms };
+	jlong returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticLongMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jlong, &returnValue);
+	return returnValue;
+}
+
+jlong JNICALL
+CallStaticLongMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticLongMethodV_64(env, clazz, methodID, parms);
+}
+
+jlong JNICALL
+CallStaticLongMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticLongMethodV_64(env, clazz, methodID, parms);
+}
+
+jlong JNICALL
+CallStaticLongMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)args };
+	jlong returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticLongMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jlong, &returnValue);
+	return returnValue;
+}
+
+static jfloat
+CallStaticFloatMethodV_64(JNIEnv *env, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)parms };
+	jfloat returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticFloatMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jfloat, &returnValue);
+	return returnValue;
+}
+
+jfloat JNICALL
+CallStaticFloatMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticFloatMethodV_64(env, clazz, methodID, parms);
+}
+
+jfloat JNICALL
+CallStaticFloatMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticFloatMethodV_64(env, clazz, methodID, parms);
+}
+
+jfloat JNICALL
+CallStaticFloatMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)args };
+	jfloat returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticFloatMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jfloat, &returnValue);
+	return returnValue;
+}
+
+static jdouble
+CallStaticDoubleMethodV_64(JNIEnv *env, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)parms };
+	jdouble returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticDoubleMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jdouble, &returnValue);
+	return returnValue;
+}
+
+jdouble JNICALL
+CallStaticDoubleMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticDoubleMethodV_64(env, clazz, methodID, parms);
+}
+
+jdouble JNICALL
+CallStaticDoubleMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return CallStaticDoubleMethodV_64(env, clazz, methodID, parms);
+}
+
+jdouble JNICALL
+CallStaticDoubleMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)args };
+	jdouble returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticDoubleMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jdouble, &returnValue);
+	return returnValue;
+}
+
+static void
+CallStaticVoidMethodV_64(JNIEnv *env, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)parms };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticVoidMethodV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+CallStaticVoidMethod(JNIEnv *env, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	CallStaticVoidMethodV_64(env, clazz, methodID, parms);
+}
+
+void JNICALL
+CallStaticVoidMethodV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list arg)
+{
+	va_list_64 parms;
+	long long value = *((int *)(((int *)(arg))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	CallStaticVoidMethodV_64(env, clazz, methodID, parms);
+}
+
+void JNICALL
+CallStaticVoidMethodA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue * args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)args };
+
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, CallStaticVoidMethodA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}

--- a/runtime/j9vm31/jnicsup.cpp
+++ b/runtime/j9vm31/jnicsup.cpp
@@ -1,0 +1,911 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9vm31.h"
+#include "omrcomp.h"
+
+extern "C" {
+
+#define GET_BOOLEAN_ARRAY_ELEMENTS ((jboolean * (JNICALL *)(JNIEnv *env, jbooleanArray array, jboolean * isCopy))getArrayElements)
+#define GET_BYTE_ARRAY_ELEMENTS ((jbyte * (JNICALL *)(JNIEnv *env, jbyteArray array, jboolean * isCopy))getArrayElements)
+#define GET_CHAR_ARRAY_ELEMENTS ((jchar * (JNICALL *)(JNIEnv *env, jcharArray array, jboolean * isCopy))getArrayElements)
+#define GET_SHORT_ARRAY_ELEMENTS ((jshort * (JNICALL *)(JNIEnv *env, jshortArray array, jboolean * isCopy))getArrayElements)
+#define GET_INT_ARRAY_ELEMENTS ((jint * (JNICALL *)(JNIEnv *env, jintArray array, jboolean * isCopy))getArrayElements)
+#define GET_LONG_ARRAY_ELEMENTS ((jlong * (JNICALL *)(JNIEnv *env, jlongArray array, jboolean * isCopy))getArrayElements)
+#define GET_FLOAT_ARRAY_ELEMENTS ((jfloat * (JNICALL *)(JNIEnv *env, jfloatArray array, jboolean * isCopy))getArrayElements)
+#define GET_DOUBLE_ARRAY_ELEMENTS ((jdouble * (JNICALL *)(JNIEnv *env, jdoubleArray array, jboolean * isCopy))getArrayElements)
+#define GET_PRIMITIVE_ARRAY_CRITICAL ((void * (JNICALL *)(JNIEnv *env, jarray array, jboolean * isCopy))getArrayElements)
+
+#define RELEASE_BOOLEAN_ARRAY_ELEMENTS ((void (JNICALL *)(JNIEnv *env, jbooleanArray array, jboolean * elems, jint mode))releaseArrayElements)
+#define RELEASE_BYTE_ARRAY_ELEMENTS ((void (JNICALL *)(JNIEnv *env, jbyteArray array, jbyte * elems, jint mode))releaseArrayElements)
+#define RELEASE_CHAR_ARRAY_ELEMENTS ((void (JNICALL *)(JNIEnv *env, jcharArray array, jchar * elems, jint mode))releaseArrayElements)
+#define RELEASE_SHORT_ARRAY_ELEMENTS ((void (JNICALL *)(JNIEnv *env, jshortArray array, jshort * elems, jint mode))releaseArrayElements)
+#define RELEASE_INT_ARRAY_ELEMENTS ((void (JNICALL *)(JNIEnv *env, jintArray array, jint * elems, jint mode))releaseArrayElements)
+#define RELEASE_LONG_ARRAY_ELEMENTS ((void (JNICALL *)(JNIEnv *env, jlongArray array, jlong * elems, jint mode))releaseArrayElements)
+#define RELEASE_FLOAT_ARRAY_ELEMENTS ((void (JNICALL *)(JNIEnv *env, jfloatArray array, jfloat * elems, jint mode))releaseArrayElements)
+#define RELEASE_DOUBLE_ARRAY_ELEMENTS ((void (JNICALL *)(JNIEnv *env, jdoubleArray array, jdouble * elems, jint mode))releaseArrayElements)
+#define RELEASE_PRIMITIVE_ARRAY_CRITICAL ((void (JNICALL *)(JNIEnv *env, jarray carray, void * elems, jint mode))releaseArrayElements)
+
+#define GET_BOOLEAN_ARRAY_REGION ((void (JNICALL *)(JNIEnv *env, jbooleanArray array, jsize start, jsize len, jboolean *buf))getArrayRegion)
+#define GET_BYTE_ARRAY_REGION ((void (JNICALL *)(JNIEnv *env, jbyteArray array, jsize start, jsize len, jbyte *buf))getArrayRegion)
+#define GET_CHAR_ARRAY_REGION ((void (JNICALL *)(JNIEnv *env, jcharArray array, jsize start, jsize len, jchar *buf))getArrayRegion)
+#define GET_SHORT_ARRAY_REGION ((void (JNICALL *)(JNIEnv *env, jshortArray array, jsize start, jsize len, jshort *buf))getArrayRegion)
+#define GET_INT_ARRAY_REGION ((void (JNICALL *)(JNIEnv *env, jintArray array, jsize start, jsize len, jint *buf))getArrayRegion)
+#define GET_LONG_ARRAY_REGION ((void (JNICALL *)(JNIEnv *env, jlongArray array, jsize start, jsize len, jlong *buf))getArrayRegion)
+#define GET_FLOAT_ARRAY_REGION ((void (JNICALL *)(JNIEnv *env, jfloatArray array, jsize start, jsize len, jfloat *buf))getArrayRegion)
+#define GET_DOUBLE_ARRAY_REGION ((void (JNICALL *)(JNIEnv *env, jdoubleArray array, jsize start, jsize len, jdouble *buf))getArrayRegion)
+
+#define SET_BOOLEAN_ARRAY_REGION ((void (JNICALL *)(JNIEnv *env, jbooleanArray array, jsize start, jsize len, jboolean *buf))setArrayRegion)
+#define SET_BYTE_ARRAY_REGION ((void (JNICALL *)(JNIEnv *env, jbyteArray array, jsize start, jsize len, jbyte *buf))setArrayRegion)
+#define SET_CHAR_ARRAY_REGION ((void (JNICALL *)(JNIEnv *env, jcharArray array, jsize start, jsize len, jchar *buf))setArrayRegion)
+#define SET_SHORT_ARRAY_REGION ((void (JNICALL *)(JNIEnv *env, jshortArray array, jsize start, jsize len, jshort *buf))setArrayRegion)
+#define SET_INT_ARRAY_REGION ((void (JNICALL *)(JNIEnv *env, jintArray array, jsize start, jsize len, jint *buf))setArrayRegion)
+#define SET_LONG_ARRAY_REGION ((void (JNICALL *)(JNIEnv *env, jlongArray array, jsize start, jsize len, jlong *buf))setArrayRegion)
+#define SET_FLOAT_ARRAY_REGION ((void (JNICALL *)(JNIEnv *env, jfloatArray array, jsize start, jsize len, jfloat *buf))setArrayRegion)
+#define SET_DOUBLE_ARRAY_REGION ((void (JNICALL *)(JNIEnv *env, jdoubleArray array, jsize start, jsize len, jdouble *buf))setArrayRegion)
+
+#define GET_STRING_CRITICAL ((const jchar * (JNICALL *)(JNIEnv *env, jstring string, jboolean *isCopy))GetStringChars)
+#define RELEASE_STRING_CRITICAL ((void (JNICALL *)(JNIEnv *env, jstring string, const jchar *carray))ReleaseStringChars)
+
+/* Given LE supports only one TCB that can cross AMODE boundary, most likely
+ * we will only have 1 JNIEnv31 in the address space. Use a static to
+ * track the live JNIEnv31 instances in case this gets expanded in the future.
+ */
+static JNIEnv31* globalRootJNIEnv31 = NULL;
+
+/* A handle on the global table from 64-bit JVM with set of function pointers. */
+static const jlong * global64BitJNIInterface_ = NULL;
+
+/* This is the function table of the 31-bit shim JNINativeInterface functions. */
+struct JNINativeInterface_ EsJNIFunctions = {
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	GetVersion,
+	DefineClass,
+	FindClass,
+	FromReflectedMethod,
+	FromReflectedField,
+	ToReflectedMethod,
+	GetSuperclass,
+	IsAssignableFrom,
+	ToReflectedField,
+	Throw,
+	ThrowNew,
+	ExceptionOccurred,
+	ExceptionDescribe,
+	ExceptionClear,
+	FatalError,
+	PushLocalFrame,
+	PopLocalFrame,
+	NewGlobalRef,
+	DeleteGlobalRef,
+	DeleteLocalRef,
+	IsSameObject,
+	NewLocalRef,
+	EnsureLocalCapacity,
+	AllocObject,
+	NewObject,
+	NewObjectV,
+	NewObjectA,
+	GetObjectClass,
+	IsInstanceOf,
+	GetMethodID,
+	CallObjectMethod,
+	CallObjectMethodV,
+	CallObjectMethodA,
+	CallBooleanMethod,
+	CallBooleanMethodV,
+	CallBooleanMethodA,
+	CallByteMethod,
+	CallByteMethodV,
+	CallByteMethodA,
+	CallCharMethod,
+	CallCharMethodV,
+	CallCharMethodA,
+	CallShortMethod,
+	CallShortMethodV,
+	CallShortMethodA,
+	CallIntMethod,
+	CallIntMethodV,
+	CallIntMethodA,
+	CallLongMethod,
+	CallLongMethodV,
+	CallLongMethodA,
+	CallFloatMethod,
+	CallFloatMethodV,
+	CallFloatMethodA,
+	CallDoubleMethod,
+	CallDoubleMethodV,
+	CallDoubleMethodA,
+	CallVoidMethod,
+	CallVoidMethodV,
+	CallVoidMethodA,
+	CallNonvirtualObjectMethod,
+	CallNonvirtualObjectMethodV,
+	CallNonvirtualObjectMethodA,
+	CallNonvirtualBooleanMethod,
+	CallNonvirtualBooleanMethodV,
+	CallNonvirtualBooleanMethodA,
+	CallNonvirtualByteMethod,
+	CallNonvirtualByteMethodV,
+	CallNonvirtualByteMethodA,
+	CallNonvirtualCharMethod,
+	CallNonvirtualCharMethodV,
+	CallNonvirtualCharMethodA,
+	CallNonvirtualShortMethod,
+	CallNonvirtualShortMethodV,
+	CallNonvirtualShortMethodA,
+	CallNonvirtualIntMethod,
+	CallNonvirtualIntMethodV,
+	CallNonvirtualIntMethodA,
+	CallNonvirtualLongMethod,
+	CallNonvirtualLongMethodV,
+	CallNonvirtualLongMethodA,
+	CallNonvirtualFloatMethod,
+	CallNonvirtualFloatMethodV,
+	CallNonvirtualFloatMethodA,
+	CallNonvirtualDoubleMethod,
+	CallNonvirtualDoubleMethodV,
+	CallNonvirtualDoubleMethodA,
+	CallNonvirtualVoidMethod,
+	CallNonvirtualVoidMethodV,
+	CallNonvirtualVoidMethodA,
+	GetFieldID,
+	GetObjectField,
+	GetBooleanField,
+	GetByteField,
+	GetCharField,
+	GetShortField,
+	GetIntField,
+	GetLongField,
+	GetFloatField,
+	GetDoubleField,
+	SetObjectField,
+	SetBooleanField,
+	SetByteField,
+	SetCharField,
+	SetShortField,
+	SetIntField,
+	SetLongField,
+	SetFloatField,
+	SetDoubleField,
+	GetStaticMethodID,
+	CallStaticObjectMethod,
+	CallStaticObjectMethodV,
+	CallStaticObjectMethodA,
+	CallStaticBooleanMethod,
+	CallStaticBooleanMethodV,
+	CallStaticBooleanMethodA,
+	CallStaticByteMethod,
+	CallStaticByteMethodV,
+	CallStaticByteMethodA,
+	CallStaticCharMethod,
+	CallStaticCharMethodV,
+	CallStaticCharMethodA,
+	CallStaticShortMethod,
+	CallStaticShortMethodV,
+	CallStaticShortMethodA,
+	CallStaticIntMethod,
+	CallStaticIntMethodV,
+	CallStaticIntMethodA,
+	CallStaticLongMethod,
+	CallStaticLongMethodV,
+	CallStaticLongMethodA,
+	CallStaticFloatMethod,
+	CallStaticFloatMethodV,
+	CallStaticFloatMethodA,
+	CallStaticDoubleMethod,
+	CallStaticDoubleMethodV,
+	CallStaticDoubleMethodA,
+	CallStaticVoidMethod,
+	CallStaticVoidMethodV,
+	CallStaticVoidMethodA,
+	GetStaticFieldID,
+	GetStaticObjectField,
+	GetStaticBooleanField,
+	GetStaticByteField,
+	GetStaticCharField,
+	GetStaticShortField,
+	GetStaticIntField,
+	GetStaticLongField,
+	GetStaticFloatField,
+	GetStaticDoubleField,
+	SetStaticObjectField,
+	SetStaticBooleanField,
+	SetStaticByteField,
+	SetStaticCharField,
+	SetStaticShortField,
+	SetStaticIntField,
+	SetStaticLongField,
+	SetStaticFloatField,
+	SetStaticDoubleField,
+	NewString,
+	GetStringLength,
+	GetStringChars,
+	ReleaseStringChars,
+	NewStringUTF,
+	GetStringUTFLength,
+	GetStringUTFChars,
+	ReleaseStringUTFChars,
+	GetArrayLength,
+	NewObjectArray,
+	GetObjectArrayElement,
+	SetObjectArrayElement,
+	NewBooleanArray,
+	NewByteArray,
+	NewCharArray,
+	NewShortArray,
+	NewIntArray,
+	NewLongArray,
+	NewFloatArray,
+	NewDoubleArray,
+	GET_BOOLEAN_ARRAY_ELEMENTS,
+	GET_BYTE_ARRAY_ELEMENTS,
+	GET_CHAR_ARRAY_ELEMENTS,
+	GET_SHORT_ARRAY_ELEMENTS,
+	GET_INT_ARRAY_ELEMENTS,
+	GET_LONG_ARRAY_ELEMENTS,
+	GET_FLOAT_ARRAY_ELEMENTS,
+	GET_DOUBLE_ARRAY_ELEMENTS,
+	RELEASE_BOOLEAN_ARRAY_ELEMENTS,
+	RELEASE_BYTE_ARRAY_ELEMENTS,
+	RELEASE_CHAR_ARRAY_ELEMENTS,
+	RELEASE_SHORT_ARRAY_ELEMENTS,
+	RELEASE_INT_ARRAY_ELEMENTS,
+	RELEASE_LONG_ARRAY_ELEMENTS,
+	RELEASE_FLOAT_ARRAY_ELEMENTS,
+	RELEASE_DOUBLE_ARRAY_ELEMENTS,
+	GET_BOOLEAN_ARRAY_REGION,
+	GET_BYTE_ARRAY_REGION,
+	GET_CHAR_ARRAY_REGION,
+	GET_SHORT_ARRAY_REGION,
+	GET_INT_ARRAY_REGION,
+	GET_LONG_ARRAY_REGION,
+	GET_FLOAT_ARRAY_REGION,
+	GET_DOUBLE_ARRAY_REGION,
+	SET_BOOLEAN_ARRAY_REGION,
+	SET_BYTE_ARRAY_REGION,
+	SET_CHAR_ARRAY_REGION,
+	SET_SHORT_ARRAY_REGION,
+	SET_INT_ARRAY_REGION,
+	SET_LONG_ARRAY_REGION,
+	SET_FLOAT_ARRAY_REGION,
+	SET_DOUBLE_ARRAY_REGION,
+	RegisterNatives,
+	UnregisterNatives,
+	MonitorEnter,
+	MonitorExit,
+	GetJavaVM,
+	GetStringRegion,
+	GetStringUTFRegion,
+	GET_PRIMITIVE_ARRAY_CRITICAL,
+	RELEASE_PRIMITIVE_ARRAY_CRITICAL,
+	GET_STRING_CRITICAL,
+	RELEASE_STRING_CRITICAL,
+	NewWeakGlobalRef,
+	DeleteWeakGlobalRef,
+	ExceptionCheck,
+	NewDirectByteBuffer,
+	GetDirectBufferAddress,
+	GetDirectBufferCapacity,
+	GetObjectRefType,
+#if JAVA_SPEC_VERSION >= 9
+	GetModule,
+#endif /* JAVA_SPEC_VERSION >= 9 */
+};
+
+static void initializeJNIEnv31(JNIEnv31 * jniEnv31, jlong jniEnv64);
+
+jint JNICALL
+GetVersion(JNIEnv *env)
+{
+	const jint NUM_ARGS = 1;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64 };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env) };
+	jint returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetVersion);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+jclass JNICALL
+DefineClass(JNIEnv *env, const char *name, jobject loader, const jbyte *buf, jsize bufLen)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_uint32_ptr, CEL4RO64_type_jobject, CEL4RO64_type_uint32_ptr, CEL4RO64_type_jsize };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), (uint64_t)name, loader, (uint64_t) buf, (uint64_t) bufLen };
+	jclass returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, DefineClass);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jclass, &returnValue);
+	return returnValue;
+}
+
+jint JNICALL
+ThrowNew(JNIEnv *env, jclass clazz, const char *message)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jclass, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, (uint64_t)message };
+	jint returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, ThrowNew);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+jthrowable JNICALL
+ExceptionOccurred(JNIEnv *env)
+{
+	const jint NUM_ARGS = 1;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64 };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env) };
+	jthrowable returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, ExceptionOccurred);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jthrowable, &returnValue);
+	return returnValue;
+}
+
+void JNICALL
+ExceptionDescribe(JNIEnv *env)
+{
+	const jint NUM_ARGS = 1;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64 };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env) };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, ExceptionDescribe);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+ExceptionClear(JNIEnv *env)
+{
+	const jint NUM_ARGS = 1;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64 };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env) };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, ExceptionClear);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+FatalError(JNIEnv *env, const char *msg)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), (uint64_t)msg };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, FatalError);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+jint JNICALL
+PushLocalFrame(JNIEnv *env, jint capacity)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), capacity };
+	jint returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, PushLocalFrame);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+jobject JNICALL
+PopLocalFrame(JNIEnv *env, jobject result)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), result };
+	jobject returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, PopLocalFrame);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+jobject JNICALL
+NewGlobalRef(JNIEnv *env, jobject obj)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj };
+	jobject returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewGlobalRef);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+void JNICALL
+DeleteGlobalRef(JNIEnv *env, jobject gref)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), gref };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, DeleteGlobalRef);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+DeleteLocalRef(JNIEnv *env, jobject localRef)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), localRef };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, DeleteLocalRef);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+jobject JNICALL
+NewLocalRef(JNIEnv *env, jobject ref)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), ref };
+	jobject returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewLocalRef);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+jint JNICALL
+EnsureLocalCapacity(JNIEnv *env, jint capacity)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jint };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), capacity };
+	jint returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, EnsureLocalCapacity);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+static jobject
+NewObjectV_64(JNIEnv *env, jclass clazz, jmethodID methodID, va_list_64 parms)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)parms };
+	jobject returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewObjectV);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+jobject JNICALL
+NewObject(JNIEnv *env, jclass clazz, jmethodID methodID, ...)
+{
+	va_list_64 parms;
+
+	long long value = *((int *)((char*)&(methodID) + sizeof(jmethodID)));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return NewObjectV_64(env, clazz, methodID, parms);
+}
+
+jobject JNICALL
+NewObjectV(JNIEnv *env, jclass clazz, jmethodID methodID, va_list args)
+{
+	va_list_64 parms;
+
+	long long value = *((int *)(((int *)(args))[1]));
+	(void)( (parms)[0] = 0, (parms)[1] =  (char *)&(methodID), (parms)[2] = 0, (parms)[3] = (parms)[1] + sizeof(jmethodID) );
+
+	return NewObjectV_64(env, clazz, methodID, parms);
+}
+
+jobject JNICALL
+NewObjectA(JNIEnv *env, jclass clazz, jmethodID methodID, jvalue *args)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, methodID, (uint64_t)args };
+	jobject returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewObjectA);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+jboolean JNICALL
+IsInstanceOf(JNIEnv *env, jobject obj, jclass clazz)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jclass };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, clazz };
+	jboolean returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, IsInstanceOf);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jboolean, &returnValue);
+	return returnValue;
+}
+
+jmethodID JNICALL
+GetMethodID(JNIEnv *env, jclass clazz, const char *name, const char *sig)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jclass, CEL4RO64_type_uint32_ptr, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, (uint64_t)name, (uint64_t)sig };
+	jmethodID returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetMethodID);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jmethodID, &returnValue);
+	return returnValue;
+}
+
+jfieldID JNICALL
+GetFieldID(JNIEnv *env, jclass clazz, const char *name, const char *sig)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jclass, CEL4RO64_type_uint32_ptr, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, (uint64_t)name, (uint64_t)sig };
+	jfieldID returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetFieldID);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jfieldID, &returnValue);
+	return returnValue;
+}
+
+jmethodID JNICALL
+GetStaticMethodID(JNIEnv *env, jclass clazz, const char *name, const char *sig)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jclass, CEL4RO64_type_uint32_ptr, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, (uint64_t)name, (uint64_t)sig };
+	jmethodID returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStaticMethodID);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jmethodID, &returnValue);
+	return returnValue;
+}
+
+jfieldID JNICALL
+GetStaticFieldID(JNIEnv *env, jclass clazz, const char *name, const char *sig)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jclass, CEL4RO64_type_uint32_ptr, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, (uint64_t)name, (uint64_t)sig };
+	jfieldID returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStaticFieldID);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jfieldID, &returnValue);
+	return returnValue;
+}
+
+jbooleanArray JNICALL
+NewBooleanArray(JNIEnv *env, jsize length)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jsize };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), length };
+	jbooleanArray returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewBooleanArray);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jarray, &returnValue);
+	return returnValue;
+}
+
+jbyteArray JNICALL
+NewByteArray(JNIEnv *env, jsize length)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jsize };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), length };
+	jbyteArray returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewByteArray);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jarray, &returnValue);
+	return returnValue;
+}
+
+jcharArray JNICALL
+NewCharArray(JNIEnv *env, jsize length)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jsize };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), length };
+	jcharArray returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewCharArray);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jarray, &returnValue);
+	return returnValue;
+}
+
+jshortArray JNICALL
+NewShortArray(JNIEnv *env, jsize length)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jsize };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), length };
+	jshortArray returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewShortArray);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jarray, &returnValue);
+	return returnValue;
+}
+
+jintArray JNICALL
+NewIntArray(JNIEnv *env, jsize length)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jsize };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), length };
+	jintArray returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewIntArray);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jarray, &returnValue);
+	return returnValue;
+}
+
+jlongArray JNICALL
+NewLongArray(JNIEnv *env, jsize length)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jsize };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), length };
+	jlongArray returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewLongArray);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jarray, &returnValue);
+	return returnValue;
+}
+
+jfloatArray JNICALL
+NewFloatArray(JNIEnv *env, jsize length)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jsize };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), length };
+	jfloatArray returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewFloatArray);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jarray, &returnValue);
+	return returnValue;
+}
+
+jdoubleArray JNICALL
+NewDoubleArray(JNIEnv *env, jsize length)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jsize };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), length };
+	jdoubleArray returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewDoubleArray);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jarray, &returnValue);
+	return returnValue;
+}
+
+jint JNICALL
+MonitorEnter(JNIEnv *env, jobject obj)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj };
+	jint returnValue = JNI_ERR;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, MonitorEnter);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+jint JNICALL
+MonitorExit(JNIEnv *env, jobject obj)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj };
+	jint returnValue = JNI_ERR;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, MonitorExit);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+jint JNICALL
+GetJavaVM(JNIEnv *env, JavaVM **vm)
+{
+	if (NULL != ((JNIEnv31 *)env)->javaVM31) {
+		/* Return cached instance of JavaVM31, if available. */
+		*vm = (JavaVM *)((JNIEnv31 *)env)->javaVM31;
+		return JNI_OK;
+	}
+
+	/* Query the JVM to get the 64-bit JavaVM pointer first, and we will return the corresponding 31-bit
+	 * JavaVM instance
+	 */
+	uint64_t JavaVM64Result = 0;
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), (uint64_t)&JavaVM64Result };
+	jint returnValue = JNI_ERR;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetJavaVM);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+
+	if (JNI_OK == returnValue) {
+		/* Find or create a matching 31-bit JavaVM instance. */
+		JavaVM31 *javaVM31 = getJavaVM31(JavaVM64Result);
+		((JNIEnv31 *)env)->javaVM31 = javaVM31;
+		*vm = (JavaVM *)javaVM31;
+	}
+	return returnValue;
+}
+
+jweak JNICALL
+NewWeakGlobalRef(JNIEnv *env, jobject obj)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj };
+	jweak returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewWeakGlobalRef);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jweak, &returnValue);
+	return returnValue;
+}
+
+void JNICALL
+DeleteWeakGlobalRef(JNIEnv *env, jweak obj)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jweak };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, DeleteWeakGlobalRef);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+jboolean JNICALL
+ExceptionCheck(JNIEnv *env)
+{
+	const jint NUM_ARGS = 1;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64 };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env) };
+	jboolean returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, ExceptionCheck);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jboolean, &returnValue);
+	return returnValue;
+}
+
+jobject JNICALL
+NewDirectByteBuffer(JNIEnv *env, void *address, jlong capacity)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_uint32_ptr, CEL4RO64_type_jlong};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), (uint32_t)address, capacity};
+	jobject returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewDirectByteBuffer);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+void * JNICALL
+GetDirectBufferAddress(JNIEnv *env, jobject buf)
+{
+	/* It is the user's responsibility to invoke GetDirectBufferAddress on DBB objects that are backed by memory
+	 * below-the-bar in order for this to be accessible. However, we will check the final address and return NULL,
+	 * which should fail more gracefully.
+	 */
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), buf };
+	jlong returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetDirectBufferAddress);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jlong, &returnValue);
+
+	if (0 != returnValue) {
+		/* If the upper 33-bits are non-zero, then the backing memory is not accessible in AMODE31.
+		 * Return NULL if that's the case.
+		 */
+		if (returnValue != (returnValue & 0x7FFFFFFF)) {
+			return NULL;
+		}
+	}
+	return (void *)returnValue;
+}
+
+jlong JNICALL
+GetDirectBufferCapacity(JNIEnv *env, jobject buf)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), buf };
+	jlong returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetDirectBufferCapacity);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jlong, &returnValue);
+	return returnValue;
+}
+
+jobjectRefType JNICALL
+GetObjectRefType(JNIEnv* env, jobject obj)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj };
+	jobjectRefType returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetObjectRefType);
+	/* Note: jobjectRefType is a 4-byte enum -- using CEL4RO64_type_jint as return type. */
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+#if JAVA_SPEC_VERSION >= 9
+jobject JNICALL
+GetModule(JNIEnv *env, jclass clazz)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jclass };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz };
+	jobject returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetModule);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+#endif /* JAVA_SPEC_VERSION >= 9 */
+
+/**
+ * Following set of functions are JNIEnv31 utility routines.
+ */
+
+
+JNIEnv31 * JNICALL
+getJNIEnv31(uint64_t jniEnv64)
+{
+	/* Traverse list to find matching JavaVM31. */
+	for (JNIEnv31 *curJNIEnv31 = globalRootJNIEnv31; curJNIEnv31 != NULL; curJNIEnv31 = curJNIEnv31->next) {
+		if (jniEnv64 == curJNIEnv31->jniEnv64) {
+			return curJNIEnv31;
+		}
+	}
+
+	/* Create and initialize a new instance. */
+	JNIEnv31 *newJNIEnv31 = (JNIEnv31 *)malloc(sizeof(JNIEnv31));
+	if (NULL != newJNIEnv31) {
+		initializeJNIEnv31(newJNIEnv31, jniEnv64);
+	}
+	return newJNIEnv31;
+}
+
+/**
+ * Initialize new JNIEnv31 structure, with references to the corresponding 64-bit
+ * JNIEnv, along with both 31-bit and 64-bit JNI function tables. Add to our
+ * list of JNIEnv31.
+ *
+ * @param[in] javaVM31 The 31-bit JNIEnv* instance to initialize.
+ * @param[in] javaVM64 The matching 64-bit JNIEnv* from JVM.
+ */
+static void
+initializeJNIEnv31(JNIEnv31 * jniEnv31, jlong jniEnv64)
+{
+	jniEnv31->functions = (JNINativeInterface_ *)GLOBAL_TABLE(EsJNIFunctions);
+	jniEnv31->jniEnv64 = jniEnv64;
+
+	/* Look up the 64-bit JNIInterface_ function table if necessary. */
+	if (NULL == global64BitJNIInterface_) {
+		const jint NUM_ARGS = 1;
+		J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64 };
+
+		uint64_t argValues[NUM_ARGS] = { (uint64_t)jniEnv64 };
+		uintptr_t returnValue = NULL;
+		uint32_t cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
+				LIBJ9VM29_NAME, "J9VM_initializeJNI31Table",
+				argTypes, argValues, NUM_ARGS, CEL4RO64_type_uint32_ptr, &returnValue);
+		global64BitJNIInterface_ = (jlong *)returnValue;
+	}
+	jniEnv31->functions64 = global64BitJNIInterface_;
+	jniEnv31->next = globalRootJNIEnv31;
+	globalRootJNIEnv31 = jniEnv31;
+}
+
+void
+j9vm31TrcJNIMethodEntry(JNIEnv* env, const char *functionName) {
+	const char* isDebug = getenv("TR_3164Debug");
+	if (isDebug) {
+		fprintf(stderr, "j9vm31Trc - 31:[%p] 64:[%llx] invoking function: %s\n", env, JNIENV64_FROM_JNIENV31(env), functionName);
+	}
+}
+
+} /* extern "C" */

--- a/runtime/j9vm31/jnifield.cpp
+++ b/runtime/j9vm31/jnifield.cpp
@@ -1,0 +1,478 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9vm31.h"
+
+jobject JNICALL
+GetObjectField(JNIEnv *env, jobject obj, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID };
+	jobject returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetObjectField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+jboolean JNICALL
+GetBooleanField(JNIEnv *env, jobject obj, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID };
+	jboolean returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetBooleanField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jboolean, &returnValue);
+	return returnValue;
+}
+
+jbyte JNICALL
+GetByteField(JNIEnv *env, jobject obj, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID };
+	jbyte returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetByteField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jbyte, &returnValue);
+	return returnValue;
+}
+
+jchar JNICALL
+GetCharField(JNIEnv *env, jobject obj, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID };
+	jchar returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetCharField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jchar, &returnValue);
+	return returnValue;
+}
+
+jshort JNICALL
+GetShortField(JNIEnv *env, jobject obj, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID };
+	jshort returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetShortField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jshort, &returnValue);
+	return returnValue;
+}
+
+jint JNICALL
+GetIntField(JNIEnv *env, jobject obj, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID };
+	jint returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetIntField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+jlong JNICALL
+GetLongField(JNIEnv *env, jobject obj, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID };
+	jlong returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetLongField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jlong, &returnValue);
+	return returnValue;
+}
+
+jfloat JNICALL
+GetFloatField(JNIEnv *env, jobject obj, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID };
+	jfloat returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetFloatField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jfloat, &returnValue);
+	return returnValue;
+}
+
+jdouble JNICALL
+GetDoubleField(JNIEnv *env, jobject obj, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID };
+	jdouble returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetDoubleField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jdouble, &returnValue);
+	return returnValue;
+}
+
+void JNICALL
+SetObjectField(JNIEnv *env, jobject obj, jfieldID fieldID, jobject value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jobject};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID, value };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetObjectField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+SetBooleanField(JNIEnv *env, jobject obj, jfieldID fieldID, jboolean value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jboolean};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID, value };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetBooleanField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+SetByteField(JNIEnv *env, jobject obj, jfieldID fieldID, jbyte value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jbyte};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID, value };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetByteField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+SetCharField(JNIEnv *env, jobject obj, jfieldID fieldID, jchar value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jchar};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID, value };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetCharField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+SetShortField(JNIEnv *env, jobject obj, jfieldID fieldID, jshort value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jshort};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID, value };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetShortField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+SetIntField(JNIEnv *env, jobject obj, jfieldID fieldID, jint value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jint};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID, value };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetIntField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+SetLongField(JNIEnv *env, jobject obj, jfieldID fieldID, jlong value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jlong};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID, value };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetLongField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+SetFloatField(JNIEnv *env, jobject obj, jfieldID fieldID, jfloat value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jfloat};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID, 0 };
+
+	/* Floating point parameters requires special handling */
+	jfloat *floatArgPtr = (jfloat *)(&(argValues[3]));
+	*floatArgPtr = value;
+
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetFloatField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+SetDoubleField(JNIEnv *env, jobject obj, jfieldID fieldID, jdouble value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jdouble};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj, fieldID, 0 };
+
+	/* Floating point parameters requires special handling */
+	jdouble *doubleArgPtr = (jdouble *)(&(argValues[3]));
+	*doubleArgPtr = value;
+
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetDoubleField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+jobject JNICALL
+GetStaticObjectField(JNIEnv *env, jclass clazz, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID };
+	jobject returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStaticObjectField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+jboolean JNICALL
+GetStaticBooleanField(JNIEnv *env, jclass clazz, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID };
+	jboolean returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStaticBooleanField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jboolean, &returnValue);
+	return returnValue;
+}
+
+jbyte JNICALL
+GetStaticByteField(JNIEnv *env, jclass clazz, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID };
+	jbyte returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStaticByteField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jbyte, &returnValue);
+	return returnValue;
+}
+
+jchar JNICALL
+GetStaticCharField(JNIEnv *env, jclass clazz, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID };
+	jchar returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStaticCharField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jchar, &returnValue);
+	return returnValue;
+}
+
+jshort JNICALL
+GetStaticShortField(JNIEnv *env, jclass clazz, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID };
+	jshort returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStaticShortField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jshort, &returnValue);
+	return returnValue;
+}
+
+jint JNICALL
+GetStaticIntField(JNIEnv *env, jclass clazz, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID };
+	jint returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStaticIntField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+jlong JNICALL
+GetStaticLongField(JNIEnv *env, jclass clazz, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID };
+	jlong returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStaticLongField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jlong, &returnValue);
+	return returnValue;
+}
+
+jfloat JNICALL
+GetStaticFloatField(JNIEnv *env, jclass clazz, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID };
+	jfloat returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStaticFloatField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jfloat, &returnValue);
+	return returnValue;
+}
+
+jdouble JNICALL
+GetStaticDoubleField(JNIEnv *env, jclass clazz, jfieldID fieldID)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID };
+	jdouble returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStaticDoubleField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jdouble, &returnValue);
+	return returnValue;
+}
+
+void JNICALL
+SetStaticObjectField(JNIEnv *env, jclass clazz, jfieldID fieldID, jobject value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jobject};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID, value };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetStaticObjectField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+SetStaticBooleanField(JNIEnv *env, jclass clazz, jfieldID fieldID, jboolean value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jboolean};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID, value };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetStaticBooleanField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+SetStaticByteField(JNIEnv *env, jclass clazz, jfieldID fieldID, jbyte value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jbyte};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID, value };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetStaticByteField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+SetStaticCharField(JNIEnv *env, jclass clazz, jfieldID fieldID, jchar value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jchar};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID, value };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetStaticCharField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+SetStaticShortField(JNIEnv *env, jclass clazz, jfieldID fieldID, jshort value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jshort};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID, value };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetStaticShortField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+SetStaticIntField(JNIEnv *env, jclass clazz, jfieldID fieldID, jint value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jint};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID, value };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetStaticIntField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+SetStaticLongField(JNIEnv *env, jclass clazz, jfieldID fieldID, jlong value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jlong};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID, value };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetStaticLongField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+SetStaticFloatField(JNIEnv *env, jclass clazz, jfieldID fieldID, jfloat value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jfloat};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID, 0 };
+	/* Floating point parameters requires special handling */
+	jfloat *floatArgPtr = (jfloat *)(&(argValues[3]));
+	*floatArgPtr = value;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetStaticFloatField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+SetStaticDoubleField(JNIEnv *env, jclass clazz, jfieldID fieldID, jdouble value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jfieldID, CEL4RO64_type_jdouble};
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, fieldID, 0 };
+
+	/* Floating point parameters requires special handling */
+	jdouble *doubleArgPtr = (jdouble *)(&(argValues[3]));
+	*doubleArgPtr = value;
+
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetStaticDoubleField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+jobject JNICALL
+GetObjectArrayElement(JNIEnv *env, jobjectArray array, jsize index)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jarray, CEL4RO64_type_jsize };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), array, index };
+	jobject returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetObjectArrayElement);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+void JNICALL
+SetObjectArrayElement(JNIEnv *env, jobjectArray array, jsize index, jobject value)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jarray, CEL4RO64_type_jsize, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), array, index , value };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetObjectArrayElement);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}

--- a/runtime/j9vm31/jniinv.cpp
+++ b/runtime/j9vm31/jniinv.cpp
@@ -1,0 +1,381 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9vm31.h"
+#include "omrcomp.h"
+
+extern "C" {
+
+/* Given LE supports only one TCB that can cross AMODE boundary, most likely
+ * we will only have 1 JavaVM in the address space. Simply use a static to
+ * track the live JavaVM31 instances.
+ */
+static JavaVM31* globalRootJavaVM31 = NULL;
+
+static void initializeJavaVM31(JavaVM31 * JavaVM31, jlong JavaVM64);
+static void freeJavaVM31(JavaVM31 * JavaVM31);
+
+/* This is the function table of the 31-bit shim JNIInvokeInterface functions. */
+struct JNIInvokeInterface_ EsJNIInvokeFunctions = {
+	NULL,
+	NULL,
+	NULL,
+	DestroyJavaVM,
+	AttachCurrentThread,
+	DetachCurrentThread,
+	GetEnv,
+	AttachCurrentThreadAsDaemon,
+};
+
+jint JNICALL
+JNI_GetDefaultJavaVMInitArgs(void * vm_args)
+{
+	/* Zero out the JavaVMInitArgs reserved / padding fields. */
+	JavaVMInitArgs *javaInitArgs = ((JavaVMInitArgs *) vm_args);
+	if (NULL != javaInitArgs) {
+		javaInitArgs->reservedOptionsPadding = NULL;
+		javaInitArgs->reservedAlignmentPadding = NULL;
+
+		for (int32_t i = 0; i < javaInitArgs->nOptions; i++) {
+			javaInitArgs->options[i].reservedOptionStringPadding = NULL;
+			javaInitArgs->options[i].reservedExtraInfoPadding = NULL;
+		}
+	}
+
+	const jint NUM_ARGS = 1;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { (uint64_t)vm_args };
+	jint returnValue = JNI_ERR;
+	uint32_t cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
+			LIBJVM_NAME, "JNI_GetDefaultJavaVMInitArgs",
+			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+
+	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+		fprintf(stderr, "JNI_GetDefaultJavaVMInitArgs failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+		return JNI_ERR;
+	}
+	return returnValue;
+}
+
+jint JNICALL
+JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args)
+{
+	uint64_t JavaVM64Result = 0;
+	uint64_t JNIEnv64Result = 0;
+
+	/* Zero out the JavaVMInitArgs reserved / padding fields. */
+	JavaVMInitArgs *javaInitArgs = ((JavaVMInitArgs *) vm_args);
+	if (NULL != javaInitArgs) {
+		javaInitArgs->reservedOptionsPadding = NULL;
+		javaInitArgs->reservedAlignmentPadding = NULL;
+
+		for (int32_t i = 0; i < javaInitArgs->nOptions; i++) {
+			javaInitArgs->options[i].reservedOptionStringPadding = NULL;
+			javaInitArgs->options[i].reservedExtraInfoPadding = NULL;
+
+			/* Abort, Exit and vsprintf hooks may be specified, in which
+			 * case, we need to high tag the AMODE31 functions.
+			 */
+			if (NULL != javaInitArgs->options[i].extraInfo) {
+				/* extraInfo may have been stale garbage, so need to compare string. */
+				char *optionString = javaInitArgs->options[i].optionString;
+				if (NULL != optionString)
+				/* Have to do the string comparisons in CCSID 1208 - UTF-8. */
+#pragma convert(1208)
+				if (0 == strncmp(optionString, "abort", strlen("abort"))) {
+					javaInitArgs->options[i].reservedExtraInfoPadding = (void *)HANDLE31_HIGHTAG;
+				} else if (0 == strncmp(optionString, "exit", strlen("exit"))) {
+					javaInitArgs->options[i].reservedExtraInfoPadding = (void *)HANDLE31_HIGHTAG;
+				}  else if (0 == strncmp(optionString, "vfprintf", strlen("vfprintf"))) {
+					javaInitArgs->options[i].reservedExtraInfoPadding = (void *)HANDLE31_HIGHTAG;
+				}
+#pragma convert(pop)
+			}
+		}
+	}
+
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JavaVM64, CEL4RO64_type_JNIEnv64, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { (uint64_t)&JavaVM64Result, (uint64_t)&JNIEnv64Result, (uint64_t)vm_args };
+	jint returnValue = JNI_ERR;
+	uint32_t cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
+			LIBJVM_NAME, "JNI_CreateJavaVM",
+			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+
+	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+		fprintf(stderr, "JNI_CreateJavaVM failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+		return JNI_ERR;
+	}
+
+	if (JNI_OK == returnValue) {
+		/* Create and return the corresponding 31-bit instance of JavaVM and JNIEnv. */
+		JavaVM31* javaVM31 = getJavaVM31(JavaVM64Result);
+		*pvm = (JavaVM*) javaVM31;
+		JNIEnv31* jniEnv31 = getJNIEnv31(JNIEnv64Result);
+		*penv = (JNIEnv*) jniEnv31;
+		jniEnv31->javaVM31 = javaVM31;
+	}
+	return returnValue;
+}
+
+jint JNICALL
+JNI_GetCreatedJavaVMs(JavaVM **vmBuf, jsize bufLen, jsize *nVMs)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_uint32_ptr, CEL4RO64_type_jsize, CEL4RO64_type_uint32_ptr };
+
+	/* Allocate a temporary buffer to store the returned JavaVM64 instances.
+	 * Will copy the corresponding 31-bit JavaVM instanes to vmBuf if successful below.
+	 */
+	uint64_t *tempJavaVM64Buffer = (uint64_t *)malloc(sizeof(jlong) * bufLen);
+	if (NULL == tempJavaVM64Buffer) {
+		return JNI_ERR;
+	}
+
+	uint64_t argValues[NUM_ARGS] = { (uint64_t)tempJavaVM64Buffer, bufLen, (uint64_t)nVMs };
+	jint returnValue = JNI_ERR;
+	uint32_t cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
+			LIBJVM_NAME, "JNI_GetCreatedJavaVMs",
+			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+
+	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+		fprintf(stderr, "JNI_GetCreatedJavaVMs failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+		returnValue = JNI_ERR;
+	}
+
+	/* On success, copy the corresponding 31-bit JavaVM instances to vmBuf. */
+	if (JNI_OK == returnValue) {
+		for (int32_t i = 0; i < *nVMs; i++) {
+			vmBuf[i] = (JavaVM*)getJavaVM31(tempJavaVM64Buffer[i]);
+		}
+	}
+	free(tempJavaVM64Buffer);
+	return returnValue;
+}
+
+jint JNICALL
+DestroyJavaVM(JavaVM *vm)
+{
+	const jint NUM_ARGS = 1;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JavaVM64 };
+	uint64_t argValues[NUM_ARGS] = { JAVAVM64_FROM_JAVAVM31(vm)};
+	jint returnValue = JNI_ERR;
+	uint32_t cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
+			LIBJ9VM29_NAME, "DestroyJavaVM",
+			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+
+	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+		fprintf(stderr, "DestroyJavaVM failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+		returnValue = JNI_ERR;
+	}
+	/* If successful, we will free our corresponding 31-bit JavaVM instance and matching 31-bit JNIEnv. */
+	if (JNI_OK == returnValue) {
+		freeJavaVM31((JavaVM31 *)vm);
+	}
+	return returnValue;
+}
+
+jint JNICALL
+AttachCurrentThread(JavaVM *vm, void **penv, void *args)
+{
+	/* The current LE CEL4RO31/64 support will only allow 1 TCB to cross the AMODE boundary. As such, we need to
+	 * check the result of CEL4RO64 for error codes, and handle accordingly.
+	 */
+	const jint NUM_ARGS = 3;
+	uint64_t JNIEnv64Result = 0;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JavaVM64, CEL4RO64_type_JNIEnv64, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JAVAVM64_FROM_JAVAVM31(vm), (uint64_t)&JNIEnv64Result, (uint64_t)args };
+	jint returnValue = JNI_ERR;
+	uint32_t cel4ro64ReturnCode = J9_CEL4RO64_RETCODE_OK;
+
+	/* Zero initialize reservedNamePadding in JavaVMAttachArgs. */
+	JavaVMAttachArgs *vmAttachArgs = ((JavaVMAttachArgs *) args);
+	if (NULL != vmAttachArgs) {
+		vmAttachArgs->reservedNamePadding = NULL;
+	}
+
+	cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
+			LIBJ9VM29_NAME, "AttachCurrentThread",
+			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+
+	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+		fprintf(stderr, "AttachCurrentThread failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+		return JNI_ERR;
+	}
+	/* If successful, we will return the correponding 31-bit JNIEnv. */
+	if (JNI_OK == returnValue) {
+		JNIEnv31* jniEnv31 = getJNIEnv31(JNIEnv64Result);
+		jniEnv31->javaVM31 = (JavaVM31 *)vm;
+		*penv = (JavaVM *)jniEnv31;
+	}
+	return returnValue;
+}
+
+jint JNICALL
+DetachCurrentThread(JavaVM *vm) {
+	/* The current LE CEL4RO31/64 support will only allow 1 TCB to cross the AMODE boundary. In theory,
+	 * we should have attached before calling DetachCurrentThread, but will confirm CEL4RO64 return code.
+	 */
+	const jint NUM_ARGS = 1;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JavaVM64 };
+	uint64_t argValues[NUM_ARGS] = { JAVAVM64_FROM_JAVAVM31(vm) };
+	jint returnValue = JNI_ERR;
+	uint32_t cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
+			LIBJ9VM29_NAME, "DetachCurrentThread",
+			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+
+	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+		fprintf(stderr, "DetachCurrentThread failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+		return JNI_ERR;
+	}
+	return returnValue;
+}
+
+jint JNICALL
+GetEnv(JavaVM *vm, void **penv, jint version)
+{
+	const jint NUM_ARGS = 3;
+	uint64_t JNIEnv64Result = 0;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JavaVM64, CEL4RO64_type_JNIEnv64, CEL4RO64_type_jint };
+	uint64_t argValues[NUM_ARGS] = { JAVAVM64_FROM_JAVAVM31(vm), (uint64_t)&JNIEnv64Result, version };
+	jint returnValue = JNI_ERR;
+	uint32_t cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
+			LIBJ9VM29_NAME, "GetEnv",
+			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+
+	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+		fprintf(stderr, "GetEnv failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+		return JNI_ERR;
+	}
+	/* If successful, we will return the correponding 31-bit JNIEnv. */
+	if (JNI_OK == returnValue) {
+		JNIEnv31* jniEnv31 = getJNIEnv31(JNIEnv64Result);
+		jniEnv31->javaVM31 = (JavaVM31 *)vm;
+		*penv = (JavaVM *)jniEnv31;
+	}
+	return returnValue;
+}
+
+jint JNICALL
+AttachCurrentThreadAsDaemon(JavaVM *vm, void **penv, void *args)
+{
+	/* The current LE CEL4RO31/64 support will only allow 1 TCB to cross the AMODE boundary. As such, we need to
+	 * check the result of CEL4RO64 for error codes, and handle accordingly.
+	 */
+	const jint NUM_ARGS = 3;
+	uint64_t JNIEnv64Result = 0;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JavaVM64, CEL4RO64_type_JNIEnv64, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JAVAVM64_FROM_JAVAVM31(vm), (uint64_t)&JNIEnv64Result, (uint64_t)args };
+	jint returnValue = JNI_ERR;
+	uint32_t cel4ro64ReturnCode = J9_CEL4RO64_RETCODE_OK;
+
+	/* Zero initialize reservedNamePadding in JavaVMAttachArgs. */
+	JavaVMAttachArgs *vmAttachArgs = ((JavaVMAttachArgs *) args);
+	if (NULL != vmAttachArgs) {
+		vmAttachArgs->reservedNamePadding = NULL;
+	}
+
+	cel4ro64ReturnCode = j9_cel4ro64_load_query_call_function(
+			LIBJ9VM29_NAME, "AttachCurrentThreadAsDaemon",
+			argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+
+	if (J9_CEL4RO64_RETCODE_OK != cel4ro64ReturnCode) {
+		fprintf(stderr, "AttachCurrentThreadAsDaemon failed. CEL4RO64 rc: %d - %s\n", cel4ro64ReturnCode, j9_cel4ro64_get_error_message(cel4ro64ReturnCode));
+		return JNI_ERR;
+	}
+	/* If successful, we will return the correponding 31-bit JNIEnv. */
+	if (JNI_OK == returnValue) {
+		JNIEnv31* jniEnv31 = getJNIEnv31(JNIEnv64Result);
+		jniEnv31->javaVM31 = (JavaVM31 *)vm;
+		*penv = (JavaVM *)jniEnv31;
+	}
+	return returnValue;
+}
+
+/**
+ * Following set of functions are JavaVM31 utility routines.
+ */
+
+
+JavaVM31 * JNICALL
+getJavaVM31(uint64_t javaVM64)
+{
+	/* Traverse list to find matching JavaVM31. */
+	for (JavaVM31 *curJavaVM31 = globalRootJavaVM31; curJavaVM31 != NULL; curJavaVM31 = curJavaVM31->next) {
+		if (javaVM64 == curJavaVM31->javaVM64) {
+			return curJavaVM31;
+		}
+	}
+
+	/* Create and initialize a new instance. */
+	JavaVM31 *newJavaVM31 = (JavaVM31 *)malloc(sizeof(JavaVM31));
+	if (NULL != newJavaVM31) {
+		initializeJavaVM31(newJavaVM31, javaVM64);
+	}
+	return newJavaVM31;
+}
+
+/**
+ * Initialize new JavaVM31 structure, with references to the corresponding 64-bit
+ * JavaVM, along with both 31-bit and 64-bit invoke function tables. Add to our
+ * list of JavaVM31.
+ *
+ * @param[in] javaVM31 The 31-bit JavaVM* instance to initialize.
+ * @param[in] javaVM64 The matching 64-bit JavaVM* from JVM.
+ */
+static void
+initializeJavaVM31(JavaVM31 * javaVM31, jlong javaVM64)
+{
+	javaVM31->functions = (JNIInvokeInterface_ *)GLOBAL_TABLE(EsJNIInvokeFunctions);
+	javaVM31->javaVM64 = javaVM64;
+	javaVM31->next = globalRootJavaVM31;
+	globalRootJavaVM31 = javaVM31;
+}
+
+/**
+ * Free the current 31-bit JavaVM31 instance.
+ *
+ * @param[in] javaVM31ToFree The 31-bit JavaVM instance to free.
+ */
+static void
+freeJavaVM31(JavaVM31 * javaVM31ToFree)
+{
+	/* Traverse globalRootJavaVM31 list and remove this instance of JavaVM31. */
+	JavaVM31 *currentJavaVM31 = globalRootJavaVM31;
+
+	if (currentJavaVM31 == javaVM31ToFree) {
+		globalRootJavaVM31 = currentJavaVM31->next;
+	} else {
+		/* Traverse list to find the entry to remove. */
+		while (NULL != currentJavaVM31) {
+			JavaVM31 *next = currentJavaVM31->next;
+			if (next == javaVM31ToFree) {
+				currentJavaVM31->next = next->next;
+				break;
+			}
+			currentJavaVM31 = next;
+		}
+	}
+	free(javaVM31ToFree);
+}
+
+} /* extern "C" */

--- a/runtime/j9vm31/jnimisc.cpp
+++ b/runtime/j9vm31/jnimisc.cpp
@@ -1,0 +1,356 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9vm31.h"
+
+jclass JNICALL
+FindClass(JNIEnv *env, const char *name)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), (uint64_t)name};
+	jclass returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, FindClass);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jclass, &returnValue);
+	return returnValue;
+}
+
+jclass JNICALL
+GetSuperclass(JNIEnv *env, jclass clazz)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jclass };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz };
+	jclass returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetSuperclass);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jclass, &returnValue);
+	return returnValue;
+}
+
+jboolean JNICALL
+IsAssignableFrom(JNIEnv *env, jclass clazz1, jclass clazz2)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jclass, CEL4RO64_type_jclass };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz1, clazz2 };
+	jboolean returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, IsAssignableFrom);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jboolean, &returnValue);
+	return returnValue;
+}
+
+jint JNICALL
+Throw(JNIEnv *env, jthrowable obj)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jthrowable };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj };
+	jint returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, Throw);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+jboolean JNICALL
+IsSameObject(JNIEnv *env, jobject ref1, jobject ref2)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), ref1, ref2 };
+	jboolean returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, IsSameObject);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jboolean, &returnValue);
+	return returnValue;
+}
+
+jobject JNICALL
+AllocObject(JNIEnv *env, jclass clazz)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jclass };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz };
+	jobject returnValue;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, AllocObject);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+jclass JNICALL
+GetObjectClass(JNIEnv *env, jobject obj)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), obj };
+	jclass returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetObjectClass);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jclass, &returnValue);
+	return returnValue;
+}
+
+jstring JNICALL
+NewString(JNIEnv *env, const jchar *unicodeChars, jsize len)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_uint32_ptr, CEL4RO64_type_jsize };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), (uint64_t)unicodeChars, len };
+	jstring returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewString);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jstring, &returnValue);
+	return returnValue;
+}
+
+jsize JNICALL
+GetStringLength(JNIEnv *env, jstring string)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jstring };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), string };
+	jsize returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStringLength);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jsize, &returnValue);
+	return returnValue;
+}
+
+const jchar *JNICALL
+GetStringChars(JNIEnv *env, jstring string, jboolean *isCopy)
+{
+	/* This routine handles both GetStringChars and GetStringCritical, as the Java Heap is not accessible in AMODE31. */
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jstring, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), string, (uint64_t)isCopy };
+	const jchar *returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStringChars);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_uint32_ptr, &returnValue);
+	return returnValue;
+}
+
+void JNICALL
+ReleaseStringChars(JNIEnv *env, jstring string, const jchar *utf)
+{
+	/* This routine handles both GetStringChars and ReleaseStringCritical, GetStringCritical invokes GetStringChars. */
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jstring, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), string, (uint64_t)utf };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, ReleaseStringChars);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+jstring JNICALL
+NewStringUTF(JNIEnv *env, const char *bytes)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), (uint64_t)bytes };
+	jstring returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewStringUTF);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jstring, &returnValue);
+	return returnValue;
+}
+
+jsize JNICALL
+GetStringUTFLength(JNIEnv *env, jstring string)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jstring };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), string };
+	jsize returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStringUTFLength);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jsize, &returnValue);
+	return returnValue;
+}
+
+const char* JNICALL
+GetStringUTFChars(JNIEnv *env, jstring string, jboolean *isCopy)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jstring, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), string, (uint64_t)isCopy };
+	const char* returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStringUTFChars);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_uint32_ptr, &returnValue);
+	return returnValue;
+}
+
+void JNICALL
+ReleaseStringUTFChars(JNIEnv *env, jstring string, const char* utf)
+{
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jstring, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), string, (uint64_t)utf };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, ReleaseStringUTFChars);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+jsize JNICALL
+GetArrayLength(JNIEnv *env, jarray array)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jarray };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), array };
+	jsize returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetArrayLength);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jsize, &returnValue);
+	return returnValue;
+}
+
+jobjectArray JNICALL
+NewObjectArray(JNIEnv *env, jsize length, jclass clazz, jobject initialElement) {
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jsize, CEL4RO64_type_jclass, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), length, clazz, initialElement };
+	jobjectArray returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, NewObjectArray);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jarray, &returnValue);
+	return returnValue;
+}
+
+void* JNICALL
+getArrayElements(JNIEnv *env, jarray array, jboolean *isCopy)
+{
+	/* This routine is used for all Get*ArrayElements and GetPrimitiveArrayCritical. The latter because
+	 * the Java heap is not addressible in AMODE 31, as such, will always return a copy.
+	 */
+	const jint NUM_ARGS = 3;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jarray, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), array, (uint64_t)isCopy };
+	void* returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetBooleanArrayElements);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_uint32_ptr, &returnValue);
+	return returnValue;
+}
+
+void JNICALL
+releaseArrayElements(JNIEnv *env, jarray array, void *elems, jint mode)
+{
+	/* This routine is used for all Release*ArrayElements and ReleasePrimitiveArrayCritical. The latter because
+	 * GetPrimitiveArrayCritical actually calls getArrayElements, so we need to release the array elements
+	 * the same way.
+	 */
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jarray, CEL4RO64_type_uint32_ptr, CEL4RO64_type_jint };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), array, (uint64_t) elems, mode };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, ReleaseBooleanArrayElements);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+getArrayRegion(JNIEnv *env, jarray array, jsize start, jsize len, void *buf)
+{
+	/* This routine is used for all Get*ArrayRegion. */
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jarray, CEL4RO64_type_jsize, CEL4RO64_type_jsize, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), array, start, len, (uint64_t)buf };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetBooleanArrayRegion);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+setArrayRegion(JNIEnv *env, jarray array, jsize start, jsize len, void *buf)
+{
+	/* This routine is used for all Get*ArrayRegion. */
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jarray, CEL4RO64_type_jsize, CEL4RO64_type_jsize, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), array, start, len, (uint64_t)buf };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, SetBooleanArrayRegion);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+/**
+ * A 64-bit representation of JNINativeMethod struct.
+ */
+typedef struct {
+	void *namePadding;        /**< Padding for upper 32-bits of name member. */
+	char *name;               /**< Method name. */
+	void *signaturePadding;   /**< Padding for upper 32-bits of signature member. */
+	char *signature;          /**< Method signature. */
+	jint fnPtrPadding;        /**< Upper 32-bits of function pointer -- to be tagged HANDLE31_HIGHTAG. */
+	void *fnPtr;              /**< Function pointer. */
+} JNINativeMethod64;
+
+jint JNICALL
+RegisterNatives(JNIEnv *env, jclass clazz, const JNINativeMethod *methods, jint nMethods)
+{
+	JNINativeMethod64* methods64 = (JNINativeMethod64 *)malloc(nMethods * sizeof(JNINativeMethod64));
+	if (NULL == methods64)
+		return JNI_ERR;
+
+	/* Zero initialize and copy the JNINativeMethod parameters, and tag the function pointers
+	* with HANDLE31_HIGHTAG to signify they are from AMODE 31.
+	*/
+	memset(methods64, 0, nMethods * sizeof(JNINativeMethod64));
+
+	for (int i = 0; i < nMethods; i++) {
+		methods64[i].fnPtr = methods[i].fnPtr;
+		methods64[i].name = methods[i].name;
+		methods64[i].signature = methods[i].signature;
+		methods64[i].fnPtrPadding = HANDLE31_HIGHTAG;
+	}
+
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jclass, CEL4RO64_type_uint32_ptr, CEL4RO64_type_jint };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz, (uint64_t)methods64, nMethods };
+	jint returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, RegisterNatives);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+
+	free(methods64);
+	return returnValue;
+}
+
+jint JNICALL
+UnregisterNatives(JNIEnv *env, jclass clazz)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jclass };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), clazz };
+	jint returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, UnregisterNatives);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jint, &returnValue);
+	return returnValue;
+}
+
+void JNICALL
+GetStringRegion(JNIEnv *env, jstring str, jsize start, jsize len, jchar *buf)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jstring, CEL4RO64_type_jsize, CEL4RO64_type_jsize, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), str, start, len, (uint64_t)buf };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStringRegion);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}
+
+void JNICALL
+GetStringUTFRegion(JNIEnv *env, jstring str, jsize start, jsize len, char *buf)
+{
+	const jint NUM_ARGS = 5;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jstring, CEL4RO64_type_jsize, CEL4RO64_type_jsize, CEL4RO64_type_uint32_ptr };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), str, start, len, (uint64_t)buf };
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, GetStringUTFRegion);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_void, NULL);
+	return;
+}

--- a/runtime/j9vm31/jnireflect.cpp
+++ b/runtime/j9vm31/jnireflect.cpp
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9vm31.h"
+
+jmethodID JNICALL
+FromReflectedMethod(JNIEnv *env, jobject method)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), method };
+	jmethodID returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, FromReflectedMethod);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jmethodID, &returnValue);
+	return returnValue;
+}
+
+jfieldID JNICALL
+FromReflectedField(JNIEnv *env, jobject field)
+{
+	const jint NUM_ARGS = 2;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jobject };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), field };
+	jfieldID returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, FromReflectedField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jfieldID, &returnValue);
+	return returnValue;
+}
+
+jobject JNICALL
+ToReflectedMethod(JNIEnv *env, jclass cls, jmethodID methodID, jboolean isStatic)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jclass, CEL4RO64_type_jmethodID, CEL4RO64_type_jboolean };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), cls, methodID, (uint64_t)isStatic };
+	jobject returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, ToReflectedMethod);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}
+
+jobject JNICALL
+ToReflectedField(JNIEnv *env, jclass cls, jfieldID fieldID, jboolean isStatic)
+{
+	const jint NUM_ARGS = 4;
+	J9_CEL4RO64_ArgType argTypes[NUM_ARGS] = { CEL4RO64_type_JNIEnv64, CEL4RO64_type_jclass, CEL4RO64_type_jfieldID, CEL4RO64_type_jboolean };
+	uint64_t argValues[NUM_ARGS] = { JNIENV64_FROM_JNIENV31(env), cls, fieldID, (uint64_t)isStatic };
+	jobject returnValue = NULL;
+	FUNCTION_DESCRIPTOR_FROM_JNIENV31(env, ToReflectedField);
+	j9_cel4ro64_call_function(functionDescriptor, argTypes, argValues, NUM_ARGS, CEL4RO64_type_jobject, &returnValue);
+	return returnValue;
+}

--- a/runtime/j9vm31/module.xml
+++ b/runtime/j9vm31/module.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2021, 2021 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<module xmlns:xi="http://www.w3.org/2001/XInclude">
+	<xi:include href="j9vm31natives.xml"></xi:include>
+
+	<artifact type="shared" name="jvm31" bundle="jvm" loadgroup="" appendrelease="false">
+		<include-if condition="spec.flags.module_j9vm31"/>
+		<options>
+			<option name="isCPlusPlus"/>
+			<option name="dllDescription" data="libjvm31"/>
+		</options>
+		<phase>core quick j2se</phase>
+		<exports>
+			<group name="all"/>
+		</exports>
+		<includes>
+			<include path="j9include31"/>
+		</includes>
+		<makefilestubs>
+			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
+			<makefilestub data="undefine j9vm_env_data64"/>
+		</makefilestubs>
+		<objects>
+			<object name="j9cel4ro64"/>
+			<object name="j9vm31floatstubs"/>
+			<object name="jnicgen"/>
+			<object name="jnicsup"/>
+			<object name="jnifield"/>
+			<object name="jniinv"/>
+			<object name="jnimisc"/>
+			<object name="jnireflect"/>
+		</objects>
+	</artifact>
+</module>

--- a/runtime/makelib/targets.mk.zos.inc.ftl
+++ b/runtime/makelib/targets.mk.zos.inc.ftl
@@ -1,5 +1,5 @@
 <#--
-Copyright (c) 1998, 2020 IBM Corp. and others
+Copyright (c) 1998, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -103,6 +103,16 @@ COMMA := ,
 
 # Compile jniargtestssystemlink with non-XPLINK (system) linkage
 ifeq ($(UMA_TARGET_NAME),jniargtestssystemlink)
+  UMA_ZOS_FLAGS := $(subst $(COMMA)xplink,,$(UMA_ZOS_FLAGS))
+  UMA_LINK_FLAGS := $(subst $(COMMA)xplink,,$(UMA_LINK_FLAGS))
+endif
+
+# Compile j9vm31 shim library requires non-XPLINK (system) linkage.
+# As a standalone 31-bit library without access to a2e library,
+# we will default to EBCDIC as convlit settings.
+ifeq ($(UMA_TARGET_NAME),jvm31)
+  UMA_ZOS_FLAGS := $(subst convlit(ISO8859-1),,$(UMA_ZOS_FLAGS))
+  UMA_ZOS_FLAGS := $(subst -I$(OMR_DIR)/util/a2e/headers,,$(UMA_ZOS_FLAGS))
   UMA_ZOS_FLAGS := $(subst $(COMMA)xplink,,$(UMA_ZOS_FLAGS))
   UMA_LINK_FLAGS := $(subst $(COMMA)xplink,,$(UMA_LINK_FLAGS))
 endif


### PR DESCRIPTION
This PR adds two new modules:

1. An `include31` modules that produces copies jni.h, jni_convert.h and jniport.h.  For jni.h, the m4 has been updated to remap any object reference types, jclass, jfieldID, jmethodID to be 64-bit... as we want to use the 64-bit handles directly passed by the JVM.   

2. A `j9vm31` 31-bit standalone shim library to support the JavaInvokeInterface and JavaNativeInterface APIs that allow
z/OS 31-bit non-XPLINK native code to interoperate with 64-bit JVM on z/OS.

Changes include:
- the CEL4RO64 utility functions to facilitate AMODE64 calls.  Specifically, getting the call arguments into the correct 64-bit representation, and extracting the appropriate return types.  One thing to note is that float/double parameters and return value handling currently invokes empty assembler functions in order to set or extract the FPR0 value out -- by leveraging the system linkage convention to get the compiler to do the right thing.  Ideally, this would have been done with a single inline asm, but alas. 
- The majority of changes are shim functions to redirect to corresponding 64-bit functions for the JavaInvokeInterface and JavaNativeInterface APIs.
    - Majority of the APIs are invoking the 64 counterparts directly.   For Call*, Array, NewObject*, and String* APIs, they will be calling the 31-bit customized version being introduced in https://github.com/eclipse/openj9/pull/12074.   RegisterNatives and JNI_CreateJavaVM need to hightag any 31-bit native functions being passed.  Some of the Invoke APIs require extra handling to zero out upper-32-bits padding.  
    - Organization wise, the shim functions are broken up similar to how they are represented in `vm` directory.
- JavaVM31 and JNIEnv31 structs for 31-bit AMODE native code to interact with JavaInvokeInterface and JavaNativeInterface APIs.  There are special handling of these, but the current LE limitation only supports a single TCB, so some of the additional logic would be exercised.

Net result of this change is a new include31 directory with 3 JNI header files, and a new libjvm31.so / x library and side-deck produced.  Although independent, the functionality in this PR is dependent on changes introduced in https://github.com/eclipse/openj9/pull/12074. 