### PR TITLE
Thread iterator inside thread list lock

### DIFF
--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -750,9 +750,9 @@ MM_ScavengerDelegate::signalThreadsToFlushCaches(MM_EnvironmentBase *currentEnvB
 	J9InternalVMFunctions const * const vmFuncs = _javaVM->internalVMFunctions;
 	J9VMThread *walkThread = NULL;
 
-	GC_VMThreadListIterator vmThreadListIterator(_javaVM);
-
 	GC_VMInterface::lockVMThreadList(_extensions);
+
+	GC_VMThreadListIterator vmThreadListIterator(_javaVM);
 
 	while((walkThread = vmThreadListIterator.nextVMThread()) != NULL) {
 		vmFuncs->J9SignalAsyncEvent(_javaVM, walkThread, _flushCachesAsyncCallbackKey);


### PR DESCRIPTION
In Concurrent Scavenger, when close to terminating concurrent phase and
signaling mutator threads to flush their copy caches, prior to thread
iteration thread lock is acquired. However, it's taken after the
iterator construction, which itself advances the iteration to main VM
thread. The main thread may race and terminate before we acquire the
lock and start iteration.

The solution is to construct the iterator after acquiring the lock.


Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>