### PR TITLE
Check for arch support when generating AGHIK instruction in Z's multiANewArrayEvaluator

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -119,6 +119,11 @@
 		<variations>
 			<variation>-Xjit:count=0</variation>
 			<variation>-Xjit:disableAsyncCompilation,count=1</variation>
+			<variation>-Xjit:count=0,disableZ196</variation>
+			<variation>-Xjit:count=0,disableZEC12</variation>
+			<variation>-Xjit:count=0,disableZ13</variation>
+			<variation>-Xjit:count=0,disableZ14</variation>
+			<variation>-Xjit:count=0,disableZ15</variation>
 		</variations>
 		<command> $(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \


### PR DESCRIPTION
The multiANewArrayEvaluator in the z/codegen generates an `AGHIK` instruction. This instruction is not supported on Z10
and lower platforms. This commit adds a check in the evaluator to make sure that the current architecture supports the instruction before generating it.

Tests for the evaluator have also been improved to account for all supported architectures.

Fixes: #12538

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>