### PR TITLE
Update classpath for JAVA17

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -172,7 +172,7 @@
 		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
 		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
-		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava16.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava17.jar"/>
 		<source path="src"/>
 		<parameter name="macro:define" value="JAVA_SPEC_VERSION=17"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>


### PR DESCRIPTION
Required due to adoption of reference implementation of String by #12209.